### PR TITLE
Validate snapshot in WaitForRunning()

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -1417,12 +1417,11 @@ func (d *portworx) ValidateVolumeSnapshotRestore(vol string, snapshotData *snap_
 			isSuccess = true
 			break
 		}
-		logrus.Infof("Alert received %v", alert.GetMessage())
 	}
 	if isSuccess {
 		return nil
 	}
-	return fmt.Errorf("restore failed")
+	return fmt.Errorf("restore failed, expected alert to be present : %v", grepMsg)
 }
 
 func init() {


### PR DESCRIPTION
Validate snapshot in WaitForRunning(). In case of cloudsnaphshot it takes longer to populate `snapshot.Spec.SnapshotDataName` we should add check whethere snapshot is ready in `WaitForRunning()`
- reduce log verbosity in VolumeSnapshotRestore()