### PR TITLE
Add IO load to elastic-search application

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ SIDECAR_WP_CLI_IMG=$(DOCKER_HUB_REPO)/wp-cli:$(SIDECAR_WP_CLI_DOCKER_TAG)
 SIDECAR_DIR=drivers/scheduler/sidecars
 SYSBENCH_IMG=$(DOCKER_HUB_REPO)/torpedo-sysbench:latest
 PGBENCH_IMG=$(DOCKER_HUB_REPO)/torpedo-pgbench:latest
+ESLOAD_IMG=$(DOCKER_HUB_REPO)/torpedo-esload:latest
 
 all: vet lint build fmt
 
@@ -110,3 +111,8 @@ sysbench:
 pgbench:
 	docker build -t $(PGBENCH_IMG) -f $(SIDECAR_DIR)/pgbench.dockerfile $(SIDECAR_DIR)
 	docker push $(PGBENCH_IMG)
+
+esload:
+	docker build -t $(ESLOAD_IMG) $(SIDECAR_DIR)/es-stress-test
+	docker push $(ESLOAD_IMG)
+

--- a/drivers/scheduler/k8s/specs/elasticsearch/px-elasticdata-app.yaml
+++ b/drivers/scheduler/k8s/specs/elasticsearch/px-elasticdata-app.yaml
@@ -14,15 +14,14 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: elasticsearch-loadbalancer
+  name: elasticsearch-api
 spec:
   selector:
     app: es-cluster
   ports:
   - name: http
-    port: 80
+    port: 9200
     targetPort: 9200
-  type: LoadBalancer
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -44,7 +43,7 @@ kind: StatefulSet
 metadata:
   name: esnode
 spec:
-  serviceName: elasticsearch
+  serviceName: elasticsearch-api
   replicas: 3
   selector:
     matchLabels:
@@ -119,3 +118,35 @@ spec:
       resources:
         requests:
           storage: 5Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: es-load
+  namespace: default
+  labels:
+    app: es-load
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: es-load
+  template:
+    metadata:
+      labels:
+        app: es-load
+    spec:
+      containers:
+      - name: es-load
+        image: portworx/torpedo-esload
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        command:
+          - /bin/bash
+          - -c
+          - "while true; do echo '=========='; python elasticsearch-stress-test.py --es_address esnode-0.elasticsearch-api.$POD_NAMESPACE.svc.cluster.local:9200 --indices 4 --documents 5 --seconds 120 --not-green --clients 1; sleep 5; done"
+      restartPolicy: Always
+

--- a/drivers/scheduler/sidecars/es-stress-test/Dockerfile
+++ b/drivers/scheduler/sidecars/es-stress-test/Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine/git AS downloader
+
+RUN cd /tmp && git clone https://github.com/logzio/elasticsearch-stress-test.git
+
+FROM python:2
+
+WORKDIR /usr/src/elasticsearch-stress-test
+
+COPY --from=downloader /tmp/elasticsearch-stress-test/elasticsearch-stress-test.py ./
+COPY --from=downloader /tmp/elasticsearch-stress-test/requirements.txt ./
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+ENTRYPOINT [ "./elasticsearch-stress-test.py" ]
+

--- a/drivers/scheduler/sidecars/es-stress-test/README.md
+++ b/drivers/scheduler/sidecars/es-stress-test/README.md
@@ -1,0 +1,3 @@
+# Elasticsearch Stress Test
+
+source: https://github.com/logzio/elasticsearch-stress-test


### PR DESCRIPTION
Use the [elastic-stress-test](https://github.com/logzio/elasticsearch-stress-test) tool to generate a load for the es cluster.