### PR TITLE
PB-1460: Support for authorization API for px-backup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: xenial
 services:
   - docker
 language: go

--- a/drivers/backup/auth.go
+++ b/drivers/backup/auth.go
@@ -1,0 +1,502 @@
+package backup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	k8s "github.com/portworx/sched-ops/k8s/core"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc/metadata"
+)
+
+const (
+	// PxCentralAdminUser px central admin
+	PxCentralAdminUser = "px-central-admin"
+	// PxCentralAdminPwd pwd for PxCentralAdminUser
+	PxCentralAdminPwd = "H@nK!0asew"
+	keycloakEndPoint  = "pxcentral-keycloak-http:80"
+	httpTimeout       = 1 * time.Minute
+)
+
+const (
+	// AuthTokenType of incoming auth token
+	AuthTokenType = "bearer"
+	// AuthHeader incoming auth request
+	AuthHeader = "authorization"
+	// OrgToken key
+	OrgToken = "PX_BACKUP_ORG_TOKEN"
+	// AdminTokenSecretName which has admin user jwt token information
+	AdminTokenSecretName = "px-backup-admin-secret"
+	// AdminTokenSecretNamespace which has admin user jwt token information
+	AdminTokenSecretNamespace = "px-backup"
+)
+
+type tokenResponse struct {
+	AccessToken string `json:"access_token"`
+}
+
+// Doc ref: https://www.keycloak.org/docs-api/5.0/rest-api/index.html#_rolerepresentation
+// Not all the fields are used and below is sample response obtained from keycloak
+// {
+//        "id": "12bfd2ee-bd3d-4260-809b-c288669ed5b1",
+//        "name": "px-backup-app.user",
+//        "description": "Portworx px-backup-app.user user role",
+//        "composite": false,
+//        "clientRole": false,
+//        "containerId": "master"
+//    },
+
+// KeycloakRoleRepresentation role repsetaton struct
+type KeycloakRoleRepresentation struct {
+	ID          string                       `json:"id"`
+	Name        string                       `json:"name"`
+	Description string                       `json:"description"`
+	Composite   bool                         `json:"composite"`
+	ClientRole  bool                         `json:"clientRole"`
+	ContainerID string                       `json:"containerId"`
+	Attributes  map[string]string            `json:"attributes"`
+	Composites  RoleRespresentationComposite `json:"composites"`
+}
+
+// RoleRespresentationComposite composite role rep
+type RoleRespresentationComposite struct {
+	Client map[string]string `json:"client"`
+	Realm  []string          `json:"realm"`
+}
+
+// KeycloakUserRepresentation user representation
+type KeycloakUserRepresentation struct {
+	ID            string                    `json:"id"`
+	Name          string                    `json:"username"`
+	FirstName     string                    `json:"firstName"`
+	LastName      string                    `json:"lastName"`
+	EmailVerified bool                      `json:"emailVerified"`
+	Enabled       bool                      `json:"enabled"`
+	Email         string                    `json:"email"`
+	Credentials   []KeycloakUserCredentials `json:"credentials"`
+}
+
+// KeycloakUserCredentials user credentials
+type KeycloakUserCredentials struct {
+	// Type is "password"
+	Type string `json:"type"`
+	// Temporary is the password temporary
+	Temporary bool `json:"temporary"`
+	// Value password for the user
+	Value string `json:"value"`
+}
+
+// GetToken fetches JWT token for given user credentials
+func GetToken(userName, password string) (string, error) {
+	fn := "GetToken"
+	values := make(url.Values)
+	values.Set("client_id", "pxcentral")
+	values.Set("username", userName)
+	values.Set("password", password)
+	values.Set("grant_type", "password")
+	values.Set("token-duration", "365d")
+	reqURL := fmt.Sprintf("http://%s/auth/realms/master/protocol/openid-connect/token", keycloakEndPoint)
+	method := "POST"
+	headers := make(http.Header)
+	headers.Add("Content-Type", "application/x-www-form-urlencoded")
+	response, err := processHTTPRequest(method, reqURL, headers, strings.NewReader(values.Encode()))
+	if err != nil {
+		logrus.Errorf("%s: %v", fn, err)
+		return "", err
+	}
+
+	token := &tokenResponse{}
+	err = json.Unmarshal(response, &token)
+	if err != nil {
+		logrus.Errorf("%s: %v", fn, err)
+		return "", err
+	}
+
+	return token.AccessToken, nil
+}
+
+// GetCommonHTTPHeaders populates http header
+func GetCommonHTTPHeaders(userName, password string) (http.Header, error) {
+	fn := "GetCommonHTTPHeaders"
+	token, err := GetToken(userName, password)
+	if err != nil {
+		logrus.Errorf("%s: %v", fn, err)
+		return nil, err
+	}
+	headers := make(http.Header)
+	headers.Add("Authorization", fmt.Sprintf("Bearer %v", token))
+	headers.Add("Content-Type", "application/json")
+
+	return headers, nil
+}
+
+// GetAllRoles lists all the available role in keycloak
+func GetAllRoles() ([]KeycloakRoleRepresentation, error) {
+	fn := "GetAllRoles"
+	headers, err := GetCommonHTTPHeaders(PxCentralAdminUser, PxCentralAdminPwd)
+	if err != nil {
+		logrus.Errorf("%s: %v", fn, err)
+		return nil, err
+	}
+	reqURL := fmt.Sprintf("http://%s/auth/admin/realms/master/roles", keycloakEndPoint)
+	method := "GET"
+	response, err := processHTTPRequest(method, reqURL, headers, nil)
+	if err != nil {
+		logrus.Errorf("%s: %v", fn, err)
+		return nil, err
+	}
+	var roles []KeycloakRoleRepresentation
+	err = json.Unmarshal(response, &roles)
+	if err != nil {
+		logrus.Errorf("%s: %v", fn, err)
+		return nil, err
+	}
+
+	return roles, nil
+}
+
+// GetRoleID gets role ID for a given role
+func GetRoleID(role string) (string, error) {
+	fn := "GetRoleID"
+	// Fetch all roles
+	roles, err := GetAllRoles()
+	if err != nil {
+		logrus.Errorf("%s: %v", fn, err)
+		return "", err
+	}
+	// Now fetch the current role ID
+	var clientID string
+	for _, r := range roles {
+		if r.Name == role {
+			clientID = r.ID
+			break
+		}
+	}
+
+	return clientID, nil
+}
+
+// GetUserRole fetches roles for a given user
+func GetUserRole(userName string) error {
+	fn := "GetUserRole"
+	// First fetch all users to get the client id for the client
+	headers, err := GetCommonHTTPHeaders(PxCentralAdminUser, PxCentralAdminPwd)
+	if err != nil {
+		logrus.Errorf("%s: %v", fn, err)
+		return err
+	}
+
+	reqURL := fmt.Sprintf("http://%s/auth/admin/realms/master/users", keycloakEndPoint)
+	method := "GET"
+	response, err := processHTTPRequest(method, reqURL, headers, nil)
+	if err != nil {
+		return err
+	}
+	var users []KeycloakUserRepresentation
+	err = json.Unmarshal(response, &users)
+	if err != nil {
+		logrus.Errorf("%s: %v", fn, err)
+		return err
+	}
+
+	var clientID string
+	for _, user := range users {
+		if user.Name == userName {
+			clientID = user.ID
+			break
+		}
+	}
+	// Now fetch all the roles for the fetched client ID
+	reqURL = fmt.Sprintf("http://%s/auth/admin/realms/master/users/%s/role-mappings/realm", keycloakEndPoint, clientID)
+	method = "GET"
+	response, err = processHTTPRequest(method, reqURL, headers, nil)
+	if err != nil {
+		return err
+	}
+	var r []KeycloakRoleRepresentation
+	err = json.Unmarshal(response, &r)
+	if err != nil {
+		logrus.Errorf("%s: %v", fn, err)
+		return err
+	}
+
+	return nil
+}
+
+// FetchIDOfUser fetches ID for a given user
+func FetchIDOfUser(userName string) (string, error) {
+	fn := "FetchIDOfUser"
+	// First fetch all users to get the client id for the client
+	headers, err := GetCommonHTTPHeaders(PxCentralAdminUser, PxCentralAdminPwd)
+	if err != nil {
+		logrus.Errorf("%s: %v", fn, err)
+		return "", err
+	}
+	reqURL := fmt.Sprintf("http://%s/auth/admin/realms/master/users", keycloakEndPoint)
+	method := "GET"
+	response, err := processHTTPRequest(method, reqURL, headers, nil)
+	if err != nil {
+		logrus.Errorf("%s: %v", fn, err)
+		return "", err
+	}
+	var users []KeycloakUserRepresentation
+	err = json.Unmarshal(response, &users)
+	if err != nil {
+		logrus.Errorf("%s: %v", fn, err)
+		return "", err
+	}
+
+	var clientID string
+	for _, user := range users {
+		if user.Name == userName {
+			clientID = user.ID
+			break
+		}
+	}
+
+	return clientID, nil
+}
+
+// AddRoleToUser assigning a given role to a existing user
+func AddRoleToUser(userName string, role string, description string) error {
+	fn := "AddRoleToUser"
+	// First fetch the client ID of the user
+	clientID, err := FetchIDOfUser(userName)
+	if err != nil {
+		logrus.Errorf("%s: %v", fn, err)
+		return err
+	}
+	// Fetch the role ID
+	roleID, err := GetRoleID(role)
+	if err != nil {
+		logrus.Errorf("%s: %v", fn, err)
+		return err
+	}
+
+	// Frame the role struct to be assigned
+	var kRoles []KeycloakRoleRepresentation
+	kRole := KeycloakRoleRepresentation{
+		ID:          roleID,
+		ClientRole:  false,
+		Composite:   false,
+		ContainerID: "master",
+		Description: description,
+		Name:        role,
+	}
+	kRoles = append(kRoles, kRole)
+	roleBytes, err := json.Marshal(&kRoles)
+	if err != nil {
+		logrus.Errorf("%s: %v", fn, err)
+		return err
+	}
+	reqURL := fmt.Sprintf("http://%s/auth/admin/realms/master/users/%s/role-mappings/realm", keycloakEndPoint, clientID)
+	method := "POST"
+	headers, err := GetCommonHTTPHeaders(PxCentralAdminUser, PxCentralAdminPwd)
+	if err != nil {
+		logrus.Errorf("%s: %v", fn, err)
+		return err
+	}
+	_, err = processHTTPRequest(method, reqURL, headers, strings.NewReader(string(roleBytes)))
+	if err != nil {
+		logrus.Errorf("%s: %v", fn, err)
+		return err
+	}
+
+	return nil
+}
+
+// DeleteRoleFromUser deleting role from a user
+func DeleteRoleFromUser(userName string, role string, description string) error {
+	fn := "DeleteRoleFromUser"
+	// First fetch the user ID of the user
+	clientID, err := FetchIDOfUser(userName)
+	if err != nil {
+		logrus.Errorf("%s: %v", fn, err)
+		return err
+	}
+	// Fetch the role ID
+	roleID, err := GetRoleID(role)
+	if err != nil {
+		logrus.Errorf("%s: %v", fn, err)
+		return err
+	}
+
+	// Frame the role struct to be assigned
+	var kRoles []KeycloakRoleRepresentation
+	kRole := KeycloakRoleRepresentation{
+		ID:          roleID,
+		ClientRole:  false,
+		Composite:   false,
+		ContainerID: "master",
+		Description: description,
+		Name:        role,
+	}
+	kRoles = append(kRoles, kRole)
+	roleBytes, err := json.Marshal(&kRoles)
+	if err != nil {
+		logrus.Errorf("%s: %v", fn, err)
+		return err
+	}
+	reqURL := fmt.Sprintf("http://%s/auth/admin/realms/master/users/%s/role-mappings/realm", keycloakEndPoint, clientID)
+	method := "DELETE"
+	headers, err := GetCommonHTTPHeaders(PxCentralAdminUser, PxCentralAdminPwd)
+	if err != nil {
+		return err
+	}
+	_, err = processHTTPRequest(method, reqURL, headers, strings.NewReader(string(roleBytes)))
+	if err != nil {
+		logrus.Errorf("%s: %v", fn, err)
+		return err
+	}
+
+	return nil
+}
+
+// AddUser adds a new user
+func AddUser(userName, firstName, lastName, email, password string) error {
+	fn := "AddUser"
+	reqURL := fmt.Sprintf("http://%s/auth/admin/realms/master/users", keycloakEndPoint)
+	method := "POST"
+	headers, err := GetCommonHTTPHeaders(PxCentralAdminUser, PxCentralAdminPwd)
+	if err != nil {
+		logrus.Errorf("%s: %v", fn, err)
+		return err
+	}
+	userRep := KeycloakUserRepresentation{
+		Name:      userName,
+		FirstName: firstName,
+		LastName:  lastName,
+		Email:     email,
+		Enabled:   true,
+		Credentials: []KeycloakUserCredentials{
+			{
+				Type:      "password",
+				Temporary: false,
+				Value:     password,
+			},
+		},
+	}
+	userBytes, err := json.Marshal(&userRep)
+	if err != nil {
+		logrus.Errorf("%s: %v", fn, err)
+		return err
+	}
+	_, err = processHTTPRequest(method, reqURL, headers, strings.NewReader(string(userBytes)))
+	if err != nil {
+		logrus.Errorf("%s: %v", fn, err)
+		return err
+	}
+
+	return nil
+}
+
+// GetPxCentralAdminToken gets token for "px-central-admin"
+func GetPxCentralAdminToken() (string, error) {
+	token, err := GetToken(PxCentralAdminUser, PxCentralAdminPwd)
+	if err != nil {
+		return "", err
+	}
+
+	return token, nil
+}
+
+// GetCtxWithToken getx ctx with passed token
+func GetCtxWithToken(token string) context.Context {
+	ctx := context.Background()
+	md := metadata.New(map[string]string{
+		AuthHeader: AuthTokenType + " " + token,
+	})
+	ctx = metadata.NewOutgoingContext(ctx, md)
+
+	return ctx
+}
+
+// GetPxCentralAdminCtx fetch px-central-admin context
+func GetPxCentralAdminCtx() (context.Context, error) {
+	token, err := GetPxCentralAdminToken()
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := GetCtxWithToken(token)
+
+	return ctx, nil
+}
+
+// UpdatePxBackupAdminSecret updating "px-backup-admin-secret" token with
+// "px-central-admin" token
+func UpdatePxBackupAdminSecret() error {
+	pxCentralAdminToken, err := GetPxCentralAdminToken()
+	if err != nil {
+		return err
+	}
+
+	secret, err := k8s.Instance().GetSecret(AdminTokenSecretName, AdminTokenSecretNamespace)
+	if err != nil {
+		return err
+	}
+	// Now update the token into "AdminTokenSecretName"
+	secret.Data[OrgToken] = ([]byte(pxCentralAdminToken))
+	_, err = k8s.Instance().UpdateSecret(secret)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GetAdminCtxFromSecret with provided name and namespace
+func GetAdminCtxFromSecret() (context.Context, error) {
+	err := UpdatePxBackupAdminSecret()
+	if err != nil {
+		return nil, err
+	}
+
+	secret, err := k8s.Instance().GetSecret(AdminTokenSecretName, AdminTokenSecretNamespace)
+	if err != nil {
+		return nil, err
+	}
+
+	token := string(secret.Data[OrgToken])
+	if token == "" {
+		return nil, fmt.Errorf("admin token is empty")
+	}
+	ctx := GetCtxWithToken(token)
+
+	return ctx, nil
+}
+
+func processHTTPRequest(
+	method string,
+	url string,
+	headers http.Header,
+	body io.Reader,
+) ([]byte, error) {
+	httpRequest, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	httpRequest.Header = headers
+	client := &http.Client{
+		Timeout: httpTimeout,
+	}
+	httpResponse, err := client.Do(httpRequest)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		err := httpResponse.Body.Close()
+		if err != nil {
+			logrus.Debugf("Error closing http response body: %v", err)
+		}
+	}()
+
+	return ioutil.ReadAll(httpResponse.Body)
+}

--- a/drivers/backup/backup.go
+++ b/drivers/backup/backup.go
@@ -54,46 +54,46 @@ type Driver interface {
 // Org object interface
 type Org interface {
 	// CreateOrganization creates Organization
-	CreateOrganization(req *api.OrganizationCreateRequest) (*api.OrganizationCreateResponse, error)
+	CreateOrganization(ctx context.Context, req *api.OrganizationCreateRequest) (*api.OrganizationCreateResponse, error)
 
 	// GetOrganization enumerates organizations
-	EnumerateOrganization() (*api.OrganizationEnumerateResponse, error)
+	EnumerateOrganization(ctx context.Context) (*api.OrganizationEnumerateResponse, error)
 }
 
 // CloudCredential object interface
 type CloudCredential interface {
 	// CreateCloudCredential creates cloud credential objects
-	CreateCloudCredential(req *api.CloudCredentialCreateRequest) (*api.CloudCredentialCreateResponse, error)
+	CreateCloudCredential(ctx context.Context, req *api.CloudCredentialCreateRequest) (*api.CloudCredentialCreateResponse, error)
 
 	// UpdateCloudCredential updates cloud credential objects
-	UpdateCloudCredential(req *api.CloudCredentialUpdateRequest) (*api.CloudCredentialUpdateResponse, error)
+	UpdateCloudCredential(ctx context.Context, req *api.CloudCredentialUpdateRequest) (*api.CloudCredentialUpdateResponse, error)
 
 	// InspectCloudCredential describes the cloud credential
-	InspectCloudCredential(req *api.CloudCredentialInspectRequest) (*api.CloudCredentialInspectResponse, error)
+	InspectCloudCredential(ctx context.Context, req *api.CloudCredentialInspectRequest) (*api.CloudCredentialInspectResponse, error)
 
 	// EnumerateCloudCredential lists the cloud credentials for given Org
-	EnumerateCloudCredential(req *api.CloudCredentialEnumerateRequest) (*api.CloudCredentialEnumerateResponse, error)
+	EnumerateCloudCredential(ctx context.Context, req *api.CloudCredentialEnumerateRequest) (*api.CloudCredentialEnumerateResponse, error)
 
 	// DeletrCloudCredential deletes a cloud credential object
-	DeleteCloudCredential(req *api.CloudCredentialDeleteRequest) (*api.CloudCredentialDeleteResponse, error)
+	DeleteCloudCredential(ctx context.Context, req *api.CloudCredentialDeleteRequest) (*api.CloudCredentialDeleteResponse, error)
 }
 
 // Cluster obj interface
 type Cluster interface {
 	// CreateCluster creates a cluster object
-	CreateCluster(req *api.ClusterCreateRequest) (*api.ClusterCreateResponse, error)
+	CreateCluster(ctx context.Context, req *api.ClusterCreateRequest) (*api.ClusterCreateResponse, error)
 
 	// UpdateCluster updates a cluster object
-	UpdateCluster(req *api.ClusterUpdateRequest) (*api.ClusterUpdateResponse, error)
+	UpdateCluster(ctx context.Context, req *api.ClusterUpdateRequest) (*api.ClusterUpdateResponse, error)
 
 	// EnumerateCluster enumerates the cluster objects
-	EnumerateCluster(req *api.ClusterEnumerateRequest) (*api.ClusterEnumerateResponse, error)
+	EnumerateCluster(ctx context.Context, req *api.ClusterEnumerateRequest) (*api.ClusterEnumerateResponse, error)
 
 	// InsepctCluster describes a cluster
-	InspectCluster(req *api.ClusterInspectRequest) (*api.ClusterInspectResponse, error)
+	InspectCluster(ctx context.Context, req *api.ClusterInspectRequest) (*api.ClusterInspectResponse, error)
 
 	// DeleteCluster deletes a cluster object
-	DeleteCluster(req *api.ClusterDeleteRequest) (*api.ClusterDeleteResponse, error)
+	DeleteCluster(ctx context.Context, req *api.ClusterDeleteRequest) (*api.ClusterDeleteResponse, error)
 
 	// WaitForClusterDeletion waits for cluster to be deleted successfully
 	// or till timeout is reached. API should poll every `timeBeforeRetry` duration
@@ -109,22 +109,22 @@ type Cluster interface {
 // BLocation obj interface
 type BLocation interface {
 	// CreateBackupLocation creates backup location object
-	CreateBackupLocation(req *api.BackupLocationCreateRequest) (*api.BackupLocationCreateResponse, error)
+	CreateBackupLocation(ctx context.Context, req *api.BackupLocationCreateRequest) (*api.BackupLocationCreateResponse, error)
 
 	// UpdateBackupLocation updates backup location object
-	UpdateBackupLocation(req *api.BackupLocationUpdateRequest) (*api.BackupLocationUpdateResponse, error)
+	UpdateBackupLocation(ctx context.Context, req *api.BackupLocationUpdateRequest) (*api.BackupLocationUpdateResponse, error)
 
 	// EnumerateBackupLocation lists backup locations for an org
-	EnumerateBackupLocation(req *api.BackupLocationEnumerateRequest) (*api.BackupLocationEnumerateResponse, error)
+	EnumerateBackupLocation(ctx context.Context, req *api.BackupLocationEnumerateRequest) (*api.BackupLocationEnumerateResponse, error)
 
 	// InspectBackupLocation enumerates backup location objects
-	InspectBackupLocation(req *api.BackupLocationInspectRequest) (*api.BackupLocationInspectResponse, error)
+	InspectBackupLocation(ctx context.Context, req *api.BackupLocationInspectRequest) (*api.BackupLocationInspectResponse, error)
 
 	// DeleteBackupLocation deletes backup location objects
-	DeleteBackupLocation(req *api.BackupLocationDeleteRequest) (*api.BackupLocationDeleteResponse, error)
+	DeleteBackupLocation(ctx context.Context, req *api.BackupLocationDeleteRequest) (*api.BackupLocationDeleteResponse, error)
 
 	// ValidateBackupLocation validates the backuplocation object
-	ValidateBackupLocation(req *api.BackupLocationValidateRequest) (*api.BackupLocationValidateResponse, error)
+	ValidateBackupLocation(ctx context.Context, req *api.BackupLocationValidateRequest) (*api.BackupLocationValidateResponse, error)
 
 	// WaitForBackupLocationDeletion watis for backup location to be deleted
 	WaitForBackupLocationDeletion(ctx context.Context, backupLocationName string, orgID string,
@@ -134,19 +134,19 @@ type BLocation interface {
 // Backup obj interface
 type Backup interface {
 	// CreateBackup creates backup
-	CreateBackup(req *api.BackupCreateRequest) (*api.BackupCreateResponse, error)
+	CreateBackup(ctx context.Context, req *api.BackupCreateRequest) (*api.BackupCreateResponse, error)
 
 	// UpdateBackup updates backup object
-	UpdateBackup(req *api.BackupUpdateRequest) (*api.BackupUpdateResponse, error)
+	UpdateBackup(ctx context.Context, req *api.BackupUpdateRequest) (*api.BackupUpdateResponse, error)
 
 	// EnumerateBackup enumerates backup objects
-	EnumerateBackup(req *api.BackupEnumerateRequest) (*api.BackupEnumerateResponse, error)
+	EnumerateBackup(ctx context.Context, req *api.BackupEnumerateRequest) (*api.BackupEnumerateResponse, error)
 
 	// InspectBackup inspects a backup object
-	InspectBackup(req *api.BackupInspectRequest) (*api.BackupInspectResponse, error)
+	InspectBackup(ctx context.Context, req *api.BackupInspectRequest) (*api.BackupInspectResponse, error)
 
 	// DeleteBackup deletes backup
-	DeleteBackup(req *api.BackupDeleteRequest) (*api.BackupDeleteResponse, error)
+	DeleteBackup(ctx context.Context, req *api.BackupDeleteRequest) (*api.BackupDeleteResponse, error)
 
 	// WaitForBackupCompletion waits for backup to complete successfully
 	// or till timeout is reached. API should poll every `timeBeforeRetry`
@@ -176,19 +176,19 @@ type Backup interface {
 // Restore object interface
 type Restore interface {
 	// CreateRestore creates restore object
-	CreateRestore(req *api.RestoreCreateRequest) (*api.RestoreCreateResponse, error)
+	CreateRestore(ctx context.Context, req *api.RestoreCreateRequest) (*api.RestoreCreateResponse, error)
 
 	// UpdateRestore updates restore object
-	UpdateRestore(req *api.RestoreUpdateRequest) (*api.RestoreUpdateResponse, error)
+	UpdateRestore(ctx context.Context, req *api.RestoreUpdateRequest) (*api.RestoreUpdateResponse, error)
 
 	// EnumerateRestore lists restore objects
-	EnumerateRestore(req *api.RestoreEnumerateRequest) (*api.RestoreEnumerateResponse, error)
+	EnumerateRestore(ctx context.Context, req *api.RestoreEnumerateRequest) (*api.RestoreEnumerateResponse, error)
 
 	// InspectRestore inspects a restore object
-	InspectRestore(req *api.RestoreInspectRequest) (*api.RestoreInspectResponse, error)
+	InspectRestore(ctx context.Context, req *api.RestoreInspectRequest) (*api.RestoreInspectResponse, error)
 
 	// DeleteRestore deletes a restore object
-	DeleteRestore(req *api.RestoreDeleteRequest) (*api.RestoreDeleteResponse, error)
+	DeleteRestore(ctx context.Context, req *api.RestoreDeleteRequest) (*api.RestoreDeleteResponse, error)
 
 	// WaitForRestoreCompletion waits for restore to complete successfully
 	// or till timeout is reached. API should poll every `timeBeforeRetry` duration
@@ -199,37 +199,37 @@ type Restore interface {
 // SchedulePolicy interface
 type SchedulePolicy interface {
 	// CreateSchedulePolicy
-	CreateSchedulePolicy(req *api.SchedulePolicyCreateRequest) (*api.SchedulePolicyCreateResponse, error)
+	CreateSchedulePolicy(ctx context.Context, req *api.SchedulePolicyCreateRequest) (*api.SchedulePolicyCreateResponse, error)
 
 	// UpdateSchedulePolicy
-	UpdateSchedulePolicy(req *api.SchedulePolicyUpdateRequest) (*api.SchedulePolicyUpdateResponse, error)
+	UpdateSchedulePolicy(ctx context.Context, req *api.SchedulePolicyUpdateRequest) (*api.SchedulePolicyUpdateResponse, error)
 
 	// EnumerateSchedulePolicy
-	EnumerateSchedulePolicy(req *api.SchedulePolicyEnumerateRequest) (*api.SchedulePolicyEnumerateResponse, error)
+	EnumerateSchedulePolicy(ctx context.Context, req *api.SchedulePolicyEnumerateRequest) (*api.SchedulePolicyEnumerateResponse, error)
 
 	// InspectSchedulePolicy
-	InspectSchedulePolicy(req *api.SchedulePolicyInspectRequest) (*api.SchedulePolicyInspectResponse, error)
+	InspectSchedulePolicy(ctx context.Context, req *api.SchedulePolicyInspectRequest) (*api.SchedulePolicyInspectResponse, error)
 
 	// DeleteSchedulePolicy
-	DeleteSchedulePolicy(req *api.SchedulePolicyDeleteRequest) (*api.SchedulePolicyDeleteResponse, error)
+	DeleteSchedulePolicy(ctx context.Context, req *api.SchedulePolicyDeleteRequest) (*api.SchedulePolicyDeleteResponse, error)
 }
 
 // ScheduleBackup interface
 type ScheduleBackup interface {
 	// CreateBackupSchedule
-	CreateBackupSchedule(req *api.BackupScheduleCreateRequest) (*api.BackupScheduleCreateResponse, error)
+	CreateBackupSchedule(ctx context.Context, req *api.BackupScheduleCreateRequest) (*api.BackupScheduleCreateResponse, error)
 
 	// UpdateBackupSchedule
-	UpdateBackupSchedule(req *api.BackupScheduleUpdateRequest) (*api.BackupScheduleUpdateResponse, error)
+	UpdateBackupSchedule(ctx context.Context, req *api.BackupScheduleUpdateRequest) (*api.BackupScheduleUpdateResponse, error)
 
 	// EnumerateBackupSchedule
-	EnumerateBackupSchedule(req *api.BackupScheduleEnumerateRequest) (*api.BackupScheduleEnumerateResponse, error)
+	EnumerateBackupSchedule(ctx context.Context, req *api.BackupScheduleEnumerateRequest) (*api.BackupScheduleEnumerateResponse, error)
 
 	// InspectBackupSchedule
-	InspectBackupSchedule(req *api.BackupScheduleInspectRequest) (*api.BackupScheduleInspectResponse, error)
+	InspectBackupSchedule(ctx context.Context, req *api.BackupScheduleInspectRequest) (*api.BackupScheduleInspectResponse, error)
 
 	// DeleteBackupSchedule
-	DeleteBackupSchedule(req *api.BackupScheduleDeleteRequest) (*api.BackupScheduleDeleteResponse, error)
+	DeleteBackupSchedule(ctx context.Context, req *api.BackupScheduleDeleteRequest) (*api.BackupScheduleDeleteResponse, error)
 
 	// BackupScheduleWaitForNBackupsCompletion, waits for backup schedule to complete successfully
 	// or till timeout is reached. API should poll every `timeBeforeRetry` duration
@@ -245,10 +245,10 @@ type ScheduleBackup interface {
 // License interface
 type License interface {
 	// ActivateLicense
-	ActivateLicense(req *api.LicenseActivateRequest) (*api.LicenseActivateResponse, error)
+	ActivateLicense(ctx context.Context, req *api.LicenseActivateRequest) (*api.LicenseActivateResponse, error)
 
 	// InspectLicense
-	InspectLicense(req *api.LicenseInspectRequest) (*api.LicenseInspectResponse, error)
+	InspectLicense(ctx context.Context, req *api.LicenseInspectRequest) (*api.LicenseInspectResponse, error)
 
 	// WaitForLicenseActivation
 	WaitForLicenseActivation(ctx context.Context, req *api.LicenseInspectRequest, timeout, retryInterval time.Duration) error
@@ -257,19 +257,19 @@ type License interface {
 // Rule interface
 type Rule interface {
 	// CreateRule creates rule object
-	CreateRule(req *api.RuleCreateRequest) (*api.RuleCreateResponse, error)
+	CreateRule(ctx context.Context, req *api.RuleCreateRequest) (*api.RuleCreateResponse, error)
 
 	// UpdateRule updates rule object
-	UpdateRule(req *api.RuleUpdateRequest) (*api.RuleUpdateResponse, error)
+	UpdateRule(ctx context.Context, req *api.RuleUpdateRequest) (*api.RuleUpdateResponse, error)
 
 	// EnumerateRule enumerates rule objects
-	EnumerateRule(req *api.RuleEnumerateRequest) (*api.RuleEnumerateResponse, error)
+	EnumerateRule(ctx context.Context, req *api.RuleEnumerateRequest) (*api.RuleEnumerateResponse, error)
 
 	// InspectRule inspects a rule object
-	InspectRule(req *api.RuleInspectRequest) (*api.RuleInspectResponse, error)
+	InspectRule(ctx context.Context, req *api.RuleInspectRequest) (*api.RuleInspectResponse, error)
 
 	// DeleteRule deletes a rule
-	DeleteRule(req *api.RuleDeleteRequest) (*api.RuleDeleteResponse, error)
+	DeleteRule(ctx context.Context, req *api.RuleDeleteRequest) (*api.RuleDeleteResponse, error)
 }
 
 var backupDrivers = make(map[string]Driver)

--- a/drivers/backup/portworx/portworx.go
+++ b/drivers/backup/portworx/portworx.go
@@ -188,52 +188,52 @@ func (p *portworx) setDriver(serviceName string, namespace string) error {
 	return fmt.Errorf("failed to get endpoint for portworx backup driver: %v", err)
 }
 
-func (p *portworx) CreateOrganization(req *api.OrganizationCreateRequest) (*api.OrganizationCreateResponse, error) {
-	return p.organizationManager.Create(context.Background(), req)
+func (p *portworx) CreateOrganization(ctx context.Context, req *api.OrganizationCreateRequest) (*api.OrganizationCreateResponse, error) {
+	return p.organizationManager.Create(ctx, req)
 }
 
-func (p *portworx) EnumerateOrganization() (*api.OrganizationEnumerateResponse, error) {
-	return p.organizationManager.Enumerate(context.Background(), &api.OrganizationEnumerateRequest{})
+func (p *portworx) EnumerateOrganization(ctx context.Context) (*api.OrganizationEnumerateResponse, error) {
+	return p.organizationManager.Enumerate(ctx, &api.OrganizationEnumerateRequest{})
 }
 
-func (p *portworx) CreateCloudCredential(req *api.CloudCredentialCreateRequest) (*api.CloudCredentialCreateResponse, error) {
-	return p.cloudCredentialManager.Create(context.Background(), req)
+func (p *portworx) CreateCloudCredential(ctx context.Context, req *api.CloudCredentialCreateRequest) (*api.CloudCredentialCreateResponse, error) {
+	return p.cloudCredentialManager.Create(ctx, req)
 }
 
-func (p *portworx) UpdateCloudCredential(req *api.CloudCredentialUpdateRequest) (*api.CloudCredentialUpdateResponse, error) {
-	return p.cloudCredentialManager.Update(context.Background(), req)
+func (p *portworx) UpdateCloudCredential(ctx context.Context, req *api.CloudCredentialUpdateRequest) (*api.CloudCredentialUpdateResponse, error) {
+	return p.cloudCredentialManager.Update(ctx, req)
 }
 
-func (p *portworx) InspectCloudCredential(req *api.CloudCredentialInspectRequest) (*api.CloudCredentialInspectResponse, error) {
-	return p.cloudCredentialManager.Inspect(context.Background(), req)
+func (p *portworx) InspectCloudCredential(ctx context.Context, req *api.CloudCredentialInspectRequest) (*api.CloudCredentialInspectResponse, error) {
+	return p.cloudCredentialManager.Inspect(ctx, req)
 }
 
-func (p *portworx) EnumerateCloudCredential(req *api.CloudCredentialEnumerateRequest) (*api.CloudCredentialEnumerateResponse, error) {
-	return p.cloudCredentialManager.Enumerate(context.Background(), req)
+func (p *portworx) EnumerateCloudCredential(ctx context.Context, req *api.CloudCredentialEnumerateRequest) (*api.CloudCredentialEnumerateResponse, error) {
+	return p.cloudCredentialManager.Enumerate(ctx, req)
 }
 
-func (p *portworx) DeleteCloudCredential(req *api.CloudCredentialDeleteRequest) (*api.CloudCredentialDeleteResponse, error) {
-	return p.cloudCredentialManager.Delete(context.Background(), req)
+func (p *portworx) DeleteCloudCredential(ctx context.Context, req *api.CloudCredentialDeleteRequest) (*api.CloudCredentialDeleteResponse, error) {
+	return p.cloudCredentialManager.Delete(ctx, req)
 }
 
-func (p *portworx) CreateCluster(req *api.ClusterCreateRequest) (*api.ClusterCreateResponse, error) {
-	return p.clusterManager.Create(context.Background(), req)
+func (p *portworx) CreateCluster(ctx context.Context, req *api.ClusterCreateRequest) (*api.ClusterCreateResponse, error) {
+	return p.clusterManager.Create(ctx, req)
 }
 
-func (p *portworx) UpdateCluster(req *api.ClusterUpdateRequest) (*api.ClusterUpdateResponse, error) {
-	return p.clusterManager.Update(context.Background(), req)
+func (p *portworx) UpdateCluster(ctx context.Context, req *api.ClusterUpdateRequest) (*api.ClusterUpdateResponse, error) {
+	return p.clusterManager.Update(ctx, req)
 }
 
-func (p *portworx) InspectCluster(req *api.ClusterInspectRequest) (*api.ClusterInspectResponse, error) {
-	return p.clusterManager.Inspect(context.Background(), req)
+func (p *portworx) InspectCluster(ctx context.Context, req *api.ClusterInspectRequest) (*api.ClusterInspectResponse, error) {
+	return p.clusterManager.Inspect(ctx, req)
 }
 
-func (p *portworx) EnumerateCluster(req *api.ClusterEnumerateRequest) (*api.ClusterEnumerateResponse, error) {
-	return p.clusterManager.Enumerate(context.Background(), req)
+func (p *portworx) EnumerateCluster(ctx context.Context, req *api.ClusterEnumerateRequest) (*api.ClusterEnumerateResponse, error) {
+	return p.clusterManager.Enumerate(ctx, req)
 }
 
-func (p *portworx) DeleteCluster(req *api.ClusterDeleteRequest) (*api.ClusterDeleteResponse, error) {
-	return p.clusterManager.Delete(context.Background(), req)
+func (p *portworx) DeleteCluster(ctx context.Context, req *api.ClusterDeleteRequest) (*api.ClusterDeleteResponse, error) {
+	return p.clusterManager.Delete(ctx, req)
 }
 
 // WaitForClusterDeletion waits for cluster to be deleted successfully
@@ -273,28 +273,28 @@ func (p *portworx) WaitForClusterDeletion(
 	return nil
 }
 
-func (p *portworx) CreateBackupLocation(req *api.BackupLocationCreateRequest) (*api.BackupLocationCreateResponse, error) {
-	return p.backupLocationManager.Create(context.Background(), req)
+func (p *portworx) CreateBackupLocation(ctx context.Context, req *api.BackupLocationCreateRequest) (*api.BackupLocationCreateResponse, error) {
+	return p.backupLocationManager.Create(ctx, req)
 }
 
-func (p *portworx) UpdateBackupLocation(req *api.BackupLocationUpdateRequest) (*api.BackupLocationUpdateResponse, error) {
-	return p.backupLocationManager.Update(context.Background(), req)
+func (p *portworx) UpdateBackupLocation(ctx context.Context, req *api.BackupLocationUpdateRequest) (*api.BackupLocationUpdateResponse, error) {
+	return p.backupLocationManager.Update(ctx, req)
 }
 
-func (p *portworx) EnumerateBackupLocation(req *api.BackupLocationEnumerateRequest) (*api.BackupLocationEnumerateResponse, error) {
-	return p.backupLocationManager.Enumerate(context.Background(), req)
+func (p *portworx) EnumerateBackupLocation(ctx context.Context, req *api.BackupLocationEnumerateRequest) (*api.BackupLocationEnumerateResponse, error) {
+	return p.backupLocationManager.Enumerate(ctx, req)
 }
 
-func (p *portworx) InspectBackupLocation(req *api.BackupLocationInspectRequest) (*api.BackupLocationInspectResponse, error) {
-	return p.backupLocationManager.Inspect(context.Background(), req)
+func (p *portworx) InspectBackupLocation(ctx context.Context, req *api.BackupLocationInspectRequest) (*api.BackupLocationInspectResponse, error) {
+	return p.backupLocationManager.Inspect(ctx, req)
 }
 
-func (p *portworx) DeleteBackupLocation(req *api.BackupLocationDeleteRequest) (*api.BackupLocationDeleteResponse, error) {
-	return p.backupLocationManager.Delete(context.Background(), req)
+func (p *portworx) DeleteBackupLocation(ctx context.Context, req *api.BackupLocationDeleteRequest) (*api.BackupLocationDeleteResponse, error) {
+	return p.backupLocationManager.Delete(ctx, req)
 }
 
-func (p *portworx) ValidateBackupLocation(req *api.BackupLocationValidateRequest) (*api.BackupLocationValidateResponse, error) {
-	return p.backupLocationManager.Validate(context.Background(), req)
+func (p *portworx) ValidateBackupLocation(ctx context.Context, req *api.BackupLocationValidateRequest) (*api.BackupLocationValidateResponse, error) {
+	return p.backupLocationManager.Validate(ctx, req)
 }
 
 // WaitForBackupLocationDeletion waits for backup location to be deleted successfully
@@ -340,24 +340,24 @@ func (p *portworx) WaitForBackupLocationDeletion(
 	return nil
 }
 
-func (p *portworx) CreateBackup(req *api.BackupCreateRequest) (*api.BackupCreateResponse, error) {
-	return p.backupManager.Create(context.Background(), req)
+func (p *portworx) CreateBackup(ctx context.Context, req *api.BackupCreateRequest) (*api.BackupCreateResponse, error) {
+	return p.backupManager.Create(ctx, req)
 }
 
-func (p *portworx) UpdateBackup(req *api.BackupUpdateRequest) (*api.BackupUpdateResponse, error) {
-	return p.backupManager.Update(context.Background(), req)
+func (p *portworx) UpdateBackup(ctx context.Context, req *api.BackupUpdateRequest) (*api.BackupUpdateResponse, error) {
+	return p.backupManager.Update(ctx, req)
 }
 
-func (p *portworx) EnumerateBackup(req *api.BackupEnumerateRequest) (*api.BackupEnumerateResponse, error) {
-	return p.backupManager.Enumerate(context.Background(), req)
+func (p *portworx) EnumerateBackup(ctx context.Context, req *api.BackupEnumerateRequest) (*api.BackupEnumerateResponse, error) {
+	return p.backupManager.Enumerate(ctx, req)
 }
 
-func (p *portworx) InspectBackup(req *api.BackupInspectRequest) (*api.BackupInspectResponse, error) {
-	return p.backupManager.Inspect(context.Background(), req)
+func (p *portworx) InspectBackup(ctx context.Context, req *api.BackupInspectRequest) (*api.BackupInspectResponse, error) {
+	return p.backupManager.Inspect(ctx, req)
 }
 
-func (p *portworx) DeleteBackup(req *api.BackupDeleteRequest) (*api.BackupDeleteResponse, error) {
-	return p.backupManager.Delete(context.Background(), req)
+func (p *portworx) DeleteBackup(ctx context.Context, req *api.BackupDeleteRequest) (*api.BackupDeleteResponse, error) {
+	return p.backupManager.Delete(ctx, req)
 }
 
 // GetVolumeBackupIDs returns backup IDs of volumes
@@ -628,24 +628,24 @@ func (p *portworx) WaitForDeletePending(
 	return nil
 }
 
-func (p *portworx) CreateRestore(req *api.RestoreCreateRequest) (*api.RestoreCreateResponse, error) {
-	return p.restoreManager.Create(context.Background(), req)
+func (p *portworx) CreateRestore(ctx context.Context, req *api.RestoreCreateRequest) (*api.RestoreCreateResponse, error) {
+	return p.restoreManager.Create(ctx, req)
 }
 
-func (p *portworx) UpdateRestore(req *api.RestoreUpdateRequest) (*api.RestoreUpdateResponse, error) {
-	return p.restoreManager.Update(context.Background(), req)
+func (p *portworx) UpdateRestore(ctx context.Context, req *api.RestoreUpdateRequest) (*api.RestoreUpdateResponse, error) {
+	return p.restoreManager.Update(ctx, req)
 }
 
-func (p *portworx) EnumerateRestore(req *api.RestoreEnumerateRequest) (*api.RestoreEnumerateResponse, error) {
-	return p.restoreManager.Enumerate(context.Background(), req)
+func (p *portworx) EnumerateRestore(ctx context.Context, req *api.RestoreEnumerateRequest) (*api.RestoreEnumerateResponse, error) {
+	return p.restoreManager.Enumerate(ctx, req)
 }
 
-func (p *portworx) InspectRestore(req *api.RestoreInspectRequest) (*api.RestoreInspectResponse, error) {
-	return p.restoreManager.Inspect(context.Background(), req)
+func (p *portworx) InspectRestore(ctx context.Context, req *api.RestoreInspectRequest) (*api.RestoreInspectResponse, error) {
+	return p.restoreManager.Inspect(ctx, req)
 }
 
-func (p *portworx) DeleteRestore(req *api.RestoreDeleteRequest) (*api.RestoreDeleteResponse, error) {
-	return p.restoreManager.Delete(context.Background(), req)
+func (p *portworx) DeleteRestore(ctx context.Context, req *api.RestoreDeleteRequest) (*api.RestoreDeleteResponse, error) {
+	return p.restoreManager.Delete(ctx, req)
 }
 
 // WaitForRestoreCompletion waits for restore to complete successfully
@@ -696,44 +696,44 @@ func (p *portworx) WaitForRestoreCompletion(
 	return nil
 }
 
-func (p *portworx) CreateSchedulePolicy(req *api.SchedulePolicyCreateRequest) (*api.SchedulePolicyCreateResponse, error) {
-	return p.schedulePolicyManager.Create(context.Background(), req)
+func (p *portworx) CreateSchedulePolicy(ctx context.Context, req *api.SchedulePolicyCreateRequest) (*api.SchedulePolicyCreateResponse, error) {
+	return p.schedulePolicyManager.Create(ctx, req)
 }
 
-func (p *portworx) UpdateSchedulePolicy(req *api.SchedulePolicyUpdateRequest) (*api.SchedulePolicyUpdateResponse, error) {
-	return p.schedulePolicyManager.Update(context.Background(), req)
+func (p *portworx) UpdateSchedulePolicy(ctx context.Context, req *api.SchedulePolicyUpdateRequest) (*api.SchedulePolicyUpdateResponse, error) {
+	return p.schedulePolicyManager.Update(ctx, req)
 }
 
-func (p *portworx) EnumerateSchedulePolicy(req *api.SchedulePolicyEnumerateRequest) (*api.SchedulePolicyEnumerateResponse, error) {
-	return p.schedulePolicyManager.Enumerate(context.Background(), req)
+func (p *portworx) EnumerateSchedulePolicy(ctx context.Context, req *api.SchedulePolicyEnumerateRequest) (*api.SchedulePolicyEnumerateResponse, error) {
+	return p.schedulePolicyManager.Enumerate(ctx, req)
 }
 
-func (p *portworx) InspectSchedulePolicy(req *api.SchedulePolicyInspectRequest) (*api.SchedulePolicyInspectResponse, error) {
-	return p.schedulePolicyManager.Inspect(context.Background(), req)
+func (p *portworx) InspectSchedulePolicy(ctx context.Context, req *api.SchedulePolicyInspectRequest) (*api.SchedulePolicyInspectResponse, error) {
+	return p.schedulePolicyManager.Inspect(ctx, req)
 }
 
-func (p *portworx) DeleteSchedulePolicy(req *api.SchedulePolicyDeleteRequest) (*api.SchedulePolicyDeleteResponse, error) {
-	return p.schedulePolicyManager.Delete(context.Background(), req)
+func (p *portworx) DeleteSchedulePolicy(ctx context.Context, req *api.SchedulePolicyDeleteRequest) (*api.SchedulePolicyDeleteResponse, error) {
+	return p.schedulePolicyManager.Delete(ctx, req)
 }
 
-func (p *portworx) CreateBackupSchedule(req *api.BackupScheduleCreateRequest) (*api.BackupScheduleCreateResponse, error) {
-	return p.backupScheduleManager.Create(context.Background(), req)
+func (p *portworx) CreateBackupSchedule(ctx context.Context, req *api.BackupScheduleCreateRequest) (*api.BackupScheduleCreateResponse, error) {
+	return p.backupScheduleManager.Create(ctx, req)
 }
 
-func (p *portworx) UpdateBackupSchedule(req *api.BackupScheduleUpdateRequest) (*api.BackupScheduleUpdateResponse, error) {
-	return p.backupScheduleManager.Update(context.Background(), req)
+func (p *portworx) UpdateBackupSchedule(ctx context.Context, req *api.BackupScheduleUpdateRequest) (*api.BackupScheduleUpdateResponse, error) {
+	return p.backupScheduleManager.Update(ctx, req)
 }
 
-func (p *portworx) EnumerateBackupSchedule(req *api.BackupScheduleEnumerateRequest) (*api.BackupScheduleEnumerateResponse, error) {
-	return p.backupScheduleManager.Enumerate(context.Background(), req)
+func (p *portworx) EnumerateBackupSchedule(ctx context.Context, req *api.BackupScheduleEnumerateRequest) (*api.BackupScheduleEnumerateResponse, error) {
+	return p.backupScheduleManager.Enumerate(ctx, req)
 }
 
-func (p *portworx) InspectBackupSchedule(req *api.BackupScheduleInspectRequest) (*api.BackupScheduleInspectResponse, error) {
-	return p.backupScheduleManager.Inspect(context.Background(), req)
+func (p *portworx) InspectBackupSchedule(ctx context.Context, req *api.BackupScheduleInspectRequest) (*api.BackupScheduleInspectResponse, error) {
+	return p.backupScheduleManager.Inspect(ctx, req)
 }
 
-func (p *portworx) DeleteBackupSchedule(req *api.BackupScheduleDeleteRequest) (*api.BackupScheduleDeleteResponse, error) {
-	return p.backupScheduleManager.Delete(context.Background(), req)
+func (p *portworx) DeleteBackupSchedule(ctx context.Context, req *api.BackupScheduleDeleteRequest) (*api.BackupScheduleDeleteResponse, error) {
+	return p.backupScheduleManager.Delete(ctx, req)
 }
 
 // BackupScheduleWaitForNBackupsCompletion waits for given number of backup to be complete successfully
@@ -956,12 +956,12 @@ func (p *portworx) WaitForRestoreRunning(
 	return nil
 }
 
-func (p *portworx) ActivateLicense(req *api.LicenseActivateRequest) (*api.LicenseActivateResponse, error) {
-	return p.licenseManager.Activate(context.Background(), req)
+func (p *portworx) ActivateLicense(ctx context.Context, req *api.LicenseActivateRequest) (*api.LicenseActivateResponse, error) {
+	return p.licenseManager.Activate(ctx, req)
 }
 
-func (p *portworx) InspectLicense(req *api.LicenseInspectRequest) (*api.LicenseInspectResponse, error) {
-	return p.licenseManager.Inspect(context.Background(), req)
+func (p *portworx) InspectLicense(ctx context.Context, req *api.LicenseInspectRequest) (*api.LicenseInspectResponse, error) {
+	return p.licenseManager.Inspect(ctx, req)
 }
 
 func (p *portworx) WaitForLicenseActivation(ctx context.Context, req *api.LicenseInspectRequest, timeout, retryInterval time.Duration) error {
@@ -999,24 +999,24 @@ func (p *portworx) WaitForLicenseActivation(ctx context.Context, req *api.Licens
 	return nil
 }
 
-func (p *portworx) CreateRule(req *api.RuleCreateRequest) (*api.RuleCreateResponse, error) {
-	return p.ruleManager.Create(context.Background(), req)
+func (p *portworx) CreateRule(ctx context.Context, req *api.RuleCreateRequest) (*api.RuleCreateResponse, error) {
+	return p.ruleManager.Create(ctx, req)
 }
 
-func (p *portworx) UpdateRule(req *api.RuleUpdateRequest) (*api.RuleUpdateResponse, error) {
-	return p.ruleManager.Update(context.Background(), req)
+func (p *portworx) UpdateRule(ctx context.Context, req *api.RuleUpdateRequest) (*api.RuleUpdateResponse, error) {
+	return p.ruleManager.Update(ctx, req)
 }
 
-func (p *portworx) EnumerateRule(req *api.RuleEnumerateRequest) (*api.RuleEnumerateResponse, error) {
-	return p.ruleManager.Enumerate(context.Background(), req)
+func (p *portworx) EnumerateRule(ctx context.Context, req *api.RuleEnumerateRequest) (*api.RuleEnumerateResponse, error) {
+	return p.ruleManager.Enumerate(ctx, req)
 }
 
-func (p *portworx) InspectRule(req *api.RuleInspectRequest) (*api.RuleInspectResponse, error) {
-	return p.ruleManager.Inspect(context.Background(), req)
+func (p *portworx) InspectRule(ctx context.Context, req *api.RuleInspectRequest) (*api.RuleInspectResponse, error) {
+	return p.ruleManager.Inspect(ctx, req)
 }
 
-func (p *portworx) DeleteRule(req *api.RuleDeleteRequest) (*api.RuleDeleteResponse, error) {
-	return p.ruleManager.Delete(context.Background(), req)
+func (p *portworx) DeleteRule(ctx context.Context, req *api.RuleDeleteRequest) (*api.RuleDeleteResponse, error) {
+	return p.ruleManager.Delete(ctx, req)
 }
 
 func init() {


### PR DESCRIPTION
**What this PR does / why we need it**:
- Added API for keycloak for role and user management

**Which issue(s) this PR fixes** (optional)
PB-1460

**Special notes for your reviewer**:
`pxbackup` branch is a placeholder branch for pxPX-BACKUP test-related changes till we move to k8s v20.4 in px-backup.
 Currently issues in moving PX_BACKUP to go mod with v20.4.
The current `pxbackup` branch is forked out of known working commit used as the last vendoring from torpedo which didn't have v20.4 k8s changes.
