### PR TITLE
Draft implementation of Kubernetes driver

### DIFF
--- a/drivers/scheduler/kubernetes/kubernetes.go
+++ b/drivers/scheduler/kubernetes/kubernetes.go
@@ -1,0 +1,355 @@
+
+package kubernetes
+
+import (
+	"fmt"
+	"io/ioutil"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api/v1"
+	sv1 "k8s.io/client-go/pkg/apis/storage/v1beta1"
+	"k8s.io/client-go/rest"
+	"log"
+	"os"
+	"time"
+)
+
+type k8sdriver struct {
+}
+
+const (
+	defaultServer string = "http://127.0.0.1:8001"
+	serverEnvVar  string = "SERVER"
+	tokenEnvVar   string = "TOKEN"
+	caFileEnvVar  string = "CA_FILE"
+)
+
+var logger *log.Logger
+
+//k8sConnect connects to kubernetes master with ip,bearer token
+//and certificate
+func k8sConnect(ip string) (*kubernetes.Clientset, error) {
+	token := os.Getenv("tokenEnvVar")
+	caFile := os.Getenv("caFileEnvVar")
+	var err error
+	var caData []byte
+	if len(caFile) > 0 {
+		caData, err = ioutil.ReadFile(caFile)
+	}
+	if err != nil {
+		logger.Println(err)
+		return nil,err
+	}
+	config := &rest.Config{
+		Host:            "https://" + ip + ":6443",
+		BearerToken:     token,
+		TLSClientConfig: rest.TLSClientConfig{CAData: caData},
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	return clientset, err
+}
+
+//createPersistentVolumeClaimSpec returns representation
+//of PersistentVolumeClaim
+func createPersistentVolumeClaimSpec(task Task) *v1.PersistentVolumeClaim {
+	pvc := v1.PersistentVolumeClaim{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "PersistentVolumeClaim",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "torpedo",
+			Annotations: map[string]string{
+				"volume.beta.kubernetes.io/storage-class": "torpedo",
+			},
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{
+				"ReadWriteOnce",
+			},
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceStorage: resource.MustParse("2Gi"),
+				},
+			},
+		},
+	}
+	return &pvc
+}
+
+//createStorageClassSpec returns representation
+//of StorageClass
+func createStorageClassSpec(task Task) *sv1.StorageClass {
+	sc := sv1.StorageClass{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "StorageClass",
+			APIVersion: "storage.k8s.io/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "torpedo",
+		},
+		Provisioner: "kubernetes.io/portworx-volume",
+		Parameters: map[string]string{
+			"repl": "1",
+		},
+	}
+	return &sc
+}
+
+func (d *k8sdriver) Init() error {
+	log.Printf("Using the Kuberntes scheduler driver.\n")
+	log.Printf("The following hosts are in the cluster: %v.\n", nodes)
+	return nil
+}
+
+func (d *k8sdriver) GetNodes() ([]string, error) {
+	return nodes, nil
+}
+
+func (d *k8sdriver) Create(task Task) (*Context, error) {
+	clientset, err := k8sConnect(task.IP)
+	if err != nil {
+		return nil, err
+	}
+	context := Context{}
+	pod := v1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "POD",
+			APIVersion: "extensions/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "torpedo",
+			Labels: map[string]string{"app": task.Name},
+		},
+		Spec: v1.PodSpec{
+			Volumes: []v1.Volume{
+				v1.Volume{
+					Name: "torpedo",
+					VolumeSource: v1.VolumeSource{
+						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "torpedo",
+						},
+					},
+				},
+			},
+			Containers: []v1.Container{
+				v1.Container{
+					Name:            "torpedo",
+					Image:           task.Img,
+					ImagePullPolicy: v1.PullIfNotPresent,
+					Command:         task.Cmd,
+					VolumeMounts: []v1.VolumeMount{
+						v1.VolumeMount{
+							MountPath: task.Vol.Path,
+							Name:      "torpedo",
+						},
+					},
+				},
+			},
+			RestartPolicy: v1.RestartPolicyNever,
+		},
+		Status: v1.PodStatus{},
+	}
+	context.Task = task
+	context.ID = "torpedo"
+	context.PodSpec = &pod
+	pvc := createPersistentVolumeClaimSpec(task)
+	_, err = clientset.Core().
+		PersistentVolumeClaims("kube-system").
+		Create(pvc)
+	if err != nil {
+		return nil, err
+	}
+	sc := createStorageClassSpec(task)
+	_, err = clientset.StorageV1beta1().
+		StorageClasses().Create(sc)
+	if err != nil {
+		return nil, err
+	}
+	return &context, nil
+}
+
+//Run to completion
+func (d *k8sdriver) Run(ctx *Context) error {
+	clientset, err := k8sConnect(ctx.Task.IP)
+	if err != nil {
+		return err
+	}
+	_, err = clientset.Core().Pods("kube-system").
+		Create(ctx.PodSpec)
+	if err != nil {
+		return err
+	}
+	log.Printf("Pod created")
+	time.Sleep(60 * time.Second)
+	podOptions := metav1.GetOptions{}
+	pod, errr := clientset.Core().Pods("kube-system").
+		Get("torpedo", podOptions)
+	if errr != nil {
+		return err
+	}
+	for {
+		if pod.Status.Phase == v1.PodSucceeded {
+			ctx.Status = 0
+			break
+		}
+
+		if pod.Status.Phase == v1.PodFailed || pod.Status.Phase == v1.PodUnknown {
+			ctx.Status = 1
+			break
+		}
+		pod, err = clientset.Core().Pods("kube-system").
+			Get("torpedo", podOptions)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *k8sdriver) Start(ctx *Context) error {
+	clientset, err := k8sConnect(ctx.Task.IP)
+	if err != nil {
+		return err
+	}
+	_, err = clientset.Core().Pods("kube-system").
+		Create(ctx.PodSpec)
+
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *k8sdriver) WaitDone(ctx *Context) error {
+	clientset, err := k8sConnect(ctx.Task.IP)
+	if err != nil {
+		return err
+	}
+	time.Sleep(60 * time.Second)
+	podOptions := metav1.GetOptions{}
+	pod, errr := clientset.Core().Pods("kube-system").
+		Get("torpedo", podOptions)
+	if errr != nil {
+		return err
+	}
+	for {
+	        if pod.Status.Phase == v1.PodSucceeded {
+			ctx.Status = 0
+			break
+		}
+
+		if pod.Status.Phase == v1.PodFailed || pod.Status.Phase == v1.PodUnknown {
+			ctx.Status = 1
+			break
+		}
+		pod, err = clientset.Core().Pods("kube-system").
+			Get("torpedo", podOptions)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *k8sdriver) InspectVolume(ip, name string) (*Volume, error) {
+	clientset, err := k8sConnect(ip)
+	if err != nil {
+		return nil, err
+	}
+	vol, err := clientset.StorageV1().
+		StorageClasses().
+		Get("torpedo", metav1.GetOptions{})
+	var driver string
+	if vol.Provisioner == "kubernetes.io/portworx-volume" {
+		driver = "pxd_k8s"
+	}
+	v := Volume{
+		Driver: driver,
+	}
+	return &v, nil
+}
+
+func (d *k8sdriver) DeleteVolume(ip, name string) error {
+	clientset, err := k8sConnect(ip)
+	if err != nil {
+		return err
+	}
+	err = clientset.PersistentVolumeClaims("kube-system").
+		Delete("torpedo", &metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+	err = clientset.
+		StorageV1beta1().
+		StorageClasses().
+		Delete("torpedo", &metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *k8sdriver) DestroyByName(ip, name string) error {
+	clientset, err := k8sConnect(ip)
+	if err != nil {
+		return err
+	}
+	err = clientset.Core().
+		PersistentVolumeClaims("kube-system").
+		Delete("torpedo", &metav1.DeleteOptions{})
+
+	if err != nil {
+		log.Println(err)
+	} else {
+		log.Println("PVC deleted")
+	}
+	err = clientset.
+		StorageV1beta1().
+		StorageClasses().
+		Delete("torpedo", &metav1.DeleteOptions{})
+	if err != nil {
+		log.Println(err)
+	} else {
+		log.Println("SC deleted")
+	}
+	err = clientset.Pods("kube-system").
+		Delete("torpedo", &metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+	log.Printf("Pod torpedo deleted")
+	log.Printf("Deleted task: %v\n", name)
+	return nil
+}
+
+func (d *k8sdriver) Destroy(ctx *Context) error {
+	clientset, err := k8sConnect(ctx.Task.IP)
+	if err != nil {
+		return err
+	}
+	err = clientset.Pods("kube-system").
+		Delete(ctx.ID, &metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+	log.Println("Pod Deleted")
+	err = clientset.Core().PersistentVolumeClaims("kube-system").
+		Delete("torpedo", &metav1.DeleteOptions{})
+	if err != nil {
+		fmt.Println(err)
+	}
+	err = clientset.StorageV1beta1().StorageClasses().
+		Delete("torpedo", &metav1.DeleteOptions{})
+	if err != nil {
+		fmt.Println(err)
+	}
+	log.Printf("Deleted task: %v\n", ctx.Task.Name)
+	return nil
+}
+
+func init() {
+	logger = log.New(os.Stdout, "", 0)
+	register("kubernetes", &k8sdriver{})
+}

--- a/drivers/volume/portworx/daemonset.yaml
+++ b/drivers/volume/portworx/daemonset.yaml
@@ -1,0 +1,107 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: portworx
+  namespace: kube-system
+spec:
+  minReadySeconds: 0
+  updateStrategy:
+    type: OnDelete
+  template:
+    metadata:
+      labels:
+        name: portworx
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: px/enabled
+                operator: NotIn
+                values:
+                - "false"
+
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
+
+      hostNetwork: true
+      hostPID: true
+      containers:
+        - name: portworx
+          image: portworx/px-enterprise:1.2.9
+          terminationMessagePath: "/tmp/px-termination-log"
+          imagePullPolicy: Always
+          args:
+             ["-k etcd://10.111.113.123:2379",
+              "-c mycluster",
+              "",
+              "",
+              " -s /dev/sdb",
+              "",
+              "",
+              "",
+              "",
+              "",
+              "",
+              "-x", "kubernetes"]
+
+          livenessProbe:
+            initialDelaySeconds: 840 # allow image pull in slow networks
+            httpGet:
+              host: 127.0.0.1
+              path: /status
+              port: 9001
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: dockersock
+              mountPath: /var/run/docker.sock
+            - name: libosd
+              mountPath: /var/lib/osd:shared
+            - name: dev
+              mountPath: /dev
+            - name: etcpwx
+              mountPath: /etc/pwx/
+            - name: optpwx
+              mountPath: /export_bin:shared
+            - name: cores
+              mountPath: /var/cores
+            - name: kubelet
+              mountPath: /var/lib/kubelet:shared
+            - name: src
+              mountPath: /usr/src
+            - name: dockerplugins
+              mountPath: /run/docker/plugins
+      restartPolicy: Always
+
+      serviceAccountName: px-account
+      volumes:
+        - name: libosd
+          hostPath:
+            path: /var/lib/osd
+        - name: dev
+          hostPath:
+            path: /dev
+        - name: etcpwx
+          hostPath:
+            path: /etc/pwx
+        - name: optpwx
+          hostPath:
+            path: /opt/pwx/bin
+        - name: cores
+          hostPath:
+            path: /var/cores
+        - name: kubelet
+          hostPath:
+            path: /var/lib/kubelet
+        - name: src
+          hostPath:
+            path: /usr/src
+        - name: dockerplugins
+          hostPath:
+            path: /run/docker/plugins
+        - name: dockersock
+          hostPath:
+            path: /var/run/docker.sock
+

--- a/drivers/volume/portworx/portworx_kubernetes.go
+++ b/drivers/volume/portworx/portworx_kubernetes.go
@@ -1,0 +1,256 @@
+
+
+package volume
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+	"io/ioutil"
+	
+
+	"github.com/libopenstorage/openstorage/api"
+	clusterclient "github.com/libopenstorage/openstorage/api/client/cluster"
+	volumeclient "github.com/libopenstorage/openstorage/api/client/volume"
+	"github.com/libopenstorage/openstorage/cluster"
+	"github.com/libopenstorage/openstorage/volume"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/apimachinery/pkg/runtime"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	//"k8s.io/client-go/pkg/api/v1"
+	dv1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
+	//av1 "k8s.io/client-go/pkg/apis/rbac/v1beta1"
+
+)
+
+type portworxK8s struct {
+	
+	clusterManager cluster.Cluster
+	volDriver      volume.VolumeDriver
+}
+
+var logger *log.Logger
+
+func convertYamltoStruct(yaml string) runtime.Object {
+	
+		d := scheme.Codecs.UniversalDeserializer()
+		obj, _, err := d.Decode([]byte(yaml), nil, nil)
+		if err != nil {
+			log.Fatalf("could not decode yaml: %s\n%s", yaml, err)
+		}
+	
+		return obj
+}
+
+func kconnect(ip string)(*kubernetes.Clientset,error){
+	
+	 token, caData, err := parseConnectionParams()
+	 if err != nil {
+		 logger.Fatalf("failed to parse configuration parameters: %s", err)
+	 }
+ 
+ 
+	 config := &rest.Config{
+		 Host:            "https://"+ip+":6443",
+		 BearerToken:     token,
+		 TLSClientConfig: rest.TLSClientConfig{CAData: caData},
+	 }
+ 
+ 
+	 clientset, err := kubernetes.NewForConfig(config)
+ 
+	 
+	 return clientset,err
+ }
+
+func parseConnectionParams() (token string, caData []byte, err error) {
+	
+
+	token = os.Getenv("tokenEnvVar")
+   // fmt.Println(token)
+	caFile := os.Getenv("caFileEnvVar")
+	if len(caFile) > 0 {
+		caData, err = ioutil.ReadFile(caFile)
+	}
+
+	return token, caData, err
+}
+
+
+
+func (d *portworxK8s) String() string {
+	return "pxd_k8s"
+}
+
+func (d *portworxK8s) Init() error {
+	log.Printf("Using the Portworx volume portworx.\n")
+
+	n := "127.0.0.1"
+	if len(nodes) > 0 {
+		n = nodes[1]
+	}
+
+	clnt, err := clusterclient.NewClusterClient("http://"+n+":9001", "v1")
+	if err != nil {
+		return err
+	}
+	d.clusterManager = clusterclient.ClusterManager(clnt)
+
+	clnt, err = volumeclient.NewDriverClient("http://"+n+":9001", "pxd", "","")
+	if err != nil {
+		return err
+	}
+	d.volDriver = volumeclient.VolumeDriver(clnt)
+
+	cluster, err := d.clusterManager.Enumerate()
+	if err != nil {
+		return err
+	}
+
+	log.Printf("The following Portworx nodes are in the cluster:\n")
+	for _, n := range cluster.Nodes {
+		log.Printf(
+			"\tNode ID: %v\tNode IP: %v\tNode Status: %v\n",
+			n.Id,
+			n.DataIp,
+			n.Status,
+		)
+	}
+
+	return nil
+}
+
+func (d *portworxK8s) RemoveVolume(name string) error {
+	locator := &api.VolumeLocator{}
+
+	volumes, err := d.volDriver.Enumerate(locator, nil)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range volumes {
+		if v.Locator.Name == name {
+			// First unmount this volume at all mount paths...
+			for _, path := range v.AttachPath {
+				if err = d.volDriver.Unmount(v.Id, path); err != nil {
+					err = fmt.Errorf(
+						"Error while unmounting %v at %v because of: %v",
+						v.Id,
+						path,
+						err,
+					)
+					log.Printf("%v", err)
+					return err
+				}
+			}
+
+			if err = d.volDriver.Detach(v.Id,true); err != nil {
+				err = fmt.Errorf(
+					"Error while detaching %v because of: %v",
+					v.Id,
+					err,
+				)
+				log.Printf("%v", err)
+				return err
+			}
+
+			if err = d.volDriver.Delete(v.Id); err != nil {
+				err = fmt.Errorf(
+					"Error while deleting %v because of: %v",
+					v.Id,
+					err,
+				)
+				log.Printf("%v", err)
+				return err
+			}
+
+			log.Printf("Succesfully removed Portworx volume %v\n", name)
+
+			return nil
+		}
+	}
+
+	return nil
+}
+
+
+func (d *portworxK8s) Stop(ip string) error{
+ 
+	clientset,err:=kconnect(ip)
+	if(err!=nil){
+		log.Println(err)
+		return err
+	}
+
+   
+	fal:=false
+	
+    daemonDelete :=&metav1.DeleteOptions{
+	  OrphanDependents:   &fal,
+	}
+	err=clientset.DaemonSets("kube-system").Delete("portworx",daemonDelete)
+	if(err!=nil){
+		log.Println(err)
+		return err
+	}
+
+	log.Println("Portworx Driver Down")
+
+	return nil
+}
+
+
+
+func (d *portworxK8s) Start(ip string) error{
+	clientset,err:=kconnect(ip)
+	if(err!=nil){
+		log.Println(err)
+		return err
+	}	
+
+	dat, err := ioutil.ReadFile("daemonset.yaml")
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
+
+	//hack
+  obj1 := convertYamltoStruct(fmt.Sprintf("%s", dat))
+		
+	
+	dms := obj1.(*dv1.DaemonSet)
+	dms, err = clientset.DaemonSets("kube-system").Create(dms)	
+	
+	log.Printf("Portworx Driver is running")
+	return nil
+}
+
+func (d *portworxK8s) WaitStart(ip string) error {
+	// Wait for Portworx to become usable.
+	status, _ := d.clusterManager.NodeStatus()
+	for i := 0; status != api.Status_STATUS_OK; i++ {
+		if i > 60 {
+			return fmt.Errorf(
+				"Portworx did not start up in time: Status is %v",
+				status,
+			)
+		}
+
+		time.Sleep(1 * time.Second)
+		status, _ = d.clusterManager.NodeStatus()
+	}
+
+	return nil
+}
+
+
+func init() {
+	nodes = strings.Split(os.Getenv("CLUSTER_NODES"), ",")
+  logger = log.New(os.Stdout, "", 0)
+
+	register("pxd_k8s", &portworxK8s{})
+}
+


### PR DESCRIPTION
This is a **WIP** implementation of Kubernetes driver. This has been tested with older structure of Torpedo project, but right now build is probably broken and hence could not test it completely. 

Overall following needs to be addressed in general for this PR to work eventually:

1) The current Porworx volume driver is strictly assuming a Docker/Swarm driver as target. For example currently the Portworx volume driver shuts down the Portworx container as part of test. In case of Kubernetes, it has to bring down Daemonset. You can not just bring down the POD as daemonset's policy will bring it back to life as soon as it dies.

2) The test ATM deletes the volume directly from host - which may not work with Kubernetes. We might have to push these operations to specific orchestrator's driver implementation and only use interfaces in tests.
 
```
	log.Printf("Deleting the attached volume: %v from %v\n", volName, nodes[1])
	if err = s.DeleteVolume(nodes[1], volName); err != nil {
		return err
	}
```
3) ATM with new structure there are few compilation issues, for example Swarm impl.go is not compiled at all. I think we should move from Make file based build/test structure to using Glide as the tool to build and test. Will send a PR soon with Glide sample code.