### PR TITLE
Fix the fbVolumeExpectedSizechange error condition

### DIFF
--- a/tests/common.go
+++ b/tests/common.go
@@ -547,14 +547,14 @@ func ValidateVolumeStatsticsDynamicUpdate(ctx *scheduler.Context, errChan ...*ch
 
 		byteUsedafter, err := Inst().V.ValidateGetByteUsedForVolume(vols[0].ID, make(map[string]string))
 		fmt.Println(fmt.Sprintf("after writing random bytes to the file the byteUsed is %v", byteUsedafter))
-		err = fbVolumeExpectedSizechange(byteUsedafter - byteUsedInitial)
+		err = fbVolumeExpectedSizechange(int64(byteUsedafter) - int64(byteUsedInitial))
 		expect(err).NotTo(haveOccurred())
 
 	})
 }
 
-func fbVolumeExpectedSizechange(sizeChangeInBytes uint64) error {
-	if sizeChangeInBytes < 502*oneMegabytes || sizeChangeInBytes > 522*oneMegabytes {
+func fbVolumeExpectedSizechange(sizeChangeInBytes int64) error {
+	if sizeChangeInBytes < -15*oneMegabytes || sizeChangeInBytes > 15*oneMegabytes {
 		return errUnexpectedSizeChangeAfterFBIO
 	}
 	return nil


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
fbVolumeExpectedSizechange error condition is wrong, because (byteUsedafter - byteUsedInitial) is passed to the function.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

