### PR TITLE
Increased initialDelaySeconds for sysbench

### DIFF
--- a/drivers/scheduler/k8s/specs/sysbench/px-sysbench-app.yml
+++ b/drivers/scheduler/k8s/specs/sysbench/px-sysbench-app.yml
@@ -33,7 +33,7 @@ spec:
           livenessProbe:
             exec:
               command: ["sh", "-c", "mysqladmin -u root -p$MYSQL_ROOT_PASSWORD ping"]
-            initialDelaySeconds: 70
+            initialDelaySeconds: 120
             periodSeconds: 10
             timeoutSeconds: 5
           readinessProbe:


### PR DESCRIPTION
It should help to fix the issue when mysql database initialization is not completed and pod restarts which causing **Access denied for user 'root'@'localhost' (using password: YES).**