### PR TITLE
Fix for autopilot tests

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -1061,7 +1061,9 @@ func (d *portworx) getExpectedPoolSizes(listApRules *apapi.AutopilotRuleList) (m
 						return nil, err
 					}
 				} else {
-					expectedPoolSizes[pool.Uuid] = pool.StoragePoolAtInit.TotalSize
+					if _, ok := expectedPoolSizes[pool.Uuid]; !ok {
+						expectedPoolSizes[pool.Uuid] = pool.StoragePoolAtInit.TotalSize
+					}
 				}
 			}
 		}

--- a/drivers/volume/portworx/portworx_test.go
+++ b/drivers/volume/portworx/portworx_test.go
@@ -121,7 +121,7 @@ func TestEstimatedVolumeSize(t *testing.T) {
 		errorExpected          bool
 	}{
 		{
-			rule:                   aututils.PVCRuleByTotalSize(5, 100, "10Gi"),
+			rule:                   aututils.PVCRuleByTotalSize(6, 100, "10Gi"),
 			initialSize:            5 * units.GiB,
 			workloadSize:           10 * units.GiB,
 			expectedCalculatedSize: 10 * units.GiB,
@@ -129,7 +129,7 @@ func TestEstimatedVolumeSize(t *testing.T) {
 			errorExpected:          false,
 		},
 		{
-			rule:                   aututils.PVCRuleByTotalSize(5, 100, "5Gi"),
+			rule:                   aututils.PVCRuleByTotalSize(6, 100, "5Gi"),
 			initialSize:            5 * units.GiB,
 			workloadSize:           10 * units.GiB,
 			expectedCalculatedSize: 5 * units.GiB,
@@ -137,7 +137,7 @@ func TestEstimatedVolumeSize(t *testing.T) {
 			errorExpected:          false,
 		},
 		{
-			rule:                   aututils.PVCRuleByTotalSize(5, 100, "12Gi"),
+			rule:                   aututils.PVCRuleByTotalSize(15, 100, "12Gi"),
 			initialSize:            5 * units.GiB,
 			workloadSize:           10 * units.GiB,
 			expectedCalculatedSize: 12 * units.GiB,
@@ -145,11 +145,27 @@ func TestEstimatedVolumeSize(t *testing.T) {
 			errorExpected:          false,
 		},
 		{
+			rule:                   aututils.PVCRuleByTotalSize(6, 100, ""),
+			initialSize:            5 * units.GiB,
+			workloadSize:           10 * units.GiB,
+			expectedCalculatedSize: 10 * units.GiB,
+			expectedResizeCount:    1,
+			errorExpected:          false,
+		},
+		{
+			rule:                   aututils.PVCRuleByUsageCapacity(50, 100, ""),
+			initialSize:            10 * units.GiB,
+			workloadSize:           4 * units.GiB,
+			expectedCalculatedSize: 10 * units.GiB,
+			expectedResizeCount:    0,
+			errorExpected:          false,
+		},
+		{
 			rule:                   aututils.PVCRuleByUsageCapacity(50, 100, ""),
 			initialSize:            10 * units.GiB,
 			workloadSize:           10 * units.GiB,
-			expectedCalculatedSize: 40 * units.GiB,
-			expectedResizeCount:    2,
+			expectedCalculatedSize: 20 * units.GiB,
+			expectedResizeCount:    1,
 			errorExpected:          false,
 		},
 		{

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/portworx/torpedo
 go 1.12
 
 require (
-	cloud.google.com/go v0.38.0 // indirect
 	github.com/Azure/azure-sdk-for-go v38.2.0+incompatible // indirect
 	github.com/Azure/go-autorest v13.3.1+incompatible // indirect
 	github.com/Azure/go-autorest/autorest v0.9.4 // indirect
@@ -22,9 +21,6 @@ require (
 	github.com/gambol99/go-marathon v0.7.1
 	github.com/golang/groupcache v0.0.0-20191002201903-404acd9df4cc // indirect
 	github.com/golang/protobuf v1.3.2
-	github.com/google/btree v1.0.0 // indirect
-	github.com/google/uuid v1.1.1 // indirect
-	github.com/gophercloud/gophercloud v0.1.0 // indirect
 	github.com/kubernetes-incubator/external-storage v0.0.0-00010101000000-000000000000
 	github.com/libopenstorage/autopilot-api v0.6.1-0.20200115200747-7383c6007283
 	github.com/libopenstorage/cloudops v0.0.0-20200114171448-10fa10d97720
@@ -37,10 +33,9 @@ require (
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709
-	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/portworx/kvdb v0.0.0-20191223203141-f42097b1fcd8 // indirect
 	github.com/portworx/px-backup-api v0.0.0-20200205061835-5dc42f2a6d0f // indirect
-	github.com/portworx/sched-ops v0.0.0-20200209173159-9fc20df3f771
+	github.com/portworx/sched-ops v0.0.0-20200221004841-9205a51a1fee
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0
 	go.opencensus.io v0.22.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -419,6 +419,8 @@ github.com/portworx/sched-ops v0.0.0-20200205200838-f224d01bafb5 h1:rPBpZXeo9M1B
 github.com/portworx/sched-ops v0.0.0-20200205200838-f224d01bafb5/go.mod h1:yb1ypNIiZQAmM7xAWGzO6dydwl/+vNC0WjUm5IvHUEY=
 github.com/portworx/sched-ops v0.0.0-20200209173159-9fc20df3f771 h1:jyovf+v7840+//M+tEKqXZvM0pcX56akKhizUjD4buA=
 github.com/portworx/sched-ops v0.0.0-20200209173159-9fc20df3f771/go.mod h1:yb1ypNIiZQAmM7xAWGzO6dydwl/+vNC0WjUm5IvHUEY=
+github.com/portworx/sched-ops v0.0.0-20200221004841-9205a51a1fee h1:HnMAyWZRxHxHEEw1/QuCkmvtf3Woej/IboUBaiuVbyo=
+github.com/portworx/sched-ops v0.0.0-20200221004841-9205a51a1fee/go.mod h1:yb1ypNIiZQAmM7xAWGzO6dydwl/+vNC0WjUm5IvHUEY=
 github.com/portworx/talisman v0.0.0-20191007232806-837747f38224 h1:r4LpGHxnh3tliXnaJcciROXU/snARMN6/OXhGPJyzGA=
 github.com/portworx/talisman v0.0.0-20191007232806-837747f38224/go.mod h1:OjpMH9Uh5o9ntVGktm4FbjLNwubJ3ITih2OfYrAeWtA=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=

--- a/pkg/aututils/aututils.go
+++ b/pkg/aututils/aututils.go
@@ -100,14 +100,14 @@ func PoolRuleByAvailableCapacity(usage, scalePercentage uint64, expandType strin
 func PVCRuleByTotalSize(capacity int, scalePercentage int, maxSize string) apapi.AutopilotRule {
 	apRuleObject := apapi.AutopilotRule{
 		ObjectMeta: meta_v1.ObjectMeta{
-			Name: fmt.Sprintf("pvc-total-size-%s", strings.ToLower(maxSize)),
+			Name: fmt.Sprintf("pool-total-%d-scale-%d", capacity, scalePercentage),
 		},
 		Spec: apapi.AutopilotRuleSpec{
 			Conditions: apapi.RuleConditions{
 				Expressions: []*apapi.LabelSelectorRequirement{
 					{
 						Key:      PxVolumeTotalCapacityMetric,
-						Operator: apapi.LabelSelectorOpGt,
+						Operator: apapi.LabelSelectorOpLt,
 						Values:   []string{fmt.Sprintf("%d", capacity)},
 					},
 				},
@@ -123,6 +123,7 @@ func PVCRuleByTotalSize(capacity int, scalePercentage int, maxSize string) apapi
 		},
 	}
 	if maxSize != "" {
+		apRuleObject.Name = fmt.Sprintf("%s-maxsize-%s", apRuleObject.Name, strings.ToLower(maxSize))
 		for _, action := range apRuleObject.Spec.Actions {
 			action.Params[RuleMaxSize] = maxSize
 		}


### PR DESCRIPTION
* fix for getExpectedPoolSizes when we have multiple autopilot rules and expectedPoolSizes map will be always overwritten with initial size
* fix for PVCRuleByTotalSize rule
* added more unit tests and fix existing tests

tested here:
https://jenkins.portworx.co/job/Torpedo/job/tp-dev-test/364/
https://jenkins.portworx.co/job/Autopilot/job/tp-aut-nextpx-aks-dev/1/

Signed-off-by: Maksym Borodin <maksym@portworx.com>