### PR TITLE
Fix for apps getting deployed in the same namespace

### DIFF
--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -647,13 +647,13 @@ func (k *K8s) Schedule(instanceID string, options scheduler.ScheduleOptions) ([]
 	}
 
 	var contexts []*scheduler.Context
+	oldOptionsNamespace := options.Namespace
 	for _, app := range apps {
 
-		var appNamespace string
+		appNamespace := app.GetID(instanceID)
 		if options.Namespace != "" {
 			appNamespace = options.Namespace
 		} else {
-			appNamespace = app.GetID(instanceID)
 			options.Namespace = appNamespace
 		}
 
@@ -679,6 +679,7 @@ func (k *K8s) Schedule(instanceID string, options scheduler.ScheduleOptions) ([]
 		}
 
 		contexts = append(contexts, ctx)
+		options.Namespace = oldOptionsNamespace
 	}
 
 	return contexts, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
* A recent change in torpedo is causing all apps to be deployed in the same namespace. 
* This PR fixes the above issue.

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PTX-4579

**Special notes for your reviewer**:

