### PR TITLE
Add resource limit for rabbitmq-io container

### DIFF
--- a/drivers/scheduler/k8s/specs/rabbitmq/px-rabbitmq-app.yml
+++ b/drivers/scheduler/k8s/specs/rabbitmq/px-rabbitmq-app.yml
@@ -219,3 +219,7 @@ spec:
             - "--autoack"
             - "--disable-connection-recovery"
             - "--shutdown-timeout=-1"
+          resources:
+            limits:
+              cpu: "1"
+              memory: "500Mi"


### PR DESCRIPTION
Add CPU and Memory resource limit for rabbitmq-io container, ran this with private image and it seems to lower the CPU usage.

Signed-off-by: nikolaypopov <nikolay.popov86@gmail.com>