### PR TITLE
support to custom app parameters

### DIFF
--- a/drivers/scheduler/dcos/dcos.go
+++ b/drivers/scheduler/dcos/dcos.go
@@ -32,7 +32,7 @@ type dcos struct {
 	volDriverName string
 }
 
-func (d *dcos) Init(specDir, volDriver, nodeDriver, secretConfigMap string) error {
+func (d *dcos) Init(schedOpts scheduler.InitOptions) error {
 	privateAgents, err := MesosClient().GetPrivateAgentNodes()
 	if err != nil {
 		return err
@@ -48,7 +48,7 @@ func (d *dcos) Init(specDir, volDriver, nodeDriver, secretConfigMap string) erro
 		}
 	}
 
-	d.specFactory, err = spec.NewFactory(specDir, d)
+	d.specFactory, err = spec.NewFactory(schedOpts.SpecDir, d)
 	if err != nil {
 		return err
 	}
@@ -58,7 +58,7 @@ func (d *dcos) Init(specDir, volDriver, nodeDriver, secretConfigMap string) erro
 		return err
 	}
 
-	d.volDriverName = volDriver
+	d.volDriverName = schedOpts.VolDriverName
 	return nil
 }
 

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -5,12 +5,14 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
+	"text/template"
 	"time"
 
 	snapv1 "github.com/kubernetes-incubator/external-storage/snapshot/pkg/apis/crd/v1"
@@ -80,7 +82,8 @@ const (
 )
 
 var (
-	namespaceRegex = regexp.MustCompile("{{NAMESPACE}}")
+	// use underscore to avoid conflicts to text/template from golang
+	namespaceRegex = regexp.MustCompile("_NAMESPACE_")
 )
 
 //K8s  The kubernetes structure
@@ -89,6 +92,7 @@ type K8s struct {
 	NodeDriverName      string
 	VolDriverName       string
 	secretConfigMapName string
+	customConfig        map[string]*scheduler.AppConfig
 }
 
 //IsNodeReady  Check whether the cluster node is ready
@@ -117,7 +121,7 @@ func (k *K8s) String() string {
 }
 
 //Init Initialize the driver
-func (k *K8s) Init(specDir, volDriverName, nodeDriverName, secretConfigMap string) error {
+func (k *K8s) Init(schedOpts scheduler.InitOptions) error {
 	nodes, err := k8sops.Instance().GetNodes()
 	if err != nil {
 		return err
@@ -129,15 +133,16 @@ func (k *K8s) Init(specDir, volDriverName, nodeDriverName, secretConfigMap strin
 		}
 	}
 
-	k.SpecFactory, err = spec.NewFactory(specDir, k)
+	k.SpecFactory, err = spec.NewFactory(schedOpts.SpecDir, k)
 	if err != nil {
 		return err
 	}
 
-	k.NodeDriverName = nodeDriverName
-	k.VolDriverName = volDriverName
+	k.NodeDriverName = schedOpts.NodeDriverName
+	k.VolDriverName = schedOpts.VolDriverName
 
-	k.secretConfigMapName = secretConfigMap
+	k.secretConfigMapName = schedOpts.SecretConfigMapName
+	k.customConfig = schedOpts.CustomAppConfig
 	return nil
 }
 
@@ -199,14 +204,36 @@ func (k *K8s) ParseSpecs(specDir string) ([]interface{}, error) {
 
 	var specs []interface{}
 
+	splitPath := strings.Split(specDir, "/")
+	appName := ""
+	if len(splitPath) > 0 {
+		appName = splitPath[len(splitPath)-1]
+	}
+
 	for _, fileName := range fileList {
-		file, err := os.Open(fileName)
+		file, err := ioutil.ReadFile(fileName)
 		if err != nil {
 			return nil, err
 		}
-		defer file.Close()
 
-		reader := bufio.NewReader(file)
+		var customConfig *scheduler.AppConfig
+		var ok bool
+
+		if customConfig, ok = k.customConfig[appName]; !ok {
+			customConfig = &scheduler.AppConfig{}
+		}
+
+		tmpl, err := template.New("customConfig").Parse(string(file))
+		if err != nil {
+			return nil, err
+		}
+		var processedFile bytes.Buffer
+		err = tmpl.Execute(&processedFile, customConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		reader := bufio.NewReader(&processedFile)
 		specReader := yaml.NewYAMLReader(reader)
 
 		for {

--- a/drivers/scheduler/k8s/specs/mysql/px-mysql-storage.yaml
+++ b/drivers/scheduler/k8s/specs/mysql/px-mysql-storage.yaml
@@ -60,7 +60,7 @@ metadata:
   name: mysql-data
   annotations:
     px/secret-name: volume-secrets
-    px/secret-namespace: "{{NAMESPACE}}"
+    px/secret-namespace: "_NAMESPACE_"
     px/secret-key: mysql-secret
     volume.beta.kubernetes.io/storage-class: px-mysql-sc
 spec:

--- a/drivers/scheduler/k8s/specs/nginx-sharedv4/px-nginx-app.yaml
+++ b/drivers/scheduler/k8s/specs/nginx-sharedv4/px-nginx-app.yaml
@@ -16,7 +16,10 @@ kind: Deployment
 metadata:
   name: nginx
 spec:
-  replicas: 3
+  {{ if .Replicas }}
+  replicas: {{ .Replicas }}
+  {{ else }}
+  replicas: 3{{ end }}
   selector:
     matchLabels:
       app: nginx

--- a/drivers/scheduler/k8s/specs/nginx-sharedv4/px-nginx-storage.yaml
+++ b/drivers/scheduler/k8s/specs/nginx-sharedv4/px-nginx-storage.yaml
@@ -36,7 +36,7 @@ metadata:
   name: px-nginx-pvc-enc
   annotations:
     px/secret-name: volume-secrets
-    px/secret-namespace: "{{NAMESPACE}}"
+    px/secret-namespace: "_NAMESPACE_"
     px/secret-key: nginx-secret
     px/secure: "true"
 spec:

--- a/drivers/scheduler/k8s/specs/nginx/px-nginx-storage.yaml
+++ b/drivers/scheduler/k8s/specs/nginx/px-nginx-storage.yaml
@@ -36,7 +36,7 @@ metadata:
   name: px-nginx-pvc-enc
   annotations:
     px/secret-name: volume-secrets
-    px/secret-namespace: "{{NAMESPACE}}"
+    px/secret-namespace: "_NAMESPACE_"
     px/secret-key: nginx-secret
     px/secure: "true"
 spec:

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -109,7 +109,7 @@ type InitOptions struct {
 	// ConfigMap  identifies what config map should be used to
 	SecretConfigMapName string
 	// CustomAppConfig custom settings for apps
-	CustomAppConfig map[string]*AppConfig
+	CustomAppConfig map[string]AppConfig
 }
 
 // ScheduleOptions are options that callers to pass to influence the apps that get schduled

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -91,6 +91,27 @@ type AutopilotParameters struct {
 	AutopilotRuleParameters AutopilotRuleParameters
 }
 
+// AppConfig custom settings
+type AppConfig struct {
+	Replicas   int    `yaml:"replicas"`
+	VolumeSize string `yaml:"volume_size"`
+}
+
+// InitOptions initialization options
+type InitOptions struct {
+
+	// SpecDir app spec directory
+	SpecDir string
+	// VolDriverName volume driver name
+	VolDriverName string
+	// NodeDriverName node driver name
+	NodeDriverName string
+	// ConfigMap  identifies what config map should be used to
+	SecretConfigMapName string
+	// CustomAppConfig custom settings for apps
+	CustomAppConfig map[string]*AppConfig
+}
+
 // ScheduleOptions are options that callers to pass to influence the apps that get schduled
 type ScheduleOptions struct {
 	// AppKeys identified a list of applications keys that users wants to schedule (Optional)
@@ -110,7 +131,7 @@ type Driver interface {
 	spec.Parser
 
 	// Init initializes the scheduler driver
-	Init(string, string, string, string) error
+	Init(schedOpts InitOptions) error
 
 	// String returns the string name of this driver.
 	String() string

--- a/drivers/scheduler/spec/factory.go
+++ b/drivers/scheduler/spec/factory.go
@@ -71,9 +71,10 @@ func NewFactory(specDir string, parser Parser) (*Factory, error) {
 		if file.IsDir() {
 			specID := file.Name()
 
-			logrus.Infof("Parsing: %v...", path.Join(f.specDir, specID))
+			specToParse := path.Join(f.specDir, specID)
+			logrus.Infof("Parsing: %v...", specToParse)
 
-			specs, err := f.specParser.ParseSpecs(path.Join(f.specDir, file.Name()))
+			specs, err := f.specParser.ParseSpecs(specToParse)
 			if err != nil {
 				return nil, err
 			}

--- a/tests/common.go
+++ b/tests/common.go
@@ -4,6 +4,7 @@ import (
 	"encoding/csv"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"strings"
 	"sync"
@@ -32,6 +33,8 @@ import (
 	// import portworx driver to invoke it's init
 	_ "github.com/portworx/torpedo/drivers/volume/portworx"
 	"github.com/portworx/torpedo/pkg/log"
+
+	yaml "gopkg.in/yaml.v2"
 )
 
 const (
@@ -100,7 +103,13 @@ func InitInstance() {
 		token = ""
 	}
 
-	err = Inst().S.Init(Inst().SpecDir, Inst().V.String(), Inst().N.String(), Inst().ConfigMap)
+	err = Inst().S.Init(scheduler.InitOptions{
+		SpecDir:             Inst().SpecDir,
+		VolDriverName:       Inst().V.String(),
+		NodeDriverName:      Inst().N.String(),
+		SecretConfigMapName: Inst().ConfigMap,
+		CustomAppConfig:     Inst().CustomAppConfig,
+	})
 	expect(err).NotTo(haveOccurred())
 
 	err = Inst().V.Init(Inst().S.String(), Inst().N.String(), token, Inst().Provisioner)
@@ -470,6 +479,7 @@ type Torpedo struct {
 	AutoStorageNodeRecoveryTimeout      time.Duration
 	ConfigMap                           string
 	BundleLocation                      string
+	CustomAppConfig                     map[string]*scheduler.AppConfig
 }
 
 // ParseFlags parses command line flags
@@ -489,6 +499,7 @@ func ParseFlags() {
 	var driverStartTimeout time.Duration
 	var autoStorageNodeRecoveryTimeout time.Duration
 	var bundleLocation string
+	var customConfigPath string
 
 	flag.StringVar(&s, schedulerCliFlag, defaultScheduler, "Name of the scheduler to use")
 	flag.StringVar(&n, nodeDriverCliFlag, defaultNodeDriver, "Name of the node driver to use")
@@ -512,6 +523,7 @@ func ParseFlags() {
 	flag.DurationVar(&autoStorageNodeRecoveryTimeout, "storagenode-recovery-timeout", defaultAutoStorageNodeRecoveryTimeout, "Maximum wait time in minutes for storageless nodes to transition to storagenodes in case of ASG")
 	flag.StringVar(&configMapName, configMapFlag, "", "Name of the config map to be used.")
 	flag.StringVar(&bundleLocation, "bundle-location", defaultBundleLocation, "Path to support bundle output files")
+	flag.StringVar(&customConfigPath, "custom-config", "", "Path to custom configuration files")
 
 	flag.Parse()
 
@@ -526,9 +538,21 @@ func ParseFlags() {
 		logrus.Fatalf("Cannot find volume driver for %v. Err: %v\n", v, err)
 	} else if nodeDriver, err = node.Get(n); err != nil {
 		logrus.Fatalf("Cannot find node driver for %v. Err: %v\n", n, err)
-	} else if err := os.MkdirAll(logLoc, os.ModeDir); err != nil {
+	} else if err = os.MkdirAll(logLoc, os.ModeDir); err != nil {
 		logrus.Fatalf("Cannot create path %s for saving support bundle. Error: %v", logLoc, err)
 	} else {
+		configs := make(map[string]*scheduler.AppConfig)
+		if _, err = os.Stat(customConfigPath); err == nil {
+			var data []byte
+			data, err = ioutil.ReadFile(customConfigPath)
+			if err != nil {
+				logrus.Fatalf("Cannot read file %s. Error: %v", customConfigPath, err)
+			}
+			err = yaml.Unmarshal(data, &configs)
+			if err != nil {
+				logrus.Fatalf("Cannot unmarshal yml %s. Error: %v", customConfigPath, err)
+			}
+		}
 		once.Do(func() {
 			instance = &Torpedo{
 				InstanceID:                          time.Now().Format("01-02-15h04m05s"),
@@ -551,6 +575,7 @@ func ParseFlags() {
 				AutoStorageNodeRecoveryTimeout:      autoStorageNodeRecoveryTimeout,
 				ConfigMap:                           configMapName,
 				BundleLocation:                      bundleLocation,
+				CustomAppConfig:                     configs,
 			}
 		})
 	}

--- a/tests/common.go
+++ b/tests/common.go
@@ -479,7 +479,7 @@ type Torpedo struct {
 	AutoStorageNodeRecoveryTimeout      time.Duration
 	ConfigMap                           string
 	BundleLocation                      string
-	CustomAppConfig                     map[string]*scheduler.AppConfig
+	CustomAppConfig                     map[string]scheduler.AppConfig
 }
 
 // ParseFlags parses command line flags
@@ -500,6 +500,7 @@ func ParseFlags() {
 	var autoStorageNodeRecoveryTimeout time.Duration
 	var bundleLocation string
 	var customConfigPath string
+	var customAppConfig map[string]scheduler.AppConfig
 
 	flag.StringVar(&s, schedulerCliFlag, defaultScheduler, "Name of the scheduler to use")
 	flag.StringVar(&n, nodeDriverCliFlag, defaultNodeDriver, "Name of the node driver to use")
@@ -541,17 +542,19 @@ func ParseFlags() {
 	} else if err = os.MkdirAll(logLoc, os.ModeDir); err != nil {
 		logrus.Fatalf("Cannot create path %s for saving support bundle. Error: %v", logLoc, err)
 	} else {
-		configs := make(map[string]*scheduler.AppConfig)
 		if _, err = os.Stat(customConfigPath); err == nil {
 			var data []byte
+
+			logrus.Infof("Using custom app config file %s", customConfigPath)
 			data, err = ioutil.ReadFile(customConfigPath)
 			if err != nil {
 				logrus.Fatalf("Cannot read file %s. Error: %v", customConfigPath, err)
 			}
-			err = yaml.Unmarshal(data, &configs)
+			err = yaml.Unmarshal(data, &customAppConfig)
 			if err != nil {
 				logrus.Fatalf("Cannot unmarshal yml %s. Error: %v", customConfigPath, err)
 			}
+			logrus.Infof("Parsed custom app config file: %+v", customAppConfig)
 		}
 		once.Do(func() {
 			instance = &Torpedo{
@@ -575,7 +578,7 @@ func ParseFlags() {
 				AutoStorageNodeRecoveryTimeout:      autoStorageNodeRecoveryTimeout,
 				ConfigMap:                           configMapName,
 				BundleLocation:                      bundleLocation,
-				CustomAppConfig:                     configs,
+				CustomAppConfig:                     customAppConfig,
 			}
 		})
 	}


### PR DESCRIPTION
this PR fixes PTX-1878  and required by PTX-1714

it adds a new parameter `custom-config` which takes a custom yml config file. expected format
```
<appId>:
   replicas: <repliicas>
   volume_size: <volume_size>
   ... <any new custom parameter which might be added in the future>
```
i.e
```yaml
nginx-sharedv4:
   replicas: 24
```

in `drivers/scheduler/scheduler.go` we have the following structure
```go
// AppConfig custom settings
type AppConfig struct {
	Replicas   int    `yaml:"replicas"`
	VolumeSize string `yaml:"volume_size"`
}
```

in specs we use text/template notation
i.e
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx
spec:
  replicas: {{ .Replicas }}
```

with this PR we can also use conditionals, loops and other features available in go `text/template`

i.e for default value 
``` yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx
spec:
  {{ if .Replicas }}
  replicas: {{ .Replicas }}
  {{ else }}
  replicas: 3{{ end }}
```