### PR TITLE
:sparkles:  Adding VolumeUpdateForAttachedNode test which removes/attaches to the given node

### DIFF
--- a/drivers/volume/common.go
+++ b/drivers/volume/common.go
@@ -176,7 +176,7 @@ func (d *DefaultDriver) GetReplicationFactor(vol *Volume) (int64, error) {
 }
 
 // SetReplicationFactor sets the volume's replication factor to the passed param rf.
-func (d *DefaultDriver) SetReplicationFactor(vol *Volume, replFactor int64, opts ...Options) error {
+func (d *DefaultDriver) SetReplicationFactor(vol *Volume, replFactor int64, nodesToBeUpdated []string, opts ...Options) error {
 	return &errors.ErrNotSupported{
 		Type:      "Function",
 		Operation: "SetReplicationFactor()",

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -809,6 +809,7 @@ func (d *portworx) StopDriver(nodes []node.Node, force bool, triggerOpts *driver
 	return driver_api.PerformTask(stopFn, triggerOpts)
 }
 
+//GetNodeForVolume returns the node on which volume is attached
 func (d *portworx) GetNodeForVolume(vol *torpedovolume.Volume, timeout time.Duration, retryInterval time.Duration) (*node.Node, error) {
 	volumeName := d.schedOps.GetVolumeName(vol)
 	r := func() (interface{}, bool, error) {
@@ -1280,7 +1281,7 @@ func (d *portworx) GetReplicationFactor(vol *torpedovolume.Volume) (int64, error
 	return replFactor, nil
 }
 
-func (d *portworx) SetReplicationFactor(vol *torpedovolume.Volume, replFactor int64, opts ...torpedovolume.Options) error {
+func (d *portworx) SetReplicationFactor(vol *torpedovolume.Volume, replFactor int64, nodesToBeUpdated []string, opts ...torpedovolume.Options) error {
 	volumeName := d.schedOps.GetVolumeName(vol)
 	var replicationUpdateTimeout time.Duration
 	if len(opts) > 0 {
@@ -1289,6 +1290,7 @@ func (d *portworx) SetReplicationFactor(vol *torpedovolume.Volume, replFactor in
 		replicationUpdateTimeout = validateReplicationUpdateTimeout
 	}
 	logrus.Infof("Setting ReplicationUpdateTimeout to %s-%v\n", replicationUpdateTimeout, replicationUpdateTimeout)
+	logrus.Infof("Setting ReplicationFactor to: %v", replFactor)
 
 	t := func() (interface{}, bool, error) {
 		volDriver := d.getVolDriver()
@@ -1299,10 +1301,16 @@ func (d *portworx) SetReplicationFactor(vol *torpedovolume.Volume, replFactor in
 			return nil, true, err
 		}
 
+		replicaSet := &api.ReplicaSet{}
+		if len(nodesToBeUpdated) > 0 {
+			replicaSet = &api.ReplicaSet{Nodes: nodesToBeUpdated}
+			logrus.Infof("Updating ReplicaSet of node(s): %v", nodesToBeUpdated)
+		}
+
 		volumeSpecUpdate := &api.VolumeSpecUpdate{
 			HaLevelOpt:          &api.VolumeSpecUpdate_HaLevel{HaLevel: int64(replFactor)},
 			SnapshotIntervalOpt: &api.VolumeSpecUpdate_SnapshotInterval{SnapshotInterval: math.MaxUint32},
-			ReplicaSet:          &api.ReplicaSet{},
+			ReplicaSet:          replicaSet,
 		}
 		_, err = volDriver.Update(d.getContext(), &api.SdkVolumeUpdateRequest{
 			VolumeId: volumeInspectResponse.Volume.Id,

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -118,8 +118,8 @@ type Driver interface {
 	// GetReplicationFactor returns the current replication factor of the volume.
 	GetReplicationFactor(vol *Volume) (int64, error)
 
-	// SetReplicationFactor sets the volume's replication factor to the passed param rf.
-	SetReplicationFactor(vol *Volume, rf int64, opts ...Options) error
+	// SetReplicationFactor sets the volume's replication factor to the passed param rf and nodes.
+	SetReplicationFactor(vol *Volume, rf int64, nodesToBeUpdated []string, opts ...Options) error
 
 	// GetMaxReplicationFactor returns the max supported repl factor of a volume
 	GetMaxReplicationFactor() int64

--- a/tests/testTriggers.go
+++ b/tests/testTriggers.go
@@ -259,7 +259,7 @@ func TriggerHAIncrease(contexts []*scheduler.Context, recordChan *chan *EventRec
 							errExpected = true
 						}
 						expReplMap[v] = int64(math.Min(float64(MaxRF), float64(currRep)+1))
-						err = Inst().V.SetReplicationFactor(v, currRep+1, opts)
+						err = Inst().V.SetReplicationFactor(v, currRep+1, nil, opts)
 						if !errExpected {
 							UpdateOutcome(event, err)
 						} else {
@@ -346,7 +346,7 @@ func TriggerHADecrease(contexts []*scheduler.Context, recordChan *chan *EventRec
 						}
 						expReplMap[v] = int64(math.Max(float64(MinRF), float64(currRep)-1))
 
-						err = Inst().V.SetReplicationFactor(v, currRep-1, opts)
+						err = Inst().V.SetReplicationFactor(v, currRep-1, nil, opts)
 						if !errExpected {
 							UpdateOutcome(event, err)
 

--- a/tests/volume_ops/volume_ops_test.go
+++ b/tests/volume_ops/volume_ops_test.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"reflect"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/reporters"
@@ -13,6 +15,12 @@ import (
 	"github.com/portworx/torpedo/drivers/scheduler"
 	"github.com/portworx/torpedo/drivers/volume"
 	. "github.com/portworx/torpedo/tests"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	defaultCommandRetry   = 5 * time.Second
+	defaultCommandTimeout = 1 * time.Minute
 )
 
 func TestVolOps(t *testing.T) {
@@ -66,7 +74,7 @@ var _ = Describe("{VolumeUpdate}", func() {
 								errExpected = true
 							}
 							expReplMap[v] = int64(math.Max(float64(MinRF), float64(currRep)-1))
-							err = Inst().V.SetReplicationFactor(v, currRep-1)
+							err = Inst().V.SetReplicationFactor(v, currRep-1, nil)
 							if !errExpected {
 								Expect(err).NotTo(HaveOccurred())
 							} else {
@@ -102,7 +110,7 @@ var _ = Describe("{VolumeUpdate}", func() {
 								errExpected = true
 							}
 							expReplMap[v] = int64(math.Min(float64(MaxRF), float64(currRep)+1))
-							err = Inst().V.SetReplicationFactor(v, currRep+1)
+							err = Inst().V.SetReplicationFactor(v, currRep+1, nil)
 							if !errExpected {
 								Expect(err).NotTo(HaveOccurred())
 							} else {
@@ -141,6 +149,172 @@ var _ = Describe("{VolumeUpdate}", func() {
 							Expect(err).NotTo(HaveOccurred())
 						}
 					})
+
+			}
+		})
+
+		Step("destroy apps", func() {
+			opts := make(map[string]bool)
+			opts[scheduler.OptionsWaitForResourceLeakCleanup] = true
+			for _, ctx := range contexts {
+				TearDownContext(ctx, opts)
+			}
+		})
+
+	})
+	JustAfterEach(func() {
+		AfterEachTest(contexts)
+	})
+})
+
+// Volume replication change
+var _ = Describe("{VolumeUpdateForAttachedNode}", func() {
+	var contexts []*scheduler.Context
+
+	It("has to schedule apps and update replication factor for attached node", func() {
+		var err error
+		contexts = make([]*scheduler.Context, 0)
+		expReplMap := make(map[*volume.Volume]int64)
+
+		for i := 0; i < Inst().GlobalScaleFactor; i++ {
+			contexts = append(contexts, ScheduleApplications(fmt.Sprintf("volupdate-%d", i))...)
+		}
+
+		ValidateApplications(contexts)
+
+		Step("get volumes for all apps in test and update replication factor and size", func() {
+			for _, ctx := range contexts {
+				var appVolumes []*volume.Volume
+				Step(fmt.Sprintf("get volumes for %s app", ctx.App.Key), func() {
+					appVolumes, err = Inst().S.GetVolumes(ctx)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(appVolumes).NotTo(BeEmpty())
+				})
+				for _, v := range appVolumes {
+					MaxRF := Inst().V.GetMaxReplicationFactor()
+					MinRF := Inst().V.GetMinReplicationFactor()
+					currReplicaSet := []string{}
+					updateReplicaSet := []string{}
+					expectedReplicaSet := []string{}
+
+					Step(
+						fmt.Sprintf("repl decrease volume driver %s on app %s's volume: %v",
+							Inst().V.String(), ctx.App.Key, v),
+						func() {
+							errExpected := false
+							currRep, err := Inst().V.GetReplicationFactor(v)
+							Expect(err).NotTo(HaveOccurred())
+							if currRep == MinRF {
+								errExpected = true
+							}
+							attachedNode, err := Inst().V.GetNodeForVolume(v, defaultCommandTimeout, defaultCommandRetry)
+
+							replicaSets, err := Inst().V.GetReplicaSets(v)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(replicaSets).NotTo(BeEmpty())
+
+							for _, nID := range replicaSets[0].Nodes {
+								currReplicaSet = append(currReplicaSet, nID)
+							}
+
+							logrus.Infof("ReplicaSet of volume %v is: %v", v.Name, currReplicaSet)
+
+							for _, n := range currReplicaSet {
+								if n == attachedNode.Id {
+									updateReplicaSet = append(updateReplicaSet, n)
+
+								} else {
+									expectedReplicaSet = append(expectedReplicaSet, n)
+
+								}
+
+							}
+
+							expReplMap[v] = int64(math.Max(float64(MinRF), float64(currRep)-1))
+							err = Inst().V.SetReplicationFactor(v, currRep-1, updateReplicaSet)
+							if !errExpected {
+								Expect(err).NotTo(HaveOccurred())
+							} else {
+								Expect(err).To(HaveOccurred())
+							}
+
+						})
+					Step(
+						fmt.Sprintf("validate successful repl decrease on app %s's volume: %v",
+							ctx.App.Key, v),
+						func() {
+							newRepl, err := Inst().V.GetReplicationFactor(v)
+							logrus.Infof("Got repl factor after update: %v", newRepl)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(newRepl).To(Equal(expReplMap[v]))
+							currReplicaSets, err := Inst().V.GetReplicaSets(v)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(currReplicaSets).NotTo(BeEmpty())
+							reducedReplicaSet := []string{}
+							for _, nID := range currReplicaSets[0].Nodes {
+								reducedReplicaSet = append(reducedReplicaSet, nID)
+							}
+
+							logrus.Infof("ReplicaSet of volume %v is: %v", v.Name, reducedReplicaSet)
+							res := reflect.DeepEqual(reducedReplicaSet, expectedReplicaSet)
+							Expect(res).To(BeTrue())
+						})
+					for _, ctx := range contexts {
+						ctx.SkipVolumeValidation = true
+					}
+					ValidateApplications(contexts)
+					for _, ctx := range contexts {
+						ctx.SkipVolumeValidation = false
+					}
+
+					Step(
+						fmt.Sprintf("repl increase volume driver %s on app %s's volume: %v",
+							Inst().V.String(), ctx.App.Key, v),
+						func() {
+							errExpected := false
+							currRep, err := Inst().V.GetReplicationFactor(v)
+							Expect(err).NotTo(HaveOccurred())
+							// GetMaxReplicationFactory is hardcoded to 3
+							// if it increases repl 3 to an aggregated 2 volume, it will fail
+							// because it would require 6 worker nodes, since
+							// number of nodes required = aggregation level * replication factor
+							currAggr, err := Inst().V.GetAggregationLevel(v)
+							Expect(err).NotTo(HaveOccurred())
+							if currAggr > 1 {
+								MaxRF = int64(len(node.GetWorkerNodes())) / currAggr
+							}
+							if currRep == MaxRF {
+								errExpected = true
+							}
+							expReplMap[v] = int64(math.Min(float64(MaxRF), float64(currRep)+1))
+							err = Inst().V.SetReplicationFactor(v, currRep+1, updateReplicaSet)
+							if !errExpected {
+								Expect(err).NotTo(HaveOccurred())
+							} else {
+								Expect(err).To(HaveOccurred())
+							}
+						})
+					Step(
+						fmt.Sprintf("validate successful repl increase on app %s's volume: %v",
+							ctx.App.Key, v),
+						func() {
+							newRepl, err := Inst().V.GetReplicationFactor(v)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(newRepl).To(Equal(expReplMap[v]))
+							currReplicaSets, err := Inst().V.GetReplicaSets(v)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(currReplicaSets).NotTo(BeEmpty())
+							increasedReplicaSet := []string{}
+							for _, nID := range currReplicaSets[0].Nodes {
+								increasedReplicaSet = append(increasedReplicaSet, nID)
+							}
+
+							logrus.Infof("ReplicaSet of volume %v is: %v", v.Name, increasedReplicaSet)
+							res := reflect.DeepEqual(increasedReplicaSet, currReplicaSet)
+							Expect(res).To(BeTrue())
+						})
+					ValidateApplications(contexts)
+				}
 
 			}
 		})


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
 Adding VolumeUpdateForAttachedNode test which removes replica on volume attached and attaches back again

**Which issue(s) this PR fixes** (optional)
Closes #PTX-3911

**Special notes for your reviewer**:

Jenkins result: http://jenkins.pwx.dev.purestorage.com/view/Control%20Plane/job/Torpedo/job/tp-basic-sharedv4/76/consoleFull

Please note : the build marked failure due to jenkins issue but tests have passed