### PR TITLE
Add azure and aws volume drivers

### DIFF
--- a/drivers/volume/aws/aws.go
+++ b/drivers/volume/aws/aws.go
@@ -1,0 +1,49 @@
+package aws
+
+import (
+	"fmt"
+
+	torpedovolume "github.com/portworx/torpedo/drivers/volume"
+	"github.com/portworx/torpedo/drivers/volume/portworx/schedops"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// DriverName is the name of the aws driver implementation
+	DriverName = "aws"
+	// AwsStorage AWS storage driver name
+	AwsStorage torpedovolume.StorageProvisionerType = "aws"
+)
+
+// Provisioners types of supported provisioners
+var provisioners = map[torpedovolume.StorageProvisionerType]torpedovolume.StorageProvisionerType{
+	AwsStorage: "kubernetes.io/aws-ebs",
+}
+
+type aws struct {
+	schedOps schedops.Driver
+	torpedovolume.DefaultDriver
+}
+
+func (d *aws) String() string {
+	return string(AwsStorage)
+}
+
+func (d *aws) Init(sched string, nodeDriver string, token string, storageProvisioner string) error {
+	logrus.Infof("Using the AWS EBS volume driver with provisioner %s under scheduler: %v", storageProvisioner, sched)
+	// Set provisioner for torpedo
+	if storageProvisioner != "" {
+		if p, ok := provisioners[torpedovolume.StorageProvisionerType(storageProvisioner)]; ok {
+			torpedovolume.StorageProvisioner = p
+		} else {
+			return fmt.Errorf("driver %s, does not support provisioner %s", DriverName, storageProvisioner)
+		}
+	} else {
+		return fmt.Errorf("Provisioner is empty for volume driver: %s", DriverName)
+	}
+	return nil
+}
+
+func init() {
+	torpedovolume.Register(DriverName, &aws{})
+}

--- a/drivers/volume/azure/azure.go
+++ b/drivers/volume/azure/azure.go
@@ -1,0 +1,49 @@
+package azure
+
+import (
+	"fmt"
+
+	torpedovolume "github.com/portworx/torpedo/drivers/volume"
+	"github.com/portworx/torpedo/drivers/volume/portworx/schedops"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// DriverName is the name of the azure driver implementation
+	DriverName = "azure"
+	// AzureStorage Azure storage driver name
+	AzureStorage torpedovolume.StorageProvisionerType = "azure"
+)
+
+// Provisioners types of supported provisioners
+var provisioners = map[torpedovolume.StorageProvisionerType]torpedovolume.StorageProvisionerType{
+	AzureStorage: "kubernetes.io/azure-disk",
+}
+
+type azure struct {
+	schedOps schedops.Driver
+	torpedovolume.DefaultDriver
+}
+
+func (d *azure) String() string {
+	return string(AzureStorage)
+}
+
+func (d *azure) Init(sched string, nodeDriver string, token string, storageProvisioner string) error {
+	logrus.Infof("Using the Azure volume driver with provisioner %s under scheduler: %v", storageProvisioner, sched)
+	// Set provisioner for torpedo
+	if storageProvisioner != "" {
+		if p, ok := provisioners[torpedovolume.StorageProvisionerType(storageProvisioner)]; ok {
+			torpedovolume.StorageProvisioner = p
+		} else {
+			return fmt.Errorf("driver %s, does not support provisioner %s", DriverName, storageProvisioner)
+		}
+	} else {
+		return fmt.Errorf("Provisioner is empty for volume driver: %s", DriverName)
+	}
+	return nil
+}
+
+func init() {
+	torpedovolume.Register(DriverName, &azure{})
+}

--- a/tests/common.go
+++ b/tests/common.go
@@ -41,6 +41,10 @@ import (
 	_ "github.com/portworx/torpedo/drivers/volume/portworx"
 	// import gce driver to invoke it's init
 	_ "github.com/portworx/torpedo/drivers/volume/gce"
+	// import aws driver to invoke it's init
+	_ "github.com/portworx/torpedo/drivers/volume/aws"
+	// import azure driver to invoke it's init
+	_ "github.com/portworx/torpedo/drivers/volume/azure"
 	"github.com/portworx/torpedo/pkg/log"
 
 	yaml "gopkg.in/yaml.v2"


### PR DESCRIPTION
**Why do we need this PR?**
Volume drivers for Azure and AWS are required to support app backups

Signed-off-by: Rohit-PX <rohit@portworx.com>