### PR TITLE
Add generic CSI driver

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -137,6 +137,11 @@ if [ -n "${MAX_STORAGE_NODES_PER_AZ}" ]; then
     MAX_STORAGE_NODES_PER_AZ_ARG="--max-storage-nodes-per-az=$MAX_STORAGE_NODES_PER_AZ"
 fi
 
+CSI_GENERIC_CONFIGMAP=""
+if [ -n "${CSI_GENERIC_DRIVER_CONFIGMAP}" ]; then
+    CSI_GENERIC_CONFIGMAP="${CSI_GENERIC_DRIVER_CONFIGMAP}"
+fi
+
 for i in $@
 do
 case $i in
@@ -404,6 +409,7 @@ spec:
             "--vault-addr=$VAULT_ADDR",
             "--vault-token=$VAULT_TOKEN",
             "--autopilot-upgrade-version=$AUTOPILOT_UPGRADE_VERSION",
+            "--csi-generic-driver-config-map=$CSI_GENERIC_CONFIGMAP",
             "$APP_DESTROY_TIMEOUT_ARG",
             "$SCHEDULER_UPGRADE_HOPS_ARG",
             "$MAX_STORAGE_NODES_PER_AZ_ARG"

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -816,10 +816,8 @@ func (k *K8s) createStorageObject(spec interface{}, ns *corev1.Namespace, app *s
 	if obj, ok := spec.(*storageapi.StorageClass); ok {
 		obj.Namespace = ns.Name
 
-		if strings.Contains(volume.GetStorageProvisioner(), "pxd") {
-			logrus.Infof("Setting provisioner of %v to %v", obj.Name, volume.GetStorageProvisioner())
-			obj.Provisioner = volume.GetStorageProvisioner()
-		}
+		logrus.Infof("Setting provisioner of %v to %v", obj.Name, volume.GetStorageProvisioner())
+		obj.Provisioner = volume.GetStorageProvisioner()
 
 		sc, err := k8sStorage.CreateStorageClass(obj)
 		if errors.IsAlreadyExists(err) {

--- a/drivers/volume/aws/aws.go
+++ b/drivers/volume/aws/aws.go
@@ -37,7 +37,7 @@ func (d *aws) RefreshDriverEndpoints() error {
 	return nil
 }
 
-func (d *aws) Init(sched string, nodeDriver string, token string, storageProvisioner string) error {
+func (d *aws) Init(sched, nodeDriver, token, storageProvisioner, csiGenericDriverConfigMap string) error {
 	logrus.Infof("Using the AWS EBS volume driver with provisioner %s under scheduler: %v", storageProvisioner, sched)
 	torpedovolume.StorageDriver = DriverName
 	// Set provisioner for torpedo

--- a/drivers/volume/azure/azure.go
+++ b/drivers/volume/azure/azure.go
@@ -37,7 +37,7 @@ func (d *azure) RefreshDriverEndpoints() error {
 	return nil
 }
 
-func (d *azure) Init(sched string, nodeDriver string, token string, storageProvisioner string) error {
+func (d *azure) Init(sched, nodeDriver, token, storageProvisioner, csiGenericDriverConfigMap string) error {
 	logrus.Infof("Using the Azure volume driver with provisioner %s under scheduler: %v", storageProvisioner, sched)
 	torpedovolume.StorageDriver = DriverName
 	// Set provisioner for torpedo

--- a/drivers/volume/common.go
+++ b/drivers/volume/common.go
@@ -22,7 +22,7 @@ func (d *DefaultDriver) String() string {
 }
 
 // Init initializes the volume driver under the given scheduler
-func (d *DefaultDriver) Init(sched string, nodeDriver string, token string, storageProvisioner string) error {
+func (d *DefaultDriver) Init(sched, nodeDriver, token, storageProvisioner, csiGenericDriverConfigMap string) error {
 	StorageProvisioner = DefaultStorageProvisioner
 	return nil
 }

--- a/drivers/volume/gce/gce.go
+++ b/drivers/volume/gce/gce.go
@@ -28,7 +28,7 @@ func (d *gce) String() string {
 	return string(GceStorage)
 }
 
-func (d *gce) Init(sched string, nodeDriver string, token string, storageProvisioner string) error {
+func (d *gce) Init(sched, nodeDriver, token, storageProvisioner, csiGenericDriverConfigMap string) error {
 	logrus.Infof("Using the GCE volume driver with provisioner %s under scheduler: %v", storageProvisioner, sched)
 	torpedovolume.StorageDriver = DriverName
 	// Set provisioner for torpedo

--- a/drivers/volume/generic_csi/generic_csi.go
+++ b/drivers/volume/generic_csi/generic_csi.go
@@ -1,0 +1,64 @@
+package csi
+
+import (
+	"fmt"
+
+	"github.com/portworx/sched-ops/k8s/core"
+	torpedovolume "github.com/portworx/torpedo/drivers/volume"
+	"github.com/portworx/torpedo/drivers/volume/portworx/schedops"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// DriverName is the name of the aws driver implementation
+	DriverName = "generic_csi"
+	// CsiStorage CSI storage driver name
+	CsiStorage torpedovolume.StorageProvisionerType = "generic_csi"
+	// CsiStorageClassKey CSI Generic driver config map key name
+	CsiStorageClassKey = "csi_storageclass_key"
+)
+
+// Provisioners types of supported provisioners
+var provisioners = map[torpedovolume.StorageProvisionerType]torpedovolume.StorageProvisionerType{
+	CsiStorage: "",
+}
+
+type genericCsi struct {
+	schedOps schedops.Driver
+	torpedovolume.DefaultDriver
+}
+
+func (d *genericCsi) String() string {
+	return string(CsiStorage)
+}
+
+func (d *genericCsi) ValidateVolumeCleanup() error {
+	return nil
+}
+
+func (d *genericCsi) RefreshDriverEndpoints() error {
+	return nil
+}
+
+func (d *genericCsi) Init(sched, nodeDriver, token, storageProvisioner, csiGenericDriverConfigMap string) error {
+	logrus.Infof("Using the generic CSI volume driver with provisioner %s under scheduler: %v", storageProvisioner, sched)
+	torpedovolume.StorageDriver = DriverName
+	// Set provisioner for torpedo, from
+	if storageProvisioner == string(CsiStorage) {
+		// Get the provisioner from the config map
+		configMap, err := core.Instance().GetConfigMap(csiGenericDriverConfigMap, "default")
+		if err != nil {
+			return fmt.Errorf("Failed to get config map for volume driver: %s, provisioner: %s", DriverName, storageProvisioner)
+		}
+		if p, ok := configMap.Data[CsiStorageClassKey]; ok {
+			torpedovolume.StorageProvisioner = torpedovolume.StorageProvisionerType(p)
+		}
+	} else {
+		return fmt.Errorf("Invalid provisioner %s for volume driver: %s", storageProvisioner, DriverName)
+	}
+	return nil
+}
+
+func init() {
+	torpedovolume.Register(DriverName, provisioners, &genericCsi{})
+}

--- a/drivers/volume/linstor/linstor.go
+++ b/drivers/volume/linstor/linstor.go
@@ -41,7 +41,7 @@ func (d *linstor) String() string {
 	return string(LinstorStorage)
 }
 
-func (d *linstor) Init(sched string, nodeDriver string, token string, storageProvisioner string) error {
+func (d *linstor) Init(sched, nodeDriver, token, storageProvisioner, csiGenericDriverConfigMap string) error {
 	logrus.Infof("Using the LINSTOR volume driver with provisioner %s under scheduler: %v", storageProvisioner, sched)
 
 	// Configuration of linstor client happens via environment variables:

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -176,7 +176,7 @@ func (d *portworx) String() string {
 	return DriverName
 }
 
-func (d *portworx) Init(sched string, nodeDriver string, token string, storageProvisioner string) error {
+func (d *portworx) Init(sched, nodeDriver, token, storageProvisioner, csiGenericDriverConfigMap string) error {
 	logrus.Infof("Using the Portworx volume driver with provisioner %s under scheduler: %v", storageProvisioner, sched)
 	var err error
 

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -48,7 +48,7 @@ type Options struct {
 // of failure scenarious that can happen with an external storage provider.
 type Driver interface {
 	// Init initializes the volume driver under the given scheduler
-	Init(sched string, nodeDriver string, token string, storageProvisioner string) error
+	Init(sched string, nodeDriver string, token string, storageProvisioner string, csiGenericConfigMap string) error
 
 	// String returns the string name of this driver.
 	String() string

--- a/tests/common.go
+++ b/tests/common.go
@@ -56,6 +56,8 @@ import (
 	_ "github.com/portworx/torpedo/drivers/volume/aws"
 	// import azure driver to invoke it's init
 	_ "github.com/portworx/torpedo/drivers/volume/azure"
+	// import generic csi driver to invoke it's init
+	_ "github.com/portworx/torpedo/drivers/volume/generic_csi"
 	"github.com/portworx/torpedo/pkg/log"
 
 	yaml "gopkg.in/yaml.v2"
@@ -87,6 +89,7 @@ const (
 	configMapFlag                        = "config-map"
 	enableStorkUpgradeFlag               = "enable-stork-upgrade"
 	autopilotUpgradeImageCliFlag         = "autopilot-upgrade-version"
+	csiGenericDriverConfigMapFlag        = "csi-generic-driver-config-map"
 )
 
 const (
@@ -155,7 +158,7 @@ func InitInstance() {
 	err = Inst().N.Init()
 	expect(err).NotTo(haveOccurred())
 
-	err = Inst().V.Init(Inst().S.String(), Inst().N.String(), token, Inst().Provisioner)
+	err = Inst().V.Init(Inst().S.String(), Inst().N.String(), token, Inst().Provisioner, Inst().CsiGenericDriverConfigMap)
 	expect(err).NotTo(haveOccurred())
 
 	if Inst().Backup != nil {
@@ -897,6 +900,7 @@ type Torpedo struct {
 	VaultToken                          string
 	SchedUpgradeHops                    string
 	AutopilotUpgradeImage               string
+	CsiGenericDriverConfigMap           string
 }
 
 // ParseFlags parses command line flags
@@ -925,6 +929,7 @@ func ParseFlags() {
 	var vaultToken string
 	var schedUpgradeHops string
 	var autopilotUpgradeImage string
+	var csiGenericDriverConfigMapName string
 
 	flag.StringVar(&s, schedulerCliFlag, defaultScheduler, "Name of the scheduler to use")
 	flag.StringVar(&n, nodeDriverCliFlag, defaultNodeDriver, "Name of the node driver to use")
@@ -956,6 +961,7 @@ func ParseFlags() {
 	flag.StringVar(&vaultToken, "vault-token", "", "Path to custom configuration files")
 	flag.StringVar(&schedUpgradeHops, "sched-upgrade-hops", "", "Comma separated list of versions scheduler upgrade to take hops")
 	flag.StringVar(&autopilotUpgradeImage, autopilotUpgradeImageCliFlag, "", "Autopilot version which will be used for checking version after upgrade autopilot")
+	flag.StringVar(&csiGenericDriverConfigMapName, csiGenericDriverConfigMapFlag, "", "Name of config map that stores provisioner details when CSI generic driver is being used")
 	flag.Parse()
 
 	appList, err := splitCsv(appListCSV)
@@ -1027,6 +1033,7 @@ func ParseFlags() {
 				VaultToken:                          vaultToken,
 				SchedUpgradeHops:                    schedUpgradeHops,
 				AutopilotUpgradeImage:               autopilotUpgradeImage,
+				CsiGenericDriverConfigMap:           csiGenericDriverConfigMapName,
 			}
 		})
 	}


### PR DESCRIPTION
### Why do we need this PR?
- Will add a new generic CSI volume driver to torped
- For this volume driver, the provisioner details will be picked from a config map
- The config map will contain the details for the provisioner that will be modified in the storage class object during runtime
- The config map will be introduced as a new parameter to torpedo
- Using this driver we can test out torpedo using any provisioner (e.g PureStorage, Digital Ocean) that is supported by the CSI driver

Signed-off-by: Rohit-PX <rohit@portworx.com>