### PR TITLE
PTX-4297: Add end_fsync=1 to fio spec

### DIFF
--- a/drivers/scheduler/k8s/specs/fio/fio-config-map.yaml
+++ b/drivers/scheduler/k8s/specs/fio/fio-config-map.yaml
@@ -12,6 +12,7 @@ data:
         randrepeat=1
         blocksize_range=4k-512k
         direct=1
+        end_fsync=1
         do_verify=1
         verify=crc32c
         verify_pattern=0xdeadbeef


### PR DESCRIPTION
Without fsync, filesystem got full before data is synced to disk on EKS longevity, causing fio pods to go in CrashLoopBackOff.