### PR TITLE
PTX-1675 change /testresults dir path to /mount/testresult

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -80,8 +80,8 @@ if [ -n "${TORPEDO_SSH_KEY}" ]; then
     TORPEDO_SSH_KEY_MOUNT="{ \"name\": \"ssh-key-volume\", \"mountPath\": \"/home/torpedo/\" }"
 fi
 
-TESTRESULTS_VOLUME="{ \"name\": \"testresults\", \"hostPath\": { \"path\": \"/testresults/\", \"type\": \"DirectoryOrCreate\" } }"
-TESTRESULTS_MOUNT="{ \"name\": \"testresults\", \"mountPath\": \"/testresults/\" }"
+TESTRESULTS_VOLUME="{ \"name\": \"testresults\", \"hostPath\": { \"path\": \"/mnt/testresults/\", \"type\": \"DirectoryOrCreate\" } }"
+TESTRESULTS_MOUNT="{ \"name\": \"testresults\", \"mountPath\": \"/mnt/testresults/\" }"
 
 VOLUMES="${TESTRESULTS_VOLUME}"
 

--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -81,7 +81,7 @@ if [ -n "${TORPEDO_SSH_KEY}" ]; then
 fi
 
 TESTRESULTS_VOLUME="{ \"name\": \"testresults\", \"hostPath\": { \"path\": \"/mnt/testresults/\", \"type\": \"DirectoryOrCreate\" } }"
-TESTRESULTS_MOUNT="{ \"name\": \"testresults\", \"mountPath\": \"/mnt/testresults/\" }"
+TESTRESULTS_MOUNT="{ \"name\": \"testresults\", \"mountPath\": \"/testresults/\" }"
 
 VOLUMES="${TESTRESULTS_VOLUME}"
 


### PR DESCRIPTION
Change /testresults dir path to /mount/testresult, due to OpenShift nodes aren't permitting to write to:
Mounts:
      /mnt/testresults/ from testresults (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from torpedo-account-token-wmdpd (ro)

Volumes:
  testresults:
    Type:          HostPath (bare host directory volume)
    Path:          /mnt/testresults/
    HostPathType:  DirectoryOrCreate

Signed-off-by: nikolaypopov <nikolay.popov86@gmail.com>