### PR TITLE
Set the priorityClassName for debug pod to system-cluster-critical

### DIFF
--- a/drivers/scheduler/k8s/specs/debug/debug.yaml
+++ b/drivers/scheduler/k8s/specs/debug/debug.yaml
@@ -24,8 +24,13 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/master
                 operator: DoesNotExist
+              - key: px/enabled
+                operator: NotIn
+                values:
+                - "false"
       hostNetwork: true
       hostPID: true
+      priorityClassName: system-cluster-critical
       containers:
       - name: debug
         image: ubuntu:latest


### PR DESCRIPTION
Set the priorityClassName for debug pod to system-cluster-critical:
  See: https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/

The debug pod is special, so we need to annotate it as critical.