### PR TITLE
Fixed color output

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -88,8 +88,6 @@ func (hook *Hook) Fire(entry *logrus.Entry) error {
 			entry.Message = green(entry.Message)
 		} else if errorMessage(entry.Message) {
 			entry.Message = red(entry.Message)
-		} else {
-			entry.Message = yellow(entry.Message)
 		}
 	}
 

--- a/tests/common.go
+++ b/tests/common.go
@@ -468,6 +468,7 @@ func ParseFlags() {
 		logrus.Fatalf("Failed to set log level due to Err: %v", err)
 	}
 	logrus.SetLevel(logLvl)
+
 }
 
 func splitCsv(in string) ([]string, error) {
@@ -485,5 +486,5 @@ func splitCsv(in string) ([]string, error) {
 func init() {
 	logrus.SetLevel(logrus.InfoLevel)
 	logrus.StandardLogger().Hooks.Add(log.NewHook())
-	logrus.SetOutput(ginkgo.GinkgoWriter)
+	logrus.SetOutput(os.Stdout)
 }


### PR DESCRIPTION
Now instead of printing ANSI escape codes
time="2019-11-18 22:31:21" level=debug msg="\x1b[31mCommand: sudo systemctl start portworx.service errors: \x1b[0m"
it will print colorized lines
10:41:19 DEBU[2019-12-17 18:41:19] Command: sudo systemctl start portworx.service errors: 