### PR TITLE
Add security annotations for group volume snaps.

### DIFF
--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -798,6 +798,12 @@ func (k *K8s) addSecurityAnnotation(spec interface{}, configMap *v1.ConfigMap) e
 		}
 		obj.Annotations[secretName] = configMap.Data[secretNameKey]
 		obj.Annotations[secretNamespace] = configMap.Data[secretNamespaceKey]
+	} else if obj, ok := spec.(*stork_api.GroupVolumeSnapshot); ok {
+		if obj.Annotations == nil {
+			obj.Annotations = make(map[string]string)
+		}
+		obj.Annotations[secretName] = configMap.Data[secretNameKey]
+		obj.Annotations[secretNamespace] = configMap.Data[secretNamespaceKey]
 	}
 	return nil
 }


### PR DESCRIPTION
Why do we need this PR?
Annotation required for auth runs are not being added currently for `GroupVolumeSnapshots`

Signed-off-by: Rohit-PX <rohit@portworx.com>