### PR TITLE
Fix for k3s cluster

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -239,7 +239,7 @@ func (d *portworx) RefreshDriverEndpoints() error {
 }
 
 func (d *portworx) updateNodes(pxNodes []api.StorageNode) error {
-	for _, n := range node.GetWorkerNodes() {
+	for _, n := range node.GetNodes() {
 		if err := d.updateNode(&n, pxNodes); err != nil {
 			return err
 		}


### PR DESCRIPTION
As we install portworx on master node in k3s environment, we have to update all nodes instead of only worker nodes.

Tests passed here:
https://jenkins.portworx.co/job/Torpedo/job/tp-dev-test/677/ (postgres,rabbitmq,sysbench,wordpress-sharedv4)
https://jenkins.portworx.co/job/Torpedo/job/tp-dev-test/671/ (elasticsearch,mysql,nginx,nginx-sharedv4)