### PR TITLE
PTX-1641 Fix Init() methods for aks and gke drivers

### DIFF
--- a/drivers/node/aks/aks.go
+++ b/drivers/node/aks/aks.go
@@ -29,6 +29,7 @@ func (a *aks) String() string {
 }
 
 func (a *aks) Init() error {
+	a.SSH.Init()
 
 	instanceGroup := os.Getenv("INSTANCE_GROUP")
 	if len(instanceGroup) != 0 {
@@ -69,12 +70,9 @@ func (a *aks) GetASGClusterSize() (int64, error) {
 }
 
 func init() {
-
-	SSHDriver := ssh.SSH{}
-	SSHDriver.Init()
-	g := &aks{
-		SSH: SSHDriver,
+	a := &aks{
+		SSH: ssh.SSH{},
 	}
 
-	node.Register(DriverName, g)
+	node.Register(DriverName, a)
 }

--- a/drivers/node/gke/gke.go
+++ b/drivers/node/gke/gke.go
@@ -28,6 +28,7 @@ func (g *gke) String() string {
 }
 
 func (g *gke) Init() error {
+	g.SSH.Init()
 
 	instanceGroup := os.Getenv("INSTANCE_GROUP")
 	if len(instanceGroup) != 0 {
@@ -76,11 +77,8 @@ func (g *gke) DeleteNode(node node.Node, timeout time.Duration) error {
 }
 
 func init() {
-
-	SSHDriver := ssh.SSH{}
-	SSHDriver.Init()
 	g := &gke{
-		SSH: SSHDriver,
+		SSH: ssh.SSH{},
 	}
 
 	node.Register(DriverName, g)


### PR DESCRIPTION

The `init()` method is called when the package is initialized: https://golang.org/doc/effective_go.html#init

However, we have our own Init() method which is called at runtime.  We need to move the SSH initialization into the Init() method so that `useSSH()`, which evaluates the `TORPEDO_SSH_KEY` and `TORPEDO_SSH_PASSWORD` variables can be evaluated properly.