### PR TITLE
PTX-4323: increase volume driver up timeout

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -101,7 +101,7 @@ if [ -z "${TIMEOUT}" ]; then
 fi
 
 if [ -z "$DRIVER_START_TIMEOUT" ]; then
-    DRIVER_START_TIMEOUT="12m0s"
+    DRIVER_START_TIMEOUT="10m0s"
     echo "Using default timeout of ${DRIVER_START_TIMEOUT}"
 fi
 

--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -101,7 +101,7 @@ if [ -z "${TIMEOUT}" ]; then
 fi
 
 if [ -z "$DRIVER_START_TIMEOUT" ]; then
-    DRIVER_START_TIMEOUT="5m0s"
+    DRIVER_START_TIMEOUT="12m0s"
     echo "Using default timeout of ${DRIVER_START_TIMEOUT}"
 fi
 

--- a/tests/common.go
+++ b/tests/common.go
@@ -117,11 +117,12 @@ const (
 )
 
 const (
-	waitResourceCleanup     = 2 * time.Minute
-	defaultTimeout          = 5 * time.Minute
-	defaultRetryInterval    = 10 * time.Second
-	defaultCmdTimeout       = 20 * time.Second
-	defaultCmdRetryInterval = 5 * time.Second
+	waitResourceCleanup       = 2 * time.Minute
+	defaultTimeout            = 5 * time.Minute
+	defaultRetryInterval      = 10 * time.Second
+	defaultCmdTimeout         = 20 * time.Second
+	defaultCmdRetryInterval   = 5 * time.Second
+	defaultDriverStartTimeout = 12 * time.Minute
 )
 
 var (
@@ -1010,7 +1011,7 @@ func ParseFlags() {
 	flag.StringVar(&provisionerName, provisionerFlag, defaultStorageProvisioner, "Name of the storage provisioner Portworx or CSI.")
 	flag.IntVar(&storageNodesPerAZ, storageNodesPerAZFlag, defaultStorageNodesPerAZ, "Maximum number of storage nodes per availability zone")
 	flag.DurationVar(&destroyAppTimeout, "destroy-app-timeout", defaultTimeout, "Maximum ")
-	flag.DurationVar(&driverStartTimeout, "driver-start-timeout", defaultTimeout, "Maximum wait volume driver startup")
+	flag.DurationVar(&driverStartTimeout, "driver-start-timeout", defaultDriverStartTimeout, "Maximum wait volume driver startup")
 	flag.DurationVar(&autoStorageNodeRecoveryTimeout, "storagenode-recovery-timeout", defaultAutoStorageNodeRecoveryTimeout, "Maximum wait time in minutes for storageless nodes to transition to storagenodes in case of ASG")
 	flag.DurationVar(&licenseExpiryTimeoutHours, licenseExpiryTimeoutHoursFlag, defaultLicenseExpiryTimeoutHours, "Maximum wait time in hours after which force expire license")
 	flag.DurationVar(&meteringIntervalMins, meteringIntervalMinsFlag, defaultMeteringIntervalMins, "Metering interval in minutes for metering agent")

--- a/tests/common.go
+++ b/tests/common.go
@@ -122,7 +122,7 @@ const (
 	defaultRetryInterval      = 10 * time.Second
 	defaultCmdTimeout         = 20 * time.Second
 	defaultCmdRetryInterval   = 5 * time.Second
-	defaultDriverStartTimeout = 12 * time.Minute
+	defaultDriverStartTimeout = 10 * time.Minute
 )
 
 var (


### PR DESCRIPTION
**What this PR does / why we need it**:
One of the jobs failed because PX took 7 minutes to become ready and the job
gave up after 6 mintues. We should increase the timeout since it is
ok for PX to take longer to get ready when there are logs to be replayed.

Signed-off-by: Neelesh Thakur <neelesh.thakur@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**Which issue(s) this PR fixes** (optional)
PTX-4323

**Special notes for your reviewer**:

