### PR TITLE
Adding missing ignoreErr option for doCmdUsingPod()

### DIFF
--- a/drivers/node/ssh/ssh.go
+++ b/drivers/node/ssh/ssh.go
@@ -405,9 +405,11 @@ func (s *SSH) doCmdUsingPod(n node.Node, options node.ConnectionOpts, cmd string
 
 	t := func() (interface{}, bool, error) {
 		output, err := k8s.Instance().RunCommandInPod(cmds, debugPod.Name, "", debugPod.Namespace)
-		if err != nil {
-			logrus.Errorf("failed to run command in pod: %v err: %v", debugPod, err)
-			return nil, true, err
+		if ignoreErr == false && err != nil {
+			return nil, true, &node.ErrFailedToRunCommand{
+				Addr:  n.UsableAddr,
+				Cause: fmt.Sprintf("failed to run command in pod: %v err: %v", debugPod, err),
+			}
 		}
 
 		return output, false, nil

--- a/drivers/node/ssh/ssh.go
+++ b/drivers/node/ssh/ssh.go
@@ -407,7 +407,7 @@ func (s *SSH) doCmdUsingPod(n node.Node, options node.ConnectionOpts, cmd string
 		output, err := k8s.Instance().RunCommandInPod(cmds, debugPod.Name, "", debugPod.Namespace)
 		if ignoreErr == false && err != nil {
 			return nil, true, &node.ErrFailedToRunCommand{
-				Addr:  n.UsableAddr,
+				Node:  n,
 				Cause: fmt.Sprintf("failed to run command in pod: %v err: %v", debugPod, err),
 			}
 		}


### PR DESCRIPTION
Adding missing ignoreErr option for doCmdUsingPod() incase we expecting command to fail like we do in validateCleanup() when it should fail if no pod resources were found after delete.

Signed-off-by: nikolaypopov <nikolay.popov86@gmail.com>