### PR TITLE
PWX-21277: Add callhome test

### DIFF
--- a/drivers/volume/common.go
+++ b/drivers/volume/common.go
@@ -354,3 +354,19 @@ func (d *DefaultDriver) RestartDriver(n node.Node, triggerOpts *driver_api.Trigg
 		Operation: "RestartDriver()",
 	}
 }
+
+//SetClusterOpts sets cluster options
+func (d *DefaultDriver) SetClusterOpts(n node.Node, rtOpts map[string]string) error {
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "SetClusterOpts()",
+	}
+}
+
+//ToggleCallHome toggles Call-home
+func (d *DefaultDriver) ToggleCallHome(n node.Node, enabled bool) error {
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "ToggleCallHome()",
+	}
+}

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -169,6 +169,12 @@ type Driver interface {
 
 	// GetLicenseSummary returns the activated license SKU and Features
 	GetLicenseSummary() (LicenseSummary, error)
+
+	//SetClusterOpts sets cluster options
+	SetClusterOpts(n node.Node, rtOpts map[string]string) error
+
+	//ToggleCallHome toggles Call-home
+	ToggleCallHome(n node.Node, enabled bool) error
 }
 
 // StorageProvisionerType provisioner to be used for torpedo volumes


### PR DESCRIPTION
Signed-off-by: Paul Theunis <paul@portworx.com>

**What this PR does / why we need it**:
Test to see that FA/FB essentials keeps working if we disable call-home

**Special notes for your reviewer**:
Waiting to get a positive test run.

http://jenkins.pwx.dev.purestorage.com/view/Control%20Plane/job/Torpedo/job/2-tp-nextpx-pure-esse/36
