### PR TITLE
PTX-2511 Add namespace mapping to ValidateApps

### DIFF
--- a/drivers/scheduler/dcos/dcos.go
+++ b/drivers/scheduler/dcos/dcos.go
@@ -639,6 +639,14 @@ func (d *dcos) ListAutopilotRules() (*apapi.AutopilotRuleList, error) {
 	}
 }
 
+func (d *dcos) SubstituteNamespaceInSpec(_ *scheduler.Context, _ map[string]string) error {
+	// TODO implement this method
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "SubstituteNamespaceInSpec()",
+	}
+}
+
 func init() {
 	d := &dcos{}
 	scheduler.Register(SchedName, d)

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -3437,6 +3437,147 @@ func (k *K8s) ListAutopilotRules() (*apapi.AutopilotRuleList, error) {
 	return k8sAutopilot.ListAutopilotRules()
 }
 
+// SubstituteNamespaceInSpec substituts original namespaces according to namespace mapping
+func (k *K8s) SubstituteNamespaceInSpec(ctx *scheduler.Context, namespaceMapping map[string]string) error {
+	for _, in := range ctx.App.SpecList {
+		if specObj, ok := in.(*appsapi.Deployment); ok {
+			logrus.Debugf("Substitute object %v namespace %s to %s\n",
+				specObj, specObj.Namespace, namespaceMapping[specObj.Namespace])
+			namespace, _ := namespaceMapping[specObj.Namespace]
+			specObj.Namespace = namespace
+		} else if specObj, ok := in.(*appsapi.StatefulSet); ok {
+			logrus.Debugf("Substitute object %v namespace %s to %s\n",
+				specObj, specObj.Namespace, namespaceMapping[specObj.Namespace])
+			namespace, _ := namespaceMapping[specObj.Namespace]
+			specObj.Namespace = namespace
+		} else if specObj, ok := in.(*appsapi.DaemonSet); ok {
+			logrus.Debugf("Substitute object %v namespace %s to %s\n",
+				specObj, specObj.Namespace, namespaceMapping[specObj.Namespace])
+			namespace, _ := namespaceMapping[specObj.Namespace]
+			specObj.Namespace = namespace
+		} else if specObj, ok := in.(*v1.Service); ok {
+			logrus.Debugf("Substitute object %v namespace %s to %s\n",
+				specObj, specObj.Namespace, namespaceMapping[specObj.Namespace])
+			namespace, _ := namespaceMapping[specObj.Namespace]
+			specObj.Namespace = namespace
+		} else if specObj, ok := in.(*v1.PersistentVolumeClaim); ok {
+			logrus.Debugf("Substitute object %v namespace %s to %s\n",
+				specObj, specObj.Namespace, namespaceMapping[specObj.Namespace])
+			namespace, _ := namespaceMapping[specObj.Namespace]
+			specObj.Namespace = namespace
+		} else if specObj, ok := in.(*storkapi.GroupVolumeSnapshot); ok {
+			logrus.Debugf("Substitute object %v namespace %s to %s\n",
+				specObj, specObj.Namespace, namespaceMapping[specObj.Namespace])
+			namespace, _ := namespaceMapping[specObj.Namespace]
+			specObj.Namespace = namespace
+		} else if specObj, ok := in.(*v1.Secret); ok {
+			logrus.Debugf("Substitute object %v namespace %s to %s\n",
+				specObj, specObj.Namespace, namespaceMapping[specObj.Namespace])
+			namespace, _ := namespaceMapping[specObj.Namespace]
+			specObj.Namespace = namespace
+		} else if specObj, ok := in.(*v1.ConfigMap); ok {
+			logrus.Debugf("Substitute object %v namespace %s to %s\n",
+				specObj, specObj.Namespace, namespaceMapping[specObj.Namespace])
+			namespace, _ := namespaceMapping[specObj.Namespace]
+			specObj.Namespace = namespace
+		} else if specObj, ok := in.(*storkapi.Rule); ok {
+			logrus.Debugf("Substitute object %v namespace %s to %s\n",
+				specObj, specObj.Namespace, namespaceMapping[specObj.Namespace])
+			namespace, _ := namespaceMapping[specObj.Namespace]
+			specObj.Namespace = namespace
+		} else if specObj, ok := in.(*v1.Pod); ok {
+			logrus.Debugf("Substitute object %v namespace %s to %s\n",
+				specObj, specObj.Namespace, namespaceMapping[specObj.Namespace])
+			namespace, _ := namespaceMapping[specObj.Namespace]
+			specObj.Namespace = namespace
+		} else if specObj, ok := in.(*storkapi.ClusterPair); ok {
+			namespace, _ := namespaceMapping[specObj.Namespace]
+			specObj.Namespace = namespace
+		} else if specObj, ok := in.(*storkapi.Migration); ok {
+			logrus.Debugf("Substitute object %v namespace %s to %s\n",
+				specObj, specObj.Namespace, namespaceMapping[specObj.Namespace])
+			namespace, _ := namespaceMapping[specObj.Namespace]
+			specObj.Namespace = namespace
+		} else if specObj, ok := in.(*storkapi.MigrationSchedule); ok {
+			logrus.Debugf("Substitute object %v namespace %s to %s\n",
+				specObj, specObj.Namespace, namespaceMapping[specObj.Namespace])
+			namespace, _ := namespaceMapping[specObj.Namespace]
+			specObj.Namespace = namespace
+		} else if specObj, ok := in.(*storkapi.BackupLocation); ok {
+			namespace, _ := namespaceMapping[specObj.Namespace]
+			specObj.Namespace = namespace
+		} else if specObj, ok := in.(*storkapi.ApplicationBackup); ok {
+			logrus.Debugf("Substitute object %v namespace %s to %s\n",
+				specObj, specObj.Namespace, namespaceMapping[specObj.Namespace])
+			namespace, _ := namespaceMapping[specObj.Namespace]
+			specObj.Namespace = namespace
+		} else if specObj, ok := in.(*storkapi.SchedulePolicy); ok {
+			logrus.Debugf("Substitute object %v namespace %s to %s\n",
+				specObj, specObj.Namespace, namespaceMapping[specObj.Namespace])
+			namespace, _ := namespaceMapping[specObj.Namespace]
+			specObj.Namespace = namespace
+		} else if specObj, ok := in.(*storkapi.ApplicationRestore); ok {
+			logrus.Debugf("Substitute object %v namespace %s to %s\n",
+				specObj, specObj.Namespace, namespaceMapping[specObj.Namespace])
+			namespace, _ := namespaceMapping[specObj.Namespace]
+			specObj.Namespace = namespace
+		} else if specObj, ok := in.(*storkapi.ApplicationClone); ok {
+			logrus.Debugf("Substitute object %v namespace %s to %s\n",
+				specObj, specObj.Namespace, namespaceMapping[specObj.Namespace])
+			namespace, _ := namespaceMapping[specObj.Namespace]
+			specObj.Namespace = namespace
+		} else if specObj, ok := in.(*storkapi.VolumeSnapshotRestore); ok {
+			logrus.Debugf("Substitute object %v namespace %s to %s\n",
+				specObj, specObj.Namespace, namespaceMapping[specObj.Namespace])
+			namespace, _ := namespaceMapping[specObj.Namespace]
+			specObj.Namespace = namespace
+		} else if specObj, ok := in.(*apapi.AutopilotRule); ok {
+			logrus.Debugf("Substitute object %v namespace %s to %s\n",
+				specObj, specObj.Namespace, namespaceMapping[specObj.Namespace])
+			namespace, _ := namespaceMapping[specObj.Namespace]
+			specObj.Namespace = namespace
+		} else if specObj, ok := in.(*v1.ServiceAccount); ok {
+			namespace, _ := namespaceMapping[specObj.Namespace]
+			specObj.Namespace = namespace
+		} else if specObj, ok := in.(*rbacv1.ClusterRole); ok {
+			namespace, _ := namespaceMapping[specObj.Namespace]
+			specObj.Namespace = namespace
+		} else if specObj, ok := in.(*rbacv1.ClusterRoleBinding); ok {
+			namespace, _ := namespaceMapping[specObj.Namespace]
+			specObj.Namespace = namespace
+		} else if specObj, ok := in.(*rbacv1.Role); ok {
+			logrus.Debugf("Substitute object %v namespace %s to %s\n",
+				specObj, specObj.Namespace, namespaceMapping[specObj.Namespace])
+			namespace, _ := namespaceMapping[specObj.Namespace]
+			specObj.Namespace = namespace
+		} else if specObj, ok := in.(*rbacv1.RoleBinding); ok {
+			logrus.Debugf("Substitute object %v namespace %s to %s\n",
+				specObj, specObj.Namespace, namespaceMapping[specObj.Namespace])
+			namespace, _ := namespaceMapping[specObj.Namespace]
+			specObj.Namespace = namespace
+		} else if specObj, ok := in.(*batchv1beta1.CronJob); ok {
+			logrus.Debugf("Substitute object %v namespace %s to %s\n",
+				specObj, specObj.Namespace, namespaceMapping[specObj.Namespace])
+			namespace, _ := namespaceMapping[specObj.Namespace]
+			specObj.Namespace = namespace
+		} else if specObj, ok := in.(*v1.LimitRange); ok {
+			logrus.Debugf("Substitute object %v namespace %s to %s\n",
+				specObj, specObj.Namespace, namespaceMapping[specObj.Namespace])
+			namespace, _ := namespaceMapping[specObj.Namespace]
+			specObj.Namespace = namespace
+		} else if specObj, ok := in.(*networkingv1beta1.Ingress); ok {
+			logrus.Debugf("Substitute object %v namespace %s to %s\n",
+				specObj, specObj.Namespace, namespaceMapping[specObj.Namespace])
+			namespace, _ := namespaceMapping[specObj.Namespace]
+			specObj.Namespace = namespace
+		} else {
+			logrus.Errorf("unsupported type %v object: %v", reflect.TypeOf(in), in)
+		}
+	}
+
+	return nil
+}
+
 func insertLineBreak(note string) string {
 	return fmt.Sprintf("------------------------------\n%s\n------------------------------\n", note)
 }

--- a/drivers/scheduler/k8s/k8s_test.go
+++ b/drivers/scheduler/k8s/k8s_test.go
@@ -1,0 +1,56 @@
+package k8s
+
+import (
+	"github.com/portworx/torpedo/drivers/scheduler"
+	"github.com/portworx/torpedo/drivers/scheduler/spec"
+	coreV1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestK8s_SubstituteNamespaceInSpec(t *testing.T) {
+	namespaceBefore := "before"
+	namespaceAfter := "after"
+
+	namespaceMapping := map[string]string{
+		namespaceBefore: namespaceAfter,
+	}
+
+	obj1 := coreV1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespaceBefore,
+		},
+	}
+	obj2 := coreV1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespaceBefore,
+		},
+	}
+
+	k := K8s{}
+		ctx := &scheduler.Context{
+			App: &spec.AppSpec{
+				SpecList: []interface{}{
+					&obj1,
+					&obj2,
+				},
+			},
+		}
+
+		err := k.SubstituteNamespaceInSpec(ctx, namespaceMapping)
+
+		if err != nil {
+			t.Errorf("unexpected error  %v", err)
+		}
+
+		if obj1.Namespace != namespaceAfter {
+			t.Errorf("expected namespace %s actual %s",
+				namespaceAfter, obj1.Namespace)
+			return
+		}
+
+		if obj2.Namespace != namespaceAfter {
+			t.Errorf("expected namespace %s actual %s",
+				namespaceAfter, obj2.Namespace)
+		}
+}

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -218,8 +218,11 @@ type Driver interface {
 	// GetWorkloadSizeFromAppSpec gets workload size from an application spec
 	GetWorkloadSizeFromAppSpec(ctx *Context) (uint64, error)
 
-	// SetConfig sets connnection config (e.g. kubeconfig in case of k8s) for scheduler driver
+	// SetConfig sets connection config (e.g. kubeconfig in case of k8s) for scheduler driver
 	SetConfig(configPath string) error
+
+	// SubstituteNamespaceInSpec substitutes namespaces in object according to namespace mapping
+	SubstituteNamespaceInSpec(ctx *Context, namespaceMapping map[string]string) error
 }
 
 var (

--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -189,6 +189,7 @@ var _ = Describe("{BackupCreateKillStoreRestore}", func() {
 					// Override default App readiness time out of 5 mins with 10 mins
 					ctx.ReadinessTimeout = appReadinessTimeout
 					namespace := GetAppNamespace(ctx, taskName)
+					namespaceMapping[namespace] = fmt.Sprintf("%s-restore", namespace)
 					bkpNamespaces = append(bkpNamespaces, namespace)
 				}
 			}
@@ -283,7 +284,7 @@ var _ = Describe("{BackupCreateKillStoreRestore}", func() {
 			backupName := fmt.Sprintf("%s-%s", BackupNamePrefix, namespace)
 			restoreName := fmt.Sprintf("%s-%s", RestoreNamePrefix, namespace)
 			Step(fmt.Sprintf("Create restore %s:%s:%s from backup %s:%s:%s",
-				DestinationClusterName, namespace, restoreName,
+				DestinationClusterName, namespaceMapping[namespace], restoreName,
 				SourceClusterName, namespace, backupName), func() {
 				CreateRestore(restoreName, backupName, namespaceMapping,
 					DestinationClusterName, orgID)
@@ -315,6 +316,11 @@ var _ = Describe("{BackupCreateKillStoreRestore}", func() {
 
 			// Populate contexts
 			for _, ctx := range contexts {
+				logrus.Infof("Substitute namespaces according to %v", namespaceMapping)
+				if err := Inst().S.SubstituteNamespaceInSpec(ctx, namespaceMapping); err != nil {
+					logrus.Warnf("Error when substituting namespace\n")
+				}
+
 				ctx.SkipClusterScopedObject = true
 				ctx.SkipVolumeValidation = true
 			}


### PR DESCRIPTION
Currently namespace mapping is not takes into account when
validate apps after restore. This PR updates namespace for each
spec object in specs before validation.