### PR TITLE
Wait a little bit longer for portworx to enter maintenance mode.

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -215,7 +215,7 @@ func (d *portworx) RecoverDriver(n node.Node) error {
 		return nil, true, fmt.Errorf("Node %v is not in Maintenance mode", n.Name)
 	}
 
-	if _, err := task.DoRetryWithTimeout(t, 1*time.Minute, 10*time.Second); err != nil {
+	if _, err := task.DoRetryWithTimeout(t, 2*time.Minute, 10*time.Second); err != nil {
 		return &ErrFailedToRecoverDriver{
 			Node:  n,
 			Cause: err.Error(),


### PR DESCRIPTION
This test failed intermittently because it took little more time to enter maintenance mode. Increasing the retry time to 2 minutes.