### PR TITLE
Adding fixes for PTX-4277

### DIFF
--- a/drivers/scheduler/k8s/specs/elasticsearch/px-elasticdata-app.yaml
+++ b/drivers/scheduler/k8s/specs/elasticsearch/px-elasticdata-app.yaml
@@ -70,6 +70,9 @@ spec:
         resources:
           requests:
             memory: 1Gi
+            cpu: "0.5"
+          limits:
+            cpu: "1.0"
         securityContext:
           privileged: true
           runAsUser: 1000


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: Right now there is no limit on the CPU for STS created for elastic search, because of which many pods deployed on the setup are crashing. 

**Which issue(s) this PR fixes** (optional)
Closes # PTX-4277

**Special notes for your reviewer**:
This change was discussed with @vilasd 
