### PR TITLE
Fix port to be used for cluster pair

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -1575,7 +1575,7 @@ func (d *portworx) GetClusterPairingInfo() (map[string]string, error) {
 	}
 	pairInfo[clusterIP] = clusterIPAddress
 	pairInfo[tokenKey] = resp.Result.Token
-	pwxServicePort, err := getSDKPort()
+	pwxServicePort, err := getRestContainerPort()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Introduced with a102306dc9cbcc609d1ba8df8938d3bb51f9183e