### PR TITLE
Bump up torpedo container to use golang 1.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,7 @@ WORKDIR /go/src/github.com/portworx/torpedo
 RUN apk update && \
     apk add git gcc  musl-dev && \
     apk add make && \
-    apk add openssh-client && \
-    go get github.com/onsi/ginkgo/ginkgo && \
-    go get github.com/onsi/gomega && \
-    go get github.com/sirupsen/logrus
+    apk add openssh-client
 
 # No need to copy *everything*. This keeps the cache useful
 COPY deployments deployments

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.10-alpine AS build
+FROM golang:1.13.7-alpine AS build
 LABEL maintainer="harsh@portworx.com"
 
 WORKDIR /go/src/github.com/portworx/torpedo
@@ -20,6 +20,8 @@ COPY scripts scripts
 COPY tests tests
 COPY vendor vendor
 COPY Makefile Makefile
+COPY go.mod go.mod
+COPY go.sum go.sum
 
 # Why? Errors if this is removed
 COPY .git .git

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,20 @@
 TORPEDO_IMG=$(DOCKER_HUB_REPO)/$(DOCKER_HUB_TORPEDO_IMAGE):$(DOCKER_HUB_TAG)
 .PHONY: vendor
 
+export GO111MODULE=on
+export GOFLAGS = -mod=vendor
+HAS_GOMODULES := $(shell go help mod why 2> /dev/null)
+
+ifndef HAS_GOMODULES
+$(error torpedo can only be built with go 1.11+ which supports go modules)
+endif
+
 ifndef TAGS
 TAGS := daemon
 endif
 
 ifndef PKGS
-PKGS := $(shell go list ./... 2>&1 | grep -v 'github.com/portworx/torpedo/vendor' | grep -v 'github.com/portworx/torpedo/tests')
+PKGS := $(shell GOFLAGS=-mod=vendor go list ./... 2>&1 | grep -v 'github.com/portworx/torpedo/tests')
 endif
 
 ifeq ($(BUILD_TYPE),debug)
@@ -26,14 +34,6 @@ SYSBENCH_IMG=$(DOCKER_HUB_REPO)/torpedo-sysbench:latest
 PGBENCH_IMG=$(DOCKER_HUB_REPO)/torpedo-pgbench:latest
 ESLOAD_IMG=$(DOCKER_HUB_REPO)/torpedo-esload:latest
 
-HAS_GOMODULES := $(shell go help mod why 2> /dev/null)
-
-ifdef HAS_GOMODULES
-export GO111MODULE=on
-export GOFLAGS = -mod=vendor
-else
-$(error torpedo can only be built with go 1.11+ which supports go modules)
-endif
 
 all: vet lint build fmt
 

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ TAGS := daemon
 endif
 
 ifndef PKGS
+# shell does not honor export command above, so we need to explicitly pass GOFLAGS here
 PKGS := $(shell GOFLAGS=-mod=vendor go list ./... 2>&1 | grep -v 'github.com/portworx/torpedo/tests')
 endif
 

--- a/tests/asg/asg_test.go
+++ b/tests/asg/asg_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"fmt"
 	"math/rand"
+	"os"
 	"testing"
 	"time"
 
@@ -203,8 +204,10 @@ var _ = AfterSuite(func() {
 	ValidateCleanup()
 })
 
-func init() {
+func TestMain(m *testing.M) {
+	// call flag.Parse() here if TestMain uses flags
 	ParseFlags()
+	os.Exit(m.Run())
 }
 
 func Scale(count int64) {

--- a/tests/autopilot/autopilot_test.go
+++ b/tests/autopilot/autopilot_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -525,6 +526,8 @@ var _ = AfterSuite(func() {
 	ValidateCleanup()
 })
 
-func init() {
+func TestMain(m *testing.M) {
+	// call flag.Parse() here if TestMain uses flags
 	ParseFlags()
+	os.Exit(m.Run())
 }

--- a/tests/basic/basic_test.go
+++ b/tests/basic/basic_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"fmt"
 	"math/rand"
+	"os"
 	"testing"
 	"time"
 
@@ -444,6 +445,8 @@ var _ = AfterSuite(func() {
 	ValidateCleanup()
 })
 
-func init() {
+func TestMain(m *testing.M) {
+	// call flag.Parse() here if TestMain uses flags
 	ParseFlags()
+	os.Exit(m.Run())
 }

--- a/tests/drive_failure/drive_failure_test.go
+++ b/tests/drive_failure/drive_failure_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -122,6 +123,8 @@ var _ = AfterSuite(func() {
 	ValidateCleanup()
 })
 
-func init() {
+func TestMain(m *testing.M) {
+	// call flag.Parse() here if TestMain uses flags
 	ParseFlags()
+	os.Exit(m.Run())
 }

--- a/tests/node_decommission/node_decommission_test.go
+++ b/tests/node_decommission/node_decommission_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"fmt"
 	"math/rand"
+	"os"
 	"testing"
 	"time"
 
@@ -121,6 +122,8 @@ var _ = AfterSuite(func() {
 	ValidateCleanup()
 })
 
-func init() {
+func TestMain(m *testing.M) {
+	// call flag.Parse() here if TestMain uses flags
 	ParseFlags()
+	os.Exit(m.Run())
 }

--- a/tests/reboot/reboot_test.go
+++ b/tests/reboot/reboot_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -160,6 +161,8 @@ var _ = AfterSuite(func() {
 	ValidateCleanup()
 })
 
-func init() {
+func TestMain(m *testing.M) {
+	// call flag.Parse() here if TestMain uses flags
 	ParseFlags()
+	os.Exit(m.Run())
 }

--- a/tests/sched/sched_test.go
+++ b/tests/sched/sched_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -83,6 +84,8 @@ var _ = AfterSuite(func() {
 	ValidateCleanup()
 })
 
-func init() {
+func TestMain(m *testing.M) {
+	// call flag.Parse() here if TestMain uses flags
 	ParseFlags()
+	os.Exit(m.Run())
 }

--- a/tests/upgrade/upgrade_test.go
+++ b/tests/upgrade/upgrade_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -116,6 +117,8 @@ var _ = AfterSuite(func() {
 	ValidateCleanup()
 })
 
-func init() {
+func TestMain(m *testing.M) {
+	// call flag.Parse() here if TestMain uses flags
 	ParseFlags()
+	os.Exit(m.Run())
 }

--- a/tests/volume_ops/volume_ops_test.go
+++ b/tests/volume_ops/volume_ops_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"fmt"
 	"math"
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -167,6 +168,8 @@ var _ = AfterSuite(func() {
 	ValidateCleanup()
 })
 
-func init() {
+func TestMain(m *testing.M) {
+	// call flag.Parse() here if TestMain uses flags
 	ParseFlags()
+	os.Exit(m.Run())
 }


### PR DESCRIPTION
In "go test" 1.13 and higher, you cannot call parse.Flags in init()

In https://golang.org/doc/go1.13#testing

    Testing flags are now registered in the new Init function,
    which is invoked by the generated main function for the test.
    As a result, testing flags are now only registered when running
    a test binary, and packages that call flag.Parse during package
    initialization may cause tests to fail.

See:
  https://groups.google.com/d/msg/golang-nuts/rkCdS1EQwSM/4gbwNh0QAwAJ
  golang/go#21051
  https://go-review.googlesource.com/c/go/+/173722/
  https://www.bountysource.com/issues/79987300-flag-provided-but-not-defined-test-timeout-go-1-13
  https://golang.org/pkg/testing/#hdr-Main
 golang-1.13