### PR TITLE
Configurable timeout for kubernetes driver

### DIFF
--- a/drivers/node/errors.go
+++ b/drivers/node/errors.go
@@ -86,7 +86,7 @@ func (e *ErrFailedToRecoverDrive) Error() string {
 
 // ErrFailedToSystemCheck error type when we fail to check for core files
 type ErrFailedToSystemCheck struct {
-	Node Node
+	Node  Node
 	Cause string
 }
 

--- a/drivers/node/node.go
+++ b/drivers/node/node.go
@@ -61,7 +61,7 @@ type FindOpts struct {
 	Name     string
 	MinDepth int
 	MaxDepth int
-	Type	 FindType
+	Type     FindType
 	ConnectionOpts
 }
 
@@ -211,7 +211,7 @@ func (d *notSupportedDriver) TestConnection(node Node, options ConnectionOpts) e
 	}
 }
 
-func (d* notSupportedDriver) SystemCheck(node Node, options ConnectionOpts) (string, error) {
+func (d *notSupportedDriver) SystemCheck(node Node, options ConnectionOpts) (string, error) {
 	return "", &errors.ErrNotSupported{
 		Type:      "Function",
 		Operation: "SystemCheck()",

--- a/drivers/node/ssh/ssh.go
+++ b/drivers/node/ssh/ssh.go
@@ -315,7 +315,6 @@ func (s *ssh) Systemctl(n node.Node, service string, options node.SystemctlOpts)
 		}
 	}
 
-
 	systemctlCmd := fmt.Sprintf("sudo systemctl %v %v", options.Action, service)
 	t := func() (interface{}, bool, error) {
 		out, err := s.doCmd(addr, systemctlCmd, false)
@@ -390,13 +389,13 @@ func (s *ssh) getOneUsableAddr(n node.Node, options node.ConnectionOpts) (string
 func (s *ssh) SystemCheck(n node.Node, options node.ConnectionOpts) (string, error) {
 	findOpts := node.FindOpts{
 		ConnectionOpts: options,
-		Name:  "core-px*",
-		Type: node.File,
+		Name:           "core-px*",
+		Type:           node.File,
 	}
 	file, err := s.FindFiles("/var/cores/", n, findOpts)
 	if err != nil {
 		return "", &node.ErrFailedToSystemCheck{
-			Node: n,
+			Node:  n,
 			Cause: fmt.Sprintf("failed to check for core files due to: %v", err),
 		}
 	}

--- a/drivers/scheduler/dcos/dcos.go
+++ b/drivers/scheduler/dcos/dcos.go
@@ -214,7 +214,7 @@ func (d *dcos) randomizeVolumeNames(application *marathon.Application) error {
 	return nil
 }
 
-func (d *dcos) WaitForRunning(ctx *scheduler.Context) error {
+func (d *dcos) WaitForRunning(ctx *scheduler.Context, timeout, retryInterval time.Duration) error {
 	for _, spec := range ctx.App.SpecList {
 		if obj, ok := spec.(*marathon.Application); ok {
 			if err := MarathonClient().WaitForApplicationStart(obj.ID); err != nil {
@@ -307,7 +307,7 @@ func (d *dcos) GetVolumeParameters(ctx *scheduler.Context) (map[string]map[strin
 	return result, nil
 }
 
-func (d *dcos) InspectVolumes(ctx *scheduler.Context) error {
+func (d *dcos) InspectVolumes(ctx *scheduler.Context, timeout, retryInterval time.Duration) error {
 	inspectDockerVolumeFunc := func(volName string, _ map[string]string) error {
 		t := func() (interface{}, bool, error) {
 			out, err := d.dockerClient.VolumeInspect(context.Background(), volName)

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -628,11 +628,11 @@ func (k *k8s) substituteNamespaceInVolumes(volumes []v1.Volume, ns string) []v1.
 	return updatedVolumes
 }
 
-func (k *k8s) WaitForRunning(ctx *scheduler.Context) error {
+func (k *k8s) WaitForRunning(ctx *scheduler.Context, timeout, retryInterval time.Duration) error {
 	k8sOps := k8s_ops.Instance()
 	for _, spec := range ctx.App.SpecList {
 		if obj, ok := spec.(*apps_api.Deployment); ok {
-			if err := k8sOps.ValidateDeployment(obj); err != nil {
+			if err := k8sOps.ValidateDeployment(obj, timeout, retryInterval); err != nil {
 				return &scheduler.ErrFailedToValidateApp{
 					App:   ctx.App,
 					Cause: fmt.Sprintf("Failed to validate Deployment: %v. Err: %v", obj.Name, err),
@@ -670,7 +670,7 @@ func (k *k8s) WaitForRunning(ctx *scheduler.Context) error {
 
 			logrus.Infof("[%v] Validated Rule: %v", ctx.App.Key, svc.Name)
 		} else if obj, ok := spec.(*v1.Pod); ok {
-			if err := k8sOps.ValidatePod(obj); err != nil {
+			if err := k8sOps.ValidatePod(obj, timeout, retryInterval); err != nil {
 				return &scheduler.ErrFailedToValidatePod{
 					App:   ctx.App,
 					Cause: fmt.Sprintf("Failed to validate Pod: [%s] %s. Err: Pod is not ready %v", obj.Namespace, obj.Name, obj.Status),
@@ -951,7 +951,7 @@ func (k *k8s) GetVolumeParameters(ctx *scheduler.Context) (map[string]map[string
 	return result, nil
 }
 
-func (k *k8s) InspectVolumes(ctx *scheduler.Context) error {
+func (k *k8s) InspectVolumes(ctx *scheduler.Context, timeout, retryInterval time.Duration) error {
 	k8sOps := k8s_ops.Instance()
 	for _, spec := range ctx.App.SpecList {
 		if obj, ok := spec.(*storage_api.StorageClass); ok {
@@ -964,7 +964,7 @@ func (k *k8s) InspectVolumes(ctx *scheduler.Context) error {
 
 			logrus.Infof("[%v] Validated storage class: %v", ctx.App.Key, obj.Name)
 		} else if obj, ok := spec.(*v1.PersistentVolumeClaim); ok {
-			if err := k8sOps.ValidatePersistentVolumeClaim(obj); err != nil {
+			if err := k8sOps.ValidatePersistentVolumeClaim(obj, timeout, retryInterval); err != nil {
 				return &scheduler.ErrFailedToValidateStorage{
 					App:   ctx.App,
 					Cause: fmt.Sprintf("Failed to validate PVC: %v. Err: %v", obj.Name, err),
@@ -973,7 +973,7 @@ func (k *k8s) InspectVolumes(ctx *scheduler.Context) error {
 
 			logrus.Infof("[%v] Validated PVC: %v", ctx.App.Key, obj.Name)
 		} else if obj, ok := spec.(*snap_v1.VolumeSnapshot); ok {
-			if err := k8sOps.ValidateSnapshot(obj.Metadata.Name, obj.Metadata.Namespace, true); err != nil {
+			if err := k8sOps.ValidateSnapshot(obj.Metadata.Name, obj.Metadata.Namespace, true, timeout, retryInterval); err != nil {
 				return &scheduler.ErrFailedToValidateStorage{
 					App:   ctx.App,
 					Cause: fmt.Sprintf("Failed to validate snapshot: %v. Err: %v", obj.Metadata.Name, err),
@@ -990,7 +990,7 @@ func (k *k8s) InspectVolumes(ctx *scheduler.Context) error {
 				}
 			}
 
-			if err := k8sOps.ValidatePVCsForStatefulSet(ss); err != nil {
+			if err := k8sOps.ValidatePVCsForStatefulSet(ss, timeout, retryInterval); err != nil {
 				return &scheduler.ErrFailedToValidateStorage{
 					App:   ctx.App,
 					Cause: fmt.Sprintf("Failed to validate PVCs for statefulset: %v. Err: %v", ss.Name, err),

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -670,7 +670,7 @@ func (k *k8s) WaitForRunning(ctx *scheduler.Context, timeout, retryInterval time
 
 			logrus.Infof("[%v] Validated Rule: %v", ctx.App.Key, svc.Name)
 		} else if obj, ok := spec.(*v1.Pod); ok {
-			if err := k8sOps.ValidatePod(obj, timeout, retryInterval); err != nil {
+			if err := k8sOps.ValidatePod(obj, timeout*2, retryInterval); err != nil {
 				return &scheduler.ErrFailedToValidatePod{
 					App:   ctx.App,
 					Cause: fmt.Sprintf("Failed to validate Pod: [%s] %s. Err: Pod is not ready %v", obj.Namespace, obj.Name, obj.Status),
@@ -990,7 +990,7 @@ func (k *k8s) InspectVolumes(ctx *scheduler.Context, timeout, retryInterval time
 				}
 			}
 
-			if err := k8sOps.ValidatePVCsForStatefulSet(ss, timeout, retryInterval); err != nil {
+			if err := k8sOps.ValidatePVCsForStatefulSet(ss, timeout*3, retryInterval); err != nil {
 				return &scheduler.ErrFailedToValidateStorage{
 					App:   ctx.App,
 					Cause: fmt.Sprintf("Failed to validate PVCs for statefulset: %v. Err: %v", ss.Name, err),

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -641,7 +641,7 @@ func (k *k8s) WaitForRunning(ctx *scheduler.Context, timeout, retryInterval time
 
 			logrus.Infof("[%v] Validated deployment: %v", ctx.App.Key, obj.Name)
 		} else if obj, ok := spec.(*apps_api.StatefulSet); ok {
-			if err := k8sOps.ValidateStatefulSet(obj, statefulSetValidateTimeout); err != nil {
+			if err := k8sOps.ValidateStatefulSet(obj, timeout*time.Duration(*obj.Spec.Replicas)); err != nil {
 				return &scheduler.ErrFailedToValidateApp{
 					App:   ctx.App,
 					Cause: fmt.Sprintf("Failed to validate StatefulSet: %v. Err: %v", obj.Name, err),
@@ -670,7 +670,7 @@ func (k *k8s) WaitForRunning(ctx *scheduler.Context, timeout, retryInterval time
 
 			logrus.Infof("[%v] Validated Rule: %v", ctx.App.Key, svc.Name)
 		} else if obj, ok := spec.(*v1.Pod); ok {
-			if err := k8sOps.ValidatePod(obj, timeout*2, retryInterval); err != nil {
+			if err := k8sOps.ValidatePod(obj, timeout, retryInterval); err != nil {
 				return &scheduler.ErrFailedToValidatePod{
 					App:   ctx.App,
 					Cause: fmt.Sprintf("Failed to validate Pod: [%s] %s. Err: Pod is not ready %v", obj.Namespace, obj.Name, obj.Status),
@@ -990,7 +990,7 @@ func (k *k8s) InspectVolumes(ctx *scheduler.Context, timeout, retryInterval time
 				}
 			}
 
-			if err := k8sOps.ValidatePVCsForStatefulSet(ss, timeout*3, retryInterval); err != nil {
+			if err := k8sOps.ValidatePVCsForStatefulSet(ss, timeout*time.Duration(*obj.Spec.Replicas), retryInterval); err != nil {
 				return &scheduler.ErrFailedToValidateStorage{
 					App:   ctx.App,
 					Cause: fmt.Sprintf("Failed to validate PVCs for statefulset: %v. Err: %v", ss.Name, err),

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/portworx/torpedo/drivers/node"
 	"github.com/portworx/torpedo/drivers/scheduler/spec"
@@ -51,7 +52,7 @@ type Driver interface {
 	Schedule(instanceID string, opts ScheduleOptions) ([]*Context, error)
 
 	// WaitForRunning waits for application to start running.
-	WaitForRunning(*Context) error
+	WaitForRunning(cc *Context, timeout, retryInterval time.Duration) error
 
 	// Destroy removes a application. It does not delete the volumes of the task.
 	Destroy(*Context, map[string]bool) error
@@ -66,7 +67,7 @@ type Driver interface {
 	GetVolumeParameters(*Context) (map[string]map[string]string, error)
 
 	// InspectVolumes inspects a storage volume.
-	InspectVolumes(*Context) error
+	InspectVolumes(cc *Context, timeout, retryInterval time.Duration) error
 
 	// DeleteVolumes will delete all storage volumes for the given context
 	DeleteVolumes(*Context) ([]*volume.Volume, error)

--- a/tests/common.go
+++ b/tests/common.go
@@ -14,15 +14,18 @@ import (
 	"github.com/portworx/sched-ops/task"
 	"github.com/portworx/torpedo/drivers/node"
 	"github.com/sirupsen/logrus"
+
 	// import aws driver to invoke it's init
 	_ "github.com/portworx/torpedo/drivers/node/aws"
 	// import ssh driver to invoke it's init
 	_ "github.com/portworx/torpedo/drivers/node/ssh"
 	"github.com/portworx/torpedo/drivers/scheduler"
+
 	// import scheduler drivers to invoke it's init
 	_ "github.com/portworx/torpedo/drivers/scheduler/dcos"
 	_ "github.com/portworx/torpedo/drivers/scheduler/k8s"
 	"github.com/portworx/torpedo/drivers/volume"
+
 	// import portworx driver to invoke it's init
 	_ "github.com/portworx/torpedo/drivers/volume/portworx"
 	"github.com/portworx/torpedo/pkg/log"
@@ -55,7 +58,9 @@ const (
 )
 
 const (
-	waitResourceCleanup = 2 * time.Minute
+	waitResourceCleanup  = 2 * time.Minute
+	k8sNodeReadyTimeout  = 5 * time.Minute
+	defaultRetryInterval = 10 * time.Second
 )
 
 var (
@@ -105,7 +110,7 @@ func ValidateContext(ctx *scheduler.Context) {
 		})
 
 		Step(fmt.Sprintf("wait for %s app to start running", ctx.App.Key), func() {
-			err := Inst().S.WaitForRunning(ctx)
+			err := Inst().S.WaitForRunning(ctx, k8sNodeReadyTimeout, defaultRetryInterval)
 			expect(err).NotTo(haveOccurred())
 		})
 
@@ -128,7 +133,7 @@ func ValidateVolumes(ctx *scheduler.Context) {
 	context("For validation of an app's volumes", func() {
 		var err error
 		Step(fmt.Sprintf("inspect %s app's volumes", ctx.App.Key), func() {
-			err = Inst().S.InspectVolumes(ctx)
+			err = Inst().S.InspectVolumes(ctx, 10*time.Second, 2*time.Second)
 			expect(err).NotTo(haveOccurred())
 		})
 

--- a/tests/common.go
+++ b/tests/common.go
@@ -59,7 +59,7 @@ const (
 
 const (
 	waitResourceCleanup  = 2 * time.Minute
-	k8sNodeReadyTimeout  = 5 * time.Minute
+	defaultTimeout       = 5 * time.Minute
 	defaultRetryInterval = 10 * time.Second
 )
 
@@ -110,7 +110,7 @@ func ValidateContext(ctx *scheduler.Context) {
 		})
 
 		Step(fmt.Sprintf("wait for %s app to start running", ctx.App.Key), func() {
-			err := Inst().S.WaitForRunning(ctx, k8sNodeReadyTimeout, defaultRetryInterval)
+			err := Inst().S.WaitForRunning(ctx, defaultTimeout, defaultRetryInterval)
 			expect(err).NotTo(haveOccurred())
 		})
 
@@ -133,7 +133,7 @@ func ValidateVolumes(ctx *scheduler.Context) {
 	context("For validation of an app's volumes", func() {
 		var err error
 		Step(fmt.Sprintf("inspect %s app's volumes", ctx.App.Key), func() {
-			err = Inst().S.InspectVolumes(ctx, 10*time.Second, 2*time.Second)
+			err = Inst().S.InspectVolumes(ctx, defaultTimeout, defaultRetryInterval)
 			expect(err).NotTo(haveOccurred())
 		})
 

--- a/vendor/github.com/libopenstorage/stork/cmd/cmdexecutor/cmdexecutor.go
+++ b/vendor/github.com/libopenstorage/stork/cmd/cmdexecutor/cmdexecutor.go
@@ -187,7 +187,7 @@ var (
 
 func init() {
 	flag.Var(&podList, "pod", "Pod on which to run the command. Format: <pod-namespace>/<pod-name> e.g dev/pod-12345")
-	flag.StringVar(&podContainer, "container", "", "(Optional) name of the container withing the pod on which to run the command. If not specified, executor will pick the first container.")
+	flag.StringVar(&podContainer, "container", "", "(Optional) name of the container within the pod on which to run the command. If not specified, executor will pick the first container.")
 	flag.StringVar(&command, "cmd", "", "The command to run inside the pod")
 	flag.StringVar(&taskID, "taskid", "", "A unique ID the caller can provide which can be later used to clean the status files created by the command executor.")
 	flag.Int64Var(&statusCheckTimeout, "timeout", int64(defaultStatusCheckTimeout), "Time in seconds to wait for the command to succeeded on a single pod")

--- a/vendor/github.com/libopenstorage/stork/drivers/volume/portworx/portworx.go
+++ b/vendor/github.com/libopenstorage/stork/drivers/volume/portworx/portworx.go
@@ -1454,6 +1454,7 @@ func (p *portworx) CreatePair(pair *stork_crd.ClusterPair) (string, error) {
 			Feature: "Cluster pair",
 			Reason:  "Only supported on PX version 2.0 onwards: " + msg,
 		}
+		return "", err
 	}
 
 	port := uint64(apiPort)
@@ -1489,6 +1490,7 @@ func (p *portworx) StartMigration(migration *stork_crd.Migration) ([]*stork_crd.
 			Feature: "Migration",
 			Reason:  "Only supported on PX version 2.0 onwards: " + msg,
 		}
+		return nil, err
 	}
 
 	if len(migration.Spec.Selectors) != 0 {
@@ -1572,7 +1574,7 @@ func (p *portworx) GetMigrationStatus(migration *stork_crd.Migration) ([]*stork_
 				} else if mInfo.CurrentStage == api.CloudMigrate_Done &&
 					mInfo.Status == api.CloudMigrate_Complete {
 					vInfo.Status = stork_crd.MigrationStatusSuccessful
-					vInfo.Reason = fmt.Sprintf("Migration succesful for volume")
+					vInfo.Reason = fmt.Sprintf("Migration successful for volume")
 				}
 				break
 			}

--- a/vendor/github.com/libopenstorage/stork/pkg/cmdexecutor/cmdexecutor.go
+++ b/vendor/github.com/libopenstorage/stork/pkg/cmdexecutor/cmdexecutor.go
@@ -26,7 +26,7 @@ const (
 	cmdStatusCheckFactor       = 1
 )
 
-// Executor is an interace to start and wait for async commands in pods
+// Executor is an interface to start and wait for async commands in pods
 type Executor interface {
 	// Start starts the command in the pod asynchronously
 	Start(chan error) error

--- a/vendor/github.com/libopenstorage/stork/pkg/cmdexecutor/status/status.go
+++ b/vendor/github.com/libopenstorage/stork/pkg/cmdexecutor/status/status.go
@@ -74,7 +74,7 @@ func Get(key string) (string, error) {
 		return "", fmt.Errorf("found empty failure status for key: %s in config map", key)
 	}
 
-	err = fmt.Errorf("cmd executor failed because: %s", status)
+	logrus.Errorf("%v cmd executor failed because: %s", key, status)
 
 	cmCopy := cm.DeepCopy()
 	delete(cmCopy.Data, key)

--- a/vendor/github.com/libopenstorage/stork/pkg/migration/controllers/migration.go
+++ b/vendor/github.com/libopenstorage/stork/pkg/migration/controllers/migration.go
@@ -201,7 +201,7 @@ func (m *MigrationController) migrateVolumes(migration *storkv1.Migration) error
 			m.Recorder.Event(migration,
 				v1.EventTypeNormal,
 				string(vInfo.Status),
-				fmt.Sprintf("Volume %v migrated successfuly", vInfo.Volume))
+				fmt.Sprintf("Volume %v migrated successfully", vInfo.Volume))
 		}
 	}
 
@@ -555,6 +555,10 @@ func (m *MigrationController) prepareApplicationResource(
 	}
 	replicas := spec["replicas"].(int64)
 	annotations, err := collections.GetMap(content, "metadata.annotations")
+	if err != nil {
+		return nil, err
+	}
+
 	annotations[storkMigrationReplicasAnnotation] = strconv.FormatInt(replicas, 10)
 	spec["replicas"] = 0
 	return object, nil

--- a/vendor/github.com/portworx/sched-ops/k8s/k8s.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/k8s.go
@@ -39,23 +39,11 @@ import (
 )
 
 const (
-	masterLabelKey                = "node-role.kubernetes.io/master"
-	hostnameKey                   = "kubernetes.io/hostname"
-	pvcStorageClassKey            = "volume.beta.kubernetes.io/storage-class"
-	pvcStorageProvisionerKey      = "volume.beta.kubernetes.io/storage-provisioner"
-	labelUpdateMaxRetries         = 5
-	nodeUpdateTimeout             = 1 * time.Minute
-	nodeUpdateRetryInterval       = 2 * time.Second
-	deploymentReadyTimeout        = 10 * time.Minute
-	validatePodReadyTimeout       = 10 * time.Minute
-	validatePodRetryInterval      = 10 * time.Second
-	validateStatefulSetPVCTimeout = 15 * time.Minute
-	validatePVCTimeout            = 5 * time.Minute
-	validatePVCRetryInterval      = 10 * time.Second
-	validateSnapshotTimeout       = 5 * time.Minute
-	validateSnapshotRetryInterval = 10 * time.Second
-	crdCreateTimeout              = 2 * time.Minute
-	crdCreateRetryInterval        = 2 * time.Second
+	masterLabelKey           = "node-role.kubernetes.io/master"
+	hostnameKey              = "kubernetes.io/hostname"
+	pvcStorageClassKey       = "volume.beta.kubernetes.io/storage-class"
+	pvcStorageProvisionerKey = "volume.beta.kubernetes.io/storage-provisioner"
+	labelUpdateMaxRetries    = 5
 )
 
 var deleteForegroundPolicy = meta_v1.DeletePropagationForeground
@@ -129,12 +117,12 @@ type NodeOps interface {
 	// WatchNode sets up a watcher that listens for the changes on Node.
 	WatchNode(node *v1.Node, fn NodeWatchFunc) error
 	// CordonNode cordons the given node
-	CordonNode(nodeName string) error
+	CordonNode(nodeName string, timeout, retryInterval time.Duration) error
 	// UnCordonNode uncordons the given node
-	UnCordonNode(nodeName string) error
+	UnCordonNode(nodeName string, timeout, retryInterval time.Duration) error
 	// DrainPodsFromNode drains given pods from given node. If timeout is set to
 	// a non-zero value, it waits for timeout duration for each pod to get deleted
-	DrainPodsFromNode(nodeName string, pods []v1.Pod, timeout time.Duration) error
+	DrainPodsFromNode(nodeName string, pods []v1.Pod, timeout, retryInterval time.Duration) error
 }
 
 // ServiceOps is an interface to perform k8s service operations
@@ -174,7 +162,7 @@ type StatefulSetOps interface {
 	// GetPVCsForStatefulSet returns all the PVCs for given stateful set
 	GetPVCsForStatefulSet(ss *apps_api.StatefulSet) (*v1.PersistentVolumeClaimList, error)
 	// ValidatePVCsForStatefulSet validates the PVCs for the given stateful set
-	ValidatePVCsForStatefulSet(ss *apps_api.StatefulSet) error
+	ValidatePVCsForStatefulSet(ss *apps_api.StatefulSet, timeout, retryInterval time.Duration) error
 }
 
 // DeploymentOps is an interface to perform k8s deployment operations
@@ -188,7 +176,7 @@ type DeploymentOps interface {
 	// DeleteDeployment deletes the given deployment
 	DeleteDeployment(name, namespace string) error
 	// ValidateDeployment validates the given deployment if it's running and healthy
-	ValidateDeployment(*apps_api.Deployment) error
+	ValidateDeployment(deployment *apps_api.Deployment, timeout, retryInterval time.Duration) error
 	// ValidateTerminatedDeployment validates if given deployment is terminated
 	ValidateTerminatedDeployment(*apps_api.Deployment) error
 	// GetDeploymentPods returns pods for the given deployment
@@ -302,7 +290,7 @@ type PodOps interface {
 	// RunCommandInPod runs given command in the given pod
 	RunCommandInPod(cmds []string, podName, containerName, namespace string) (string, error)
 	// ValidatePod validates the given pod if it's ready
-	ValidatePod(pod *v1.Pod) error
+	ValidatePod(pod *v1.Pod, timeout, retryInterval time.Duration) error
 }
 
 // StorageClassOps is an interface to perform k8s storage class operations
@@ -330,7 +318,7 @@ type PersistentVolumeClaimOps interface {
 	// DeletePersistentVolumeClaim deletes the given persistent volume claim
 	DeletePersistentVolumeClaim(name, namespace string) error
 	// ValidatePersistentVolumeClaim validates the given pvc
-	ValidatePersistentVolumeClaim(*v1.PersistentVolumeClaim) error
+	ValidatePersistentVolumeClaim(vv *v1.PersistentVolumeClaim, timeout, retryInterval time.Duration) error
 	// GetPersistentVolumeClaim returns the PVC for given name and namespace
 	GetPersistentVolumeClaim(pvcName string, namespace string) (*v1.PersistentVolumeClaim, error)
 	// GetPersistentVolumeClaims returns all PVCs in given namespace and that match the optional labelSelector
@@ -364,7 +352,7 @@ type SnapshotOps interface {
 	// DeleteSnapshot deletes the given snapshot
 	DeleteSnapshot(name string, namespace string) error
 	// ValidateSnapshot validates the given snapshot.
-	ValidateSnapshot(name string, namespace string, retry bool) error
+	ValidateSnapshot(name string, namespace string, retry bool, timeout, retryInterval time.Duration) error
 	// GetVolumeForSnapshot returns the volumeID for the given snapshot
 	GetVolumeForSnapshot(name string, namespace string) (string, error)
 	// GetSnapshotStatus returns the status of the given snapshot
@@ -376,7 +364,7 @@ type SnapshotOps interface {
 	// DeleteSnapshotData deletes the given snapshot
 	DeleteSnapshotData(name string) error
 	// ValidateSnapshotData validates the given snapshot data object
-	ValidateSnapshotData(name string, retry bool) error
+	ValidateSnapshotData(name string, retry bool, timeout, retryInterval time.Duration) error
 }
 
 // RuleOps is an interface to perform operations for k8s stork rule
@@ -420,7 +408,7 @@ type CRDOps interface {
 	// CreateCRD creates the given custom resource
 	CreateCRD(resource CustomResource) error
 	// ValidateCRD checks if the given CRD is registered
-	ValidateCRD(resource CustomResource) error
+	ValidateCRD(resource CustomResource, timeout, retryInterval time.Duration) error
 }
 
 // ClusterPairOps is an interface to perfrom k8s ClusterPair operations
@@ -429,16 +417,20 @@ type ClusterPairOps interface {
 	CreateClusterPair(*v1alpha1.ClusterPair) error
 	// GetClusterPair gets the ClusterPair
 	GetClusterPair(string) (*v1alpha1.ClusterPair, error)
+	// ListClusterPairs gets all the ClusterPairs
+	ListClusterPairs() (*v1alpha1.ClusterPairList, error)
 	// DeleteClusterPair deletes the ClusterPair
 	DeleteClusterPair(string) error
 }
 
-// MigrationsOps is an interface to perfrom k8s Migration operations
+// MigrationOps is an interface to perfrom k8s Migration operations
 type MigrationOps interface {
 	// CreateMigration creates the Migration
 	CreateMigration(*v1alpha1.Migration) error
 	// GetMigration gets the Migration
 	GetMigration(string, string) (*v1alpha1.Migration, error)
+	// ListMigrations lists all the Migration
+	ListMigrations(string) (*v1alpha1.MigrationList, error)
 	// UpdateMigration updates the Migration
 	UpdateMigration(*v1alpha1.Migration) (*v1alpha1.Migration, error)
 	// DeleteMigration deletes the Migration
@@ -790,7 +782,7 @@ func (k *k8sOps) WatchNode(node *v1.Node, watchNodeFn NodeWatchFunc) error {
 	return nil
 }
 
-func (k *k8sOps) CordonNode(nodeName string) error {
+func (k *k8sOps) CordonNode(nodeName string, timeout, retryInterval time.Duration) error {
 	t := func() (interface{}, bool, error) {
 		if err := k.initK8sClient(); err != nil {
 			return nil, true, err
@@ -812,14 +804,14 @@ func (k *k8sOps) CordonNode(nodeName string) error {
 
 	}
 
-	if _, err := task.DoRetryWithTimeout(t, nodeUpdateTimeout, nodeUpdateRetryInterval); err != nil {
+	if _, err := task.DoRetryWithTimeout(t, timeout, retryInterval); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (k *k8sOps) UnCordonNode(nodeName string) error {
+func (k *k8sOps) UnCordonNode(nodeName string, timeout, retryInterval time.Duration) error {
 	t := func() (interface{}, bool, error) {
 		if err := k.initK8sClient(); err != nil {
 			return nil, true, err
@@ -841,22 +833,22 @@ func (k *k8sOps) UnCordonNode(nodeName string) error {
 
 	}
 
-	if _, err := task.DoRetryWithTimeout(t, nodeUpdateTimeout, nodeUpdateRetryInterval); err != nil {
+	if _, err := task.DoRetryWithTimeout(t, timeout, retryInterval); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (k *k8sOps) DrainPodsFromNode(nodeName string, pods []v1.Pod, timeout time.Duration) error {
-	err := k.CordonNode(nodeName)
+func (k *k8sOps) DrainPodsFromNode(nodeName string, pods []v1.Pod, timeout time.Duration, retryInterval time.Duration) error {
+	err := k.CordonNode(nodeName, timeout, retryInterval)
 	if err != nil {
 		return err
 	}
 
 	err = k.DeletePods(pods, false)
 	if err != nil {
-		e := k.UnCordonNode(nodeName) // rollback cordon
+		e := k.UnCordonNode(nodeName, timeout, retryInterval) // rollback cordon
 		if e != nil {
 			log.Printf("failed to uncordon node: %s", nodeName)
 		}
@@ -1078,7 +1070,7 @@ func (k *k8sOps) UpdateDeployment(deployment *apps_api.Deployment) (*apps_api.De
 	return k.appsClient().Deployments(deployment.Namespace).Update(deployment)
 }
 
-func (k *k8sOps) ValidateDeployment(deployment *apps_api.Deployment) error {
+func (k *k8sOps) ValidateDeployment(deployment *apps_api.Deployment, timeout, retryInterval time.Duration) error {
 	t := func() (interface{}, bool, error) {
 		dep, err := k.GetDeployment(deployment.Name, deployment.Namespace)
 		if err != nil {
@@ -1173,7 +1165,7 @@ func (k *k8sOps) ValidateDeployment(deployment *apps_api.Deployment) error {
 		}
 	}
 
-	if _, err := task.DoRetryWithTimeout(t, deploymentReadyTimeout, 10*time.Second); err != nil {
+	if _, err := task.DoRetryWithTimeout(t, timeout, retryInterval); err != nil {
 		return err
 	}
 	return nil
@@ -1677,7 +1669,7 @@ func (k *k8sOps) GetPVCsForStatefulSet(ss *apps_api.StatefulSet) (*v1.Persistent
 	return k.getPVCsWithListOptions(ss.Namespace, listOptions)
 }
 
-func (k *k8sOps) ValidatePVCsForStatefulSet(ss *apps_api.StatefulSet) error {
+func (k *k8sOps) ValidatePVCsForStatefulSet(ss *apps_api.StatefulSet, timeout, retryTimeout time.Duration) error {
 	listOptions, err := k.getListOptionsForStatefulSet(ss)
 	if err != nil {
 		return err
@@ -1694,7 +1686,7 @@ func (k *k8sOps) ValidatePVCsForStatefulSet(ss *apps_api.StatefulSet) error {
 		}
 
 		for _, pvc := range pvcList.Items {
-			if err := k.ValidatePersistentVolumeClaim(&pvc); err != nil {
+			if err := k.ValidatePersistentVolumeClaim(&pvc, timeout, retryTimeout); err != nil {
 				return nil, true, err
 			}
 		}
@@ -1702,7 +1694,7 @@ func (k *k8sOps) ValidatePVCsForStatefulSet(ss *apps_api.StatefulSet) error {
 		return nil, false, nil
 	}
 
-	if _, err := task.DoRetryWithTimeout(t, validateStatefulSetPVCTimeout, validatePVCRetryInterval); err != nil {
+	if _, err := task.DoRetryWithTimeout(t, timeout, retryTimeout); err != nil {
 		return err
 	}
 	return nil
@@ -2104,7 +2096,7 @@ func (k *k8sOps) IsPodBeingManaged(pod v1.Pod) bool {
 	return false
 }
 
-func (k *k8sOps) ValidatePod(pod *v1.Pod) error {
+func (k *k8sOps) ValidatePod(pod *v1.Pod, timeout, retryInterval time.Duration) error {
 	t := func() (interface{}, bool, error) {
 		currPod, err := k.GetPodByUID(pod.UID, pod.Namespace)
 		if err != nil {
@@ -2118,7 +2110,7 @@ func (k *k8sOps) ValidatePod(pod *v1.Pod) error {
 
 		return "", false, nil
 	}
-	if _, err := task.DoRetryWithTimeout(t, validatePodReadyTimeout, validatePodRetryInterval); err != nil {
+	if _, err := task.DoRetryWithTimeout(t, timeout, retryInterval); err != nil {
 		return err
 	}
 	return nil
@@ -2200,7 +2192,7 @@ func (k *k8sOps) DeletePersistentVolumeClaim(name, namespace string) error {
 	return k.client.CoreV1().PersistentVolumeClaims(namespace).Delete(name, &meta_v1.DeleteOptions{})
 }
 
-func (k *k8sOps) ValidatePersistentVolumeClaim(pvc *v1.PersistentVolumeClaim) error {
+func (k *k8sOps) ValidatePersistentVolumeClaim(pvc *v1.PersistentVolumeClaim, timeout, retryInterval time.Duration) error {
 	t := func() (interface{}, bool, error) {
 		if err := k.initK8sClient(); err != nil {
 			return "", true, err
@@ -2223,7 +2215,7 @@ func (k *k8sOps) ValidatePersistentVolumeClaim(pvc *v1.PersistentVolumeClaim) er
 		}
 	}
 
-	if _, err := task.DoRetryWithTimeout(t, validatePVCTimeout, validatePVCRetryInterval); err != nil {
+	if _, err := task.DoRetryWithTimeout(t, timeout, retryInterval); err != nil {
 		return err
 	}
 	return nil
@@ -2419,7 +2411,7 @@ func (k *k8sOps) DeleteSnapshot(name string, namespace string) error {
 		Do().Error()
 }
 
-func (k *k8sOps) ValidateSnapshot(name string, namespace string, retry bool) error {
+func (k *k8sOps) ValidateSnapshot(name string, namespace string, retry bool, timeout, retryInterval time.Duration) error {
 	if err := k.initK8sClient(); err != nil {
 		return err
 	}
@@ -2447,7 +2439,7 @@ func (k *k8sOps) ValidateSnapshot(name string, namespace string, retry bool) err
 	}
 
 	if retry {
-		if _, err := task.DoRetryWithTimeout(t, validateSnapshotTimeout, validateSnapshotRetryInterval); err != nil {
+		if _, err := task.DoRetryWithTimeout(t, timeout, retryInterval); err != nil {
 			return err
 		}
 	} else {
@@ -2459,7 +2451,7 @@ func (k *k8sOps) ValidateSnapshot(name string, namespace string, retry bool) err
 	return nil
 }
 
-func (k *k8sOps) ValidateSnapshotData(name string, retry bool) error {
+func (k *k8sOps) ValidateSnapshotData(name string, retry bool, timeout, retryInterval time.Duration) error {
 	if err := k.initK8sClient(); err != nil {
 		return err
 	}
@@ -2490,7 +2482,7 @@ func (k *k8sOps) ValidateSnapshotData(name string, retry bool) error {
 	}
 
 	if retry {
-		if _, err := task.DoRetryWithTimeout(t, validateSnapshotTimeout, validateSnapshotRetryInterval); err != nil {
+		if _, err := task.DoRetryWithTimeout(t, timeout, retryInterval); err != nil {
 			return err
 		}
 	} else {
@@ -2746,15 +2738,23 @@ func (k *k8sOps) UpdateConfigMap(configMap *v1.ConfigMap) (*v1.ConfigMap, error)
 // ClusterPair APIs - BEGIN
 func (k *k8sOps) GetClusterPair(name string) (*v1alpha1.ClusterPair, error) {
 	if err := k.initK8sClient(); err != nil {
-		return nil, nil
+		return nil, err
 	}
 
 	return k.storkClient.Stork().ClusterPairs().Get(name, meta_v1.GetOptions{})
 }
 
+func (k *k8sOps) ListClusterPairs() (*v1alpha1.ClusterPairList, error) {
+	if err := k.initK8sClient(); err != nil {
+		return nil, err
+	}
+
+	return k.storkClient.Stork().ClusterPairs().List(meta_v1.ListOptions{})
+}
+
 func (k *k8sOps) CreateClusterPair(pair *v1alpha1.ClusterPair) error {
 	if err := k.initK8sClient(); err != nil {
-		return nil
+		return err
 	}
 
 	_, err := k.storkClient.Stork().ClusterPairs().Create(pair)
@@ -2763,7 +2763,7 @@ func (k *k8sOps) CreateClusterPair(pair *v1alpha1.ClusterPair) error {
 
 func (k *k8sOps) DeleteClusterPair(name string) error {
 	if err := k.initK8sClient(); err != nil {
-		return nil
+		return err
 	}
 
 	return k.storkClient.Stork().ClusterPairs().Delete(name, &meta_v1.DeleteOptions{
@@ -2776,15 +2776,23 @@ func (k *k8sOps) DeleteClusterPair(name string) error {
 // Migration APIs - BEGIN
 func (k *k8sOps) GetMigration(name string, namespace string) (*v1alpha1.Migration, error) {
 	if err := k.initK8sClient(); err != nil {
-		return nil, nil
+		return nil, err
 	}
 
 	return k.storkClient.Stork().Migrations(namespace).Get(name, meta_v1.GetOptions{})
 }
 
+func (k *k8sOps) ListMigrations(namespace string) (*v1alpha1.MigrationList, error) {
+	if err := k.initK8sClient(); err != nil {
+		return nil, err
+	}
+
+	return k.storkClient.Stork().Migrations(namespace).List(meta_v1.ListOptions{})
+}
+
 func (k *k8sOps) CreateMigration(migration *v1alpha1.Migration) error {
 	if err := k.initK8sClient(); err != nil {
-		return nil
+		return err
 	}
 
 	_, err := k.storkClient.Stork().Migrations(migration.Namespace).Create(migration)
@@ -2793,7 +2801,7 @@ func (k *k8sOps) CreateMigration(migration *v1alpha1.Migration) error {
 
 func (k *k8sOps) DeleteMigration(name string, namespace string) error {
 	if err := k.initK8sClient(); err != nil {
-		return nil
+		return err
 	}
 
 	return k.storkClient.Stork().Migrations(namespace).Delete(name, &meta_v1.DeleteOptions{
@@ -2803,7 +2811,7 @@ func (k *k8sOps) DeleteMigration(name string, namespace string) error {
 
 func (k *k8sOps) UpdateMigration(migration *v1alpha1.Migration) (*v1alpha1.Migration, error) {
 	if err := k.initK8sClient(); err != nil {
-		return nil, nil
+		return nil, err
 	}
 
 	return k.storkClient.Stork().Migrations(migration.Namespace).Update(migration)
@@ -2857,9 +2865,9 @@ func (k *k8sOps) CreateCRD(resource CustomResource) error {
 	return nil
 }
 
-func (k *k8sOps) ValidateCRD(resource CustomResource) error {
+func (k *k8sOps) ValidateCRD(resource CustomResource, timeout, retryInterval time.Duration) error {
 	crdName := fmt.Sprintf("%s.%s", resource.Plural, resource.Group)
-	return wait.Poll(crdCreateRetryInterval, crdCreateRetryInterval, func() (bool, error) {
+	return wait.Poll(timeout, retryInterval, func() (bool, error) {
 		crd, err := k.apiExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(crdName, meta_v1.GetOptions{})
 		if err != nil {
 			return false, err

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -4,227 +4,209 @@
 	"package": [
 		{
 			"checksumSHA1": "pTNpLIAO7meoPq5L4VKaSkuO0K8=",
-			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/cmd/cmdexecutor",
 			"path": "github.com/libopenstorage/stork/cmd/cmdexecutor",
 			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
 			"revisionTime": "2018-09-28T19:57:16Z"
 		},
 		{
 			"checksumSHA1": "34NEH3T/rlFiY1gONfF3Yaami+k=",
-			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/cmd/stork",
 			"path": "github.com/libopenstorage/stork/cmd/stork",
 			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
 			"revisionTime": "2018-09-28T19:57:16Z"
 		},
 		{
 			"checksumSHA1": "dg3vXU6rM7hBTXVOo3yQHNYuyfs=",
-			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/drivers",
 			"path": "github.com/libopenstorage/stork/drivers",
 			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
 			"revisionTime": "2018-09-28T19:57:16Z"
 		},
 		{
 			"checksumSHA1": "ARAkiBsKNxbXLq7FPGcln0bVPVI=",
-			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/drivers/volume",
 			"path": "github.com/libopenstorage/stork/drivers/volume",
 			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
 			"revisionTime": "2018-09-28T19:57:16Z"
 		},
 		{
 			"checksumSHA1": "tnRaHsEPlHjAjlrHrqpk2pC7HdU=",
-			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/drivers/volume/mock",
 			"path": "github.com/libopenstorage/stork/drivers/volume/mock",
 			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
 			"revisionTime": "2018-09-28T19:57:16Z"
 		},
 		{
 			"checksumSHA1": "ARyjbRS8cjNoG3YyDktnOA+LqU0=",
-			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/drivers/volume/portworx",
 			"path": "github.com/libopenstorage/stork/drivers/volume/portworx",
 			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
 			"revisionTime": "2018-09-28T19:57:16Z"
 		},
 		{
 			"checksumSHA1": "mwGN10tzepjEWhMSsP3WH+kIJAo=",
-			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/apis/stork",
 			"path": "github.com/libopenstorage/stork/pkg/apis/stork",
 			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
 			"revisionTime": "2018-09-28T19:57:16Z"
 		},
 		{
 			"checksumSHA1": "djw8KLgN0Sj3L0JMnftbG3fd84o=",
-			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1",
 			"path": "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1",
 			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
 			"revisionTime": "2018-09-28T19:57:16Z"
 		},
 		{
 			"checksumSHA1": "2Q6RvZbqDjBI5vPOGGHrK1HIKrE=",
-			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/client/clientset/versioned",
 			"path": "github.com/libopenstorage/stork/pkg/client/clientset/versioned",
 			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
 			"revisionTime": "2018-09-28T19:57:16Z"
 		},
 		{
 			"checksumSHA1": "8/9iQoDzKmaBGud71u+mDwJJ90U=",
-			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/client/clientset/versioned/fake",
 			"path": "github.com/libopenstorage/stork/pkg/client/clientset/versioned/fake",
 			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
 			"revisionTime": "2018-09-28T19:57:16Z"
 		},
 		{
 			"checksumSHA1": "4pE+CbIN0A60tJq+tJOEvWMKwHc=",
-			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/client/clientset/versioned/scheme",
 			"path": "github.com/libopenstorage/stork/pkg/client/clientset/versioned/scheme",
 			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
 			"revisionTime": "2018-09-28T19:57:16Z"
 		},
 		{
 			"checksumSHA1": "f0ZokcdvcmIuu7uC/0TMgN7meNs=",
-			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/client/clientset/versioned/typed/stork/v1alpha1",
 			"path": "github.com/libopenstorage/stork/pkg/client/clientset/versioned/typed/stork/v1alpha1",
 			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
 			"revisionTime": "2018-09-28T19:57:16Z"
 		},
 		{
 			"checksumSHA1": "D+OKpPyca4R3/dkwakg1ewnNknA=",
-			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/client/clientset/versioned/typed/stork/v1alpha1/fake",
 			"path": "github.com/libopenstorage/stork/pkg/client/clientset/versioned/typed/stork/v1alpha1/fake",
 			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
 			"revisionTime": "2018-09-28T19:57:16Z"
 		},
 		{
 			"checksumSHA1": "b9I24GYnA7/fqET/U7D6ZVcC4bM=",
-			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/client/informers/externalversions",
 			"path": "github.com/libopenstorage/stork/pkg/client/informers/externalversions",
 			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
 			"revisionTime": "2018-09-28T19:57:16Z"
 		},
 		{
 			"checksumSHA1": "+tZtjKcSwHxWU2zJR3INXbSmzEI=",
-			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/client/informers/externalversions/internalinterfaces",
 			"path": "github.com/libopenstorage/stork/pkg/client/informers/externalversions/internalinterfaces",
 			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
 			"revisionTime": "2018-09-28T19:57:16Z"
 		},
 		{
 			"checksumSHA1": "/YhwatQP720Ze8q3rmsBmglsawY=",
-			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/client/informers/externalversions/stork",
 			"path": "github.com/libopenstorage/stork/pkg/client/informers/externalversions/stork",
 			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
 			"revisionTime": "2018-09-28T19:57:16Z"
 		},
 		{
 			"checksumSHA1": "KSq140bjbZTFD7aUr3t5P6jXX1w=",
-			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/client/informers/externalversions/stork/v1alpha1",
 			"path": "github.com/libopenstorage/stork/pkg/client/informers/externalversions/stork/v1alpha1",
 			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
 			"revisionTime": "2018-09-28T19:57:16Z"
 		},
 		{
 			"checksumSHA1": "8l9vfVUyr1byg4oQrcAXINSAy9k=",
-			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/client/listers/stork/v1alpha1",
 			"path": "github.com/libopenstorage/stork/pkg/client/listers/stork/v1alpha1",
 			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
 			"revisionTime": "2018-09-28T19:57:16Z"
 		},
 		{
 			"checksumSHA1": "1/mIBFDlj7ws4aUC6oxuutQ9VdY=",
-			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/cmdexecutor",
 			"path": "github.com/libopenstorage/stork/pkg/cmdexecutor",
 			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
 			"revisionTime": "2018-09-28T19:57:16Z"
 		},
 		{
 			"checksumSHA1": "ryJHa/KrDsqviOJcL7GhiJL5eRw=",
-			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/cmdexecutor/status",
 			"path": "github.com/libopenstorage/stork/pkg/cmdexecutor/status",
 			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
 			"revisionTime": "2018-09-28T19:57:16Z"
 		},
 		{
 			"checksumSHA1": "324xi+IKkHUwPI3NDL7e2cc+2N8=",
-			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/controller",
 			"path": "github.com/libopenstorage/stork/pkg/controller",
 			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
 			"revisionTime": "2018-09-28T19:57:16Z"
 		},
 		{
 			"checksumSHA1": "mpdA63hH+LwDI1Xi4Gv9aZDul6o=",
-			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/errors",
 			"path": "github.com/libopenstorage/stork/pkg/errors",
 			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
 			"revisionTime": "2018-09-28T19:57:16Z"
 		},
 		{
 			"checksumSHA1": "ibj/MRfg8dw4tLpaV+0Zx2mBlhE=",
-			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/extender",
 			"path": "github.com/libopenstorage/stork/pkg/extender",
 			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
 			"revisionTime": "2018-09-28T19:57:16Z"
 		},
 		{
 			"checksumSHA1": "R9dsFeXkXMbXFzh27e3VB1MJ7B4=",
-			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/initializer",
 			"path": "github.com/libopenstorage/stork/pkg/initializer",
 			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
 			"revisionTime": "2018-09-28T19:57:16Z"
 		},
 		{
 			"checksumSHA1": "wupfeJa4rxdTNUc2yz1JBa6nhiw=",
-			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/log",
 			"path": "github.com/libopenstorage/stork/pkg/log",
 			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
 			"revisionTime": "2018-09-28T19:57:16Z"
 		},
 		{
 			"checksumSHA1": "ICLiDHxKXMSDLsNMlSme+q5aEk4=",
-			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/migration",
 			"path": "github.com/libopenstorage/stork/pkg/migration",
 			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
 			"revisionTime": "2018-09-28T19:57:16Z"
 		},
 		{
 			"checksumSHA1": "5RH29JRoy/OVcL8DwzhVO5qX7hA=",
-			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/migration/controllers",
 			"path": "github.com/libopenstorage/stork/pkg/migration/controllers",
 			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
 			"revisionTime": "2018-09-28T19:57:16Z"
 		},
 		{
 			"checksumSHA1": "ThME5Nmrn2qpmExCJgw8nnbcUAc=",
-			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/monitor",
 			"path": "github.com/libopenstorage/stork/pkg/monitor",
 			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
 			"revisionTime": "2018-09-28T19:57:16Z"
 		},
 		{
 			"checksumSHA1": "NlG7Pnb7F4upVKHjdSfGGaI0TBo=",
-			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/snapshot",
 			"path": "github.com/libopenstorage/stork/pkg/snapshot",
 			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
 			"revisionTime": "2018-09-28T19:57:16Z"
 		},
 		{
 			"checksumSHA1": "GTeCq3wCejFLZBVj3g6CqX0rHyw=",
-			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/snapshot/rule",
 			"path": "github.com/libopenstorage/stork/pkg/snapshot/rule",
 			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
 			"revisionTime": "2018-09-28T19:57:16Z"
 		},
 		{
 			"checksumSHA1": "F5uohlV+5UqNtw5C1HVPTRTnH/U=",
-			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/version",
 			"path": "github.com/libopenstorage/stork/pkg/version",
 			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
 			"revisionTime": "2018-09-28T19:57:16Z"
 		},
 		{
 			"checksumSHA1": "HA6laUeUCM4wnypCBqw3sL8lYY4=",
-			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/test/integration_test",
 			"path": "github.com/libopenstorage/stork/test/integration_test",
 			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
 			"revisionTime": "2018-09-28T19:57:16Z"
+		},
+		{
+			"checksumSHA1": "qZSmQqTpM7GF32orPe1KdI+d+rA=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/portworx/sched-ops/k8s",
+			"path": "github.com/portworx/sched-ops/k8s",
+			"revision": "f56504b2d8c6cc9680234650f6ad52f9f0f70f1d",
+			"revisionTime": "2018-10-04T10:58:25Z"
+		},
+		{
+			"checksumSHA1": "5Nh7ppJlsyP/6c2zK5joEHz3I30=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/portworx/sched-ops/task",
+			"path": "github.com/portworx/sched-ops/task",
+			"revision": "f56504b2d8c6cc9680234650f6ad52f9f0f70f1d",
+			"revisionTime": "2018-10-04T10:58:25Z"
 		}
 	],
 	"rootPath": "github.com/portworx/torpedo"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,0 +1,231 @@
+{
+	"comment": "",
+	"ignore": "",
+	"package": [
+		{
+			"checksumSHA1": "pTNpLIAO7meoPq5L4VKaSkuO0K8=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/cmd/cmdexecutor",
+			"path": "github.com/libopenstorage/stork/cmd/cmdexecutor",
+			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
+			"revisionTime": "2018-09-28T19:57:16Z"
+		},
+		{
+			"checksumSHA1": "34NEH3T/rlFiY1gONfF3Yaami+k=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/cmd/stork",
+			"path": "github.com/libopenstorage/stork/cmd/stork",
+			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
+			"revisionTime": "2018-09-28T19:57:16Z"
+		},
+		{
+			"checksumSHA1": "dg3vXU6rM7hBTXVOo3yQHNYuyfs=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/drivers",
+			"path": "github.com/libopenstorage/stork/drivers",
+			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
+			"revisionTime": "2018-09-28T19:57:16Z"
+		},
+		{
+			"checksumSHA1": "ARAkiBsKNxbXLq7FPGcln0bVPVI=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/drivers/volume",
+			"path": "github.com/libopenstorage/stork/drivers/volume",
+			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
+			"revisionTime": "2018-09-28T19:57:16Z"
+		},
+		{
+			"checksumSHA1": "tnRaHsEPlHjAjlrHrqpk2pC7HdU=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/drivers/volume/mock",
+			"path": "github.com/libopenstorage/stork/drivers/volume/mock",
+			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
+			"revisionTime": "2018-09-28T19:57:16Z"
+		},
+		{
+			"checksumSHA1": "ARyjbRS8cjNoG3YyDktnOA+LqU0=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/drivers/volume/portworx",
+			"path": "github.com/libopenstorage/stork/drivers/volume/portworx",
+			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
+			"revisionTime": "2018-09-28T19:57:16Z"
+		},
+		{
+			"checksumSHA1": "mwGN10tzepjEWhMSsP3WH+kIJAo=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/apis/stork",
+			"path": "github.com/libopenstorage/stork/pkg/apis/stork",
+			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
+			"revisionTime": "2018-09-28T19:57:16Z"
+		},
+		{
+			"checksumSHA1": "djw8KLgN0Sj3L0JMnftbG3fd84o=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1",
+			"path": "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1",
+			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
+			"revisionTime": "2018-09-28T19:57:16Z"
+		},
+		{
+			"checksumSHA1": "2Q6RvZbqDjBI5vPOGGHrK1HIKrE=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/client/clientset/versioned",
+			"path": "github.com/libopenstorage/stork/pkg/client/clientset/versioned",
+			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
+			"revisionTime": "2018-09-28T19:57:16Z"
+		},
+		{
+			"checksumSHA1": "8/9iQoDzKmaBGud71u+mDwJJ90U=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/client/clientset/versioned/fake",
+			"path": "github.com/libopenstorage/stork/pkg/client/clientset/versioned/fake",
+			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
+			"revisionTime": "2018-09-28T19:57:16Z"
+		},
+		{
+			"checksumSHA1": "4pE+CbIN0A60tJq+tJOEvWMKwHc=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/client/clientset/versioned/scheme",
+			"path": "github.com/libopenstorage/stork/pkg/client/clientset/versioned/scheme",
+			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
+			"revisionTime": "2018-09-28T19:57:16Z"
+		},
+		{
+			"checksumSHA1": "f0ZokcdvcmIuu7uC/0TMgN7meNs=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/client/clientset/versioned/typed/stork/v1alpha1",
+			"path": "github.com/libopenstorage/stork/pkg/client/clientset/versioned/typed/stork/v1alpha1",
+			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
+			"revisionTime": "2018-09-28T19:57:16Z"
+		},
+		{
+			"checksumSHA1": "D+OKpPyca4R3/dkwakg1ewnNknA=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/client/clientset/versioned/typed/stork/v1alpha1/fake",
+			"path": "github.com/libopenstorage/stork/pkg/client/clientset/versioned/typed/stork/v1alpha1/fake",
+			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
+			"revisionTime": "2018-09-28T19:57:16Z"
+		},
+		{
+			"checksumSHA1": "b9I24GYnA7/fqET/U7D6ZVcC4bM=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/client/informers/externalversions",
+			"path": "github.com/libopenstorage/stork/pkg/client/informers/externalversions",
+			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
+			"revisionTime": "2018-09-28T19:57:16Z"
+		},
+		{
+			"checksumSHA1": "+tZtjKcSwHxWU2zJR3INXbSmzEI=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/client/informers/externalversions/internalinterfaces",
+			"path": "github.com/libopenstorage/stork/pkg/client/informers/externalversions/internalinterfaces",
+			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
+			"revisionTime": "2018-09-28T19:57:16Z"
+		},
+		{
+			"checksumSHA1": "/YhwatQP720Ze8q3rmsBmglsawY=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/client/informers/externalversions/stork",
+			"path": "github.com/libopenstorage/stork/pkg/client/informers/externalversions/stork",
+			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
+			"revisionTime": "2018-09-28T19:57:16Z"
+		},
+		{
+			"checksumSHA1": "KSq140bjbZTFD7aUr3t5P6jXX1w=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/client/informers/externalversions/stork/v1alpha1",
+			"path": "github.com/libopenstorage/stork/pkg/client/informers/externalversions/stork/v1alpha1",
+			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
+			"revisionTime": "2018-09-28T19:57:16Z"
+		},
+		{
+			"checksumSHA1": "8l9vfVUyr1byg4oQrcAXINSAy9k=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/client/listers/stork/v1alpha1",
+			"path": "github.com/libopenstorage/stork/pkg/client/listers/stork/v1alpha1",
+			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
+			"revisionTime": "2018-09-28T19:57:16Z"
+		},
+		{
+			"checksumSHA1": "1/mIBFDlj7ws4aUC6oxuutQ9VdY=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/cmdexecutor",
+			"path": "github.com/libopenstorage/stork/pkg/cmdexecutor",
+			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
+			"revisionTime": "2018-09-28T19:57:16Z"
+		},
+		{
+			"checksumSHA1": "ryJHa/KrDsqviOJcL7GhiJL5eRw=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/cmdexecutor/status",
+			"path": "github.com/libopenstorage/stork/pkg/cmdexecutor/status",
+			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
+			"revisionTime": "2018-09-28T19:57:16Z"
+		},
+		{
+			"checksumSHA1": "324xi+IKkHUwPI3NDL7e2cc+2N8=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/controller",
+			"path": "github.com/libopenstorage/stork/pkg/controller",
+			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
+			"revisionTime": "2018-09-28T19:57:16Z"
+		},
+		{
+			"checksumSHA1": "mpdA63hH+LwDI1Xi4Gv9aZDul6o=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/errors",
+			"path": "github.com/libopenstorage/stork/pkg/errors",
+			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
+			"revisionTime": "2018-09-28T19:57:16Z"
+		},
+		{
+			"checksumSHA1": "ibj/MRfg8dw4tLpaV+0Zx2mBlhE=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/extender",
+			"path": "github.com/libopenstorage/stork/pkg/extender",
+			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
+			"revisionTime": "2018-09-28T19:57:16Z"
+		},
+		{
+			"checksumSHA1": "R9dsFeXkXMbXFzh27e3VB1MJ7B4=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/initializer",
+			"path": "github.com/libopenstorage/stork/pkg/initializer",
+			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
+			"revisionTime": "2018-09-28T19:57:16Z"
+		},
+		{
+			"checksumSHA1": "wupfeJa4rxdTNUc2yz1JBa6nhiw=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/log",
+			"path": "github.com/libopenstorage/stork/pkg/log",
+			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
+			"revisionTime": "2018-09-28T19:57:16Z"
+		},
+		{
+			"checksumSHA1": "ICLiDHxKXMSDLsNMlSme+q5aEk4=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/migration",
+			"path": "github.com/libopenstorage/stork/pkg/migration",
+			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
+			"revisionTime": "2018-09-28T19:57:16Z"
+		},
+		{
+			"checksumSHA1": "5RH29JRoy/OVcL8DwzhVO5qX7hA=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/migration/controllers",
+			"path": "github.com/libopenstorage/stork/pkg/migration/controllers",
+			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
+			"revisionTime": "2018-09-28T19:57:16Z"
+		},
+		{
+			"checksumSHA1": "ThME5Nmrn2qpmExCJgw8nnbcUAc=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/monitor",
+			"path": "github.com/libopenstorage/stork/pkg/monitor",
+			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
+			"revisionTime": "2018-09-28T19:57:16Z"
+		},
+		{
+			"checksumSHA1": "NlG7Pnb7F4upVKHjdSfGGaI0TBo=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/snapshot",
+			"path": "github.com/libopenstorage/stork/pkg/snapshot",
+			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
+			"revisionTime": "2018-09-28T19:57:16Z"
+		},
+		{
+			"checksumSHA1": "GTeCq3wCejFLZBVj3g6CqX0rHyw=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/snapshot/rule",
+			"path": "github.com/libopenstorage/stork/pkg/snapshot/rule",
+			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
+			"revisionTime": "2018-09-28T19:57:16Z"
+		},
+		{
+			"checksumSHA1": "F5uohlV+5UqNtw5C1HVPTRTnH/U=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/pkg/version",
+			"path": "github.com/libopenstorage/stork/pkg/version",
+			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
+			"revisionTime": "2018-09-28T19:57:16Z"
+		},
+		{
+			"checksumSHA1": "HA6laUeUCM4wnypCBqw3sL8lYY4=",
+			"origin": "github.com/portworx/torpedo/vendor/github.com/libopenstorage/stork/test/integration_test",
+			"path": "github.com/libopenstorage/stork/test/integration_test",
+			"revision": "5bd7347a775eaa2fd102fd4b9780ffb707092276",
+			"revisionTime": "2018-09-28T19:57:16Z"
+		}
+	],
+	"rootPath": "github.com/portworx/torpedo"
+}


### PR DESCRIPTION
This PR adds following ,
- vendor update for stork (govendor)
- vendor update for sched-ops(govendor)
- Update torpedo scheduler driver to use updated interfaces in sched-ops

