### PR TITLE
Don't test connection after rebooting node in aws driver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ before_install:
   - sudo apt-get -o Dpkg::Options::="--force-confnew" install -yq docker-ce
 script:
   - make all
-  - docker login -u="$DOCKER_USER" -p="$DOCKER_PASS"
-  - make deploy
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then docker login -u="$DOCKER_USER" -p="$DOCKER_PASS"; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then make deploy; fi'
 notifications:
   email:
     recipients:

--- a/drivers/node/aws/aws.go
+++ b/drivers/node/aws/aws.go
@@ -166,14 +166,7 @@ func (a *aws) RebootNode(n node.Node, options node.RebootNodeOpts) error {
 			Cause: fmt.Sprintf("failed to reboot instance due to: %v", err),
 		}
 	}
-	//TestConnection after node reboot
-	err = a.TestConnection(n, node.ConnectionOpts{Timeout: 5 * time.Minute, TimeBeforeRetry: 10 * time.Second})
-	if err != nil {
-		return &node.ErrFailedToRebootNode{
-			Node:  n,
-			Cause: fmt.Sprintf("failed to connect instance after reboot due to: %v", err),
-		}
-	}
+
 	return nil
 }
 


### PR DESCRIPTION
The reboot function should just reboot and return. Testing for connection is a separate call to the node driver interface which caller is responsible for calling.