### PR TITLE
Add delete options to delete volume API

### DIFF
--- a/drivers/scheduler/dcos/dcos.go
+++ b/drivers/scheduler/dcos/dcos.go
@@ -400,7 +400,7 @@ func (d *dcos) ValidateVolumes(ctx *scheduler.Context, timeout, retryInterval ti
 	return d.volumeOperation(ctx, inspectDockerVolumeFunc)
 }
 
-func (d *dcos) DeleteVolumes(ctx *scheduler.Context) ([]*volume.Volume, error) {
+func (d *dcos) DeleteVolumes(ctx *scheduler.Context, options *scheduler.DeleteVolumeOptions) ([]*volume.Volume, error) {
 	var vols []*volume.Volume
 
 	deleteDockerVolumeFunc := func(volName string, _ map[string]string) error {

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -221,6 +221,7 @@ type DeleteTasksOptions struct {
 
 // DeleteVolumeOptions are options supplied to the DeleteVolume API
 type DeleteVolumeOptions struct {
+	// SkipClusterScopedObjects skips deletion of cluster scoped objects like storage class
 	SkipClusterScopedObjects bool
 }
 

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -131,7 +131,7 @@ type Driver interface {
 	ValidateVolumes(cc *Context, timeout, retryInterval time.Duration) error
 
 	// DeleteVolumes will delete all storage volumes for the given context
-	DeleteVolumes(*Context) ([]*volume.Volume, error)
+	DeleteVolumes(*Context, *DeleteVolumeOptions) ([]*volume.Volume, error)
 
 	// GetVolumes returns all storage volumes for the given context
 	GetVolumes(*Context) ([]*volume.Volume, error)
@@ -217,6 +217,11 @@ var (
 // DeleteTasksOptions are options supplied to the DeleteTasks API
 type DeleteTasksOptions struct {
 	TriggerOptions
+}
+
+// DeleteVolumeOptions are options supplied to the DeleteVolume API
+type DeleteVolumeOptions struct {
+	SkipClusterScopedObjects bool
 }
 
 // Event collects kubernetes events data for further validation

--- a/tests/basic/basic_test.go
+++ b/tests/basic/basic_test.go
@@ -242,7 +242,7 @@ var _ = Describe("{VolumeDriverAppDown}", func() {
 					Expect(err).NotTo(HaveOccurred())
 				})
 
-				DeleteVolumesAndWait(ctx)
+				DeleteVolumesAndWait(ctx, nil)
 			}
 		})
 	})

--- a/tests/common.go
+++ b/tests/common.go
@@ -52,7 +52,7 @@ import (
 )
 
 const (
-	SkipClusterScopedObjects = "skipClusterScopedObjects"
+	skipClusterScopedObjects = "skipClusterScopedObjects"
 )
 
 const (
@@ -700,7 +700,7 @@ func splitCsv(in string) ([]string, error) {
 }
 
 func mapToDeleteOptions(options map[string]bool) *scheduler.DeleteVolumeOptions {
-	if val, ok := options[SkipClusterScopedObjects]; ok {
+	if val, ok := options[skipClusterScopedObjects]; ok {
 		return &scheduler.DeleteVolumeOptions{
 			SkipClusterScopedObjects: val,
 		}

--- a/tests/common.go
+++ b/tests/common.go
@@ -52,7 +52,7 @@ import (
 )
 
 const (
-	SkipClusterScopedObjects             = "skipClusterScopedObjects"
+	SkipClusterScopedObjects = "skipClusterScopedObjects"
 )
 
 const (

--- a/tests/common.go
+++ b/tests/common.go
@@ -52,6 +52,10 @@ import (
 )
 
 const (
+	SkipClusterScopedObjects             = "skipClusterScopedObjects"
+)
+
+const (
 	// defaultSpecsRoot specifies the default location of the base specs directory in the Torpedo container
 	defaultSpecsRoot                     = "/specs"
 	schedulerCliFlag                     = "scheduler"
@@ -221,7 +225,8 @@ func TearDownContext(ctx *scheduler.Context, opts map[string]bool) {
 	context("For tearing down of an app context", func() {
 		var err error
 
-		vols := DeleteVolumes(ctx)
+		options := mapToDeleteOptions(opts)
+		vols := DeleteVolumes(ctx, options)
 
 		Step(fmt.Sprintf("start destroying %s app", ctx.App.Key), func() {
 			err = Inst().S.Destroy(ctx, opts)
@@ -234,11 +239,11 @@ func TearDownContext(ctx *scheduler.Context, opts map[string]bool) {
 }
 
 // DeleteVolumes deletes volumes of a given context
-func DeleteVolumes(ctx *scheduler.Context) []*volume.Volume {
+func DeleteVolumes(ctx *scheduler.Context, options *scheduler.DeleteVolumeOptions) []*volume.Volume {
 	var err error
 	var vols []*volume.Volume
 	Step(fmt.Sprintf("destroy the %s app's volumes", ctx.App.Key), func() {
-		vols, err = Inst().S.DeleteVolumes(ctx)
+		vols, err = Inst().S.DeleteVolumes(ctx, options)
 		expect(err).NotTo(haveOccurred())
 	})
 	return vols
@@ -256,8 +261,8 @@ func ValidateVolumesDeleted(appName string, vols []*volume.Volume) {
 }
 
 // DeleteVolumesAndWait deletes volumes of given context and waits till they are deleted
-func DeleteVolumesAndWait(ctx *scheduler.Context) {
-	vols := DeleteVolumes(ctx)
+func DeleteVolumesAndWait(ctx *scheduler.Context, options *scheduler.DeleteVolumeOptions) {
+	vols := DeleteVolumes(ctx, options)
 	ValidateVolumesDeleted(ctx.App.Key, vols)
 }
 
@@ -692,6 +697,18 @@ func splitCsv(in string) ([]string, error) {
 		return []string{}, fmt.Errorf("Multiline CSV not supported")
 	}
 	return records[0], err
+}
+
+func mapToDeleteOptions(options map[string]bool) *scheduler.DeleteVolumeOptions {
+	if val, ok := options[SkipClusterScopedObjects]; ok {
+		return &scheduler.DeleteVolumeOptions{
+			SkipClusterScopedObjects: val,
+		}
+	}
+
+	return &scheduler.DeleteVolumeOptions{
+		SkipClusterScopedObjects: false,
+	}
 }
 
 func init() {


### PR DESCRIPTION
Add delete options stuct to volume api
to avoid deleting cluster scoped objects e.g. StorageClass when
teardown apps