### PR TITLE
Add APIs to add stop/start labels to PX service.

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -568,7 +568,7 @@ func (d *portworx) StopDriver(nodes []node.Node, force bool) error {
 				return err
 			}
 		} else {
-			err = d.schedOps.DisableOnNode(n)
+			err = d.schedOps.StopPxOnNode(n)
 			if err != nil {
 				return err
 			}

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -1020,6 +1020,10 @@ func (d *portworx) testAndSetEndpoint(endpoint string) error {
 }
 
 func (d *portworx) StartDriver(n node.Node) error {
+	err := d.schedOps.StartPxOnNode(n)
+	if err != nil {
+		return err
+	}
 	return d.nodeDriver.Systemctl(n, pxSystemdServiceName, node.SystemctlOpts{
 		Action: "start",
 		ConnectionOpts: node.ConnectionOpts{

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -568,6 +568,10 @@ func (d *portworx) StopDriver(nodes []node.Node, force bool) error {
 				return err
 			}
 		} else {
+			err = d.schedOps.DisableOnNode(n)
+			if err != nil {
+				return err
+			}
 			err = d.nodeDriver.Systemctl(n, pxSystemdServiceName, node.SystemctlOpts{
 				Action: "stop",
 				ConnectionOpts: node.ConnectionOpts{

--- a/drivers/volume/portworx/schedops/dcos-schedops.go
+++ b/drivers/volume/portworx/schedops/dcos-schedops.go
@@ -9,6 +9,14 @@ import (
 
 type dcosSchedOps struct{}
 
+func (d *dcosSchedOps) EnableOnNode(n node.Node) error {
+	return nil
+}
+
+func (d *dcosSchedOps) DisableOnNode(n node.Node) error {
+	return nil
+}
+
 func (d *dcosSchedOps) ValidateOnNode(n node.Node) error {
 	return &errors.ErrNotSupported{
 		Type:      "Function",

--- a/drivers/volume/portworx/schedops/dcos-schedops.go
+++ b/drivers/volume/portworx/schedops/dcos-schedops.go
@@ -9,11 +9,11 @@ import (
 
 type dcosSchedOps struct{}
 
-func (d *dcosSchedOps) EnableOnNode(n node.Node) error {
+func (d *dcosSchedOps) StartPxOnNode(n node.Node) error {
 	return nil
 }
 
-func (d *dcosSchedOps) DisableOnNode(n node.Node) error {
+func (d *dcosSchedOps) StopPxOnNode(n node.Node) error {
 	return nil
 }
 

--- a/drivers/volume/portworx/schedops/k8s-schedops.go
+++ b/drivers/volume/portworx/schedops/k8s-schedops.go
@@ -84,11 +84,11 @@ func (e *errLabelAbsent) Error() string {
 
 type k8sSchedOps struct{}
 
-func (k *k8sSchedOps) EnableOnNode(n node.Node) error {
+func (k *k8sSchedOps) StopPxOnNode(n node.Node) error {
 	return k8s.Instance().AddLabelOnNode(n.Name, k8sPxServiceLabelKey, k8sServiceOperationStart)
 }
 
-func (k *k8sSchedOps) DisableOnNode(n node.Node) error {
+func (k *k8sSchedOps) StartPxOnNode(n node.Node) error {
 	return k8s.Instance().AddLabelOnNode(n.Name, k8sPxServiceLabelKey, k8sServiceOperationStop)
 }
 

--- a/drivers/volume/portworx/schedops/k8s-schedops.go
+++ b/drivers/volume/portworx/schedops/k8s-schedops.go
@@ -85,11 +85,11 @@ func (e *errLabelAbsent) Error() string {
 type k8sSchedOps struct{}
 
 func (k *k8sSchedOps) StopPxOnNode(n node.Node) error {
-	return k8s.Instance().AddLabelOnNode(n.Name, k8sPxServiceLabelKey, k8sServiceOperationStart)
+	return k8s.Instance().AddLabelOnNode(n.Name, k8sPxServiceLabelKey, k8sServiceOperationStop)
 }
 
 func (k *k8sSchedOps) StartPxOnNode(n node.Node) error {
-	return k8s.Instance().AddLabelOnNode(n.Name, k8sPxServiceLabelKey, k8sServiceOperationStop)
+	return k8s.Instance().AddLabelOnNode(n.Name, k8sPxServiceLabelKey, k8sServiceOperationStart)
 }
 
 func (k *k8sSchedOps) ValidateOnNode(n node.Node) error {

--- a/drivers/volume/portworx/schedops/k8s-schedops.go
+++ b/drivers/volume/portworx/schedops/k8s-schedops.go
@@ -27,6 +27,12 @@ const (
 	PXNamespace = "kube-system"
 	// PXDaemonSet is the name of portworx daemon set in k8s deployment
 	PXDaemonSet = "portworx"
+	// k8sPxServiceLabelKey is the label key used for px systemd service control
+	k8sPxServiceLabelKey = "px/service"
+	// k8sServiceOperationStart is label value for starting Portworx service
+	k8sServiceOperationStart = "start"
+	// k8sServiceOperationStop is label value for stopping Portworx service
+	k8sServiceOperationStop = "stop"
 	// k8sPodsRootDir is the directory under which k8s keeps all pods data
 	k8sPodsRootDir = "/var/lib/kubelet/pods"
 	// snapshotAnnotation is the annotation used to get the parent of a PVC
@@ -77,6 +83,14 @@ func (e *errLabelAbsent) Error() string {
 }
 
 type k8sSchedOps struct{}
+
+func (k *k8sSchedOps) EnableOnNode(n node.Node) error {
+	return k8s.Instance().AddLabelOnNode(n.Name, k8sPxServiceLabelKey, k8sServiceOperationStart)
+}
+
+func (k *k8sSchedOps) DisableOnNode(n node.Node) error {
+	return k8s.Instance().AddLabelOnNode(n.Name, k8sPxServiceLabelKey, k8sServiceOperationStop)
+}
 
 func (k *k8sSchedOps) ValidateOnNode(n node.Node) error {
 	return &errors.ErrNotSupported{

--- a/drivers/volume/portworx/schedops/schedops.go
+++ b/drivers/volume/portworx/schedops/schedops.go
@@ -12,9 +12,9 @@ import (
 // Driver is the interface for portworx operations under various schedulers
 type Driver interface {
 	// EnableOnNode enable portworx on given node
-	EnableOnNode(n node.Node) error
+	StartPxOnNode(n node.Node) error
 	// DisableOnNode disable portworx on given node
-	DisableOnNode(n node.Node) error
+	StopPxOnNode(n node.Node) error
 	// ValidateOnNode validates portworx on given node (from scheduler perspective)
 	ValidateOnNode(n node.Node) error
 	// ValidateAddLabels validates whether the labels for the volume are applied appropriately on the vol replica nodes

--- a/drivers/volume/portworx/schedops/schedops.go
+++ b/drivers/volume/portworx/schedops/schedops.go
@@ -11,6 +11,10 @@ import (
 
 // Driver is the interface for portworx operations under various schedulers
 type Driver interface {
+	// EnableOnNode enable portworx on given node
+	EnableOnNode(n node.Node) error
+	// DisableOnNode disable portworx on given node
+	DisableOnNode(n node.Node) error
 	// ValidateOnNode validates portworx on given node (from scheduler perspective)
 	ValidateOnNode(n node.Node) error
 	// ValidateAddLabels validates whether the labels for the volume are applied appropriately on the vol replica nodes


### PR DESCRIPTION
Why is this PR needed?
* https://portworx.atlassian.net/browse/PTX-1247

Impacts:
* Torpedo tests that stop PX driver
* Stork integration tests

Signed-off-by: Rohit-PX <rohit@portworx.com>