### PR TITLE
PTX-1930 Added ability to run one test suite

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -80,6 +80,21 @@ if [ -z "$STORAGENODE_RECOVERY_TIMEOUT" ]; then
     echo "Using default storage node recovery timeout of ${STORAGENODE_RECOVERY_TIMEOUT}"
 fi
 
+if [ -z "$TEST_SUITE" ]; then
+    TEST_SUITE='"bin/asg.test",
+            "bin/autopilot-capacity.test",
+            "bin/basic.test",
+            "bin/reboot.test",
+            "bin/upgrade.test",
+            "bin/drive_failure.test",
+            "bin/volume_ops.test",
+            "bin/sched.test",
+            "bin/node_decommission.test",'
+else
+  TEST_SUITE=$(echo \"$TEST_SUITE\" | sed "s/,/\",\n\"/g")","
+fi
+echo "Using list of test suite(s): ${TEST_SUITE}"
+
 
 kubectl delete pod torpedo
 state=`kubectl get pod torpedo | grep -v NAME | awk '{print $3}'`
@@ -241,15 +256,7 @@ spec:
             "$VERBOSE",
             "$FOCUS_ARG",
             "$SKIP_ARG",
-            "bin/asg.test",
-            "bin/autopilot-capacity.test",
-            "bin/basic.test",
-            "bin/reboot.test",
-            "bin/upgrade.test",
-            "bin/drive_failure.test",
-            "bin/volume_ops.test",
-            "bin/sched.test",
-            "bin/node_decommission.test",
+            $TEST_SUITE
             "--",
             "--spec-dir", "../drivers/scheduler/k8s/specs",
             "--app-list", "$APP_LIST",


### PR DESCRIPTION
These changes will let you run Torpedo with one or more test suites. Now Torpedo framework will accept comma separated string TEST_SUITE variable which defines which test suite will be run.
For instance:
 TEST_SUITE=bin/basic.test or
 TEST_SUITE=bin/basic.test,bin/reboot.test

If you don't define this variable it will run all tests.

Tested with next following parameters:
FOCUS_TESTS=SetupTeardown -e SCALE_FACTOR=1 -e TEST_SUITE=bin/basic.test -e FAIL_FAST=true
Ginkgo ran 1 suite in 5m55.981106111s
Test Suite Passed

FOCUS_TESTS=SetupTeardown -e SCALE_FACTOR=1 -e TEST_SUITE=bin/basic.test,bin/reboot.test -e FAIL_FAST=true
Ginkgo ran 2 suites in 1m3.671989904s
Test Suite Passed

FOCUS_TESTS=SetupTeardown -e SCALE_FACTOR=1 -e FAIL_FAST=true
Ginkgo ran 9 suites in 1m21.002268159s
Test Suite Passed