### PR TITLE
Override scheduler name using options

### DIFF
--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -927,6 +927,9 @@ func (k *K8s) createCoreObject(spec interface{}, ns *v1.Namespace, app *spec.App
 	if obj, ok := spec.(*appsapi.Deployment); ok {
 		obj.Namespace = ns.Name
 		obj.Spec.Template.Spec.Volumes = k.substituteNamespaceInVolumes(obj.Spec.Template.Spec.Volumes, ns.Name)
+		if options.Scheduler != "" {
+			obj.Spec.Template.Spec.SchedulerName = options.Scheduler
+		}
 		dep, err := k8sApps.CreateDeployment(obj)
 		if errors.IsAlreadyExists(err) {
 			if dep, err = k8sApps.GetDeployment(obj.Name, obj.Namespace); err == nil {
@@ -964,6 +967,9 @@ func (k *K8s) createCoreObject(spec interface{}, ns *v1.Namespace, app *spec.App
 
 		obj.Namespace = ns.Name
 		obj.Spec.Template.Spec.Volumes = k.substituteNamespaceInVolumes(obj.Spec.Template.Spec.Volumes, ns.Name)
+		if options.Scheduler != "" {
+			obj.Spec.Template.Spec.SchedulerName = options.Scheduler
+		}
 		ss, err := k8sApps.CreateStatefulSet(obj)
 		if errors.IsAlreadyExists(err) {
 			if ss, err = k8sApps.GetStatefulSet(obj.Name, obj.Namespace); err == nil {

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -80,6 +80,8 @@ type ScheduleOptions struct {
 	ConfigMap string
 	// AutopilotRule identifies options for autopilot (Optional)
 	AutopilotRule apapi.AutopilotRule
+	// Scheduler  identifies what scheduler will be used
+	Scheduler string
 	// Labels is a map of {key,value} pairs for labeling spec objects
 	Labels map[string]string
 }


### PR DESCRIPTION
##### Why do we need this PR?
Allow torpedo to override the scheduler when deploying apps

Signed-off-by: Rohit-PX <rohit@portworx.com>