### PR TITLE
:wrench: fixing ha decrease issue with node

### DIFF
--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -95,7 +95,7 @@ const (
 	// DefaultRetryInterval  Default retry interval
 	DefaultRetryInterval = 10 * time.Second
 	// DefaultTimeout default timeout
-	DefaultTimeout = 2 * time.Minute
+	DefaultTimeout = 3 * time.Minute
 
 	autopilotServiceName          = "autopilot"
 	autopilotDefaultNamespace     = "kube-system"

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -1301,6 +1301,8 @@ func (d *portworx) SetReplicationFactor(vol *torpedovolume.Volume, replFactor in
 		if len(nodesToBeUpdated) > 0 {
 			replicaSet = &api.ReplicaSet{Nodes: nodesToBeUpdated}
 			logrus.Infof("Updating ReplicaSet of node(s): %v", nodesToBeUpdated)
+		} else {
+			logrus.Infof("Nodes not passed, random node will be choosen")
 		}
 
 		volumeSpecUpdate := &api.VolumeSpecUpdate{

--- a/tests/volume_ops/volume_ops_test.go
+++ b/tests/volume_ops/volume_ops_test.go
@@ -218,16 +218,20 @@ var _ = Describe("{VolumeUpdateForAttachedNode}", func() {
 							}
 
 							logrus.Infof("ReplicaSet of volume %v is: %v", v.Name, currReplicaSet)
+							logrus.Infof("Volume %v is attached to : %v", v.Name, attachedNode.Id)
 
 							for _, n := range currReplicaSet {
 								if n == attachedNode.Id {
 									updateReplicaSet = append(updateReplicaSet, n)
-
 								} else {
 									expectedReplicaSet = append(expectedReplicaSet, n)
-
 								}
+							}
 
+							if len(updateReplicaSet) == 0 {
+								logrus.Info("Attached node in not part of ReplicatSet, choosing a random node part of set for setting replication factor")
+								updateReplicaSet = append(updateReplicaSet, expectedReplicaSet[0])
+								expectedReplicaSet = expectedReplicaSet[1:]
 							}
 
 							expReplMap[v] = int64(math.Max(float64(MinRF), float64(currRep)-1))
@@ -256,6 +260,7 @@ var _ = Describe("{VolumeUpdateForAttachedNode}", func() {
 							}
 
 							logrus.Infof("ReplicaSet of volume %v is: %v", v.Name, reducedReplicaSet)
+							logrus.Infof("Expected ReplicaSet of volume %v is: %v", v.Name, expectedReplicaSet)
 							res := reflect.DeepEqual(reducedReplicaSet, expectedReplicaSet)
 							Expect(res).To(BeTrue())
 						})


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Fixes the ga-decrease failure in case of a node attached is not part of the replica set

**Which issue(s) this PR fixes** (optional)
Closes #ptx-4136

**Special notes for your reviewer**:
signee-off by: lsrinivas

Result:
http://jenkins.pwx.dev.purestorage.com/view/Control%20Plane/job/Torpedo/job/tp-failover-sharedv4/17/

