### PR TITLE
[PWX-21005] make sure nfs server pod restarted after failover

### DIFF
--- a/drivers/scheduler/k8s/specs/nginx-sv4-svc-1pv/px-nginx-app.yaml
+++ b/drivers/scheduler/k8s/specs/nginx-sv4-svc-1pv/px-nginx-app.yaml
@@ -1,0 +1,53 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: nginx-service
+spec:
+  selector:
+    app: nginx
+  type: NodePort
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+spec:
+  {{ if .Replicas }}
+  replicas: {{ .Replicas }}
+  {{ else }}
+  replicas: 2{{ end }}
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - nginx
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - name: nginx
+        image: bitnami/nginx
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        - name: nginx-persistent-storage
+          mountPath: /usr/share/nginx/html
+      volumes:
+      - name: nginx-persistent-storage
+        persistentVolumeClaim:
+          claimName: px-nginx-pvc-sharedv4

--- a/drivers/scheduler/k8s/specs/nginx-sv4-svc-1pv/px-nginx-app.yaml
+++ b/drivers/scheduler/k8s/specs/nginx-sv4-svc-1pv/px-nginx-app.yaml
@@ -50,4 +50,4 @@ spec:
       volumes:
       - name: nginx-persistent-storage
         persistentVolumeClaim:
-          claimName: px-nginx-pvc-sharedv4
+          claimName: sharedv4-svc

--- a/drivers/scheduler/k8s/specs/nginx-sv4-svc-1pv/px-nginx-storage.yaml
+++ b/drivers/scheduler/k8s/specs/nginx-sv4-svc-1pv/px-nginx-storage.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: volume-secrets
+type: Opaque
+data:
+  nginx-secret: WW91IHNuZWFreSBsaXR0bGUgcGlnbGV0IQ==
+---
+##### Portworx storage class
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: px-nginx-sc-sharedv4-svc
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  repl: "2"
+  sharedv4: "true"
+  sharedv4_svc_type: "ClusterIP"
+allowVolumeExpansion: true
+---
+##### Portworx persistent volume claim
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: px-nginx-pvc-sharedv4
+spec:
+  storageClassName: px-nginx-sc-sharedv4-svc
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi

--- a/drivers/scheduler/k8s/specs/nginx-sv4-svc-1pv/px-nginx-storage.yaml
+++ b/drivers/scheduler/k8s/specs/nginx-sv4-svc-1pv/px-nginx-storage.yaml
@@ -22,7 +22,7 @@ allowVolumeExpansion: true
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: px-nginx-pvc-sharedv4
+  name: sharedv4-svc
 spec:
   storageClassName: px-nginx-sc-sharedv4-svc
   accessModes:

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -800,7 +800,11 @@ func (d *portworx) GetNodeForVolume(vol *torpedovolume.Volume, timeout time.Dura
 		}
 		pxVol := volumeInspectResponse.Volume
 		for _, n := range node.GetStorageDriverNodes() {
-			if ok, err := d.isVolumeAttachedOnNode(pxVol, n); !ok || err != nil {
+			ok, err := d.isVolumeAttachedOnNode(pxVol, n)
+			if err != nil {
+				return nil, false, err
+			}
+			if ok {
 				return &n, false, err
 			}
 		}

--- a/tests/basic/shared_nfsv4_test.go
+++ b/tests/basic/shared_nfsv4_test.go
@@ -1,0 +1,173 @@
+package tests
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/portworx/sched-ops/k8s/core"
+	"github.com/portworx/torpedo/drivers/node"
+	"github.com/portworx/torpedo/drivers/scheduler"
+	"github.com/portworx/torpedo/drivers/volume"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/portworx/torpedo/tests"
+)
+
+const (
+	defaultCommandRetry   = 5 * time.Second
+	defaultCommandTimeout = 1 * time.Minute
+)
+
+var _ = Describe("{NFSServerFailover}", func() {
+	var contexts []*scheduler.Context
+
+	It("has to setup, validate, failover, make sure pods on old server got restarted, and teardown apps", func() {
+		contexts = make([]*scheduler.Context, 0)
+
+		for i := 0; i < Inst().GlobalScaleFactor; i++ {
+			contexts = append(contexts, ScheduleApplications(fmt.Sprintf("nfsserverfailover-%d", i))...)
+		}
+
+		ValidateApplications(contexts)
+
+		for _, ctx := range contexts {
+			oneMinute := time.Second * time.Duration(60)
+			var nodesNonReplica []node.Node
+			var volume *volume.Volume
+			Step("disable scheduling on non replica nodes", func() {
+				vols, err := Inst().S.GetVolumes(ctx)
+				if err != nil {
+					logrus.Infof("get volumes error %v", err)
+				}
+				volume = vols[0]
+				replicaSets, err := Inst().V.GetReplicaSets(volume)
+				if err != nil {
+					logrus.Infof("get replicaSets error %v", err)
+				}
+				var replicaNodes []string
+				for _, replicaSet := range replicaSets {
+					nodes := replicaSet.Nodes
+					replicaNodes = append(replicaNodes, nodes...)
+				}
+				allNodes := node.GetWorkerNodes()
+				for _, node := range allNodes {
+					if !contains(replicaNodes, node.VolDriverNodeID) {
+						nodesNonReplica = append(nodesNonReplica, node)
+					}
+				}
+				for _, node := range nodesNonReplica {
+					Inst().S.DisableSchedulingOnNode(node)
+				}
+
+			})
+
+			// scale down and then scale up the app, so that pods are only scheduled on replica nodes
+			Step(fmt.Sprintf("scale down app: %s to 0 ", ctx.App.Key), func() {
+				applicationScaleUpMap, err := Inst().S.GetScaleFactorMap(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				for name := range applicationScaleUpMap {
+					applicationScaleUpMap[name] = int32(0)
+				}
+				err = Inst().S.ScaleApplication(ctx, applicationScaleUpMap)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			Step(fmt.Sprintf("scale up app: %s to 2, and re-enable scheduling on all nodes", ctx.App.Key), func() {
+				applicationScaleUpMap, err := Inst().S.GetScaleFactorMap(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				for name := range applicationScaleUpMap {
+					applicationScaleUpMap[name] = int32(2)
+				}
+				err = Inst().S.ScaleApplication(ctx, applicationScaleUpMap)
+				Expect(err).NotTo(HaveOccurred())
+				ValidateApplications(contexts)
+				for _, node := range nodesNonReplica {
+					Inst().S.EnableSchedulingOnNode(node)
+				}
+			})
+
+			Step("fail over nfs server, and make sure the pod on server gets restarted", func() {
+				oldServer, err := Inst().V.GetNodeForVolume(volume, defaultCommandTimeout, defaultCommandRetry)
+				Expect(err).NotTo(HaveOccurred())
+				logrus.Infof("old nfs server %v [%v]", oldServer.SchedulerNodeName, oldServer.Addresses[0])
+				pods, err := core.Instance().GetPodsUsingPV(volume.ID)
+				Expect(err).NotTo(HaveOccurred())
+				var oldPodOnOldServer corev1.Pod
+				for _, pod := range pods {
+					if pod.Spec.NodeName == oldServer.Name {
+						oldPodOnOldServer = pod
+					}
+				}
+				// make sure there is a pod running on the old nfs server
+				Expect(&oldPodOnOldServer).NotTo(BeNil())
+				logrus.Infof("pod on old server %v, creation time %v", oldPodOnOldServer.Name, oldPodOnOldServer.CreationTimestamp)
+
+				timestampBeforeFailOver := time.Now()
+				err = Inst().V.StopDriver([]node.Node{*oldServer}, false, nil)
+				Expect(err).NotTo(HaveOccurred())
+				err = Inst().V.WaitDriverDownOnNode(*oldServer)
+				Expect(err).NotTo(HaveOccurred())
+				logrus.Infof("stopped px on nfs server node %v [%v]", oldServer.SchedulerNodeName, oldServer.Addresses[0])
+
+				var newServer *node.Node
+
+				for i := 0; i < 10; i++ {
+					server, err := Inst().V.GetNodeForVolume(volume, defaultCommandTimeout, defaultCommandRetry)
+					Expect(err).NotTo(HaveOccurred())
+					if server.Id != oldServer.Id {
+						logrus.Infof("nfs server failed over, new nfs server is %s [%s]", server.SchedulerNodeName, server.Addresses[0])
+						newServer = server
+						break
+					}
+					time.Sleep(oneMinute)
+				}
+				// make sure nfs server failed over
+				Expect(newServer).NotTo(BeNil())
+				logrus.Infof("new nfs server is %v", newServer)
+
+				logrus.Infof("start px on old nfs server Id %v, Name %v", oldServer.Id, oldServer.Name)
+				Inst().V.StartDriver(*oldServer)
+				err = Inst().V.WaitDriverUpOnNode(*oldServer, Inst().DriverStartTimeout)
+				Expect(err).NotTo(HaveOccurred())
+				logrus.Infof("px is up on old nfs server Id %v, Name %v", oldServer.Id, oldServer.Name)
+
+				// make sure the pods on both old and new server are restarted
+				pods, err = core.Instance().GetPodsUsingPV(volume.ID)
+				Expect(err).NotTo(HaveOccurred())
+				for _, pod := range pods {
+					if pod.Spec.NodeName == oldServer.Name {
+						logrus.Infof("pod on old server %v, creation time %v", oldPodOnOldServer.Name, oldPodOnOldServer.CreationTimestamp)
+						logrus.Infof("After failover, pod on old server %v, creation time %v", pod.Name, pod.CreationTimestamp)
+						Expect(pod.CreationTimestamp.After(timestampBeforeFailOver)).To(BeTrue())
+					}
+					if pod.Spec.NodeName == newServer.Name {
+						logrus.Infof("After failover, pod on new server %v, creation time %v", pod.Name, pod.CreationTimestamp)
+						Expect(pod.CreationTimestamp.After(timestampBeforeFailOver)).To(BeTrue())
+					}
+				}
+			})
+		}
+
+		opts := make(map[string]bool)
+		opts[scheduler.OptionsWaitForResourceLeakCleanup] = true
+
+		for _, ctx := range contexts {
+			TearDownContext(ctx, opts)
+		}
+	})
+	JustAfterEach(func() {
+		AfterEachTest(contexts)
+	})
+})
+
+func contains(arr []string, str string) bool {
+	for _, a := range arr {
+		if a == str {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/basic/sharedv4_svc_test.go
+++ b/tests/basic/sharedv4_svc_test.go
@@ -23,8 +23,7 @@ const (
 
 var _ = Describe("{NFSServerFailover}", func() {
 	var contexts []*scheduler.Context
-
-	It("has to setup, validate, failover, make sure pods on old server got restarted, and teardown apps", func() {
+	It("has to setup, validate, failover, make sure pods on old and new server got restarted, and teardown apps", func() {
 		contexts = make([]*scheduler.Context, 0)
 
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -34,34 +33,27 @@ var _ = Describe("{NFSServerFailover}", func() {
 		ValidateApplications(contexts)
 
 		for _, ctx := range contexts {
-			oneMinute := time.Second * time.Duration(60)
-			var nodesNonReplica []node.Node
+			nodeReplicaMap := make(map[string]bool)
 			var volume *volume.Volume
 			Step("disable scheduling on non replica nodes", func() {
 				vols, err := Inst().S.GetVolumes(ctx)
-				if err != nil {
-					logrus.Infof("get volumes error %v", err)
-				}
+				Expect(err).NotTo(HaveOccurred())
 				volume = vols[0]
 				replicaSets, err := Inst().V.GetReplicaSets(volume)
-				if err != nil {
-					logrus.Infof("get replicaSets error %v", err)
-				}
-				var replicaNodes []string
+				Expect(err).NotTo(HaveOccurred())
 				for _, replicaSet := range replicaSets {
-					nodes := replicaSet.Nodes
-					replicaNodes = append(replicaNodes, nodes...)
-				}
-				allNodes := node.GetWorkerNodes()
-				for _, node := range allNodes {
-					if !contains(replicaNodes, node.VolDriverNodeID) {
-						nodesNonReplica = append(nodesNonReplica, node)
+					for _, node := range replicaSet.Nodes {
+						nodeReplicaMap[node] = true
 					}
 				}
-				for _, node := range nodesNonReplica {
-					Inst().S.DisableSchedulingOnNode(node)
+				// make sure there are 2 replicas
+				Expect(len(nodeReplicaMap)).To(Equal(2))
+				allNodes := node.GetWorkerNodes()
+				for _, node := range allNodes {
+					if !nodeReplicaMap[node.VolDriverNodeID] {
+						Inst().S.DisableSchedulingOnNode(node)
+					}
 				}
-
 			})
 
 			// scale down and then scale up the app, so that pods are only scheduled on replica nodes
@@ -84,9 +76,6 @@ var _ = Describe("{NFSServerFailover}", func() {
 				err = Inst().S.ScaleApplication(ctx, applicationScaleUpMap)
 				Expect(err).NotTo(HaveOccurred())
 				ValidateApplications(contexts)
-				for _, node := range nodesNonReplica {
-					Inst().S.EnableSchedulingOnNode(node)
-				}
 			})
 
 			Step("fail over nfs server, and make sure the pod on server gets restarted", func() {
@@ -102,7 +91,7 @@ var _ = Describe("{NFSServerFailover}", func() {
 					}
 				}
 				// make sure there is a pod running on the old nfs server
-				Expect(&oldPodOnOldServer).NotTo(BeNil())
+				Expect(oldPodOnOldServer.Name).NotTo(Equal(""))
 				logrus.Infof("pod on old server %v, creation time %v", oldPodOnOldServer.Name, oldPodOnOldServer.CreationTimestamp)
 
 				timestampBeforeFailOver := time.Now()
@@ -116,17 +105,21 @@ var _ = Describe("{NFSServerFailover}", func() {
 
 				for i := 0; i < 10; i++ {
 					server, err := Inst().V.GetNodeForVolume(volume, defaultCommandTimeout, defaultCommandRetry)
-					Expect(err).NotTo(HaveOccurred())
-					if server.Id != oldServer.Id {
-						logrus.Infof("nfs server failed over, new nfs server is %s [%s]", server.SchedulerNodeName, server.Addresses[0])
-						newServer = server
-						break
+					// there could be intermittent error here
+					if err != nil {
+						logrus.Infof("Failed to get node for volume. Error: %v", err)
+					} else {
+						if server.Id != oldServer.Id {
+							logrus.Infof("nfs server failed over, new nfs server is %s [%s]", server.SchedulerNodeName, server.Addresses[0])
+							newServer = server
+							break
+						}
 					}
-					time.Sleep(oneMinute)
+					time.Sleep(time.Minute)
 				}
 				// make sure nfs server failed over
 				Expect(newServer).NotTo(BeNil())
-				logrus.Infof("new nfs server is %v", newServer)
+				logrus.Infof("new nfs server is %v [%v]", newServer.SchedulerNodeName, newServer.Addresses[0])
 
 				logrus.Infof("start px on old nfs server Id %v, Name %v", oldServer.Id, oldServer.Name)
 				Inst().V.StartDriver(*oldServer)
@@ -134,28 +127,42 @@ var _ = Describe("{NFSServerFailover}", func() {
 				Expect(err).NotTo(HaveOccurred())
 				logrus.Infof("px is up on old nfs server Id %v, Name %v", oldServer.Id, oldServer.Name)
 
+				ValidateApplications(contexts)
+
 				// make sure the pods on both old and new server are restarted
 				pods, err = core.Instance().GetPodsUsingPV(volume.ID)
 				Expect(err).NotTo(HaveOccurred())
+				podRestartedOnOldServer := false
+				podRestartedOnNewServer := false
 				for _, pod := range pods {
 					if pod.Spec.NodeName == oldServer.Name {
 						logrus.Infof("pod on old server %v, creation time %v", oldPodOnOldServer.Name, oldPodOnOldServer.CreationTimestamp)
 						logrus.Infof("After failover, pod on old server %v, creation time %v", pod.Name, pod.CreationTimestamp)
 						Expect(pod.CreationTimestamp.After(timestampBeforeFailOver)).To(BeTrue())
+						podRestartedOnOldServer = true
 					}
 					if pod.Spec.NodeName == newServer.Name {
 						logrus.Infof("After failover, pod on new server %v, creation time %v", pod.Name, pod.CreationTimestamp)
 						Expect(pod.CreationTimestamp.After(timestampBeforeFailOver)).To(BeTrue())
+						podRestartedOnNewServer = true
+					}
+				}
+
+				Expect(podRestartedOnOldServer).To(BeTrue())
+				Expect(podRestartedOnNewServer).To(BeTrue())
+
+				// re-enable scheduling on non replica nodes
+				allNodes := node.GetWorkerNodes()
+				for _, node := range allNodes {
+					if !nodeReplicaMap[node.VolDriverNodeID] {
+						Inst().S.EnableSchedulingOnNode(node)
 					}
 				}
 			})
 		}
 
-		opts := make(map[string]bool)
-		opts[scheduler.OptionsWaitForResourceLeakCleanup] = true
-
 		for _, ctx := range contexts {
-			TearDownContext(ctx, opts)
+			TearDownContext(ctx, map[string]bool{scheduler.OptionsWaitForResourceLeakCleanup: true})
 		}
 	})
 	JustAfterEach(func() {

--- a/tests/basic/sharedv4_svc_test.go
+++ b/tests/basic/sharedv4_svc_test.go
@@ -103,7 +103,7 @@ var _ = Describe("{NFSServerFailover}", func() {
 
 				var newServer *node.Node
 
-				for i := 0; i < 10; i++ {
+				for i := 0; i < 60; i++ {
 					server, err := Inst().V.GetNodeForVolume(volume, defaultCommandTimeout, defaultCommandRetry)
 					// there could be intermittent error here
 					if err != nil {
@@ -115,7 +115,7 @@ var _ = Describe("{NFSServerFailover}", func() {
 							break
 						}
 					}
-					time.Sleep(time.Minute)
+					time.Sleep(10 * time.Second)
 				}
 				// make sure nfs server failed over
 				Expect(newServer).NotTo(BeNil())
@@ -152,8 +152,7 @@ var _ = Describe("{NFSServerFailover}", func() {
 				Expect(podRestartedOnNewServer).To(BeTrue())
 
 				// re-enable scheduling on non replica nodes
-				allNodes := node.GetWorkerNodes()
-				for _, node := range allNodes {
+				for _, node := range node.GetWorkerNodes() {
 					if !nodeReplicaMap[node.VolDriverNodeID] {
 						Inst().S.EnableSchedulingOnNode(node)
 					}


### PR DESCRIPTION
This test makes sure app pods scheduled to the nfs server, and validate
the pod would get restarted after nfs server failover.

this change also fix: portworx.GetNodeForVolume() didn't return the correct node
that the volume attached on

test notes: the test passed with Neelesh's fix for PWX-20953, and it failed
without that fix

