### PR TITLE
Fixed px driver init fail if one of node does not  have portworx installed

### DIFF
--- a/drivers/node/node.go
+++ b/drivers/node/node.go
@@ -19,12 +19,13 @@ const (
 
 // Node encapsulates a node in the cluster
 type Node struct {
-	uuid            string
-	VolDriverNodeID string
-	Name            string
-	Addresses       []string
-	UsableAddr      string
-	Type            Type
+	uuid              string
+	VolDriverNodeID   string
+	Name              string
+	Addresses         []string
+	UsableAddr        string
+	Type              Type
+	IsDriverInstalled bool
 }
 
 // ConnectionOpts provide basic options for all operations and can be embedded by other options

--- a/drivers/node/node.go
+++ b/drivers/node/node.go
@@ -19,13 +19,13 @@ const (
 
 // Node encapsulates a node in the cluster
 type Node struct {
-	uuid              string
-	VolDriverNodeID   string
-	Name              string
-	Addresses         []string
-	UsableAddr        string
-	Type              Type
-	IsDriverInstalled bool
+	uuid                     string
+	VolDriverNodeID          string
+	Name                     string
+	Addresses                []string
+	UsableAddr               string
+	Type                     Type
+	IsStorageDriverInstalled bool
 }
 
 // ConnectionOpts provide basic options for all operations and can be embedded by other options

--- a/drivers/node/node_registry.go
+++ b/drivers/node/node_registry.go
@@ -55,6 +55,18 @@ func GetWorkerNodes() []Node {
 	return nodeList
 }
 
+// GetStorageDriverNodes returns only the worker node where storage
+// driver is installed
+func GetStorageDriverNodes() []Node {
+	var nodeList []Node
+	for _, n := range nodeRegistry {
+		if n.Type == TypeWorker && n.IsStorageDriverInstalled {
+			nodeList = append(nodeList, n)
+		}
+	}
+	return nodeList
+}
+
 // GetNodesByName returns map of nodes where the node name is the key
 func GetNodesByName() map[string]Node {
 	nodeMap := make(map[string]Node)

--- a/drivers/volume/portworx/schedops/dcos-schedops.go
+++ b/drivers/volume/portworx/schedops/dcos-schedops.go
@@ -61,6 +61,11 @@ func (d *dcosSchedOps) IsPXReadyOnNode(n node.Node) bool {
 	return true
 }
 
+// IsPXInstalled should return whether perticualr node has px installed or not
+func (d *dcosSchedOps) IsPXInstalled(n node.Node) bool {
+	// TODO: Implement this method
+	return true
+}
 func init() {
 	d := &dcosSchedOps{}
 	Register("dcos", d)

--- a/drivers/volume/portworx/schedops/dcos-schedops.go
+++ b/drivers/volume/portworx/schedops/dcos-schedops.go
@@ -61,10 +61,10 @@ func (d *dcosSchedOps) IsPXReadyOnNode(n node.Node) bool {
 	return true
 }
 
-// IsPXInstalled should return whether perticualr node has px installed or not
-func (d *dcosSchedOps) IsPXInstalled(n node.Node) bool {
+// IsPXEnabled should return whether given node has px installed or not
+func (d *dcosSchedOps) IsPXEnabled(n node.Node) (bool, error) {
 	// TODO: Implement this method
-	return true
+	return true, nil
 }
 func init() {
 	d := &dcosSchedOps{}

--- a/drivers/volume/portworx/schedops/k8s-schedops.go
+++ b/drivers/volume/portworx/schedops/k8s-schedops.go
@@ -39,7 +39,9 @@ const (
 	// pvcLabel is the label used on volume to identify the pvc name
 	pvcLabel = "pvc"
 	// pxenable is label used to check whethere px installation is enabled/disabled on node
-	pxenabled              = "px/enabled"
+	pxenabled = "px/enabled"
+	// nodeType is label used to check kubernetes node-type
+	nodeType               = "kubernetes.dcos.io/node-type"
 	talismanServiceAccount = "talisman-account"
 	talismanImage          = "portworx/talisman:latest"
 )
@@ -490,9 +492,9 @@ func (k *k8sSchedOps) IsPXInstalled(n node.Node) bool {
 		return false
 	}
 
-	// if label is set make above assumption wrong
-	// TODO: add taint check and kubernetes.dcos.io/node-type=public check
-	if kubeNode.Labels[pxenabled] == "false" {
+	// if node has px/enabled label set to false or node-type public or
+	// has any taints then make above assumption wrong
+	if kubeNode.Labels[pxenabled] == "false" || kubeNode.Labels[nodeType] == "public" || len(kubeNode.Spec.Taints) > 0 {
 		logrus.Infof("[%v] Px Disabled: ", n.Name)
 		isPxInstalled = false
 	}

--- a/drivers/volume/portworx/schedops/schedops.go
+++ b/drivers/volume/portworx/schedops/schedops.go
@@ -31,8 +31,8 @@ type Driver interface {
 	UpgradePortworx(image, tag string) error
 	// IsPXReadyOnNode returns true if PX pod is up on that node, else returns false
 	IsPXReadyOnNode(n node.Node) bool
-	// IsPXInstalled returns true is px/enable flag is disabled/not applied on node
-	IsPXInstalled(n node.Node) bool
+	// IsPXEnabled returns true if portworx is enabled on given node
+	IsPXEnabled(n node.Node) (bool, error)
 }
 
 var (

--- a/drivers/volume/portworx/schedops/schedops.go
+++ b/drivers/volume/portworx/schedops/schedops.go
@@ -29,8 +29,10 @@ type Driver interface {
 	GetServiceEndpoint() (string, error)
 	// UpgradePortworx upgrades portworx to the given docker image and tag
 	UpgradePortworx(image, tag string) error
-	//IsPXReadyOnNode returns true if PX pod is up on that node, else returns false
+	// IsPXReadyOnNode returns true if PX pod is up on that node, else returns false
 	IsPXReadyOnNode(n node.Node) bool
+	// IsPXInstalled returns true is px/enable flag is disabled/not applied on node
+	IsPXInstalled(n node.Node) bool
 }
 
 var (


### PR DESCRIPTION
This PR adds check before updating node in px driver if corresponding node has px/enabled=false/  kubernetes.dcos.io/node-type=public  /  or node has any taints 

This is how I tested changes ->
- I created 4 node kubernetes cluster , disabled px installation on one of worker node using px/enabled=false and installed portworx on remaining two worker node.
- Applied label kubernetes.dcos.io/node-type=public 
- Marked node as tainted using `kubectl taint nodes node-name key:value:NoSchedule`

`
[root@ram-horn-seer-0 ~]# kubectl describe  node ram-horn-seer-1

Name:               ram-horn-seer-1
Roles:              ingress,node
Labels:             beta.kubernetes.io/arch=amd64
                    beta.kubernetes.io/os=linux
                    elasticdata-vol-elasticsearch-data-0=true
                    kubernetes.dcos.io/node-type=private
                    kubernetes.io/hostname=ram-horn-seer-1
                    mysql-data=true
                    node-role.kubernetes.io/ingress=true
                    node-role.kubernetes.io/node=true
                    postgres-data=true
                    px-nginx-pvc=true
                    px/enabled=true
                    wp-pv-claim=true
Annotations:        node.alpha.kubernetes.io/ttl=0
                    volumes.kubernetes.io/controller-managed-attach-detach=true
CreationTimestamp:  Tue, 25 Sep 2018 09:05:33 -0700
Taints:             dedicated=foo:PreferNoSchedule
`
