### PR TITLE
Add custom app name param to schedule options

### DIFF
--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -1002,6 +1002,9 @@ func (k *K8s) createCoreObject(spec interface{}, ns *v1.Namespace, app *spec.App
 	if obj, ok := spec.(*appsapi.Deployment); ok {
 		obj.Namespace = ns.Name
 		obj.Spec.Template.Spec.Volumes = k.substituteNamespaceInVolumes(obj.Spec.Template.Spec.Volumes, ns.Name)
+		if options.CustomAppName != "" {
+			obj.Name = options.CustomAppName
+		}
 		if options.Scheduler != "" {
 			obj.Spec.Template.Spec.SchedulerName = options.Scheduler
 		}

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -88,6 +88,8 @@ type ScheduleOptions struct {
 	Scheduler string
 	// Labels is a map of {key,value} pairs for labeling spec objects
 	Labels map[string]string
+	// CustomAppName  use this custom name to deploy app, if specified
+	CustomAppName string
 }
 
 // Driver must be implemented to provide test support to various schedulers.


### PR DESCRIPTION
**Why do we need this PR?**
Provide a way to provide a custom app name for deploying a spec, that way the same spec file 
can be used to deploy different apps in the same namespace

Signed-off-by: Rohit-PX <rohit@portworx.com>