### PR TITLE
PWX-19384: Rename folders to nginx-sv4-svc and wordpress-sv4-svc

### DIFF
--- a/drivers/scheduler/k8s/specs/nginx-sv4-svc/px-nginx-app.yaml
+++ b/drivers/scheduler/k8s/specs/nginx-sv4-svc/px-nginx-app.yaml
@@ -1,0 +1,47 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: nginx-service
+spec:
+  selector:
+    app: nginx
+  type: NodePort
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+spec:
+  {{ if .Replicas }}
+  replicas: {{ .Replicas }}
+  {{ else }}
+  replicas: 3{{ end }}
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: bitnami/nginx
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        - name: nginx-persistent-storage
+          mountPath: /usr/share/nginx/html
+        - name: nginx-persistent-storage-enc
+          mountPath: /usr/share/nginx/html-enc
+      volumes:
+      - name: nginx-persistent-storage
+        persistentVolumeClaim:
+          claimName: px-nginx-pvc-sharedv4
+      - name: nginx-persistent-storage-enc
+        persistentVolumeClaim:
+          claimName: px-nginx-pvc-enc-sharedv4

--- a/drivers/scheduler/k8s/specs/nginx-sv4-svc/px-nginx-storage.yaml
+++ b/drivers/scheduler/k8s/specs/nginx-sv4-svc/px-nginx-storage.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: volume-secrets
+type: Opaque
+data:
+  nginx-secret: WW91IHNuZWFreSBsaXR0bGUgcGlnbGV0IQ==
+---
+##### Portworx storage class
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: px-nginx-sc-sharedv4-svc
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  repl: "3"
+  sharedv4: "true"
+  sharedv4_svc_type: "ClusterIP"
+allowVolumeExpansion: true
+---
+##### Portworx persistent volume claim
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: px-nginx-pvc-sharedv4
+spec:
+  storageClassName: px-nginx-sc-sharedv4-svc
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: px-nginx-pvc-enc-sharedv4
+  annotations:
+    px/secret-name: volume-secrets
+    px/secret-namespace: "_NAMESPACE_"
+    px/secret-key: nginx-secret
+    px/secure: "true"
+spec:
+  storageClassName: px-nginx-sc-sharedv4-svc
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 2Gi

--- a/drivers/scheduler/k8s/specs/wordpress-sv4-svc/load-driver.yaml
+++ b/drivers/scheduler/k8s/specs/wordpress-sv4-svc/load-driver.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: load-driver
+  labels:
+    app: wordpress
+    tier: load-driver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wordpress
+      tier: load-driver
+  template:
+    metadata:
+      labels:
+        app: wordpress
+        tier: load-driver
+    spec:
+      initContainers:
+      - image: appropriate/curl
+        name: wait-until-wordpress-up
+        args:
+        - "sh"
+        - "-c"
+        - "while ! curl --connect-timeout 2 'wordpress:80' ; do sleep 1 ; done"
+      containers:
+      - image: centminmod/docker-centos6-siege
+        name: siege
+        args:
+        - "siege"
+        - "--benchmark"
+        - "--time=24H"
+        - "http://wordpress:80"

--- a/drivers/scheduler/k8s/specs/wordpress-sv4-svc/mysql.yaml
+++ b/drivers/scheduler/k8s/specs/wordpress-sv4-svc/mysql.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysql-pass
+type: Opaque
+data:
+  password: bXlzcWwxMjM=
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wordpress-mysql
+  labels:
+    app: wordpress
+spec:
+  ports:
+    - port: 3306
+  selector:
+    app: wordpress
+    tier: mysql
+  clusterIP: None
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wordpress-mysql
+  labels:
+    app: wordpress
+spec:
+  selector:
+    matchLabels:
+      app: wordpress
+      tier: mysql
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: wordpress
+        tier: mysql
+    spec:
+      containers:
+      - image: mysql:5.6
+        name: mysql
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql-pass
+              key: password
+        ports:
+        - containerPort: 3306
+          name: mysql
+        volumeMounts:
+        - name: mysql-persistent-storage
+          mountPath: /var/lib/mysql
+      volumes:
+      - name: mysql-persistent-storage
+        persistentVolumeClaim:
+          claimName: mysql-pvc-1-wordpress

--- a/drivers/scheduler/k8s/specs/wordpress-sv4-svc/storage.yaml
+++ b/drivers/scheduler/k8s/specs/wordpress-sv4-svc/storage.yaml
@@ -1,0 +1,51 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: portworx-sc-cms-repl3-sharedv4-svc
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  repl: "3"
+  priority_io: "high"
+  sharedv4: "true"
+  sharedv4_svc_type: "ClusterIP"
+  io_profile: "cms"
+allowVolumeExpansion: true
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: portworx-sc-db-repl3
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  repl: "3"
+  io_profile: "db"
+  priority_io: "high"
+allowVolumeExpansion: true
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: wp-pv-claim-sharedv4
+  labels:
+    app: wordpress
+  annotations:
+    volume.beta.kubernetes.io/storage-class: portworx-sc-cms-repl3-sharedv4-svc
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-pvc-1-wordpress
+  annotations:
+    volume.beta.kubernetes.io/storage-class: portworx-sc-db-repl3
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/drivers/scheduler/k8s/specs/wordpress-sv4-svc/wordpress.yaml
+++ b/drivers/scheduler/k8s/specs/wordpress-sv4-svc/wordpress.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wordpress
+  labels:
+    app: wordpress
+    tier: frontend
+spec:
+  selector:
+    matchLabels:
+      app: wordpress
+      tier: frontend
+  replicas: 3
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: wordpress
+        tier: frontend
+    spec:
+      containers:
+      - image: wordpress:4.8-apache
+        name: wordpress
+        env:
+        - name: WORDPRESS_DB_HOST
+          value: wordpress-mysql
+        - name: WORDPRESS_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql-pass
+              key: password
+        ports:
+        - containerPort: 80
+          name: wordpress
+        volumeMounts:
+        - name: wordpress-persistent-storage
+          mountPath: /var/www/html
+          subPath: html
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 15
+          timeoutSeconds: 5
+        resources:
+          requests:
+            memory: "2Gi"
+      volumes:
+      - name: wordpress-persistent-storage
+        persistentVolumeClaim:
+          claimName: wp-pv-claim-sharedv4
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wordpress
+  labels:
+    app: wordpress
+spec:
+  ports:
+    - port: 80
+      name: web
+  selector:
+    app: wordpress
+    tier: frontend
+  type: NodePort
+  sessionAffinity: ClientIP


### PR DESCRIPTION
Running into name too long for namespace creation 

14:23:11 2021/05/10 21:23:11 Failed to schedule app: wordpress-sharedv4-svc due to err: Failed to create namespace: wordpress-sharedv4-svc-voldriverdownattachednode-0-05-10-19h09m43s. Err: Namespace "wordpress-sharedv4-svc-voldriverdownattachednode-0-05-10-19h09m43s" is invalid: metadata.name: Invalid value: "wordpress-sharedv4-svc-voldriverdownattachednode-0-05-10-19h09m43s": must be no more than 63 characters Next retry in: 10s
