### PR TITLE
Set ConfigMap name when initializing volume driver.

### DIFF
--- a/drivers/scheduler/dcos/dcos.go
+++ b/drivers/scheduler/dcos/dcos.go
@@ -32,7 +32,7 @@ type dcos struct {
 	volDriverName string
 }
 
-func (d *dcos) Init(specDir, volDriver, nodeDriver string) error {
+func (d *dcos) Init(specDir, volDriver, nodeDriver, secretConfigMap string) error {
 	privateAgents, err := MesosClient().GetPrivateAgentNodes()
 	if err != nil {
 		return err

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -85,9 +85,10 @@ var (
 
 //K8s  The kubernetes structure
 type K8s struct {
-	SpecFactory    *spec.Factory
-	NodeDriverName string
-	VolDriverName  string
+	SpecFactory         *spec.Factory
+	NodeDriverName      string
+	VolDriverName       string
+	secretConfigMapName string
 }
 
 //IsNodeReady  Check whether the cluster node is ready
@@ -116,7 +117,7 @@ func (k *K8s) String() string {
 }
 
 //Init Initialize the driver
-func (k *K8s) Init(specDir, volDriverName, nodeDriverName string) error {
+func (k *K8s) Init(specDir, volDriverName, nodeDriverName, secretConfigMap string) error {
 	nodes, err := k8s_ops.Instance().GetNodes()
 	if err != nil {
 		return err
@@ -139,6 +140,8 @@ func (k *K8s) Init(specDir, volDriverName, nodeDriverName string) error {
 
 	k.NodeDriverName = nodeDriverName
 	k.VolDriverName = volDriverName
+
+	k.secretConfigMapName = secretConfigMap
 	return nil
 }
 
@@ -574,7 +577,7 @@ func (k *K8s) createStorageObject(spec interface{}, ns *v1.Namespace, app *spec.
 	k8sOps := k8s_ops.Instance()
 
 	// Add security annotations if running with auth-enabled
-	configMapName := options.ConfigMap
+	configMapName := k.secretConfigMapName
 	if configMapName != "" {
 		configMap, err := k8sOps.GetConfigMap(configMapName, "default")
 		if err != nil {
@@ -823,7 +826,7 @@ func (k *K8s) createCoreObject(spec interface{}, ns *v1.Namespace, app *spec.App
 
 	} else if obj, ok := spec.(*apps_api.StatefulSet); ok {
 		// Add security annotations if running with auth-enabled
-		configMapName := options.ConfigMap
+		configMapName := k.secretConfigMapName
 		if configMapName != "" {
 			configMap, err := k8sOps.GetConfigMap(configMapName, "default")
 			if err != nil {

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -102,7 +102,7 @@ type Driver interface {
 	spec.Parser
 
 	// Init initializes the scheduler driver
-	Init(string, string, string) error
+	Init(string, string, string, string) error
 
 	// String returns the string name of this driver.
 	String() string

--- a/tests/common.go
+++ b/tests/common.go
@@ -90,9 +90,6 @@ var (
 func InitInstance() {
 	var err error
 	var token string
-	err = Inst().S.Init(Inst().SpecDir, Inst().V.String(), Inst().N.String())
-	expect(err).NotTo(haveOccurred())
-
 	if Inst().ConfigMap != "" {
 		logrus.Infof("Using Config Map: %s ", Inst().ConfigMap)
 		token, err = Inst().S.GetTokenFromConfigMap(Inst().ConfigMap)
@@ -101,6 +98,10 @@ func InitInstance() {
 	} else {
 		token = ""
 	}
+
+	err = Inst().S.Init(Inst().SpecDir, Inst().V.String(), Inst().N.String(), Inst().ConfigMap)
+	expect(err).NotTo(haveOccurred())
+
 	err = Inst().V.Init(Inst().S.String(), Inst().N.String(), token, Inst().Provisioner)
 	expect(err).NotTo(haveOccurred())
 
@@ -235,7 +236,6 @@ func ScheduleAndValidate(testname string) []*scheduler.Context {
 		contexts, err = Inst().S.Schedule(taskName, scheduler.ScheduleOptions{
 			AppKeys:            Inst().AppList,
 			StorageProvisioner: Inst().Provisioner,
-			ConfigMap:          Inst().ConfigMap,
 		})
 		expect(err).NotTo(haveOccurred())
 		expect(contexts).NotTo(beEmpty())


### PR DESCRIPTION
Why do we need this PR?
* Currently, we are passing the config map name as part of `options` params to the `Schedule` method. 
* Instead we will now set the config map name when initializing the `Scheduler` driver.
* That way when using the Schedule method from torpedo, config map name need not be passed and will be retrieved from the Scheduler driver.


Signed-off-by: Rohit-PX <rohit@portworx.com>