### PR TITLE
don't delete k8s namespace in destroy implementation

### DIFF
--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -447,16 +447,6 @@ func (k *k8s) Destroy(ctx *scheduler.Context, opts map[string]bool) error {
 		}
 	}
 
-	appNamespace := getAppNamespaceName(ctx.App, ctx.UID)
-	if err := k8sOps.DeleteNamespace(appNamespace); err != nil {
-		return &scheduler.ErrFailedToDestroyApp{
-			App:   ctx.App,
-			Cause: fmt.Sprintf("Failed to destroy namespace: %#v. Err: %v", appNamespace, err),
-		}
-	}
-
-	logrus.Infof("[%v] Destroyed Namespace: %v", ctx.App.Key, appNamespace)
-
 	if value, ok := opts[scheduler.OptionsWaitForResourceLeakCleanup]; ok && value {
 		if err := k.WaitForDestroy(ctx); err != nil {
 			return err


### PR DESCRIPTION
fixes #93