### PR TITLE
[PWX-21546] RefreshDriverEndpoints after nfs failover

### DIFF
--- a/tests/basic/sharedv4_svc_test.go
+++ b/tests/basic/sharedv4_svc_test.go
@@ -104,6 +104,8 @@ var _ = Describe("{NFSServerFailover}", func() {
 				var newServer *node.Node
 
 				for i := 0; i < 60; i++ {
+					err := Inst().V.RefreshDriverEndpoints()
+					Expect(err).NotTo(HaveOccurred())
 					server, err := Inst().V.GetNodeForVolume(volume, defaultCommandTimeout, defaultCommandRetry)
 					// there could be intermittent error here
 					if err != nil {


### PR DESCRIPTION
After old nfs server failover, some time we fail to inspect volume because
torpedo keeps trying to talk to the old nfs server. I found that RefreshDriverEndpoints
would make torpedo find out the new server, and fixed the issue.

test: ran on jenkins, and had 4 successful build in a row