### PR TITLE
Copy deployments and scripts directories into the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,14 @@ RUN mkdir bin && \
 # Build a fresh container with just the binaries
 FROM alpine
 
+# Copy scripts into container
+WORKDIR /torpedo
+COPY deployments deployments
+COPY scripts scripts
+
 WORKDIR /go/src/github.com/portworx/torpedo
 
-# Copy just ginkgo & binaries over from previous container
+# Copy ginkgo & binaries over from previous container
 COPY --from=build /go/bin/ginkgo /bin/ginkgo
 COPY --from=build /go/src/github.com/portworx/torpedo/bin bin
 COPY drivers drivers


### PR DESCRIPTION
In Jenkins jobs which run torpedo, I want to pull the scripts out of the container,
and eliminate the step which checks out torpedo from git in order to run the torpedo scripts