### PR TITLE
[PTX-1532] Increase px service start timeout to 4 mins.

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -53,7 +53,7 @@ const (
 	validateReplicationUpdateTimeout = 10 * time.Minute
 	validateClusterStartTimeout      = 2 * time.Minute
 	validateNodeStartTimeout         = 3 * time.Minute
-	validatePXStartTimeout           = 2 * time.Minute
+	validatePXStartTimeout           = 4 * time.Minute
 	validateNodeStopTimeout          = 2 * time.Minute
 	stopDriverTimeout                = 5 * time.Minute
 	crashDriverTimeout               = 2 * time.Minute
@@ -554,7 +554,7 @@ func (d *portworx) ValidateDeleteVolume(vol *torpedovolume.Volume) error {
 			return nil, true, err
 		}
 		// TODO remove shared validation when PWX-6894 and PWX-8790 are fixed
-		if len(vols) > 0 && !vol.Shared{
+		if len(vols) > 0 && !vol.Shared {
 			return nil, true, fmt.Errorf("Volume %v is not yet removed from the system", name)
 		}
 		return nil, false, nil


### PR DESCRIPTION
In recent GKE torpedo runs, it is seen that PX service takes slightly more than 3 mins to come up.
Hence, increasing this timeout to 4 mins.