### PR TITLE
PTX-2744 Added test for autopilot rebalance and pool resize

### DIFF
--- a/drivers/scheduler/dcos/dcos.go
+++ b/drivers/scheduler/dcos/dcos.go
@@ -88,6 +88,13 @@ func (d *dcos) ValidateAutopilotEvents(ctx *scheduler.Context) error {
 	}
 }
 
+// ValidateAutopilotRuleObjects validates autopilot rule objects
+func (d *dcos) ValidateAutopilotRuleObjects() error {
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "ValidateAutopilotRuleObjects()",
+	}
+}
 func (d *dcos) ParseSpecs(specDir, storageProvisioner string) ([]interface{}, error) {
 	fileList := []string{}
 	if err := filepath.Walk(specDir, func(path string, f os.FileInfo, err error) error {
@@ -600,6 +607,14 @@ func (d *dcos) AddLabelOnNode(n node.Node, lKey string, lValue string) error {
 	}
 }
 
+func (d *dcos) RemoveLabelOnNode(n node.Node, lKey string) error {
+	// TODO implement this method
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "RemoveLabelOnNode()",
+	}
+}
+
 func (d *dcos) IsAutopilotEnabledForVolume(*volume.Volume) bool {
 	// TODO implement this method
 	return false
@@ -622,6 +637,14 @@ func (d *dcos) SaveSchedulerLogsToFile(n node.Node, location string) error {
 func (d *dcos) GetWorkloadSizeFromAppSpec(ctx *scheduler.Context) (uint64, error) {
 	// TODO: not implemented
 	return 0, nil
+}
+
+func (d *dcos) GetAutopilotNamespace() (string, error) {
+	// TODO implement this method
+	return "", &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "GetAutopilotNamespace()",
+	}
 }
 
 func (d *dcos) CreateAutopilotRule(apRule apapi.AutopilotRule) (*apapi.AutopilotRule, error) {

--- a/drivers/scheduler/errors.go
+++ b/drivers/scheduler/errors.go
@@ -342,6 +342,20 @@ func (e *ErrFailedToAddLabelOnNode) Error() string {
 	return fmt.Sprintf("Failed to add label: %s=%s on node %v due to err: %v", e.Key, e.Value, e.Node, e.Cause)
 }
 
+// ErrFailedToRemoveLabelOnNode error type for failing to remove label on node
+type ErrFailedToRemoveLabelOnNode struct {
+	// Key is the label key
+	Key string
+	// Node is the node where label should be added
+	Node node.Node
+	// Cause is the underlying cause of the error
+	Cause string
+}
+
+func (e *ErrFailedToRemoveLabelOnNode) Error() string {
+	return fmt.Sprintf("Failed to remove label: %s on node: %v due to err: %v", e.Key, e.Node, e.Cause)
+}
+
 // ErrFailedToGetCustomSpec error type for failing to get config map
 type ErrFailedToGetCustomSpec struct {
 	// Name of config map

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -95,6 +95,8 @@ const (
 	// DefaultTimeout default timeout
 	DefaultTimeout = 2 * time.Minute
 
+	autopilotServiceName          = "autopilot"
+	autopilotDefaultNamespace     = "kube-system"
 	resizeSupportedAnnotationKey  = "torpedo.io/resize-supported"
 	autopilotEnabledAnnotationKey = "torpedo.io/autopilot-enabled"
 	pvcLabelsAnnotationKey        = "torpedo.io/pvclabels-enabled"
@@ -857,7 +859,7 @@ func (k *K8s) createStorageObject(spec interface{}, ns *corev1.Namespace, app *s
 			pvcNodesEnabled, _ := strconv.ParseBool(pvcNodesAnnotationValue)
 			if pvcNodesEnabled {
 				if len(options.PvcNodesAnnotation) > 0 {
-					k.addAnnotationsToPVC(obj, map[string]string{"nodes": options.PvcNodesAnnotation})
+					k.addAnnotationsToPVC(obj, map[string]string{"nodes": strings.Join(options.PvcNodesAnnotation, ",")})
 				}
 			}
 		}
@@ -3483,6 +3485,49 @@ func (k *K8s) ValidateAutopilotEvents(ctx *scheduler.Context) error {
 	return nil
 }
 
+// ValidateAutopilotRuleObjects validates autopilot rule objects
+func (k *K8s) ValidateAutopilotRuleObjects() error {
+
+	// TODO: Implement ARO validation for specific pool if autopilot rule has pool LabelSelector
+	namespace, err := k.GetAutopilotNamespace()
+	if err != nil {
+		return err
+	}
+
+	expectedAroStates := []apapi.RuleState{
+		apapi.RuleStateInit,
+		apapi.RuleStateNormal,
+		apapi.RuleStateTriggered,
+		apapi.RuleStateActiveActionsPending,
+		apapi.RuleStateActiveActionsInProgress,
+		apapi.RuleStateActiveActionsTaken,
+		apapi.RuleStateNormal,
+	}
+
+	listAutopilotRuleObjects, err := k8sAutopilot.ListAutopilotRuleObjects(namespace)
+	if err != nil {
+		return err
+	}
+	if len(listAutopilotRuleObjects.Items) == 0 {
+		logrus.Warnf("the list of autopilot rule objects is empty, please make sure that you have an appropriate autopilot rule")
+		return nil
+	}
+	for _, aro := range listAutopilotRuleObjects.Items {
+		var aroStates []apapi.RuleState
+		for _, aroStatusItem := range aro.Status.Items {
+			aroStates = append(aroStates, aroStatusItem.State)
+		}
+		if reflect.DeepEqual(aroStates, expectedAroStates) {
+			logrus.Debugf("autopilot rule object: %s has all expected states", aro.Name)
+			return nil
+		}
+		logrus.Debugf("autopilot rule object: %s doesn't have all expected states", aro.Name)
+	}
+
+	formattedObject, _ := json.MarshalIndent(listAutopilotRuleObjects.Items, "", "\t")
+	return fmt.Errorf("none of the autopilot rule objects have all expected states\n autopilot rule objects items: %s", string(formattedObject))
+}
+
 func validateEvents(objName string, events map[string]int32, count int32) error {
 	logrus.Debugf("expected %d resized in events validation", count)
 	if count == 0 {
@@ -3638,6 +3683,21 @@ func (k *K8s) AddLabelOnNode(n node.Node, lKey string, lValue string) error {
 	return nil
 }
 
+// RemoveLabelOnNode adds label for a given node
+func (k *K8s) RemoveLabelOnNode(n node.Node, lKey string) error {
+	k8sOps := k8sCore
+
+	if err := k8sOps.RemoveLabelOnNode(n.Name, lKey); err != nil {
+		return &scheduler.ErrFailedToRemoveLabelOnNode{
+			Key:   lKey,
+			Node:  n,
+			Cause: fmt.Sprintf("Failed to remove label on node. Err: %v", err),
+		}
+	}
+	logrus.Infof("Removed label: %s on node: %s", lKey, n.Name)
+	return nil
+}
+
 // IsAutopilotEnabledForVolume checks if autopilot enabled for a given volume
 func (k *K8s) IsAutopilotEnabledForVolume(vol *volume.Volume) bool {
 	autopilotEnabled := false
@@ -3675,6 +3735,20 @@ func (k *K8s) addAnnotationsToPVC(pvc *corev1.PersistentVolumeClaim, annotations
 	for k, v := range annotations {
 		pvc.Annotations[k] = v
 	}
+}
+
+// GetAutopilotNamespace returns the autopilot namespace
+func (k *K8s) GetAutopilotNamespace() (string, error) {
+	allServices, err := k8sCore.ListServices("", metav1.ListOptions{})
+	if err != nil {
+		return "", err
+	}
+	for _, svc := range allServices.Items {
+		if svc.Name == autopilotServiceName {
+			return svc.Namespace, nil
+		}
+	}
+	return autopilotDefaultNamespace, nil
 }
 
 // CreateAutopilotRule creates the AutopilotRule object

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -104,8 +104,8 @@ type ScheduleOptions struct {
 	Scheduler string
 	// Labels is a map of {key,value} pairs for labeling spec objects
 	Labels map[string]string
-	// PvcNodesAnnotation is a map of {key,value} pairs for pvc annotations
-	PvcNodesAnnotation string
+	// PvcNodesAnnotation is a comma separated Node ID's  to use for replication sets of the volume
+	PvcNodesAnnotation []string
 	// PvcSize is the size of PVC
 	PvcSize int64
 }
@@ -208,14 +208,20 @@ type Driver interface {
 	// GetTokenFromConfigMap gets token for a volume
 	GetTokenFromConfigMap(string) (string, error)
 
-	// AddLabelOnNode adds key value labels on the node
+	// AddLabelOnNode adds key value label on the node
 	AddLabelOnNode(node.Node, string, string) error
+
+	// RemoveLabelOnNode removes label on the node
+	RemoveLabelOnNode(node.Node, string) error
 
 	// IsAutopilotEnabledForVolume checks if autopilot enabled for a given volume
 	IsAutopilotEnabledForVolume(*volume.Volume) bool
 
 	// SaveSchedulerLogsToFile gathers all scheduler logs into a file
 	SaveSchedulerLogsToFile(node.Node, string) error
+
+	// GetAutopilotNamespace gets the Autopilot namespace
+	GetAutopilotNamespace() (string, error)
 
 	// CreateAutopilotRule creates the AutopilotRule object
 	CreateAutopilotRule(apRule apapi.AutopilotRule) (*apapi.AutopilotRule, error)
@@ -249,6 +255,9 @@ type Driver interface {
 
 	// ValidateAutopilotEvents validates events for PVCs injected by autopilot
 	ValidateAutopilotEvents(ctx *Context) error
+
+	// ValidateAutopilotRuleObject validates Autopilot rule object
+	ValidateAutopilotRuleObjects() error
 
 	// GetWorkloadSizeFromAppSpec gets workload size from an application spec
 	GetWorkloadSizeFromAppSpec(ctx *Context) (uint64, error)

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -612,14 +612,7 @@ func (d *portworx) ValidateCreateVolume(volumeName string, params map[string]str
 	for k, v := range params {
 		switch k {
 		case api.SpecNodes:
-			contains := false
-			for _, sn := range vol.Spec.ReplicaSet.Nodes {
-				if sn == v {
-					contains = true
-					break
-				}
-			}
-			if !contains {
+			if v != strings.Join(vol.Spec.ReplicaSet.Nodes, ",") {
 				return errFailedToInspectVolume(volumeName, k, v, vol.Spec.ReplicaSet.Nodes)
 			}
 		case api.SpecParent:
@@ -2263,7 +2256,7 @@ func (d *portworx) EstimatePoolExpandSize(apRule apapi.AutopilotRule, pool node.
 						requiredNewDisks := uint64(math.Ceil(requiredScaleSize / float64(baseDiskSize)))
 						calculatedTotalSize += requiredNewDisks * baseDiskSize
 					} else {
-						calculatedTotalSize += uint64(requiredScaleSize)
+						calculatedTotalSize += uint64(requiredScaleSize) * uint64(len(node.Disks))
 					}
 				}
 			} else {

--- a/drivers/volume/portworx/portworx_test.go
+++ b/drivers/volume/portworx/portworx_test.go
@@ -62,6 +62,18 @@ func TestCalculateAutopilotObjectSize(t *testing.T) {
 			expectedSize: 50 * units.GiB,
 		},
 		{
+			rule:         aututils.PoolRuleFixedScaleSizeByTotalSize(31, "1Gi", aututils.RuleScaleTypeResizeDisk, nil),
+			pool:         getTestPool(30, 2, api.StorageMedium_STORAGE_MEDIUM_MAGNETIC),
+			node:         getTestNode(30, 3, api.StorageMedium_STORAGE_MEDIUM_MAGNETIC),
+			expectedSize: 33 * units.GiB,
+		},
+		{
+			rule:         aututils.PoolRuleFixedScaleSizeByTotalSize(650, "23Gi", aututils.RuleScaleTypeResizeDisk, nil),
+			pool:         getTestPool(640, 2, api.StorageMedium_STORAGE_MEDIUM_MAGNETIC),
+			node:         getTestNode(640, 5, api.StorageMedium_STORAGE_MEDIUM_MAGNETIC),
+			expectedSize: 755 * units.GiB,
+		},
+		{
 			rule:         aututils.PoolRuleFixedScaleSizeByTotalSize(11, "5Gi", aututils.RuleScaleTypeAddDisk, nil),
 			pool:         getTestPool(10, 2, api.StorageMedium_STORAGE_MEDIUM_MAGNETIC),
 			node:         getTestNode(10, 1, api.StorageMedium_STORAGE_MEDIUM_MAGNETIC),

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/pborman/uuid v1.2.0
 	github.com/portworx/kvdb v0.0.0-20191223203141-f42097b1fcd8 // indirect
 	github.com/portworx/px-backup-api v1.0.1-0.20200915150042-274508e876ef
-	github.com/portworx/sched-ops v0.0.0-20210129165423-2b83087e7388
+	github.com/portworx/sched-ops v0.0.0-20210202202336-6d3053100643
 	github.com/sendgrid/rest v2.6.0+incompatible // indirect
 	github.com/sendgrid/sendgrid-go v3.6.0+incompatible
 	github.com/sirupsen/logrus v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -813,8 +813,8 @@ github.com/portworx/kvdb v0.0.0-20191223203141-f42097b1fcd8/go.mod h1:Q8YyrNDvPp
 github.com/portworx/px-backup-api v1.0.1-0.20200915150042-274508e876ef h1:/N+yBbOHOb/psKqokxktQ1lnrnu8hbU/d6NPR2AqL+Y=
 github.com/portworx/px-backup-api v1.0.1-0.20200915150042-274508e876ef/go.mod h1:puy7YVXeb6glot1vVCIePIiRLSwB//+rFtN2ZjvXeEw=
 github.com/portworx/sched-ops v0.0.0-20200123020607-b0799c4686f5/go.mod h1:yb1ypNIiZQAmM7xAWGzO6dydwl/+vNC0WjUm5IvHUEY=
-github.com/portworx/sched-ops v0.0.0-20210129165423-2b83087e7388 h1:aCtwcCD4TCFq6rGcGbGhaqlhUOYmNBSNbxLhSBTZBUI=
-github.com/portworx/sched-ops v0.0.0-20210129165423-2b83087e7388/go.mod h1:XN9iXuKMVNauIScaSGFIifJhijSFJJ2pyX5H0bvpsn4=
+github.com/portworx/sched-ops v0.0.0-20210202202336-6d3053100643 h1:ZfeCc2LhcndKRMBl1mEuocDMDTestILjw9ca1xqu/Jw=
+github.com/portworx/sched-ops v0.0.0-20210202202336-6d3053100643/go.mod h1:XN9iXuKMVNauIScaSGFIifJhijSFJJ2pyX5H0bvpsn4=
 github.com/portworx/talisman v0.0.0-20191007232806-837747f38224 h1:r4LpGHxnh3tliXnaJcciROXU/snARMN6/OXhGPJyzGA=
 github.com/portworx/talisman v0.0.0-20191007232806-837747f38224/go.mod h1:OjpMH9Uh5o9ntVGktm4FbjLNwubJ3ITih2OfYrAeWtA=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=

--- a/pkg/aututils/aututils.go
+++ b/pkg/aututils/aututils.go
@@ -63,12 +63,14 @@ var (
 	ActionAwaitingApprovalToActiveActionsPending = fmt.Sprintf("%s => %s", apapi.RuleStateActionAwaitingApproval, apapi.RuleStateActiveActionsPending)
 	// ActiveActionsPendingToActiveActionsInProgress is an event which contains "ActiveActionsPending => ActiveActionsInProgress" message
 	ActiveActionsPendingToActiveActionsInProgress = fmt.Sprintf("%s => %s", apapi.RuleStateActiveActionsPending, apapi.RuleStateActiveActionsInProgress)
+	// ActiveActionsInProgressToActiveActionsPending is an event which contains "ActiveActionsInProgress => ActiveActionsPending" message
+	ActiveActionsInProgressToActiveActionsPending = fmt.Sprintf("%s => %s", apapi.RuleStateActiveActionsInProgress, apapi.RuleStateActiveActionsPending)
 	// ActiveActionsInProgressToActiveActionsTaken is an event which contains "ActiveActionsInProgress => ActiveActionsTaken" message
 	ActiveActionsInProgressToActiveActionsTaken = fmt.Sprintf("%s => %s", apapi.RuleStateActiveActionsInProgress, apapi.RuleStateActiveActionsTaken)
-	// PendingToInProgressEvent is an event which contains "Pending => InProgress" message
-	PendingToInProgressEvent = fmt.Sprintf("%s => %s", apapi.RuleStateActiveActionsPending, apapi.RuleStateActiveActionsInProgress)
 	// ActiveActionTakenToNormalEvent is an event which contains "ActiveActionTaken => Normal" message
 	ActiveActionTakenToNormalEvent = fmt.Sprintf("%s => %s", apapi.RuleStateActiveActionsTaken, apapi.RuleStateNormal)
+	// FailedToExecuteActionEvent is an event for failed action
+	FailedToExecuteActionEvent = "failed to execute Action for rule"
 )
 
 // PoolRuleByTotalSize returns an autopilot pool expand rule that uses total pool size
@@ -107,7 +109,7 @@ func PoolRuleByTotalSize(total, scalePercentage uint64, expandType string, label
 
 // PoolRuleFixedScaleSizeByTotalSize returns an autopilot pool expand rule that
 // uses total pool size and fixed scale size action
-func PoolRuleFixedScaleSizeByTotalSize(total int, scaleSize, expandType string, labelSelector map[string]string) apapi.AutopilotRule {
+func PoolRuleFixedScaleSizeByTotalSize(total uint64, scaleSize, expandType string, labelSelector map[string]string) apapi.AutopilotRule {
 	return apapi.AutopilotRule{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name: fmt.Sprintf("pool-%s-fixedsize-%s-total-%d", expandType, strings.ToLower(scaleSize), total),
@@ -341,8 +343,8 @@ func WaitForAutopilotEvent(apRule apapi.AutopilotRule, reason string, messages [
 		}
 
 		for _, ruleEvent := range ruleEvents.Items {
-			// skip old events and verify only events which were in last 10 seconds
-			if ruleEvent.LastTimestamp.Unix() < meta_v1.Now().Unix()-10 {
+			// skip old events and verify only events which were in last 20 seconds
+			if ruleEvent.LastTimestamp.Unix() < meta_v1.Now().Unix()-20 {
 				continue
 			}
 			ruleReasonFound := false

--- a/vendor/github.com/portworx/sched-ops/k8s/autopilot/autopilot.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/autopilot/autopilot.go
@@ -18,6 +18,7 @@ var (
 // Ops provides an interface to Autopilot operations.
 type Ops interface {
 	RuleOps
+	RuleObjectOps
 	ActionApprovalInterface
 	// SetConfig sets the config and resets the client
 	SetConfig(config *rest.Config)

--- a/vendor/github.com/portworx/sched-ops/k8s/autopilot/autopilotrule.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/autopilot/autopilotrule.go
@@ -1,26 +1,26 @@
 package autopilot
 
 import (
-	autv1alpaha1 "github.com/libopenstorage/autopilot-api/pkg/apis/autopilot/v1alpha1"
+	autv1alpha1 "github.com/libopenstorage/autopilot-api/pkg/apis/autopilot/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // RuleOps is an interface to perform k8s AutopilotRule operations
 type RuleOps interface {
 	// CreateAutopilotRule creates the AutopilotRule object
-	CreateAutopilotRule(*autv1alpaha1.AutopilotRule) (*autv1alpaha1.AutopilotRule, error)
+	CreateAutopilotRule(*autv1alpha1.AutopilotRule) (*autv1alpha1.AutopilotRule, error)
 	// GetAutopilotRule gets the AutopilotRule for the provided name
-	GetAutopilotRule(string) (*autv1alpaha1.AutopilotRule, error)
+	GetAutopilotRule(string) (*autv1alpha1.AutopilotRule, error)
 	// UpdateAutopilotRule updates the AutopilotRule
-	UpdateAutopilotRule(*autv1alpaha1.AutopilotRule) (*autv1alpaha1.AutopilotRule, error)
+	UpdateAutopilotRule(*autv1alpha1.AutopilotRule) (*autv1alpha1.AutopilotRule, error)
 	// DeleteAutopilotRule deletes the AutopilotRule of the given name
 	DeleteAutopilotRule(string) error
 	// ListAutopilotRules lists AutopilotRules
-	ListAutopilotRules() (*autv1alpaha1.AutopilotRuleList, error)
+	ListAutopilotRules() (*autv1alpha1.AutopilotRuleList, error)
 }
 
 // CreateAutopilotRule creates the AutopilotRule object
-func (c *Client) CreateAutopilotRule(rule *autv1alpaha1.AutopilotRule) (*autv1alpaha1.AutopilotRule, error) {
+func (c *Client) CreateAutopilotRule(rule *autv1alpha1.AutopilotRule) (*autv1alpha1.AutopilotRule, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
@@ -28,7 +28,7 @@ func (c *Client) CreateAutopilotRule(rule *autv1alpaha1.AutopilotRule) (*autv1al
 }
 
 // GetAutopilotRule gets the AutopilotRule for the provided name
-func (c *Client) GetAutopilotRule(name string) (*autv1alpaha1.AutopilotRule, error) {
+func (c *Client) GetAutopilotRule(name string) (*autv1alpha1.AutopilotRule, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
@@ -36,7 +36,7 @@ func (c *Client) GetAutopilotRule(name string) (*autv1alpaha1.AutopilotRule, err
 }
 
 // UpdateAutopilotRule updates the AutopilotRule
-func (c *Client) UpdateAutopilotRule(rule *autv1alpaha1.AutopilotRule) (*autv1alpaha1.AutopilotRule, error) {
+func (c *Client) UpdateAutopilotRule(rule *autv1alpha1.AutopilotRule) (*autv1alpha1.AutopilotRule, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
@@ -52,7 +52,7 @@ func (c *Client) DeleteAutopilotRule(name string) error {
 }
 
 // ListAutopilotRules lists AutopilotRules
-func (c *Client) ListAutopilotRules() (*autv1alpaha1.AutopilotRuleList, error) {
+func (c *Client) ListAutopilotRules() (*autv1alpha1.AutopilotRuleList, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/portworx/sched-ops/k8s/autopilot/autopilotruleobject.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/autopilot/autopilotruleobject.go
@@ -1,0 +1,60 @@
+package autopilot
+
+import (
+	autv1alpha1 "github.com/libopenstorage/autopilot-api/pkg/apis/autopilot/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// RuleObjectOps is an interface to perform k8s AutopilotRuleObjects operations
+type RuleObjectOps interface {
+	// CreateAutopilotRuleObject creates the AutopilotRuleObject object
+	CreateAutopilotRuleObject(*autv1alpha1.AutopilotRuleObject) (*autv1alpha1.AutopilotRuleObject, error)
+	// GetAutopilotRuleObject gets the AutopilotRuleObject for the provided name
+	GetAutopilotRuleObject(namespace, name string) (*autv1alpha1.AutopilotRuleObject, error)
+	// UpdateAutopilotRuleObject updates the AutopilotRuleObject
+	UpdateAutopilotRuleObject(namespace string, object *autv1alpha1.AutopilotRuleObject) (*autv1alpha1.AutopilotRuleObject, error)
+	// DeleteAutopilotRuleObject deletes the AutopilotRuleObject of the given name
+	DeleteAutopilotRuleObject(namespace, name string) error
+	// ListAutopilotRules lists AutopilotRulesObjects
+	ListAutopilotRuleObjects(namespace string) (*autv1alpha1.AutopilotRuleObjectList, error)
+}
+
+// CreateAutopilotRuleObject creates the AutopilotRuleObject object
+func (c *Client) CreateAutopilotRuleObject(ruleObject *autv1alpha1.AutopilotRuleObject) (*autv1alpha1.AutopilotRuleObject, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.autopilot.AutopilotV1alpha1().AutopilotRuleObjects(ruleObject.Namespace).Create(ruleObject)
+}
+
+// GetAutopilotRuleObject gets the AutopilotRuleObject for the provided name
+func (c *Client) GetAutopilotRuleObject(namespace, name string) (*autv1alpha1.AutopilotRuleObject, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.autopilot.AutopilotV1alpha1().AutopilotRuleObjects(namespace).Get(name, metav1.GetOptions{})
+}
+
+// UpdateAutopilotRuleObject updates the AutopilotRuleObject
+func (c *Client) UpdateAutopilotRuleObject(namespace string, ruleObject *autv1alpha1.AutopilotRuleObject) (*autv1alpha1.AutopilotRuleObject, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.autopilot.AutopilotV1alpha1().AutopilotRuleObjects(namespace).Update(ruleObject)
+}
+
+// DeleteAutopilotRuleObject deletes the AutopilotRuleObject of the given name
+func (c *Client) DeleteAutopilotRuleObject(namespace, name string) error {
+	if err := c.initClient(); err != nil {
+		return err
+	}
+	return c.autopilot.AutopilotV1alpha1().AutopilotRuleObjects(namespace).Delete(name, &metav1.DeleteOptions{})
+}
+
+// ListAutopilotRuleObjects lists AutopilotRuleObjects
+func (c *Client) ListAutopilotRuleObjects(namespace string) (*autv1alpha1.AutopilotRuleObjectList, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.autopilot.AutopilotV1alpha1().AutopilotRuleObjects(namespace).List(metav1.ListOptions{})
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -369,7 +369,7 @@ github.com/portworx/kvdb/common
 github.com/portworx/kvdb/mem
 # github.com/portworx/px-backup-api v1.0.1-0.20200915150042-274508e876ef
 github.com/portworx/px-backup-api/pkg/apis/v1
-# github.com/portworx/sched-ops v0.0.0-20210129165423-2b83087e7388
+# github.com/portworx/sched-ops v0.0.0-20210202202336-6d3053100643
 github.com/portworx/sched-ops/k8s/apps
 github.com/portworx/sched-ops/k8s/autopilot
 github.com/portworx/sched-ops/k8s/batch


### PR DESCRIPTION
This PR is also covering:
* PTX-2740 Implement automation for validation autopilot aro statuses
* PTX-2853 Modify pool resize (add-disk) autopilot test to be able run on different size clusters

Signed-off-by: Maksym Borodin <mborodin@purestorage.com>