### PR TITLE
Check if config map is empty before retrieving secrets.

### DIFF
--- a/tests/common.go
+++ b/tests/common.go
@@ -95,10 +95,14 @@ func InitInstance() {
 	err = Inst().S.Init(Inst().SpecDir, Inst().V.String(), Inst().N.String())
 	expect(err).NotTo(haveOccurred())
 
-	logrus.Infof("Using Config Map: %s ", Inst().ConfigMap)
-	token, err = Inst().S.GetTokenFromConfigMap(Inst().ConfigMap)
-	expect(err).NotTo(haveOccurred())
-	logrus.Infof("Token used for initializing: %s ", token)
+	if Inst().ConfigMap != "" {
+		logrus.Infof("Using Config Map: %s ", Inst().ConfigMap)
+		token, err = Inst().S.GetTokenFromConfigMap(Inst().ConfigMap)
+		expect(err).NotTo(haveOccurred())
+		logrus.Infof("Token used for initializing: %s ", token)
+	} else {
+		token = ""
+	}
 	err = Inst().V.Init(Inst().S.String(), Inst().N.String(), token, Inst().Provisioner)
 	expect(err).NotTo(haveOccurred())
 


### PR DESCRIPTION
Why do we need this PR?
If config map is not being created in the job, retrieving secrets should skipped.

Failed here:
https://jenkins.portworx.co/job/Torpedo/view/Torpedo%202.2/job/tp-2-2-sysbench/68/console

Signed-off-by: Rohit-PX <rohit@portworx.com>