### PR TITLE
Get k8sOps instance using kubeconfig file

### DIFF
--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -20,8 +20,9 @@ const (
 
 // Context holds the execution context of a test task.
 type Context struct {
-	UID string
-	App *spec.AppSpec
+	UID        string
+	App        *spec.AppSpec
+	KubeConfig string
 }
 
 // ScheduleOptions are options that callers to pass to influence the apps that get schduled


### PR DESCRIPTION
This PR allow user to call WaitForRunning() with kubeConfig file of k8s server, so that we can check application status running on given server.

If no config file path passed then k8s instance will be set to default inclusterConfig() instance. 

**Note** : This is proposed change, please let me know what do you think and if there is better alternative for achieving this.