### PR TITLE
Remove nfs_v4 from wordpress-sharedv4

### DIFF
--- a/drivers/scheduler/k8s/specs/wordpress-sharedv4/storage.yaml
+++ b/drivers/scheduler/k8s/specs/wordpress-sharedv4/storage.yaml
@@ -7,7 +7,6 @@ parameters:
   repl: "3"
   priority_io: "high"
   sharedv4: "true"
-  nfs_v4: "true"
   io_profile: "cms"
 allowVolumeExpansion: true
 ---


### PR DESCRIPTION
Removing `nfs_v4: "true"` from `wordpress-sharedv4` spec for now due to too many failures.

Signed-off-by: nikolaypopov <nikolay.popov86@gmail.com>