### PR TITLE
PTX-4456 add support to ocp fast channel

### DIFF
--- a/drivers/scheduler/openshift/openshift.go
+++ b/drivers/scheduler/openshift/openshift.go
@@ -416,6 +416,13 @@ func getChannel(version string) (string, error) {
 		return version, nil
 	}
 
+	versionSplit := strings.Split(version, "-")
+	channel := "stable"
+	if len(versionSplit) > 1 {
+		channel = versionSplit[0]
+		version = versionSplit[1]
+	}
+
 	ver, err := semver.Make(version)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse version: %s. cause: %v", version, err)
@@ -424,22 +431,10 @@ func getChannel(version string) (string, error) {
 	channels := map[string]string{
 		"stable":    fmt.Sprintf("stable-%d.%d", ver.Major, ver.Minor),
 		"candidate": fmt.Sprintf("candidate-%d.%d", ver.Major, ver.Minor),
+		"fast":      fmt.Sprintf("fast-%d.%d", ver.Major, ver.Minor),
 	}
-	var output, previousOutput []byte
-	selectedChannel := ""
-	for _, channel := range channels {
-		url := fmt.Sprintf("curl -sL %s/%s | grep %s || true", OpenshiftMirror, channel, version)
-		if output, err = exec.Command("sh", "-c", url).CombinedOutput(); err != nil {
-			break
-		}
-		if string(output) == string(previousOutput) {
-			selectedChannel = channels["stable"]
-		} else {
-			selectedChannel = channel
-		}
-		previousOutput = output
-	}
-	return selectedChannel, err
+
+	return channels[channel], err
 }
 
 func downloadOCP4Client(ocpVersion string) error {


### PR DESCRIPTION
Signed-off-by: Thiago Gonzaga <tgonzaga@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR adds support to the explicit channel parameter when using `<channel>-<version>` i.e `fast-4.9.5`. by default `stable` channel is used when the channel is not explicitly set.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

