### PR TITLE
fix nginx sharedv4 to use a different name

### DIFF
--- a/drivers/scheduler/k8s/specs/nginx-sharedv4/px-nginx-storage.yaml
+++ b/drivers/scheduler/k8s/specs/nginx-sharedv4/px-nginx-storage.yaml
@@ -10,7 +10,7 @@ data:
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-  name: px-nginx-sc
+  name: px-nginx-sc-v4
 provisioner: kubernetes.io/portworx-volume
 parameters:
   repl: "3"
@@ -23,7 +23,7 @@ apiVersion: v1
 metadata:
   name: px-nginx-pvc
 spec:
-  storageClassName: px-nginx-sc
+  storageClassName: px-nginx-sc-v4
   accessModes:
     - ReadWriteMany
   resources:
@@ -40,7 +40,7 @@ metadata:
     px/secret-key: nginx-secret
     px/secure: "true"
 spec:
-  storageClassName: px-nginx-sc
+  storageClassName: px-nginx-sc-v4
   accessModes:
   - ReadWriteMany
   resources:


### PR DESCRIPTION
to avoid conflicting nginx sharedv4 storageclass to regular nginx shared storageclass