### PR TITLE
Add DeepCopy for AppSpec

### DIFF
--- a/drivers/scheduler/spec/factory.go
+++ b/drivers/scheduler/spec/factory.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"path"
 
-	"github.com/mohae/deepcopy"
 	"github.com/portworx/torpedo/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -29,11 +28,10 @@ func (f *Factory) register(id string, app *AppSpec) {
 // Get returns a registered application
 func (f *Factory) Get(id string) (*AppSpec, error) {
 	if d, ok := appSpecFactory[id]; ok && d.Enabled {
-		dCopy := deepcopy.Copy(d)
-		if copy, ok := dCopy.(*AppSpec); ok {
-			return copy, nil
+		if copy := d.DeepCopy(); copy != nil {
+			return d.DeepCopy(), nil
 		}
-		return nil, fmt.Errorf("error creating copy of spec: %v", d)
+		return nil, fmt.Errorf("error creating copy of app: %v", d)
 	}
 
 	return nil, &errors.ErrNotFound{
@@ -47,11 +45,9 @@ func (f *Factory) GetAll() []*AppSpec {
 	var specs []*AppSpec
 	for _, val := range appSpecFactory {
 		if val.Enabled {
-			valCopy := deepcopy.Copy(val)
-			if copy, ok := valCopy.(*AppSpec); ok {
-				specs = append(specs, copy)
-			} else {
-				logrus.Errorf("Error creating copy of spec: %v", val)
+			valCopy := val.DeepCopy()
+			if valCopy != nil {
+				specs = append(specs, valCopy)
 			}
 		}
 	}

--- a/drivers/scheduler/spec/spec.go
+++ b/drivers/scheduler/spec/spec.go
@@ -14,3 +14,18 @@ type AppSpec struct {
 	// Enabled indicates if the application is enabled in the factory
 	Enabled bool
 }
+
+// DeepCopy Creates a copy of the AppSpec
+func (in *AppSpec) DeepCopy() *AppSpec {
+	if in == nil {
+		return nil
+	}
+	out := new(AppSpec)
+	out.Key = in.Key
+	out.Enabled = in.Enabled
+	out.SpecList = make([]interface{}, 0)
+	for _, spec := range in.SpecList {
+		out.SpecList = append(out.SpecList, spec)
+	}
+	return out
+}


### PR DESCRIPTION
The kubernetes APIs are no longer in 1.10 which causes issues
in projects that vendor torpedo. The recommended way is to generate
deepcopy functions, but AppSpec is simple enough.