### PR TITLE
Add missing GetClusterPairInfo() Interface

### DIFF
--- a/drivers/scheduler/dcos/dcos.go
+++ b/drivers/scheduler/dcos/dcos.go
@@ -424,9 +424,8 @@ func (d *dcos) StartSchedOnNode(node node.Node) error {
 	return nil
 }
 
-// CreateCRDObjects and Validate their deployment
-func (d *dcos) CreateCRDObjects(ctx *scheduler.Context, timeout, retryInterval time.Duration) error {
-	// TODO: Implement this method
+func (d *dcos) RescanSpecs(specDir string) error {
+	// TODO implement this method
 	return nil
 }
 

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -55,6 +55,7 @@ const (
 	volDirCleanupTimeout         = 5 * time.Minute
 	k8sObjectCreateTimeout       = 2 * time.Minute
 	k8sDestroyTimeout            = 2 * time.Minute
+	migrationObjectTimeout       = 10 * time.Minute
 	findFilesOnWorkerTimeout     = 1 * time.Minute
 	deleteTasksWaitTimeout       = 3 * time.Minute
 	defaultRetryInterval         = 10 * time.Second
@@ -117,6 +118,16 @@ func (k *k8s) Init(specDir, volDriverName, nodeDriverName string) error {
 	}
 
 	k.nodeDriverName = nodeDriverName
+	return nil
+}
+
+func (k *k8s) RescanSpecs(specDir string) error {
+	var err error
+	logrus.Infof("Rescanning specs for %v", specDir)
+	k.specFactory, err = spec.NewFactory(specDir, k)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -273,6 +284,16 @@ func (k *k8s) Schedule(instanceID string, options scheduler.ScheduleOptions) ([]
 		}
 
 		var specObjects []interface{}
+		for _, spec := range app.SpecList {
+			obj, err := k.createCRDObjects(spec, defaultTimeout, defaultRetryInterval)
+			if err != nil {
+				return nil, err
+			}
+			if obj != nil {
+				specObjects = append(specObjects, obj)
+			}
+		}
+
 		for _, spec := range app.SpecList {
 			t := func() (interface{}, bool, error) {
 				obj, err := k.createStorageObject(spec, ns, app)
@@ -1251,7 +1272,7 @@ func (k *k8s) GetNodesForApp(ctx *scheduler.Context) ([]node.Node, error) {
 			}
 		}
 
-		if len(result) > 0{
+		if len(result) > 0 {
 			return result, false, nil
 		}
 
@@ -1482,51 +1503,45 @@ func (k *k8s) StartSchedOnNode(n node.Node) error {
 	return nil
 }
 
-// CreateCRDObjects and Validate their deployment
-func (k *k8s) CreateCRDObjects(ctx *scheduler.Context, timeout, retryInterval time.Duration) error {
+// createCRDObjects and Validate their deployment
+func (k *k8s) createCRDObjects(specObj interface{}, timeout, retryInterval time.Duration) (interface{}, error) {
 	var err error
+	var obj interface{}
 	k8sOps := k8s_ops.Instance()
-	for _, specObj := range ctx.App.SpecList {
-		if obj, ok := specObj.(*stork_api.ClusterPair); ok {
-			logrus.Info("Applying clusterpair spec")
-			err = k8sOps.CreateClusterPair(obj)
-			if err != nil {
-				return &scheduler.ErrFailedToApplyCustomSpec{
-					Name:  obj.Name,
-					Cause: fmt.Sprintf("Failed to apply spec: %v. Err: %v", obj.Name, err),
-					Type:  obj,
-				}
+	if obj, ok := specObj.(*stork_api.ClusterPair); ok {
+		logrus.Info("Applying clusterpair spec")
+		err = k8sOps.CreateClusterPair(obj)
+		if err != nil {
+			return nil, &scheduler.ErrFailedToApplyCustomSpec{
+				Name:  obj.Name,
+				Cause: fmt.Sprintf("Failed to apply spec: %v. Err: %v", obj.Name, err),
+				Type:  obj,
 			}
-			if err := k8sOps.ValidateClusterPair(obj.Name, defaultTimeout, defaultRetryInterval); err != nil {
-				return &scheduler.ErrFailedToApplyCustomSpec{
-					Name:  obj.Name,
-					Cause: fmt.Sprintf("Failed to validate cluster Pair: %v. Err: %v", obj.Name, err),
-				}
+		}
+		if err := k8sOps.ValidateClusterPair(obj.Name, defaultTimeout, defaultRetryInterval); err != nil {
+			return nil, &scheduler.ErrFailedToApplyCustomSpec{
+				Name:  obj.Name,
+				Cause: fmt.Sprintf("Failed to validate cluster Pair: %v. Err: %v", obj.Name, err),
 			}
-
-		} else if obj, ok := specObj.(*stork_api.Migration); ok {
-			logrus.Info("Applying Migration Spec")
-			err = k8sOps.CreateMigration(obj)
-			if err != nil {
-				return &scheduler.ErrFailedToApplyCustomSpec{
-					Name:  obj.Name,
-					Cause: fmt.Sprintf("Failed to apply spec: %v. Err: %v", obj.Name, err),
-					Type:  obj,
-				}
+		}
+	} else if obj, ok := specObj.(*stork_api.Migration); ok {
+		logrus.Info("Applying Migration Spec")
+		err = k8sOps.CreateMigration(obj)
+		if err != nil {
+			return nil, &scheduler.ErrFailedToApplyCustomSpec{
+				Name:  obj.Name,
+				Cause: fmt.Sprintf("Failed to apply spec: %v. Err: %v", obj.Name, err),
+				Type:  obj,
 			}
-			if err := k8sOps.ValidateMigration(obj.Name, defaultTimeout, defaultRetryInterval); err != nil {
-				return &scheduler.ErrFailedToApplyCustomSpec{
-					Name:  obj.Name,
-					Cause: fmt.Sprintf("Failed to validate cluster Pair: %v. Err: %v", obj.Name, err),
-				}
+		}
+		if err := k8sOps.ValidateMigration(obj.Name, migrationObjectTimeout, defaultRetryInterval); err != nil {
+			return nil, &scheduler.ErrFailedToApplyCustomSpec{
+				Name:  obj.Name,
+				Cause: fmt.Sprintf("Failed to validate cluster Pair: %v. Err: %v", obj.Name, err),
 			}
-		} else {
-			return fmt.Errorf("Unsupported object: %v", reflect.TypeOf(specObj))
 		}
 	}
-
-	logrus.Info("Custom specs created successfully")
-	return nil
+	return obj, nil
 }
 
 func insertLineBreak(note string) string {

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -96,8 +96,8 @@ type Driver interface {
 	// Start scheduler service on the given node
 	StartSchedOnNode(n node.Node) error
 
-	// CreateCRDObjects and Validate their deployment
-	CreateCRDObjects(ctx *Context, timeout, retryInterval time.Duration) error
+	// RescanSpecs specified in specDir
+	RescanSpecs(specDir string) error
 }
 
 var (

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -36,8 +36,8 @@ const (
 	pxSystemdServiceName    = "portworx.service"
 	storageStatusUp         = "Up"
 	tokenKey                = "token"
-	clusterIP               = "clusterip"
-	clusterPort             = "clusterport"
+	clusterIP               = "ip"
+	clusterPort             = "port"
 	remoteKubeConfigPath    = "/tmp/kubeconfig"
 )
 

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -1055,13 +1055,16 @@ func (d *portworx) UpgradeDriver(version string) error {
 	return nil
 }
 
-// GetClusterPairingInfo return underlying storage details
+// GetClusterPairingInfo returns cluster pair information
 func (d *portworx) GetClusterPairingInfo() (map[string]string, error) {
 	pairInfo := make(map[string]string)
 	pxNodes, err := d.schedOps.GetRemotePXNodes(remoteKubeConfigPath)
 	if err != nil {
 		logrus.Errorf("err retrieving remote px nodes: %v", err)
 		return nil, err
+	}
+	if len(pxNodes) == 0 {
+		return nil, fmt.Errorf("No PX Node found")
 	}
 
 	clusterMgr, err := d.getClusterManagerByAddress(pxNodes[0].Addresses[0])

--- a/drivers/volume/portworx/schedops/k8s-schedops.go
+++ b/drivers/volume/portworx/schedops/k8s-schedops.go
@@ -631,7 +631,8 @@ func getPXNodes(destKubeConfig string) ([]corev1.Node, error) {
 
 	// get label on node where PX is Enabled
 	for _, node := range nodes.Items {
-		if node.Labels[pxEnabled] == "true" {
+		// worker node and px is not disabled
+		if !destClient.IsNodeMaster(node) && node.Labels[pxEnabled] != "false" {
 			pxNodes = append(pxNodes, node)
 		}
 	}

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -100,6 +100,9 @@ type Driver interface {
 
 	// GetAggregationLevel returns the aggregation level for the given volume
 	GetAggregationLevel(vol *Volume) (int64, error)
+
+	// GetClusterPairingInfo returns cluster pairing information from remote cluster
+	GetClusterPairingInfo() (map[string]string, error)
 }
 
 var (


### PR DESCRIPTION
This PR adds Missing GetClusterPairingInfo() API.
   - also add additional check detecting PX Nodes
   - check for empty pxNodes
- adds RescanSpecs() from given specDir
- add customCRDobjects under Schedule() call
