### PR TITLE
PWX-22057: Stabilize Diag test, remove test we don't need anymore.

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -2317,11 +2317,9 @@ func collectDiags(n node.Node, config *torpedovolume.DiagRequestConfig, diagOps 
 		}
 		defer resp.Body.Close()
 
-		/* PWX-19768
 		// Check S3 bucket for diags
 
 		// TODO: Waiting for S3 credentials.
-		*/
 	}
 
 	logrus.Debugf("Successfully collected diags on node %v", pxNode.Hostname)
@@ -2377,42 +2375,42 @@ func collectAsyncDiags(n node.Node, config *torpedovolume.DiagRequestConfig, dia
 		time.Sleep(5 * time.Second)
 	}
 
-	/* TODO: Verify we can see the files once we return a filename
-	if diagOps.Validate() {
-	pxNode, err := d.getPxNode(&n)
-	if err != nil {
-		return err
-	}
+	//TODO: Verify we can see the files once we return a filename
+	/*
+		if diagOps.Validate {
+			pxNode, err := d.getPxNode(&n)
+			if err != nil {
+				return err
+			}
 
-	opts := node.ConnectionOpts{
-		IgnoreError:     false,
-		TimeBeforeRetry: defaultRetryInterval,
-		Timeout:         defaultTimeout,
-		Sudo:            true,
-	}
+			opts := node.ConnectionOpts{
+				IgnoreError:     false,
+				TimeBeforeRetry: defaultRetryInterval,
+				Timeout:         defaultTimeout,
+				Sudo:            true,
+			}
 
-	cmd := fmt.Sprintf("test -f %s", config.OutputFile)
-	out, err := d.nodeDriver.RunCommand(n, cmd, opts)
-	if err != nil {
-		return fmt.Errorf("failed to locate diags on node %v, Err: %v %v", pxNode.Hostname, err, out)
-	}
+			cmd := fmt.Sprintf("test -f %s", config.OutputFile)
+			out, err := d.nodeDriver.RunCommand(n, cmd, opts)
+			if err != nil {
+				return fmt.Errorf("failed to locate diags on node %v, Err: %v %v", pxNode.Hostname, err, out)
+			}
 
-	logrus.Debug("Validating CCM health")
-	// Change to config package.
-	url := fmt.Sprintf("http://%s:%d/1.0/status/troubleshoot-cloud-connection", n.MgmtIp, 1970)
-	ccmresp, err := http.Get(url)
-	if err != nil {
-		return fmt.Errorf("failed to talk to CCM on node %v, Err: %v", pxNode.Hostname, err)
-	}
+			logrus.Debug("Validating CCM health")
+			// Change to config package.
+			url := fmt.Sprintf("http://%s:%d/1.0/status/troubleshoot-cloud-connection", n.MgmtIp, 1970)
+			ccmresp, err := http.Get(url)
+			if err != nil {
+				return fmt.Errorf("failed to talk to CCM on node %v, Err: %v", pxNode.Hostname, err)
+			}
 
-	defer ccmresp.Body.Close()
+			defer ccmresp.Body.Close()
 
-	// Check S3 bucket for diags
-	// TODO: Waiting for S3 credentials.
+			// Check S3 bucket for diags
+			// TODO: Waiting for S3 credentials.
 
-	}
+		}
 	*/
-
 	logrus.Debugf("Successfully collected diags on node %v", n.Name)
 	return nil
 }

--- a/tests/telemetry/telemetry_test.go
+++ b/tests/telemetry/telemetry_test.go
@@ -39,12 +39,9 @@ var _ = Describe("{DiagsBasic}", func() {
 
 		ValidateApplications(contexts)
 
-		opts := make(map[string]bool)
-		opts[scheduler.OptionsWaitForResourceLeakCleanup] = true
-
 		// One node at a time, collect diags and verify in S3
 		for _, currNode := range node.GetWorkerNodes() {
-			Step(fmt.Sprintf("collect diags on node: %s", currNode.Name), func() {
+			Step(fmt.Sprintf("collect diags on node: %s | %s", currNode.Name, currNode.Type), func() {
 
 				config := &torpedovolume.DiagRequestConfig{
 					DockerHost:    "unix:///var/run/docker.sock",
@@ -58,7 +55,7 @@ var _ = Describe("{DiagsBasic}", func() {
 		}
 
 		for _, ctx := range contexts {
-			TearDownContext(ctx, opts)
+			TearDownContext(ctx, nil)
 		}
 	})
 	JustAfterEach(func() {
@@ -77,9 +74,6 @@ var _ = Describe("{DiagsAsyncBasic}", func() {
 
 		ValidateApplications(contexts)
 
-		opts := make(map[string]bool)
-		opts[scheduler.OptionsWaitForResourceLeakCleanup] = true
-
 		// One node at a time, collect diags and verify in S3
 		for _, currNode := range node.GetWorkerNodes() {
 			Step(fmt.Sprintf("collect diags on node: %s", currNode.Name), func() {
@@ -96,48 +90,7 @@ var _ = Describe("{DiagsAsyncBasic}", func() {
 		}
 
 		for _, ctx := range contexts {
-			TearDownContext(ctx, opts)
-		}
-	})
-
-	JustAfterEach(func() {
-		AfterEachTest(contexts)
-	})
-})
-
-// This test performs basic test of starting an application and destroying it (along with storage)
-var _ = Describe("{DiagsAsyncLiveBasic}", func() {
-	var contexts []*scheduler.Context
-	It("has to setup, validate, try to get a-sync diags on nodes and teardown apps", func() {
-		contexts = make([]*scheduler.Context, 0)
-		for i := 0; i < Inst().GlobalScaleFactor; i++ {
-			contexts = append(contexts, ScheduleApplications(fmt.Sprintf("diagsasynclivebasic-%d", i))...)
-		}
-
-		ValidateApplications(contexts)
-
-		opts := make(map[string]bool)
-		opts[scheduler.OptionsWaitForResourceLeakCleanup] = true
-
-		// One node at a time, collect diags and verify in S3
-		for _, currNode := range node.GetWorkerNodes() {
-			Step(fmt.Sprintf("collect diags on node: %s", currNode.Name), func() {
-
-				config := &torpedovolume.DiagRequestConfig{
-					DockerHost:    "unix:///var/run/docker.sock",
-					OutputFile:    fmt.Sprintf("/var/cores/torpedo-diagsasynclive-%s-%d.tar.gz", currNode.Name, time.Now().Unix()),
-					ContainerName: "",
-					Live:          true,
-					OnHost:        true,
-				}
-
-				err := Inst().V.CollectDiags(currNode, config, torpedovolume.DiagOps{Validate: true, Async: true})
-				Expect(err).NotTo(HaveOccurred())
-			})
-		}
-
-		for _, ctx := range contexts {
-			TearDownContext(ctx, opts)
+			TearDownContext(ctx, nil)
 		}
 	})
 


### PR DESCRIPTION
Signed-off-by: pault84 <paul@portworx.com>


**What this PR does / why we need it**:
Remove obsolete code.

**Special notes for your reviewer**:
A-sync diags still needs some changes to porx because we can't actually check if the file exists as we don't know the filename.
We do not allow a filename to be passed in either so that's an oversight.
