### PR TITLE
Increase timeout for pgbench

### DIFF
--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -58,7 +58,7 @@ const (
 	defaultTimeout       = 5 * time.Minute
 	defaultRetryInterval = 5 * time.Second
 
-	appReadinessTimeout = 10 * time.Minute
+	appReadinessTimeout = 20 * time.Minute
 )
 
 var (


### PR DESCRIPTION
Ussually pgbench took about 19 minutes to complete data population
and pass readiness  probe. We need to increate readiness timeout
too be big enought for that.