### PR TITLE
Add fsgroup to PodSecurityContext of wordpress installer.

### DIFF
--- a/drivers/scheduler/k8s/specs/wordpress/installer.yaml
+++ b/drivers/scheduler/k8s/specs/wordpress/installer.yaml
@@ -19,6 +19,8 @@ spec:
         app: wordpress
         tier: installer
     spec:
+      securityContext:
+        fsGroup: 1000
       containers:
       - image: samuelmyers/wp-cli:1.2.23
         name: installer


### PR DESCRIPTION
- Kubelet would set the permissions of the PV to the fsgroup ID. It will
  also add the UID with which the container is running to that fsgroupID.

  More info [here](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#podsecuritycontext-v1-core)