### PR TITLE
Fix for TearDownContext

### DIFF
--- a/tests/autopilot-capacity/aut_test.go
+++ b/tests/autopilot-capacity/aut_test.go
@@ -125,11 +125,11 @@ var _ = BeforeSuite(func() {
 // PVC sizes of the volumes
 var _ = Describe(fmt.Sprintf("{%sWaitForWorkload}", testNameSuite), func() {
 	It("has to fill up the volume completely, resize the volume, validate and teardown apps", func() {
-		var contexts []*scheduler.Context
 		var err error
 		testName := strings.ToLower(fmt.Sprintf("%sWaitForWorkload", testNameSuite))
 
 		for _, apRule := range autopilotruleBasicTestCases {
+			var contexts []*scheduler.Context
 			apParameters := &scheduler.AutopilotParameters{
 				Enabled:                 true,
 				Name:                    testName,
@@ -182,8 +182,6 @@ var _ = Describe(fmt.Sprintf("{%sWaitForWorkload}", testNameSuite), func() {
 					TearDownContext(ctx, opts)
 				}
 			})
-
-			contexts = nil
 		}
 	})
 })
@@ -193,11 +191,11 @@ var _ = Describe(fmt.Sprintf("{%sWaitForWorkload}", testNameSuite), func() {
 // validates PVC sizes of the volumes
 var _ = Describe(fmt.Sprintf("{%sDoesNotWaitForWorkload}", testNameSuite), func() {
 	It("will resize the volume until the max size of the volume", func() {
-		var contexts []*scheduler.Context
 		var err error
 		testName := strings.ToLower(fmt.Sprintf("%sDoesNotWaitForWorkload", testNameSuite))
 
 		for _, apRule := range autopilotruleScaleTestCases {
+			var contexts []*scheduler.Context
 			apParameters := &scheduler.AutopilotParameters{
 				Enabled:                 true,
 				Name:                    testName,
@@ -252,11 +250,11 @@ var _ = Describe(fmt.Sprintf("{%sDoesNotWaitForWorkload}", testNameSuite), func(
 // driver and validates PVC sizes of the volumes
 var _ = Describe(fmt.Sprintf("{%sVolumeDriverDown}", testNameSuite), func() {
 	It("has to fill up the volume completely, resize the volume, validate and teardown apps", func() {
-		var contexts []*scheduler.Context
 		var err error
 		testName := strings.ToLower(fmt.Sprintf("%sVolumeDriverDown", testNameSuite))
 
 		for _, apRule := range autopilotruleBasicTestCases {
+			var contexts []*scheduler.Context
 			apParameters := &scheduler.AutopilotParameters{
 				Enabled:                 true,
 				Name:                    testName,


### PR DESCRIPTION
In case of running multiple scenarios, context will never be reset.