### PR TITLE
Revert "PTX-2691 fix wordpress deployment to use nfsv4 without cms"

### DIFF
--- a/drivers/scheduler/k8s/specs/wordpress-sharedv4/mysql.yaml
+++ b/drivers/scheduler/k8s/specs/wordpress-sharedv4/mysql.yaml
@@ -40,7 +40,7 @@ spec:
         tier: mysql
     spec:
       containers:
-      - image: mysql:5.7
+      - image: mysql:5.6
         name: mysql
         env:
         - name: MYSQL_ROOT_PASSWORD

--- a/drivers/scheduler/k8s/specs/wordpress-sharedv4/storage.yaml
+++ b/drivers/scheduler/k8s/specs/wordpress-sharedv4/storage.yaml
@@ -7,7 +7,7 @@ parameters:
   repl: "3"
   priority_io: "high"
   sharedv4: "true"
-  nfs_v4: "true"
+  io_profile: "cms"
 allowVolumeExpansion: true
 ---
 apiVersion: storage.k8s.io/v1
@@ -34,7 +34,7 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: 10Gi
+      storage: 1Gi
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -47,4 +47,4 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 8Gi
+      storage: 1Gi

--- a/drivers/scheduler/k8s/specs/wordpress-sharedv4/wordpress.yaml
+++ b/drivers/scheduler/k8s/specs/wordpress-sharedv4/wordpress.yaml
@@ -12,7 +12,7 @@ spec:
       tier: frontend
   replicas: 3
   strategy:
-    type: RollingUpdate
+    type: Recreate
   template:
     metadata:
       labels:
@@ -20,11 +20,9 @@ spec:
         tier: frontend
     spec:
       containers:
-      - image: wordpress:5.5.0-php7.2-apache
+      - image: wordpress:4.8-apache
         name: wordpress
         env:
-        - name: WORDPRESS_DEBUG
-          value: "1"
         - name: WORDPRESS_DB_HOST
           value: wordpress-mysql
         - name: WORDPRESS_DB_PASSWORD
@@ -41,26 +39,13 @@ spec:
           subPath: html
         livenessProbe:
           httpGet:
-            path: /wp-admin/install.php
+            path: /
             port: 80
-          initialDelaySeconds: 120
-          periodSeconds: 10
+          initialDelaySeconds: 15
           timeoutSeconds: 5
-          failureThreshold: 6
-          successThreshold: 1
-        readinessProbe:
-          httpGet:
-            path: /wp-login.php
-            port: 80
-          initialDelaySeconds: 30
-          periodSeconds: 10
-          timeoutSeconds: 5
-          failureThreshold: 6
-          successThreshold: 1
         resources:
           requests:
-            memory: "512Mi"
-            cpu: "300m"
+            memory: "2Gi"
       volumes:
       - name: wordpress-persistent-storage
         persistentVolumeClaim:


### PR DESCRIPTION
Reverts portworx/torpedo#527