### PR TITLE
Reboot all node test should reboot all nodes

### DIFF
--- a/tests/reboot/reboot_test.go
+++ b/tests/reboot/reboot_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Reboot one node test", func() {
 })
 
 var _ = Describe("Reboot all nodes test", func() {
-	rebootNodesTest("rebootallnodes", false)
+	rebootNodesTest("rebootallnodes", true)
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
The only difference at present between the reboot one node and all node test is the name of the test