### PR TITLE
PTX-3795 double check if the node is really up

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -968,7 +968,15 @@ func (d *portworx) WaitDriverUpOnNode(n node.Node, timeout time.Duration) error 
 		logrus.Debugf("checking PX status on node: %s", n.Name)
 		pxNode := nodeInspectResponse.Node
 		switch pxNode.Status {
-		case api.Status_STATUS_DECOMMISSION, api.Status_STATUS_OK: // do nothing
+		case api.Status_STATUS_DECOMMISSION: // do nothing
+		case api.Status_STATUS_OK:
+			err := d.testAndSetEndpointUsingNodeIP(pxNode.MgmtIp)
+			if err != nil {
+				return "", true, &ErrFailedToWaitForPx{
+					Node:  n,
+					Cause: fmt.Sprintf("px is not yet up on node. cause: %v", err),
+				}
+			}
 		case api.Status_STATUS_OFFLINE:
 			// in case node is offline and it is a storageless node, the id might have changed so update it
 			if len(pxNode.Pools) == 0 {


### PR DESCRIPTION
Signed-off-by: Thiago Gonzaga <tgonzaga@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR Is needed to avoid PX SDK to report node up before it's really up

