### PR TITLE
Changed volume size for autopilot

### DIFF
--- a/drivers/scheduler/k8s/specs/aut-postgres/aut-postgres-storage.yaml
+++ b/drivers/scheduler/k8s/specs/aut-postgres/aut-postgres-storage.yaml
@@ -32,7 +32,7 @@ spec:
       {{ if .VolumeSize }}
       storage: {{ .VolumeSize }}
       {{ else }}
-      storage: 7Gi{{ end }}
+      storage: 8Gi{{ end }}
 ---
 ##### Portworx persistent volume claim
 kind: PersistentVolumeClaim


### PR DESCRIPTION
**Special notes for your reviewer**:
Changed the volume size for autopilot application, to fix the issue where volume will be resized to round volume size. Currently we have an autopilot rule which resized volume by 50%. When volume size is 7Gb it will be  next following sequence: 7 -> 10.5 -> 15.75 -> 23.625, and k8s rounds these values and the final volume size becomes 24Gb.

Tested here: http://jenkins.pwx.dev.purestorage.com/job/Autopilot/job/tp-aut-op-nextpx-security-resize-pvc/
