### PR TITLE
PTX-1886 Remove in-line snapshots from mysql spec

### DIFF
--- a/drivers/scheduler/k8s/specs/mysql/px-mysql-snapshot-clones.yaml
+++ b/drivers/scheduler/k8s/specs/mysql/px-mysql-snapshot-clones.yaml
@@ -1,18 +1,3 @@
-##### Portworx PVC clone from snapshot
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-   name: ns.{{NAMESPACE}}-name.mysql-snap-clone
-   annotations:
-    px/snapshot-source-pvc: ns.{{NAMESPACE}}-name.mysql-snapshot
-spec:
-   storageClassName: px-mysql-sc
-   accessModes:
-     - ReadWriteOnce
-   resources:
-     requests:
-       storage: 2Gi
----
 ##### Portworx PVC clone from VolumeSnapshot using Stork
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/drivers/scheduler/k8s/specs/mysql/px-mysql-snapshots.yaml
+++ b/drivers/scheduler/k8s/specs/mysql/px-mysql-snapshots.yaml
@@ -1,18 +1,3 @@
-##### Portworx PVC Snapshot
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: ns.{{NAMESPACE}}-name.mysql-snapshot
-  annotations:
-    px/snapshot-source-pvc: mysql-data
-spec:
-   storageClassName: px-mysql-sc
-   accessModes:
-     - ReadWriteOnce
-   resources:
-     requests:
-       storage: 2Gi
----
 ##### Portworx Stork Snapshot
 apiVersion: volumesnapshot.external-storage.k8s.io/v1
 kind: VolumeSnapshot


### PR DESCRIPTION
Remove in-line snapshots from mysql spec, since we don't use it like that anymore. We use stork now.

Signed-off-by: nikolaypopov <nikolay.popov86@gmail.com>