### PR TITLE
PTX-4036: increase HA increase timeout

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -70,7 +70,7 @@ const (
 	inspectVolumeTimeout              = 30 * time.Second
 	inspectVolumeRetryInterval        = 2 * time.Second
 	validateDeleteVolumeTimeout       = 3 * time.Minute
-	validateReplicationUpdateTimeout  = 10 * time.Minute
+	validateReplicationUpdateTimeout  = 30 * time.Minute
 	validateClusterStartTimeout       = 2 * time.Minute
 	validatePXStartTimeout            = 5 * time.Minute
 	validateNodeStopTimeout           = 5 * time.Minute


### PR DESCRIPTION
**What this PR does / why we need it**:
Torpedo is not running in a controlled environment and PX does not make any
guarantees about how long it will take to increase the HA level. This patch
increases the timeout for repl increase operation to finish.

Signed-off-by: Neelesh Thakur <neelesh.thakur@purestorage.com>

**Which issue(s) this PR fixes** (optional)
PTX-4036

**Special notes for your reviewer**:

