### PR TITLE
Implement modifying security context constraints when scheduling apps for OC driver

### DIFF
--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -387,6 +387,7 @@ func (k *K8s) Schedule(instanceID string, options scheduler.ScheduleOptions) ([]
 	return contexts, nil
 }
 
+// CreateSpecObjects Create application
 func (k *K8s) CreateSpecObjects(app *spec.AppSpec, namespace, storageprovisioner string) ([]interface{}, error) {
 	var specObjects []interface{}
 	ns, err := k.createNamespace(app, namespace)

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -367,7 +367,7 @@ func (k *K8s) Schedule(instanceID string, options scheduler.ScheduleOptions) ([]
 	for _, app := range apps {
 
 		appNamespace := app.GetID(instanceID)
-		specObjects, err := k.createSpecObjects(app, appNamespace, options.StorageProvisioner)
+		specObjects, err := k.CreateSpecObjects(app, appNamespace, options.StorageProvisioner)
 		if err != nil {
 			return nil, err
 		}
@@ -387,7 +387,7 @@ func (k *K8s) Schedule(instanceID string, options scheduler.ScheduleOptions) ([]
 	return contexts, nil
 }
 
-func (k *K8s) createSpecObjects(app *spec.AppSpec, namespace, storageprovisioner string) ([]interface{}, error) {
+func (k *K8s) CreateSpecObjects(app *spec.AppSpec, namespace, storageprovisioner string) ([]interface{}, error) {
 	var specObjects []interface{}
 	ns, err := k.createNamespace(app, namespace)
 	if err != nil {
@@ -507,7 +507,7 @@ func (k *K8s) AddTasks(ctx *scheduler.Context, options scheduler.ScheduleOptions
 		apps = append(apps, spec)
 	}
 	for _, app := range apps {
-		objects, err := k.createSpecObjects(app, appNamespace, options.StorageProvisioner)
+		objects, err := k.CreateSpecObjects(app, appNamespace, options.StorageProvisioner)
 		if err != nil {
 			return err
 		}

--- a/drivers/scheduler/openshift/openshift.go
+++ b/drivers/scheduler/openshift/openshift.go
@@ -1,9 +1,11 @@
 package openshift
 
 import (
+	k8s_ops "github.com/portworx/sched-ops/k8s"
 	"github.com/portworx/torpedo/drivers/node"
 	"github.com/portworx/torpedo/drivers/scheduler"
 	kube "github.com/portworx/torpedo/drivers/scheduler/k8s"
+	"github.com/portworx/torpedo/drivers/scheduler/spec"
 )
 
 const (
@@ -54,6 +56,70 @@ func (k *openshift) StartSchedOnNode(n node.Node) error {
 			Cause:         err.Error(),
 		}
 	}
+	return nil
+}
+
+func (k *openshift) Schedule(instanceID string, options scheduler.ScheduleOptions) ([]*scheduler.Context, error) {
+	var apps []*spec.AppSpec
+	if len(options.AppKeys) > 0 {
+		for _, key := range options.AppKeys {
+			spec, err := k.SpecFactory.Get(key)
+			if err != nil {
+				return nil, err
+			}
+			apps = append(apps, spec)
+		}
+	} else {
+		apps = k.SpecFactory.GetAll()
+	}
+
+	var contexts []*scheduler.Context
+	for _, app := range apps {
+
+		appNamespace := app.GetID(instanceID)
+		k8sOps := k8s_ops.Instance()
+
+		// Update security context for namespace and user
+		if err := k.updateSecurityContextConstraints(k8sOps, appNamespace); err != nil {
+			return nil, err
+		}
+
+		specObjects, err := k.CreateSpecObjects(app, appNamespace, options.StorageProvisioner)
+		if err != nil {
+			return nil, err
+		}
+
+		ctx := &scheduler.Context{
+			UID: instanceID,
+			App: &spec.AppSpec{
+				Key:      app.Key,
+				SpecList: specObjects,
+				Enabled:  app.Enabled,
+			},
+		}
+
+		contexts = append(contexts, ctx)
+	}
+
+	return contexts, nil
+}
+
+func (k *openshift) updateSecurityContextConstraints(k8sOps k8s_ops.Ops, namespace string) error {
+	// Get priviledged context
+	context, err := k8sOps.GetSecurityContextConstraints("privileged")
+	if err != nil {
+		return err
+	}
+
+	// Add user and namespace to context
+	context.Users = append(context.Users, "system:serviceaccount:"+namespace+":default")
+
+	// Update context
+	_, err = k8sOps.UpdateSecurityContextConstraints(context)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/drivers/scheduler/openshift/openshift.go
+++ b/drivers/scheduler/openshift/openshift.go
@@ -77,10 +77,9 @@ func (k *openshift) Schedule(instanceID string, options scheduler.ScheduleOption
 	for _, app := range apps {
 
 		appNamespace := app.GetID(instanceID)
-		k8sOps := k8s_ops.Instance()
 
 		// Update security context for namespace and user
-		if err := k.updateSecurityContextConstraints(k8sOps, appNamespace); err != nil {
+		if err := k.updateSecurityContextConstraints(appNamespace); err != nil {
 			return nil, err
 		}
 
@@ -104,9 +103,9 @@ func (k *openshift) Schedule(instanceID string, options scheduler.ScheduleOption
 	return contexts, nil
 }
 
-func (k *openshift) updateSecurityContextConstraints(k8sOps k8s_ops.Ops, namespace string) error {
-	// Get priviledged context
-	context, err := k8sOps.GetSecurityContextConstraints("privileged")
+func (k *openshift) updateSecurityContextConstraints(namespace string) error {
+	// Get privileged context
+	context, err := k8s_ops.Instance().GetSecurityContextConstraints("privileged")
 	if err != nil {
 		return err
 	}
@@ -115,7 +114,7 @@ func (k *openshift) updateSecurityContextConstraints(k8sOps k8s_ops.Ops, namespa
 	context.Users = append(context.Users, "system:serviceaccount:"+namespace+":default")
 
 	// Update context
-	_, err = k8sOps.UpdateSecurityContextConstraints(context)
+	_, err = k8s_ops.Instance().UpdateSecurityContextConstraints(context)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adding Schedule func() to OC driver to be able to use security context constraints APIs to overwrite permissions to allow privileged container creation.

Signed-off-by: nikolaypopov <nikolay.popov86@gmail.com>