### PR TITLE
reverted the changes in the previous commit updateNodes in init of portworx driver.

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -186,10 +186,7 @@ func (d *portworx) Init(sched, nodeDriver, token, storageProvisioner, csiGeneric
 	if len(storageNodes) == 0 {
 		return fmt.Errorf("cluster inspect returned empty nodes")
 	}
-	// NOTE:
-	// Commenting out as when run on EKS this casues problems as ec2 instances
-	// on EKS can't sshed using internal IPs causing pxctl status to fail
-	/*
+
 	err = d.updateNodes(storageNodes)
 	if err != nil {
 		return err
@@ -199,7 +196,6 @@ func (d *portworx) Init(sched, nodeDriver, token, storageProvisioner, csiGeneric
 			return err
 		}
 	}
-	*/
 
 	logrus.Infof("The following Portworx nodes are in the cluster:")
 	for _, n := range storageNodes {


### PR DESCRIPTION
**What this PR does / why we need it**:
reverted the changes in the previous commit updateNodes in init of portworx driver.

**Which issue(s) this PR fixes** (optional)
Closes # -

**Special notes for your reviewer**:

