### PR TITLE
PTX-2123 [openshift] nginx-sharedv4 is failing with permission denined

### DIFF
--- a/drivers/scheduler/k8s/specs/nginx-sharedv4/px-nginx-app.yaml
+++ b/drivers/scheduler/k8s/specs/nginx-sharedv4/px-nginx-app.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx
+        image: bitnami/nginx
         ports:
         - containerPort: 80
         volumeMounts:


### PR DESCRIPTION
bitnami image used to run nginx on openshift