### PR TITLE
Users can pass comma-separated tests to skip or focus

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -9,13 +9,13 @@ if [ -z "${SCALE_FACTOR}" ]; then
 fi
 
 SKIP_ARG=""
-if [ -n "${SKIP_TESTS}" ]; then
-    SKIP_ARG="--skip=$SKIP_TESTS"
+if [ -n "$SKIP_TESTS" ]; then
+    SKIP_ARG="--skip=$(echo $SKIP_TESTS | sed -e 's/,/ | /g')"
 fi
 
 FOCUS_ARG=""
-if [ -n "${FOCUS_TESTS}" ]; then
-    FOCUS_ARG="--focus=$FOCUS_TESTS"
+if [ -n "$FOCUS_TESTS" ]; then
+    FOCUS_ARG="--focus=$(echo $FOCUS_TESTS | sed -e 's/,/ | /g')"
 fi
 
 UPGRADE_VERSION_ARG=""
@@ -92,8 +92,9 @@ spec:
     command: [ "ginkgo" ]
     args: [ "--trace",
             "--failFast",
+            "$FOCUS_ARG",
             "$SKIP_ARG",
-             "--slowSpecThreshold", "600",
+            "--slowSpecThreshold", "600",
             "$VERBOSE",
             "bin/basic.test",
             "bin/reboot.test",


### PR DESCRIPTION
Now the args will look like -
FOCUS_TESTS=SetupTeardown,AppTasksDown
SKIP_TESTS=SetupTeardown,AppTasksDown

Also these will be complete names of the test. For instance, in the above example `ScaleSetupTeardown` or `SetupTeardownReturns` will not get selected/skipped, unless the full name is explicitly given.