### PR TITLE
PTX-1773 On EKS run torpedo where there is no PX

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -135,6 +135,12 @@ if [ -n "${K8S_VENDOR}" ]; then
             K8S_VENDOR_OPERATOR="In"
             K8S_VENDOR_VALUE='values: ["false"]'
             ;;
+        eks)
+            # Run torpedo on worker node, where px installation is disabled.
+            K8S_VENDOR_KEY=px/enabled
+            K8S_VENDOR_OPERATOR="In"
+            K8S_VENDOR_VALUE='values: ["false"]'
+            ;;
     esac
 else
     K8S_VENDOR_KEY=node-role.kubernetes.io/master


### PR DESCRIPTION
EKS does not deploy a master node which is visible to
us, so we need to run torpedo on a node where PX is not scheduled to
run.