### PR TITLE
PTX-4303 fix an issue when checking px status outside k8s network

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -965,14 +965,6 @@ func (d *portworx) WaitDriverUpOnNode(n node.Node, timeout time.Duration) error 
 		switch pxNode.Status {
 		case api.Status_STATUS_DECOMMISSION: // do nothing
 		case api.Status_STATUS_OK:
-			err := d.testAndSetEndpointUsingNodeIP(pxNode.MgmtIp)
-			if err != nil {
-				return "", true, &ErrFailedToWaitForPx{
-					Node:  n,
-					Cause: fmt.Sprintf("px is not yet up on node. cause: %v", err),
-				}
-			}
-
 			pxStatus, err := d.getPxctlStatus(n)
 			if err != nil {
 				return "", true, &ErrFailedToWaitForPx{


### PR DESCRIPTION
Signed-off-by: Thiago Gonzaga <tgonzaga@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR removes an additional check which tries to reach px using direct IP causing jobs that run outside the Kubernetes network to fail

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

