### PR TITLE
Fix for VolumeUpdate test

### DIFF
--- a/tests/volume_ops/volume_ops_test.go
+++ b/tests/volume_ops/volume_ops_test.go
@@ -52,9 +52,10 @@ var _ = Describe("{VolumeUpdate}", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(appVolumes).NotTo(BeEmpty())
 				})
-				MaxRF := Inst().V.GetMaxReplicationFactor()
-				MinRF := Inst().V.GetMinReplicationFactor()
 				for _, v := range appVolumes {
+					MaxRF := Inst().V.GetMaxReplicationFactor()
+					MinRF := Inst().V.GetMinReplicationFactor()
+
 					Step(
 						fmt.Sprintf("repl decrease volume driver %s on app %s's volume: %v",
 							Inst().V.String(), ctx.App.Key, v),


### PR DESCRIPTION
Found an issue in VolumeUpdate Torpedo test. If volume aggregation level more than 1, we set MaxRF:
```
if currAggr > 1 {
MaxRF = int64(len(node.GetWorkerNodes())) / currAggr
}
```
and never reset that value on next iteration for volume.