### PR TITLE
Comment out code to check pxctl status due to issues on EKS nodes

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -203,15 +203,19 @@ func (d *portworx) Init(sched, nodeDriver, token, storageProvisioner, csiGeneric
 		return fmt.Errorf("cluster inspect returned empty nodes")
 	}
 
-	err = d.updateNodes(storageNodes)
-	if err != nil {
-		return err
-	}
-	for _, n := range node.GetStorageDriverNodes() {
-		if err = d.WaitDriverUpOnNode(n, validatePXStartTimeout); err != nil {
-			return err
-		}
-	}
+	// NOTE:
+	// Commenting out as when run on EKS this casues problems as ec2 instances
+	// on EKS can't sshed using internal IPs causing pxctl status to fail
+
+	// err = d.updateNodes(storageNodes)
+	// if err != nil {
+	//	return err
+	// }
+	// for _, n := range node.GetStorageDriverNodes() {
+	//	if err = d.WaitDriverUpOnNode(n, validatePXStartTimeout); err != nil {
+	//		return err
+	//	}
+	// }
 
 	logrus.Infof("The following Portworx nodes are in the cluster:")
 	for _, n := range storageNodes {


### PR DESCRIPTION
Change:
Commenting out code which perfroms pxctl status to avoid failures
in eks runs as we can't ssh into EKS cluster's ec2 instances using
internal|cluster ip addresses.

Signed-off-by: kshithijiyer-px <kiyer@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes # PB-1408

**Special notes for your reviewer**:
This is a temporary fix, we'll need to work on a permanent one.
