### PR TITLE
[PTX-3449] Continue longevity in case of test failures

### DIFF
--- a/drivers/scheduler/k8s/specs/cassandra/cassandra-stress.yaml
+++ b/drivers/scheduler/k8s/specs/cassandra/cassandra-stress.yaml
@@ -48,6 +48,13 @@ spec:
       containers:
       - name: cassandra-stress
         image: scylladb/scylla:4.1.11
+        resources:
+          limits:
+            cpu: "2000m"
+            memory: 4Gi
+          requests:
+            cpu: "1000m"
+            memory: 4Gi
         readinessProbe:
             exec:
               command:

--- a/drivers/scheduler/k8s/specs/elasticsearch-rally/es-rally.yaml
+++ b/drivers/scheduler/k8s/specs/elasticsearch-rally/es-rally.yaml
@@ -17,6 +17,13 @@ spec:
       containers:
       - name: es-rally
         image: disrani/es-rally:latest
+        resources:
+          limits:
+            cpu: "2"
+            memory: 4Gi
+          requests:
+            cpu: "1"
+            memory: 4Gi
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/drivers/scheduler/k8s/specs/elasticsearch-rally/es-rally.yaml
+++ b/drivers/scheduler/k8s/specs/elasticsearch-rally/es-rally.yaml
@@ -41,6 +41,6 @@ spec:
                 "--pipeline",
                 "benchmark-only",
                 "--track-params",
-                "index_name:'index2',index_alias:'index2'"
+                "index_name:'index2',index_alias:'index2',clients:10"
         ]
       restartPolicy: Always

--- a/drivers/scheduler/k8s/specs/elasticsearch-rally/px-elasticdata-app.yaml
+++ b/drivers/scheduler/k8s/specs/elasticsearch-rally/px-elasticdata-app.yaml
@@ -68,8 +68,12 @@ spec:
       containers:
       - name: elasticsearch
         resources:
+          limits:
+            cpu: "2"
+            memory: 4Gi
           requests:
-            memory: 1Gi
+            cpu: "1"
+            memory: 4Gi
         securityContext:
           privileged: true
           runAsUser: 1000

--- a/drivers/scheduler/k8s/specs/fio/fio.yaml
+++ b/drivers/scheduler/k8s/specs/fio/fio.yaml
@@ -21,6 +21,13 @@ spec:
       - name: fio
         image: portworx/fio_drv
         command: ["fio"]
+        resources:
+          limits:
+            cpu: "2"
+            memory: 4Gi
+          requests:
+            cpu: "1"
+            memory: 4Gi
         args: ["/configs/fio.job", "--status-interval=1", "--eta=never", "--output=/logs/fio.log"]
         volumeMounts:
         - name: fio-config-vol

--- a/drivers/scheduler/k8s/specs/mongodb/px-mongo-app.yaml
+++ b/drivers/scheduler/k8s/specs/mongodb/px-mongo-app.yaml
@@ -63,6 +63,13 @@ spec:
       - name: px-mongo-mongodb
         image: docker.io/bitnami/mongodb:4.2.4-debian-10-r0
         imagePullPolicy: "IfNotPresent"
+        resources:
+          limits:
+            cpu: "2"
+            memory: 4Gi
+          requests:
+            cpu: "1"
+            memory: 4Gi
         securityContext:
           runAsNonRoot: true
           runAsUser: 1001

--- a/drivers/scheduler/k8s/specs/mongodb/ycsb.yaml
+++ b/drivers/scheduler/k8s/specs/mongodb/ycsb.yaml
@@ -17,6 +17,13 @@
         containers:
         - name: ycsb
           image: alvarobrandon/ycsb:latest
+          resources:
+            limits:
+              cpu: "2"
+              memory: 4Gi
+            requests:
+              cpu: "1"
+              memory: 4Gi
           env:
           - name: POD_NAMESPACE
             valueFrom:

--- a/drivers/scheduler/k8s/specs/pgbench-io-portion/px-pgbench-app.yaml
+++ b/drivers/scheduler/k8s/specs/pgbench-io-portion/px-pgbench-app.yaml
@@ -46,6 +46,13 @@ spec:
         - name: pgbench
           image: portworx/torpedo-pgbench:ioportion
           imagePullPolicy: "Always"
+          resources:
+            limits:
+              cpu: "1"
+              memory: 4Gi
+            requests:
+              cpu: "500m"
+              memory: 1Gi
           env:
             - name: PG_HOST
               value: 127.0.0.1

--- a/drivers/scheduler/k8s/specs/sysbench-heavyload/px-sysbench-app.yml
+++ b/drivers/scheduler/k8s/specs/sysbench-heavyload/px-sysbench-app.yml
@@ -24,6 +24,9 @@ spec:
         - image: mysql:5.7
           name: mysql
           resources:
+            limits:
+              cpu: 1000m
+              memory: 500Mi
             requests:
               memory: 256Mi
               cpu: 100m
@@ -46,6 +49,13 @@ spec:
             - name: mysql-persistent-storage
               mountPath: /var/lib/mysql
         - name: sysbench
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 500Mi
+            requests:
+              memory: 256Mi
+              cpu: 100m
           image: portworx/torpedo-sysbench:new
           env:
             - name: MYSQL_HOST

--- a/drivers/scheduler/k8s/specs/vdbench-heavyload/px-vdbench-app.yml
+++ b/drivers/scheduler/k8s/specs/vdbench-heavyload/px-vdbench-app.yml
@@ -16,6 +16,13 @@ spec:
       containers:
         - name: vdbench
           image: openebs/tests-vdbench
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 500Mi
+            requests:
+              memory: 256Mi
+              cpu: 100m
           command: ["./bench_runner.sh"]
           args: ["Writes", "21600"]
           volumeMounts:

--- a/tests/longevity/longevity_test.go
+++ b/tests/longevity/longevity_test.go
@@ -260,6 +260,7 @@ func populateIntervals() {
 	triggerInterval[HADecrease] = map[int]time.Duration{}
 	triggerInterval[EmailReporter] = map[int]time.Duration{}
 	triggerInterval[AppTaskDown] = map[int]time.Duration{}
+	triggerInterval[DeployApps] = map[int]time.Duration{}
 
 	baseInterval := 10 * time.Minute
 	triggerInterval[RebootNode][10] = 1 * baseInterval

--- a/tests/longevity/longevity_test.go
+++ b/tests/longevity/longevity_test.go
@@ -56,6 +56,7 @@ var _ = Describe("{Longevity}", func() {
 	var triggerLock sync.Mutex
 	triggerEventsChan := make(chan *EventRecord, 100)
 	triggerFunctions := map[string]func([]*scheduler.Context, *chan *EventRecord){
+		DeployApps:       TriggerDeployNewApps,
 		RebootNode:       TriggerRebootNodes,
 		RestartVolDriver: TriggerRestartVolDriver,
 		CrashVolDriver:   TriggerCrashVolDriver,
@@ -71,12 +72,7 @@ var _ = Describe("{Longevity}", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		Step("Deploy applications", func() {
-			for i := 0; i < Inst().GlobalScaleFactor; i++ {
-				contexts = append(contexts, ScheduleApplications(fmt.Sprintf("longevity-%d", i))...)
-			}
-			ValidateApplications(contexts)
-		})
+		TriggerDeployNewApps([]*scheduler.Context{}, &triggerEventsChan)
 
 		var wg sync.WaitGroup
 		Step("Register test triggers", func() {
@@ -328,7 +324,19 @@ func populateIntervals() {
 	triggerInterval[HADecrease][2] = 9 * baseInterval
 	triggerInterval[HADecrease][1] = 10 * baseInterval
 
+	triggerInterval[DeployApps][10] = 1 * baseInterval
+	triggerInterval[DeployApps][9] = 2 * baseInterval
+	triggerInterval[DeployApps][8] = 3 * baseInterval
+	triggerInterval[DeployApps][7] = 4 * baseInterval
+	triggerInterval[DeployApps][6] = 5 * baseInterval
+	triggerInterval[DeployApps][5] = 6 * baseInterval // Default global chaos level, 3 hrs
+	triggerInterval[DeployApps][4] = 7 * baseInterval
+	triggerInterval[DeployApps][3] = 8 * baseInterval
+	triggerInterval[DeployApps][2] = 9 * baseInterval
+	triggerInterval[DeployApps][1] = 10 * baseInterval
+
 	// Chaos Level of 0 means disable test trigger
+	triggerInterval[DeployApps][0] = 0
 	triggerInterval[RebootNode][0] = 0
 	triggerInterval[CrashVolDriver][0] = 0
 	triggerInterval[HAIncrease][0] = 0

--- a/tests/longevity/longevity_test.go
+++ b/tests/longevity/longevity_test.go
@@ -64,6 +64,7 @@ var _ = Describe("{Longevity}", func() {
 		HADecrease:       TriggerHADecrease,
 		EmailReporter:    TriggerEmailReporter,
 		AppTaskDown:      TriggerAppTaskDown,
+		CoreChecker:      TriggerCoreChecker,
 	}
 	It("has to schedule app and introduce test triggers", func() {
 		Step(fmt.Sprintf("Start watch on K8S configMap [%s/%s]",
@@ -262,6 +263,7 @@ func populateIntervals() {
 	triggerInterval[EmailReporter] = map[int]time.Duration{}
 	triggerInterval[AppTaskDown] = map[int]time.Duration{}
 	triggerInterval[DeployApps] = map[int]time.Duration{}
+	triggerInterval[CoreChecker] = map[int]time.Duration{}
 
 	baseInterval := 60 * time.Minute
 	triggerInterval[RebootNode][10] = 1 * baseInterval
@@ -341,6 +343,17 @@ func populateIntervals() {
 	triggerInterval[EmailReporter][3] = 8 * baseInterval
 	triggerInterval[EmailReporter][2] = 9 * baseInterval
 	triggerInterval[EmailReporter][1] = 10 * baseInterval
+
+	triggerInterval[CoreChecker][10] = 1 * baseInterval
+	triggerInterval[CoreChecker][9] = 2 * baseInterval
+	triggerInterval[CoreChecker][8] = 3 * baseInterval
+	triggerInterval[CoreChecker][7] = 4 * baseInterval
+	triggerInterval[CoreChecker][6] = 5 * baseInterval
+	triggerInterval[CoreChecker][5] = 6 * baseInterval // Default global chaos level, 3 hrs
+	triggerInterval[CoreChecker][4] = 7 * baseInterval
+	triggerInterval[CoreChecker][3] = 8 * baseInterval
+	triggerInterval[CoreChecker][2] = 9 * baseInterval
+	triggerInterval[CoreChecker][1] = 10 * baseInterval
 
 	triggerInterval[DeployApps][10] = 1 * baseInterval
 	triggerInterval[DeployApps][9] = 2 * baseInterval

--- a/tests/longevity/longevity_test.go
+++ b/tests/longevity/longevity_test.go
@@ -195,6 +195,7 @@ func populateDisruptiveTriggers() {
 		RebootNode:       true,
 		EmailReporter:    false,
 		AppTaskDown:      false,
+		DeployApps:       false,
 	}
 }
 
@@ -262,36 +263,74 @@ func populateIntervals() {
 	triggerInterval[AppTaskDown] = map[int]time.Duration{}
 	triggerInterval[DeployApps] = map[int]time.Duration{}
 
-	baseInterval := 10 * time.Minute
+	baseInterval := 60 * time.Minute
 	triggerInterval[RebootNode][10] = 1 * baseInterval
-	triggerInterval[RebootNode][9] = 2 * baseInterval
-	triggerInterval[RebootNode][8] = 3 * baseInterval
-	triggerInterval[RebootNode][7] = 4 * baseInterval
-	triggerInterval[RebootNode][6] = 5 * baseInterval
-	triggerInterval[RebootNode][5] = 6 * baseInterval // Default global chaos level, 3 hrs
+	triggerInterval[RebootNode][9] = 3 * baseInterval
+	triggerInterval[RebootNode][8] = 6 * baseInterval
+	triggerInterval[RebootNode][7] = 9 * baseInterval
+	triggerInterval[RebootNode][6] = 12 * baseInterval
+	triggerInterval[RebootNode][5] = 15 * baseInterval
+	triggerInterval[RebootNode][4] = 18 * baseInterval
+	triggerInterval[RebootNode][3] = 21 * baseInterval
+	triggerInterval[RebootNode][2] = 24 * baseInterval
+	triggerInterval[RebootNode][1] = 27 * baseInterval
 
 	triggerInterval[CrashVolDriver][10] = 1 * baseInterval
-	triggerInterval[CrashVolDriver][9] = 2 * baseInterval
-	triggerInterval[CrashVolDriver][8] = 3 * baseInterval
-	triggerInterval[CrashVolDriver][7] = 4 * baseInterval
-	triggerInterval[CrashVolDriver][6] = 5 * baseInterval
-	triggerInterval[CrashVolDriver][5] = 6 * baseInterval // Default global chaos level, 3 hrs
+	triggerInterval[CrashVolDriver][9] = 3 * baseInterval
+	triggerInterval[CrashVolDriver][8] = 6 * baseInterval
+	triggerInterval[CrashVolDriver][7] = 9 * baseInterval
+	triggerInterval[CrashVolDriver][6] = 12 * baseInterval
+	triggerInterval[CrashVolDriver][5] = 15 * baseInterval
+	triggerInterval[CrashVolDriver][4] = 18 * baseInterval
+	triggerInterval[CrashVolDriver][3] = 21 * baseInterval
+	triggerInterval[CrashVolDriver][2] = 24 * baseInterval
+	triggerInterval[CrashVolDriver][1] = 27 * baseInterval
 
 	triggerInterval[RestartVolDriver][10] = 1 * baseInterval
-	triggerInterval[RestartVolDriver][9] = 2 * baseInterval
-	triggerInterval[RestartVolDriver][8] = 3 * baseInterval
-	triggerInterval[RestartVolDriver][7] = 4 * baseInterval
-	triggerInterval[RestartVolDriver][6] = 5 * baseInterval
-	triggerInterval[RestartVolDriver][5] = 6 * baseInterval // Default global chaos level, 3 hrs
+	triggerInterval[RestartVolDriver][9] = 3 * baseInterval
+	triggerInterval[RestartVolDriver][8] = 6 * baseInterval
+	triggerInterval[RestartVolDriver][7] = 9 * baseInterval
+	triggerInterval[RestartVolDriver][6] = 12 * baseInterval
+	triggerInterval[RestartVolDriver][5] = 15 * baseInterval // Default global chaos level, 3 hrs
+	triggerInterval[RestartVolDriver][4] = 18 * baseInterval
+	triggerInterval[RestartVolDriver][3] = 21 * baseInterval
+	triggerInterval[RestartVolDriver][2] = 24 * baseInterval
+	triggerInterval[RestartVolDriver][1] = 27 * baseInterval
 
 	triggerInterval[AppTaskDown][10] = 1 * baseInterval
-	triggerInterval[AppTaskDown][9] = 2 * baseInterval
-	triggerInterval[AppTaskDown][8] = 3 * baseInterval
-	triggerInterval[AppTaskDown][7] = 4 * baseInterval
-	triggerInterval[AppTaskDown][6] = 5 * baseInterval
-	triggerInterval[AppTaskDown][5] = 6 * baseInterval // Default global chaos level, 1 hr
+	triggerInterval[AppTaskDown][9] = 3 * baseInterval
+	triggerInterval[AppTaskDown][8] = 6 * baseInterval
+	triggerInterval[AppTaskDown][7] = 9 * baseInterval
+	triggerInterval[AppTaskDown][6] = 12 * baseInterval
+	triggerInterval[AppTaskDown][5] = 15 * baseInterval // Default global chaos level, 1 hr
+	triggerInterval[AppTaskDown][4] = 18 * baseInterval
+	triggerInterval[AppTaskDown][3] = 21 * baseInterval
+	triggerInterval[AppTaskDown][2] = 24 * baseInterval
+	triggerInterval[AppTaskDown][1] = 27 * baseInterval
 
-	baseInterval = 30 * time.Minute
+	triggerInterval[HAIncrease][10] = 1 * baseInterval
+	triggerInterval[HAIncrease][9] = 3 * baseInterval
+	triggerInterval[HAIncrease][8] = 6 * baseInterval
+	triggerInterval[HAIncrease][7] = 9 * baseInterval
+	triggerInterval[HAIncrease][6] = 12 * baseInterval
+	triggerInterval[HAIncrease][5] = 15 * baseInterval // Default global chaos level, 1.5 hrs
+	triggerInterval[HAIncrease][4] = 18 * baseInterval
+	triggerInterval[HAIncrease][3] = 21 * baseInterval
+	triggerInterval[HAIncrease][2] = 24 * baseInterval
+	triggerInterval[HAIncrease][1] = 27 * baseInterval
+
+	triggerInterval[HADecrease][10] = 1 * baseInterval
+	triggerInterval[HADecrease][9] = 3 * baseInterval
+	triggerInterval[HADecrease][8] = 6 * baseInterval
+	triggerInterval[HADecrease][7] = 9 * baseInterval
+	triggerInterval[HADecrease][6] = 12 * baseInterval
+	triggerInterval[HADecrease][5] = 15 * baseInterval // Default global chaos level, 3 hrs
+	triggerInterval[HADecrease][4] = 18 * baseInterval
+	triggerInterval[HADecrease][3] = 21 * baseInterval
+	triggerInterval[HADecrease][2] = 24 * baseInterval
+	triggerInterval[HADecrease][1] = 27 * baseInterval
+
+	baseInterval = 6 * time.Hour
 	triggerInterval[EmailReporter][10] = 1 * baseInterval
 	triggerInterval[EmailReporter][9] = 2 * baseInterval
 	triggerInterval[EmailReporter][8] = 3 * baseInterval
@@ -302,28 +341,6 @@ func populateIntervals() {
 	triggerInterval[EmailReporter][3] = 8 * baseInterval
 	triggerInterval[EmailReporter][2] = 9 * baseInterval
 	triggerInterval[EmailReporter][1] = 10 * baseInterval
-
-	triggerInterval[HAIncrease][10] = 1 * baseInterval
-	triggerInterval[HAIncrease][9] = 2 * baseInterval
-	triggerInterval[HAIncrease][8] = 3 * baseInterval
-	triggerInterval[HAIncrease][7] = 4 * baseInterval
-	triggerInterval[HAIncrease][6] = 5 * baseInterval
-	triggerInterval[HAIncrease][5] = 6 * baseInterval // Default global chaos level, 1.5 hrs
-	triggerInterval[HAIncrease][4] = 7 * baseInterval
-	triggerInterval[HAIncrease][3] = 8 * baseInterval
-	triggerInterval[HAIncrease][2] = 9 * baseInterval
-	triggerInterval[HAIncrease][1] = 10 * baseInterval
-
-	triggerInterval[HADecrease][10] = 1 * baseInterval
-	triggerInterval[HADecrease][9] = 2 * baseInterval
-	triggerInterval[HADecrease][8] = 3 * baseInterval
-	triggerInterval[HADecrease][7] = 4 * baseInterval
-	triggerInterval[HADecrease][6] = 5 * baseInterval
-	triggerInterval[HADecrease][5] = 6 * baseInterval // Default global chaos level, 3 hrs
-	triggerInterval[HADecrease][4] = 7 * baseInterval
-	triggerInterval[HADecrease][3] = 8 * baseInterval
-	triggerInterval[HADecrease][2] = 9 * baseInterval
-	triggerInterval[HADecrease][1] = 10 * baseInterval
 
 	triggerInterval[DeployApps][10] = 1 * baseInterval
 	triggerInterval[DeployApps][9] = 2 * baseInterval

--- a/tests/testTriggers.go
+++ b/tests/testTriggers.go
@@ -85,6 +85,8 @@ func UpdateOutcome(event *EventRecord, err error) {
 }
 
 const (
+	// DeployApps installs new apps
+	DeployApps = "deployApps"
 	// HAIncrease performs repl-add
 	HAIncrease = "haIncrease"
 	// HADecrease performs repl-reduce
@@ -100,6 +102,41 @@ const (
 	// EmailReporter notifies via email outcome of past events
 	EmailReporter = "emailReporter"
 )
+
+// TriggerDeployNewApps deploys applications in separate namespaces
+func TriggerDeployNewApps(contexts []*scheduler.Context, recordChan *chan *EventRecord) {
+	defer ginkgo.GinkgoRecover()
+	event := &EventRecord{
+		Event: Event{
+			ID:   GenerateUUID(),
+			Type: DeployApps,
+		},
+		Start:   time.Now().Format(time.RFC1123),
+		Outcome: []error{},
+	}
+
+	defer func() {
+		event.End = time.Now().Format(time.RFC1123)
+		*recordChan <- event
+	}()
+	errorChan := make(chan error, errorChannelSize)
+
+	Step("Deploy applications", func() {
+		contexts := []*scheduler.Context{}
+		for i := 0; i < Inst().GlobalScaleFactor; i++ {
+			newContexts := ScheduleApplications(fmt.Sprintf("longevity-%d", i), &errorChan)
+			contexts = append(contexts, newContexts...)
+		}
+
+		for _, ctx := range contexts {
+			ctx.SkipVolumeValidation = false
+			ValidateContext(ctx, &errorChan)
+			for err := range errorChan {
+				UpdateOutcome(event, err)
+			}
+		}
+	})
+}
 
 // TriggerHAIncrease peforms repl-add on all volumes of given contexts
 func TriggerHAIncrease(contexts []*scheduler.Context, recordChan *chan *EventRecord) {
@@ -127,7 +164,9 @@ func TriggerHAIncrease(contexts []*scheduler.Context, recordChan *chan *EventRec
 			Step(fmt.Sprintf("get volumes for %s app", ctx.App.Key), func() {
 				appVolumes, err = Inst().S.GetVolumes(ctx)
 				UpdateOutcome(event, err)
-				expect(appVolumes).NotTo(beEmpty())
+				if len(appVolumes) == 0 {
+					UpdateOutcome(event, fmt.Errorf("found no volumes for app %s", ctx.App.Key))
+				}
 			})
 			opts := volume.Options{
 				ValidateReplicationUpdateTimeout: validateReplicationUpdateTimeout,
@@ -142,14 +181,14 @@ func TriggerHAIncrease(contexts []*scheduler.Context, recordChan *chan *EventRec
 						errExpected := false
 						currRep, err := Inst().V.GetReplicationFactor(v)
 						UpdateOutcome(event, err)
-						expect(err).NotTo(haveOccurred())
+
 						// GetMaxReplicationFactory is hardcoded to 3
 						// if it increases repl 3 to an aggregated 2 volume, it will fail
 						// because it would require 6 worker nodes, since
 						// number of nodes required = aggregation level * replication factor
 						currAggr, err := Inst().V.GetAggregationLevel(v)
 						UpdateOutcome(event, err)
-						expect(err).NotTo(haveOccurred())
+
 						if currAggr > 1 {
 							MaxRF = int64(len(node.GetWorkerNodes())) / currAggr
 						}
@@ -160,10 +199,9 @@ func TriggerHAIncrease(contexts []*scheduler.Context, recordChan *chan *EventRec
 						err = Inst().V.SetReplicationFactor(v, currRep+1, opts)
 						if !errExpected {
 							UpdateOutcome(event, err)
-							expect(err).NotTo(haveOccurred())
 						} else {
 							if !expect(err).To(haveOccurred()) {
-								UpdateOutcome(event, fmt.Errorf("Expected HA increase to fail since new repl factor is greater than %v but it did not", MaxRF))
+								UpdateOutcome(event, fmt.Errorf("expected HA increase to fail since new repl factor is greater than %v but it did not", MaxRF))
 							}
 						}
 					})
@@ -173,12 +211,15 @@ func TriggerHAIncrease(contexts []*scheduler.Context, recordChan *chan *EventRec
 					func() {
 						newRepl, err := Inst().V.GetReplicationFactor(v)
 						UpdateOutcome(event, err)
-						expect(err).NotTo(haveOccurred())
+
 						if newRepl != expReplMap[v] {
 							err = fmt.Errorf("volume has invalid repl value. Expected:%d Actual:%d", expReplMap[v], newRepl)
 							UpdateOutcome(event, err)
 						}
-						expect(newRepl).To(equal(expReplMap[v]))
+						if newRepl != expReplMap[v] {
+							UpdateOutcome(event,
+								fmt.Errorf("actual volume replica %d does not match with expected volume replica %d for volume [%s]", newRepl, expReplMap[v], v.Name))
+						}
 					})
 			}
 			Step(fmt.Sprintf("validating context after increasing HA for app: %s",
@@ -219,7 +260,9 @@ func TriggerHADecrease(contexts []*scheduler.Context, recordChan *chan *EventRec
 			Step(fmt.Sprintf("get volumes for %s app", ctx.App.Key), func() {
 				appVolumes, err = Inst().S.GetVolumes(ctx)
 				UpdateOutcome(event, err)
-				expect(appVolumes).NotTo(beEmpty())
+				if len(appVolumes) == 0 {
+					UpdateOutcome(event, fmt.Errorf("found no volumes for app %s", ctx.App.Key))
+				}
 			})
 			opts := volume.Options{
 				ValidateReplicationUpdateTimeout: validateReplicationUpdateTimeout,
@@ -234,7 +277,6 @@ func TriggerHADecrease(contexts []*scheduler.Context, recordChan *chan *EventRec
 						errExpected := false
 						currRep, err := Inst().V.GetReplicationFactor(v)
 						UpdateOutcome(event, err)
-						expect(err).NotTo(haveOccurred())
 
 						if currRep == MinRF {
 							errExpected = true
@@ -244,7 +286,7 @@ func TriggerHADecrease(contexts []*scheduler.Context, recordChan *chan *EventRec
 						err = Inst().V.SetReplicationFactor(v, currRep-1, opts)
 						if !errExpected {
 							UpdateOutcome(event, err)
-							expect(err).NotTo(haveOccurred())
+
 						} else {
 							if !expect(err).To(haveOccurred()) {
 								UpdateOutcome(event, fmt.Errorf("Expected HA reduce to fail since new repl factor is less than %v but it did not", MinRF))
@@ -258,11 +300,14 @@ func TriggerHADecrease(contexts []*scheduler.Context, recordChan *chan *EventRec
 					func() {
 						newRepl, err := Inst().V.GetReplicationFactor(v)
 						UpdateOutcome(event, err)
-						expect(err).NotTo(haveOccurred())
+
 						if newRepl != expReplMap[v] {
 							UpdateOutcome(event, fmt.Errorf("volume has invalid repl value. Expected:%d Actual:%d", expReplMap[v], newRepl))
 						}
-						expect(newRepl).To(equal(expReplMap[v]))
+						if newRepl != expReplMap[v] {
+							UpdateOutcome(event,
+								fmt.Errorf("actual volume replica %d does not match with expected volume replica %d for volume [%s]", newRepl, expReplMap[v], v.Name))
+						}
 					})
 			}
 			Step(fmt.Sprintf("validating context after reducing HA for app: %s",
@@ -299,7 +344,6 @@ func TriggerAppTaskDown(contexts []*scheduler.Context, recordChan *chan *EventRe
 		Step(fmt.Sprintf("delete tasks for app: [%s]", ctx.App.Key), func() {
 			err := Inst().S.DeleteTasks(ctx, nil)
 			UpdateOutcome(event, err)
-			expect(err).NotTo(haveOccurred())
 		})
 
 		Step(fmt.Sprintf("validating context after delete tasks for app: [%s]",
@@ -336,7 +380,11 @@ func TriggerCrashVolDriver(contexts []*scheduler.Context, recordChan *chan *Even
 				fmt.Sprintf("crash volume driver %s on node: %v",
 					Inst().V.String(), appNode.Name),
 				func() {
-					CrashVolDriverAndWait([]node.Node{appNode})
+					errorChan := make(chan error, errorChannelSize)
+					CrashVolDriverAndWait([]node.Node{appNode}, &errorChan)
+					for err := range errorChan {
+						UpdateOutcome(event, err)
+					}
 				})
 		}
 	})
@@ -364,14 +412,22 @@ func TriggerRestartVolDriver(contexts []*scheduler.Context, recordChan *chan *Ev
 				fmt.Sprintf("stop volume driver %s on node: %s",
 					Inst().V.String(), appNode.Name),
 				func() {
-					StopVolDriverAndWait([]node.Node{appNode})
+					errorChan := make(chan error, errorChannelSize)
+					StopVolDriverAndWait([]node.Node{appNode}, &errorChan)
+					for err := range errorChan {
+						UpdateOutcome(event, err)
+					}
 				})
 
 			Step(
 				fmt.Sprintf("starting volume %s driver on node %s",
 					Inst().V.String(), appNode.Name),
 				func() {
-					StartVolDriverAndWait([]node.Node{appNode})
+					errorChan := make(chan error, errorChannelSize)
+					StartVolDriverAndWait([]node.Node{appNode}, &errorChan)
+					for err := range errorChan {
+						UpdateOutcome(event, err)
+					}
 				})
 
 			Step("Giving few seconds for volume driver to stabilize", func() {
@@ -424,7 +480,6 @@ func TriggerRebootNodes(contexts []*scheduler.Context, recordChan *chan *EventRe
 								TimeBeforeRetry: 5 * time.Second,
 							},
 						})
-						expect(err).NotTo(haveOccurred())
 						UpdateOutcome(event, err)
 					})
 
@@ -433,13 +488,11 @@ func TriggerRebootNodes(contexts []*scheduler.Context, recordChan *chan *EventRe
 							Timeout:         15 * time.Minute,
 							TimeBeforeRetry: 10 * time.Second,
 						})
-						expect(err).NotTo(haveOccurred())
 						UpdateOutcome(event, err)
 					})
 
 					Step(fmt.Sprintf("wait for volume driver to stop on node: %v", n.Name), func() {
 						err := Inst().V.WaitDriverDownOnNode(n)
-						expect(err).NotTo(haveOccurred())
 						UpdateOutcome(event, err)
 					})
 
@@ -447,11 +500,9 @@ func TriggerRebootNodes(contexts []*scheduler.Context, recordChan *chan *EventRe
 						Inst().S.String(), Inst().V.String()), func() {
 
 						err := Inst().S.IsNodeReady(n)
-						expect(err).NotTo(haveOccurred())
 						UpdateOutcome(event, err)
 
 						err = Inst().V.WaitDriverUpOnNode(n, Inst().DriverStartTimeout)
-						expect(err).NotTo(haveOccurred())
 						UpdateOutcome(event, err)
 					})
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**Changes as part of this PR**:
1.  Added CPU/Mem resource limits for all the apps deployed as part of torpedo tests
2. Longevity requires tests to continue and not to stop because if some Ginkgo assertion fails. For this, introduced `*chan Error` to our library functions. If error channel is supplied to these library func,  function will return error over channel and not fail the assertions. For other test suites, this `*chan Error` is not supplied and these library functions will fail the assertions as usual.
3. Added  new `TriggerDeployNewApps` trigger.
4. Changed time intervals for longevity triggers.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
tp-dev-test successful run:
https://jenkins.portworx.dev/job/Torpedo/job/tp-dev-test/922/

It ran below set of tests successfully:

SetupTeardown,AppTasksDown,VolumeDriverDown,VolumeDriverAppDown,VolumeDriverCrash,RebootOneNode,VolumeUpdate