### PR TITLE
Added wait APIs for backup schedule objects.

### DIFF
--- a/drivers/backup/backup.go
+++ b/drivers/backup/backup.go
@@ -194,6 +194,16 @@ type ScheduleBackup interface {
 
 	// DeleteBackupSchedule
 	DeleteBackupSchedule(req *api.BackupScheduleDeleteRequest) (*api.BackupScheduleDeleteResponse, error)
+
+	// BackupScheduleWaitForNBackupsCompletion, waits for backup schedule to complete successfully
+	// or till timeout is reached. API should poll every `timeBeforeRetry` duration
+	BackupScheduleWaitForNBackupsCompletion(name, orgID string, count int,
+		timeout time.Duration, timeBeforeRetry time.Duration) error
+	// WaitForBackupScheduleDeletion waits for backupschedule to be deleted successfully
+	// or till timeout is reached. API should poll every `timeBeforeRetry` duration
+	// This wait function is for the backupschedule deletion with delete-backup option set.
+	WaitForBackupScheduleDeletion(backupScheduleName, namespace, orgID string,
+		clusterObj *api.ClusterObject, timeout time.Duration, timeBeforeRetry time.Duration) error
 }
 
 var backupDrivers = make(map[string]Driver)

--- a/drivers/backup/backup.go
+++ b/drivers/backup/backup.go
@@ -1,6 +1,7 @@
 package backup
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -36,7 +37,7 @@ type Driver interface {
 	Init(schedulerDriverName string, nodeDriverName string, volumeDriverName string, token string) error
 
 	// WaitForRunning waits for application to start running.
-	WaitForRunning(req *api.BackupInspectRequest, timeout, retryInterval time.Duration) error
+	WaitForRunning(ctx context.Context, req *api.BackupInspectRequest, timeout, retryInterval time.Duration) error
 
 	// String returns the name of this driver
 	String() string
@@ -105,7 +106,7 @@ type BLocation interface {
 	DeleteBackupLocation(req *api.BackupLocationDeleteRequest) (*api.BackupLocationDeleteResponse, error)
 
 	// WaitForBackupLocationDeletion watis for backup location to be deleted
-	WaitForBackupLocationDeletion(backupLocationName string, orgID string,
+	WaitForBackupLocationDeletion(ctx context.Context, backupLocationName string, orgID string,
 		timeout time.Duration, timeBeforeRetry time.Duration) error
 }
 
@@ -128,12 +129,12 @@ type Backup interface {
 
 	// WaitForBackupCompletion waits for backup to complete successfully
 	// or till timeout is reached. API should poll every `timeBeforeRetry`
-	WaitForBackupCompletion(backupName string, orgID string,
+	WaitForBackupCompletion(ctx context.Context, backupName string, orgID string,
 		timeout time.Duration, timeBeforeRetry time.Duration) error
 
 	// WaitForBackupDeletion waits for backup to be deleted successfully
 	// or till timeout is reached. API should poll every `timeBeforeRetry
-	WaitForBackupDeletion(backupName string, orgID string,
+	WaitForBackupDeletion(ctx context.Context, backupName string, orgID string,
 		timeout time.Duration, timeBeforeRetry time.Duration) error
 }
 
@@ -156,7 +157,7 @@ type Restore interface {
 
 	// WaitForRestoreCompletion waits for restore to complete successfully
 	// or till timeout is reached. API should poll every `timeBeforeRetry` duration
-	WaitForRestoreCompletion(restoreName string, orgID string,
+	WaitForRestoreCompletion(ctx context.Context, restoreName string, orgID string,
 		timeout time.Duration, timeBeforeRetry time.Duration) error
 }
 
@@ -197,12 +198,12 @@ type ScheduleBackup interface {
 
 	// BackupScheduleWaitForNBackupsCompletion, waits for backup schedule to complete successfully
 	// or till timeout is reached. API should poll every `timeBeforeRetry` duration
-	BackupScheduleWaitForNBackupsCompletion(name, orgID string, count int,
+	BackupScheduleWaitForNBackupsCompletion(ctx context.Context, name, orgID string, count int,
 		timeout time.Duration, timeBeforeRetry time.Duration) error
 	// WaitForBackupScheduleDeletion waits for backupschedule to be deleted successfully
 	// or till timeout is reached. API should poll every `timeBeforeRetry` duration
 	// This wait function is for the backupschedule deletion with delete-backup option set.
-	WaitForBackupScheduleDeletion(backupScheduleName, namespace, orgID string,
+	WaitForBackupScheduleDeletion(ctx context.Context, backupScheduleName, namespace, orgID string,
 		clusterObj *api.ClusterObject, timeout time.Duration, timeBeforeRetry time.Duration) error
 }
 

--- a/drivers/backup/portworx/portworx.go
+++ b/drivers/backup/portworx/portworx.go
@@ -250,15 +250,20 @@ func (p *portworx) DeleteBackupLocation(req *api.BackupLocationDeleteRequest) (*
 
 // WaitForBackupLocationDeletion waits for backup location to be deleted successfully
 // or till timeout is reached. API should poll every `timeBeforeRetry` duration
-func (p *portworx) WaitForBackupLocationDeletion(backupLocationName string, orgID string,
-	timeout time.Duration, timeBeforeRetry time.Duration) error {
+func (p *portworx) WaitForBackupLocationDeletion(
+	ctx context.Context,
+	backupLocationName,
+	orgID string,
+	timeout time.Duration,
+	timeBeforeRetry time.Duration,
+) error {
 	req := &api.BackupLocationInspectRequest{
 		Name:  backupLocationName,
 		OrgId: orgID,
 	}
 	var blError error
 	f := func() (interface{}, bool, error) {
-		inspectBlResp, err := p.backupLocationManager.Inspect(context.Background(), req)
+		inspectBlResp, err := p.backupLocationManager.Inspect(ctx, req)
 		if err == nil {
 			// Object still exsts, just retry
 			currentStatus := inspectBlResp.GetBackupLocation().GetStatus().GetStatus()
@@ -308,15 +313,20 @@ func (p *portworx) DeleteBackup(req *api.BackupDeleteRequest) (*api.BackupDelete
 
 // WaitForBackupCompletion waits for backup to complete successfully
 // or till timeout is reached. API should poll every `timeBeforeRetry` duration
-func (p *portworx) WaitForBackupCompletion(backupName string, orgID string,
-	timeout time.Duration, timeBeforeRetry time.Duration) error {
+func (p *portworx) WaitForBackupCompletion(
+	ctx context.Context,
+	backupName,
+	orgID string,
+	timeout time.Duration,
+	timeBeforeRetry time.Duration,
+) error {
 	req := &api.BackupInspectRequest{
 		Name:  backupName,
 		OrgId: orgID,
 	}
 	var backupError error
 	f := func() (interface{}, bool, error) {
-		inspectBkpResp, err := p.backupManager.Inspect(context.Background(), req)
+		inspectBkpResp, err := p.backupManager.Inspect(ctx, req)
 		if err != nil {
 			// Error occured, just retry
 			return nil, true, err
@@ -351,15 +361,20 @@ func (p *portworx) WaitForBackupCompletion(backupName string, orgID string,
 
 // WaitForBackupDeletion waits for backup to be deleted successfully
 // or till timeout is reached. API should poll every `timeBeforeRetry` duration
-func (p *portworx) WaitForBackupDeletion(backupName string, orgID string,
-	timeout time.Duration, timeBeforeRetry time.Duration) error {
+func (p *portworx) WaitForBackupDeletion(
+	ctx context.Context,
+	backupName,
+	orgID string,
+	timeout time.Duration,
+	timeBeforeRetry time.Duration,
+) error {
 	req := &api.BackupInspectRequest{
 		Name:  backupName,
 		OrgId: orgID,
 	}
 	var backupError error
 	f := func() (interface{}, bool, error) {
-		inspectBackupResp, err := p.backupManager.Inspect(context.Background(), req)
+		inspectBackupResp, err := p.backupManager.Inspect(ctx, req)
 		if err == nil {
 			// Object still exists, just retry
 			currentStatus := inspectBackupResp.GetBackup().GetStatus().GetStatus()
@@ -419,15 +434,20 @@ func (p *portworx) DeleteRestore(req *api.RestoreDeleteRequest) (*api.RestoreDel
 
 // WaitForRestoreCompletion waits for restore to complete successfully
 // or till timeout is reached. API should poll every `timeBeforeRetry` duration
-func (p *portworx) WaitForRestoreCompletion(restoreName string, orgID string,
-	timeout time.Duration, timeBeforeRetry time.Duration) error {
+func (p *portworx) WaitForRestoreCompletion(
+	ctx context.Context,
+	restoreName,
+	orgID string,
+	timeout time.Duration,
+	timeBeforeRetry time.Duration,
+) error {
 	req := &api.RestoreInspectRequest{
 		Name:  restoreName,
 		OrgId: orgID,
 	}
 	var restoreError error
 	f := func() (interface{}, bool, error) {
-		inspectRestoreResp, err := p.restoreManager.Inspect(context.Background(), req)
+		inspectRestoreResp, err := p.restoreManager.Inspect(ctx, req)
 		if err != nil {
 			// Error occured, just retry
 			return nil, true, err
@@ -503,6 +523,7 @@ func (p *portworx) DeleteBackupSchedule(req *api.BackupScheduleDeleteRequest) (*
 // BackupScheduleWaitForNBackupsCompletion waits for given number of backup to be complete successfully
 // or till timeout is reached. API should poll every `timeBeforeRetry` duration
 func (p *portworx) BackupScheduleWaitForNBackupsCompletion(
+	ctx context.Context,
 	name,
 	orgID string,
 	count int,
@@ -515,7 +536,7 @@ func (p *portworx) BackupScheduleWaitForNBackupsCompletion(
 	f := func() (interface{}, bool, error) {
 		var backups []*api.BackupObject
 		// Get backup list
-		resp, err := p.backupManager.Enumerate(context.Background(), req)
+		resp, err := p.backupManager.Enumerate(ctx, req)
 		if err != nil {
 			return nil, true, err
 		}
@@ -554,6 +575,7 @@ func (p *portworx) BackupScheduleWaitForNBackupsCompletion(
 // or till timeout is reached. API should poll every `timeBeforeRetry` duration
 // This wait function is for the backupschedule deletion with delete-backup option set.
 func (p *portworx) WaitForBackupScheduleDeletion(
+	ctx context.Context,
 	backupScheduleName,
 	namespace,
 	orgID string,
@@ -566,7 +588,7 @@ func (p *portworx) WaitForBackupScheduleDeletion(
 		OrgId: orgID,
 	}
 	f := func() (interface{}, bool, error) {
-		inspectBackupScheduleResp, err := p.backupScheduleManager.Inspect(context.Background(), req)
+		inspectBackupScheduleResp, err := p.backupScheduleManager.Inspect(ctx, req)
 		if err == nil {
 			// Object still exists, just retry
 			currentStatus := inspectBackupScheduleResp.GetBackupSchedule().GetStatus().GetStatus()
@@ -583,7 +605,7 @@ func (p *portworx) WaitForBackupScheduleDeletion(
 			OrgId: orgID,
 		}
 		// Get backup list
-		resp, err := p.backupManager.Enumerate(context.Background(), req)
+		resp, err := p.backupManager.Enumerate(ctx, req)
 		if err != nil {
 			return nil, true, err
 		}
@@ -620,11 +642,16 @@ func (p *portworx) WaitForBackupScheduleDeletion(
 }
 
 // Wait for backup to start running
-func (p *portworx) WaitForRunning(req *api.BackupInspectRequest, timeout, retryInterval time.Duration) error {
+func (p *portworx) WaitForRunning(
+	ctx context.Context,
+	req *api.BackupInspectRequest,
+	timeout,
+	retryInterval time.Duration,
+) error {
 	var backupErr error
 
 	t := func() (interface{}, bool, error) {
-		resp, err := p.backupManager.Inspect(context.Background(), req)
+		resp, err := p.backupManager.Inspect(ctx, req)
 
 		if err != nil {
 			return nil, true, err
@@ -658,14 +685,19 @@ func (p *portworx) WaitForRunning(req *api.BackupInspectRequest, timeout, retryI
 
 // WaitForClusterDeletion waits for cluster to be deleted successfully
 // or till timeout is reached. API should poll every `timeBeforeRetry` duration
-func (p *portworx) WaitForClusterDeletion(clusterName string, orgID string,
-	timeout time.Duration, timeBeforeRetry time.Duration) error {
+func (p *portworx) WaitForClusterDeletion(
+	ctx context.Context,
+	clusterName,
+	orgID string,
+	timeout time.Duration,
+	timeBeforeRetry time.Duration,
+) error {
 	req := &api.ClusterInspectRequest{
 		Name:  clusterName,
 		OrgId: orgID,
 	}
 	f := func() (interface{}, bool, error) {
-		inspectClusterResp, err := p.clusterManager.Inspect(context.Background(), req)
+		inspectClusterResp, err := p.clusterManager.Inspect(ctx, req)
 		if err == nil {
 			// Object still exists, just retry
 			currentStatus := inspectClusterResp.GetCluster().GetStatus().GetStatus()

--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
@@ -102,7 +103,7 @@ var _ = Describe("{BackupCreateRestore}", func() {
 		})
 
 		Step(fmt.Sprintf("Wait for Backup [%s] to complete", BackupName), func() {
-			err := Inst().Backup.WaitForBackupCompletion(BackupName, orgID,
+			err := Inst().Backup.WaitForBackupCompletion(context.Background(), BackupName, orgID,
 				BackupRestoreCompletionTimeoutMin*time.Minute,
 				RetrySeconds*time.Second)
 			Expect(err).NotTo(HaveOccurred(),
@@ -116,7 +117,7 @@ var _ = Describe("{BackupCreateRestore}", func() {
 		})
 
 		Step(fmt.Sprintf("Wait for Restore [%s] to complete", RestoreName), func() {
-			err := Inst().Backup.WaitForRestoreCompletion(RestoreName, orgID,
+			err := Inst().Backup.WaitForRestoreCompletion(context.Background(), RestoreName, orgID,
 				BackupRestoreCompletionTimeoutMin*time.Minute,
 				RetrySeconds*time.Second)
 			Expect(err).NotTo(HaveOccurred(),


### PR DESCRIPTION
**Description:**
 Added wait APIs for backup schedule objects.

        - Added WaitForBackupScheduleForNBackupCompletion api, which will wait for 'n' number of
          backup completed from the given backupschedule.
        - Added WaitForBackupScheduleDeletion api, which will wait for all dependent resources
          of given backup schedule are deleted.
