### PR TITLE
Fix FB Torpedo test failure

### DIFF
--- a/tests/common.go
+++ b/tests/common.go
@@ -543,7 +543,7 @@ func ValidateVolumeStatsticsDynamicUpdate(ctx *scheduler.Context, errChan ...*ch
 		err = osutils.Kubectl(cmdArgs)
 		processError(err, errChan...)
 		// wait until the backends size is reflected before making the REST call
-		time.Sleep(90 * time.Second)
+		time.Sleep(125 * time.Second)
 
 		byteUsedafter, err := Inst().V.ValidateGetByteUsedForVolume(vols[0].ID, make(map[string]string))
 		fmt.Println(fmt.Sprintf("after writing random bytes to the file the byteUsed is %v", byteUsedafter))
@@ -554,7 +554,7 @@ func ValidateVolumeStatsticsDynamicUpdate(ctx *scheduler.Context, errChan ...*ch
 }
 
 func fbVolumeExpectedSizechange(sizeChangeInBytes uint64) error {
-	if sizeChangeInBytes > 502*oneMegabytes && sizeChangeInBytes < 521*oneMegabytes {
+	if sizeChangeInBytes < 502*oneMegabytes || sizeChangeInBytes > 522*oneMegabytes {
 		return errUnexpectedSizeChangeAfterFBIO
 	}
 	return nil

--- a/tests/common.go
+++ b/tests/common.go
@@ -543,7 +543,7 @@ func ValidateVolumeStatsticsDynamicUpdate(ctx *scheduler.Context, errChan ...*ch
 		err = osutils.Kubectl(cmdArgs)
 		processError(err, errChan...)
 		// wait until the backends size is reflected before making the REST call
-		time.Sleep(20 * time.Second)
+		time.Sleep(90 * time.Second)
 
 		byteUsedafter, err := Inst().V.ValidateGetByteUsedForVolume(vols[0].ID, make(map[string]string))
 		fmt.Println(fmt.Sprintf("after writing random bytes to the file the byteUsed is %v", byteUsedafter))


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
FB Torpedo test was failed due to 1. wrong error condition, 2. not enough time for write op finishing. So the PR adds more waiting time and fixed the condition.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
None

