### PR TITLE
PTX-2232 Added px-backup tests for portworx backend

### DIFF
--- a/drivers/backup/portworx/portworx.go
+++ b/drivers/backup/portworx/portworx.go
@@ -284,8 +284,9 @@ func (p *portworx) WaitForBackupCompletion(backupName string, orgID string,
 		} else if currentStatus == api.BackupInfo_StatusInfo_Failed ||
 			currentStatus == api.BackupInfo_StatusInfo_Aborted ||
 			currentStatus == api.BackupInfo_StatusInfo_Invalid {
-			backupError = fmt.Errorf("backup [%v] is in [%s] state",
-				req.GetName(), currentStatus)
+			backupError = fmt.Errorf("backup [%v] is in [%s] state. reason: [%v]",
+				req.GetName(), currentStatus,
+				inspectBkpResp.GetBackup().GetStatus().GetReason())
 			return nil, false, backupError
 		}
 		return nil,

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -217,6 +217,8 @@ func (d *portworx) Init(sched string, nodeDriver string, token string, storagePr
 }
 
 func (d *portworx) RefreshDriverEndpoints() error {
+	// Force update px endpoints
+	d.refreshEndpoint = true
 	storageNodes, err := d.getStorageNodesOnStart()
 	if err != nil {
 		return err
@@ -261,9 +263,10 @@ func (d *portworx) updateNode(n *node.Node, pxNodes []api.StorageNode) error {
 					n.StorageNode = pxNode
 					n.VolDriverNodeID = pxNode.Id
 					n.IsStorageDriverInstalled = isPX
+					// TODO: PTX-2445 Replace isMetadataNode API call with SDK call
 					isMetadataNode, err := d.isMetadataNode(*n, address)
 					if err != nil {
-						return err
+						logrus.Warnf("can not check if %v is metadata node", *n)
 					}
 					n.IsMetadataNode = isMetadataNode
 


### PR DESCRIPTION
Test bed setup:
**Cluster 1:** PX-Backup and torpedo runs on this cluster
**Cluster 2:** Source cluster for px-backup
**Cluster 3:** Destination cluster for px-backup

Torpedo, 
1.  Deploys apps on Cluster 2*
2. Initiates backup
3. Restores apps on Cluster 3.
4. Validates restore.

***Note:** Currently apps using encrypted PVCs using K8S secrets can not be restored correctly due to 
PB-119

**Jenkins Job with backup test enabled:**
https://jenkins.portworx.co/job/Torpedo/job/vinayak-tp-backup/57/console

**Jenkins Job with backup test disabled:**
https://jenkins.portworx.co/job/Torpedo/job/vinayak-tp-backup/58/console