### PR TITLE
Added Node Driver APIs to set and get cluster versions.

### DIFF
--- a/drivers/node/node.go
+++ b/drivers/node/node.go
@@ -143,6 +143,12 @@ type Driver interface {
 
 	// GetASGClusterSize gets node count for an asg cluster
 	GetASGClusterSize() (int64, error)
+
+	// SetClusterVersion sets desired version for cluster and its node pools
+	SetClusterVersion(version string) error
+
+	// GetClusterVersion returns version of cluster and its node pools
+	GetClusterVersion() (clusterVersion string, nodePoolsVersion []string, err error)
 }
 
 // Register registers the given node driver
@@ -264,5 +270,21 @@ func (d *notSupportedDriver) DeleteNode(node Node, timeout time.Duration) error 
 	return &errors.ErrNotSupported{
 		Type:      "Function",
 		Operation: "DeleteNode()",
+	}
+}
+
+func (d *notSupportedDriver) SetClusterVersion(version string) error {
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "SetClusterVersion()",
+	}
+}
+
+func (d *notSupportedDriver) GetClusterVersion() (clusterVersion string,
+	nodePoolsVersion []string,
+	err error) {
+	return "", []string{}, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "GetClusterVersion()",
 	}
 }


### PR DESCRIPTION
K8S upgrade test would look like:

1. Spawn creates a k8s cluster with the initial version. (K8S version is variable here)
2. Deploy PX. (PX version is not variable)
3. Deploy torpedo in separate node pool (on managed clusters like GKE so that during k8s node upgrade torpedo does not get affected.)
4. Torpedo to perform existing tests like VolumeDriverDown, ASG scale up/down (In cases of managed clusters)
5. Trigger cluster upgrade
6. Validate Apps are running as expected after upgrade.