### PR TITLE
Fix for ValidateVolumeCleanup method for cloud runs

### DIFF
--- a/drivers/volume/portworx/schedops/k8s-schedops.go
+++ b/drivers/volume/portworx/schedops/k8s-schedops.go
@@ -408,7 +408,7 @@ func (k *k8sSchedOps) ValidateVolumeCleanup(d node.Driver) error {
 		Name:           "*portworx-volume",
 	}
 
-	for _, n := range node.GetWorkerNodes() {
+	for _, n := range node.GetStorageDriverNodes() {
 		volDirList, _ := d.FindFiles(k8sPodsRootDir, n, listVolOpts)
 		nodeToPodsMap[n.Name] = separateFilePaths(volDirList)
 		nodeMap[n.Name] = n


### PR DESCRIPTION
I have noticed that when we run torpedo on AKS, we are running ValidateVolumeCleanup function on torpedo instance which doesn't have installed portworx on it.

`2020/06/15 21:04:51 Failed to run command on: . Cause: debug pod not found in node {{ 0 0 0 0 0 STATUS_NONE map[] []    map[]  UnknownMachine {} [] 0} 10b59f59-eca3-44a6-946f-f853ebd7fb31  aks-torpedo-24102394-vmss000000 [10.240.0.7]  Worker 0 eastus false false []} Next retry in: 10s`

Signed-off-by: Maksym Borodin <maksym@portworx.com>