### PR TITLE
Use output of /proc/mounts instead of the mount command output

### DIFF
--- a/drivers/volume/portworx/schedops/k8s-schedops.go
+++ b/drivers/volume/portworx/schedops/k8s-schedops.go
@@ -182,10 +182,10 @@ func (k *k8sSchedOps) ValidateVolumeSetup(vol *volume.Volume) error {
 
 		containerPaths := getContainerPVCMountMap(p)
 		for containerName, path := range containerPaths {
-			pxMountCheckRegex := regexp.MustCompile(fmt.Sprintf("^(/dev/pxd.+|pxfs.+) on %s.+", path))
+			pxMountCheckRegex := regexp.MustCompile(fmt.Sprintf("^(/dev/pxd.+|pxfs.+) %s.+", path))
 
 			t := func() (interface{}, bool, error) {
-				output, err := k8s.Instance().RunCommandInPod([]string{"mount"}, p.Name, containerName, p.Namespace)
+				output, err := k8s.Instance().RunCommandInPod([]string{"cat", "/proc/mounts"}, p.Name, containerName, p.Namespace)
 				if err != nil {
 					logrus.Errorf("failed to run command in pod: %v err: %v", p, err)
 					return nil, true, err


### PR DESCRIPTION
I found an app container where the `mount` command output is empty but all mounts show up in `/proc/mounts`. Apart from the empty `mount` command output, everything else was properly functional in the app.

Signed-off-by: Harsh Desai <harsh@portworx.com>