### PR TITLE
PB-1716: Change code to use secret instead of password str

### DIFF
--- a/drivers/backup/backup.go
+++ b/drivers/backup/backup.go
@@ -7,6 +7,7 @@ import (
 
 	api "github.com/portworx/px-backup-api/pkg/apis/v1"
 	"github.com/portworx/torpedo/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // Image Generic struct
@@ -308,4 +309,13 @@ func Get(name string) (Driver, error) {
 		ID:   name,
 		Type: "BackupDriver",
 	}
+}
+
+func init() {
+	str, err := GetPxCentralAdminPwd()
+	if err != nil {
+		logrus.Errorf("Error fetching password from secret: %v", err)
+		panic("Failed to fetch password from px-central-admin!")
+	}
+	PxCentralAdminPwd = str
 }


### PR DESCRIPTION
Problem:
Currently all the integration-test runs fail with the below error:
```
time="2021-07-07T08:44:52Z" level=error msg="FetchIDOfUser: json: cannot unmarshal object into Go value of type []backup.KeycloakUserRepresentation"
time="2021-07-07T08:44:52Z" level=error msg="AddRoleToUser: json: cannot unmarshal object into Go value of type []backup.KeycloakUserRepresentation"
time="2021-07-07T08:44:52Z" level=error msg="Setup failed: json: cannot unmarshal object into Go value of type []backup.KeycloakUserRepresentation"
```
This is mostly because px-central-admin password is now stored in secret in px-backup namespace.

Solution:
Adding a function GetPxCentralAdminPwd() and init() to fetch the password from the secret.

Signed-off-by: kshithijiyer-px <kiyer@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #PB-1716

**Special notes for your reviewer**:

