### PR TITLE
:sprinkles: adding pool resize test for longevity

### DIFF
--- a/drivers/volume/common.go
+++ b/drivers/volume/common.go
@@ -412,6 +412,14 @@ func (d *DefaultDriver) ValidateRebalanceJobs() error {
 	}
 }
 
+// ResizeStoragePoolByPercentage validates pool resize
+func (d *DefaultDriver) ResizeStoragePoolByPercentage(string, api.SdkStoragePool_ResizeOperationType, uint64) error {
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "ResizeStoragePoolByPercentage()",
+	}
+}
+
 // CreateAutopilotRules creates autopilot rules
 func (d *DefaultDriver) CreateAutopilotRules([]apapi.AutopilotRule) error {
 	return &errors.ErrNotSupported{

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -1267,6 +1267,7 @@ func (d *portworx) ResizeStoragePoolByPercentage(poolUUID string, e api.SdkStora
 
 	// start a task to check if pool  resize is done
 	t := func() (interface{}, bool, error) {
+		logrus.Infof("Initiating pool %v resize by %v with operationtype %v", poolUUID, percentage, e.String())
 
 		jobListResp, err := d.storagePoolManager.Resize(d.getContext(), &api.SdkStoragePoolResizeRequest{
 			Uuid: poolUUID,
@@ -1278,8 +1279,9 @@ func (d *portworx) ResizeStoragePoolByPercentage(poolUUID string, e api.SdkStora
 		if err != nil {
 			return nil, true, err
 		}
-		logrus.Infof("Resize respone: %v", jobListResp)
-
+		if jobListResp.String() != "" {
+			logrus.Infof("Resize respone: %v", jobListResp.String())
+		}
 		return nil, false, nil
 	}
 	if _, err := task.DoRetryWithTimeout(t, validateRebalanceJobsTimeout, validateRebalanceJobsInterval); err != nil {

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -1265,10 +1265,10 @@ func (d *portworx) ValidateRebalanceJobs() error {
 
 func (d *portworx) ResizeStoragePoolByPercentage(poolUUID string, e api.SdkStoragePool_ResizeOperationType, percentage uint64) error {
 
+	logrus.Infof("Initiating pool %v resize by %v with operationtype %v", poolUUID, percentage, e.String())
+
 	// start a task to check if pool  resize is done
 	t := func() (interface{}, bool, error) {
-		logrus.Infof("Initiating pool %v resize by %v with operationtype %v", poolUUID, percentage, e.String())
-
 		jobListResp, err := d.storagePoolManager.Resize(d.getContext(), &api.SdkStoragePoolResizeRequest{
 			Uuid: poolUUID,
 			ResizeFactor: &api.SdkStoragePoolResizeRequest_Percentage{
@@ -1280,7 +1280,7 @@ func (d *portworx) ResizeStoragePoolByPercentage(poolUUID string, e api.SdkStora
 			return nil, true, err
 		}
 		if jobListResp.String() != "" {
-			logrus.Infof("Resize respone: %v", jobListResp.String())
+			logrus.Debugf("Resize respone: %v", jobListResp.String())
 		}
 		return nil, false, nil
 	}

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -184,6 +184,9 @@ type Driver interface {
 	// ValidateRebalanceJobs validates rebalance jobs
 	ValidateRebalanceJobs() error
 
+	// ResizeStoragePoolByPercentage resizes the given stroage poolby percentage
+	ResizeStoragePoolByPercentage(string, api.SdkStoragePool_ResizeOperationType, uint64) error
+
 	// IsStorageExpansionEnabled returns true if storage expansion enabled
 	IsStorageExpansionEnabled() (bool, error)
 

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -184,7 +184,7 @@ type Driver interface {
 	// ValidateRebalanceJobs validates rebalance jobs
 	ValidateRebalanceJobs() error
 
-	// ResizeStoragePoolByPercentage resizes the given stroage poolby percentage
+	// ResizeStoragePoolByPercentage resizes the given stroage pool by percentage
 	ResizeStoragePoolByPercentage(string, api.SdkStoragePool_ResizeOperationType, uint64) error
 
 	// IsStorageExpansionEnabled returns true if storage expansion enabled

--- a/tests/longevity/longevity_test.go
+++ b/tests/longevity/longevity_test.go
@@ -70,6 +70,7 @@ var _ = Describe("{Longevity}", func() {
 		CoreChecker:      TriggerCoreChecker,
 		CloudSnapShot:    TriggerCloudSnapShot,
 		PoolResizeDisk:   TriggerPoolResizeDisk,
+		PoolAddDisk:      TriggerPoolAddDisk,
 	}
 	It("has to schedule app and introduce test triggers", func() {
 		Step(fmt.Sprintf("Start watch on K8S configMap [%s/%s]",
@@ -303,6 +304,7 @@ func populateIntervals() {
 	triggerInterval[CoreChecker] = map[int]time.Duration{}
 	triggerInterval[VolumeResize] = make(map[int]time.Duration)
 	triggerInterval[PoolResizeDisk] = make(map[int]time.Duration)
+	triggerInterval[PoolAddDisk] = make(map[int]time.Duration)
 	triggerInterval[BackupAllApps] = map[int]time.Duration{}
 	triggerInterval[BackupScheduleAll] = map[int]time.Duration{}
 	triggerInterval[BackupScheduleScale] = map[int]time.Duration{}
@@ -529,6 +531,17 @@ func populateIntervals() {
 	triggerInterval[PoolResizeDisk][2] = 24 * baseInterval
 	triggerInterval[PoolResizeDisk][1] = 27 * baseInterval
 
+	triggerInterval[PoolAddDisk][10] = 1 * baseInterval
+	triggerInterval[PoolAddDisk][9] = 3 * baseInterval
+	triggerInterval[PoolAddDisk][8] = 6 * baseInterval
+	triggerInterval[PoolAddDisk][7] = 9 * baseInterval
+	triggerInterval[PoolAddDisk][6] = 12 * baseInterval
+	triggerInterval[PoolAddDisk][5] = 15 * baseInterval
+	triggerInterval[PoolAddDisk][4] = 18 * baseInterval
+	triggerInterval[PoolAddDisk][3] = 21 * baseInterval
+	triggerInterval[PoolAddDisk][2] = 24 * baseInterval
+	triggerInterval[PoolAddDisk][1] = 27 * baseInterval
+
 	triggerInterval[BackupDeleteBackupPod][10] = 1 * baseInterval
 	triggerInterval[BackupDeleteBackupPod][9] = 2 * baseInterval
 	triggerInterval[BackupDeleteBackupPod][8] = 3 * baseInterval
@@ -590,6 +603,7 @@ func populateIntervals() {
 	triggerInterval[AppTaskDown][0] = 0
 	triggerInterval[VolumeResize][0] = 0
 	triggerInterval[PoolResizeDisk][0] = 0
+	triggerInterval[PoolAddDisk][0] = 0
 	triggerInterval[BackupAllApps][0] = 0
 	triggerInterval[BackupScheduleAll][0] = 0
 	triggerInterval[BackupSpecificResource][0] = 0

--- a/tests/longevity/longevity_test.go
+++ b/tests/longevity/longevity_test.go
@@ -69,6 +69,7 @@ var _ = Describe("{Longevity}", func() {
 		AppTaskDown:      TriggerAppTaskDown,
 		CoreChecker:      TriggerCoreChecker,
 		CloudSnapShot:    TriggerCloudSnapShot,
+		PoolResizeDisk:   TriggerPoolResizeDisk,
 	}
 	It("has to schedule app and introduce test triggers", func() {
 		Step(fmt.Sprintf("Start watch on K8S configMap [%s/%s]",
@@ -301,6 +302,7 @@ func populateIntervals() {
 	triggerInterval[DeployApps] = map[int]time.Duration{}
 	triggerInterval[CoreChecker] = map[int]time.Duration{}
 	triggerInterval[VolumeResize] = make(map[int]time.Duration)
+	triggerInterval[PoolResizeDisk] = make(map[int]time.Duration)
 	triggerInterval[BackupAllApps] = map[int]time.Duration{}
 	triggerInterval[BackupScheduleAll] = map[int]time.Duration{}
 	triggerInterval[BackupScheduleScale] = map[int]time.Duration{}
@@ -516,6 +518,17 @@ func populateIntervals() {
 	triggerInterval[VolumeResize][2] = 24 * baseInterval
 	triggerInterval[VolumeResize][1] = 27 * baseInterval
 
+	triggerInterval[PoolResizeDisk][10] = 1 * baseInterval
+	triggerInterval[PoolResizeDisk][9] = 3 * baseInterval
+	triggerInterval[PoolResizeDisk][8] = 6 * baseInterval
+	triggerInterval[PoolResizeDisk][7] = 9 * baseInterval
+	triggerInterval[PoolResizeDisk][6] = 12 * baseInterval
+	triggerInterval[PoolResizeDisk][5] = 15 * baseInterval
+	triggerInterval[PoolResizeDisk][4] = 18 * baseInterval
+	triggerInterval[PoolResizeDisk][3] = 21 * baseInterval
+	triggerInterval[PoolResizeDisk][2] = 24 * baseInterval
+	triggerInterval[PoolResizeDisk][1] = 27 * baseInterval
+
 	triggerInterval[BackupDeleteBackupPod][10] = 1 * baseInterval
 	triggerInterval[BackupDeleteBackupPod][9] = 2 * baseInterval
 	triggerInterval[BackupDeleteBackupPod][8] = 3 * baseInterval
@@ -576,6 +589,7 @@ func populateIntervals() {
 	triggerInterval[RestartVolDriver][0] = 0
 	triggerInterval[AppTaskDown][0] = 0
 	triggerInterval[VolumeResize][0] = 0
+	triggerInterval[PoolResizeDisk][0] = 0
 	triggerInterval[BackupAllApps][0] = 0
 	triggerInterval[BackupScheduleAll][0] = 0
 	triggerInterval[BackupSpecificResource][0] = 0

--- a/tests/testTriggers.go
+++ b/tests/testTriggers.go
@@ -162,8 +162,10 @@ const (
 	EmailReporter = "emailReporter"
 	// CoreChecker checks if any cores got generated
 	CoreChecker = "coreChecker"
-	// PoolResizeDisk resize-disk operation on storage pool
+	// PoolResizeDisk resize storage pool using resize-disk
 	PoolResizeDisk = "poolResizeDisk"
+	// PoolAddDisk resize storage pool using add-disk
+	PoolAddDisk = "poolAddDisk"
 	// BackupAllApps Perform backups of all deployed apps
 	BackupAllApps = "backupAllApps"
 	// BackupScheduleAll Creates and deletes namespaces and checks a scheduled backup for inclusion
@@ -2375,12 +2377,86 @@ func TriggerPoolResizeDisk(contexts *[]*scheduler.Context, recordChan *chan *Eve
 				}
 
 				for id := range poolSet {
-					err = Inst().V.ResizeStoragePoolByPercentage(id, 2, uint64(5))
+					//TODO : Parametrize the resize percentage
+					err = Inst().V.ResizeStoragePoolByPercentage(id, 2, uint64(10))
 					UpdateOutcome(event, err)
 				}
-				logrus.Infof("Waiting for 10 mins for resize to finish")
+				logrus.Infof("Waiting for 10 mins for resize to initiate and check status")
 				time.Sleep(10 * time.Minute)
 				Step("Validate the Pool status after re-size disk", func() {
+					nodeList := node.GetStorageDriverNodes()
+					if len(nodeList) == 0 {
+						UpdateOutcome(event, fmt.Errorf("unable to get node list"))
+					}
+					for _, n := range nodeList {
+						for _, p := range n.StoragePools {
+							poolID := p.GetUuid()
+							poolLastOperationType := p.GetLastOperation().GetType().String()
+							poolLastOperationStatus := p.GetLastOperation().GetStatus().String()
+							poolLastOperationMsg := p.GetLastOperation().GetMsg()
+							logrus.Infof("Pool ID: %s, LastOperation: %s, Status: %s, Message:%s", poolID, poolLastOperationType, poolLastOperationStatus, poolLastOperationMsg)
+							if poolLastOperationStatus != "OPERATION_SUCCESSFUL" {
+								UpdateOutcome(event, fmt.Errorf("last operation %v for pool %v is failed with Msg: %v", poolLastOperationType, poolID, poolLastOperationMsg))
+							}
+						}
+					}
+
+				})
+
+			})
+		}
+	})
+
+}
+
+// TriggerPoolAddDisk peforms add-disk on the storage pools for the given contexts
+func TriggerPoolAddDisk(contexts *[]*scheduler.Context, recordChan *chan *EventRecord) {
+	defer ginkgo.GinkgoRecover()
+	event := &EventRecord{
+		Event: Event{
+			ID:   GenerateUUID(),
+			Type: PoolResizeDisk,
+		},
+		Start:   time.Now().Format(time.RFC1123),
+		Outcome: []error{},
+	}
+
+	defer func() {
+		event.End = time.Now().Format(time.RFC1123)
+		*recordChan <- event
+	}()
+	Step("get storage pools and perform add-disk by 10 percentage on it ", func() {
+		time.Sleep(1 * time.Minute)
+		for _, ctx := range *contexts {
+			var appVolumes []*volume.Volume
+			var err error
+			Step("Get StoragePool IDs from the app volumes", func() {
+				appVolumes, err = Inst().S.GetVolumes(ctx)
+				UpdateOutcome(event, err)
+				if len(appVolumes) == 0 {
+					UpdateOutcome(event, fmt.Errorf("found no volumes for app %s", ctx.App.Key))
+				}
+				poolSet := make(map[string]struct{})
+				var exists = struct{}{}
+				for _, vol := range appVolumes {
+					replicaSets, err := Inst().V.GetReplicaSets(vol)
+					UpdateOutcome(event, err)
+
+					for _, poolUUID := range replicaSets[0].PoolUuids {
+						logrus.Infof("Pool UUID: %v, Vol: %v", poolUUID, vol.Name)
+						poolSet[poolUUID] = exists
+
+					}
+				}
+
+				for id := range poolSet {
+					//TODO : Parametrize the resize percentage
+					err = Inst().V.ResizeStoragePoolByPercentage(id, 1, uint64(10))
+					UpdateOutcome(event, err)
+				}
+				logrus.Infof("Waiting for 10 mins for add disk to initiate and check status")
+				time.Sleep(10 * time.Minute)
+				Step("Validate the Pool status after add disk", func() {
 					nodeList := node.GetStorageDriverNodes()
 					if len(nodeList) == 0 {
 						UpdateOutcome(event, fmt.Errorf("unable to get node list"))


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Added pool resize-disk and add-disk tests as poer of longevity

**Which issue(s) this PR fixes** (optional)
Closes # PTX-4702, PTX-4700

**Special notes for your reviewer**:

Logs:
###############Resize Disk##############
INFO[2022-01-18 13:36:06] Successfully taken lock for trigger [poolResizeDisk]

STEP: get storage pools and perform resize-disk by 10 percentage on it
STEP: Get StoragePool IDs from the app volumes
INFO[2022-01-18 13:37:28] testAndSetEndpoint failed for 10.233.29.53: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 10.233.29.53:9020: i/o timeout"
INFO[2022-01-18 13:37:28] Getting new driver.
INFO[2022-01-18 13:37:30] Using 10.13.9.199:9020 as endpoint for portworx volume driver
INFO[2022-01-18 13:37:31] Pool UUID: 77dd8718-33b6-447b-b8f2-28453b6c7cb2, Vol: cassandra-data-cassandra-0
INFO[2022-01-18 13:37:31] Pool UUID: e8c4c390-cfad-44f9-bb41-44cd9cc0d6e2, Vol: cassandra-data-cassandra-0
INFO[2022-01-18 13:37:52] testAndSetEndpoint failed for 10.233.29.53: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 10.233.29.53:9020: i/o timeout"
INFO[2022-01-18 13:37:52] Getting new driver.
INFO[2022-01-18 13:37:54] Using 10.13.9.199:9020 as endpoint for portworx volume driver
INFO[2022-01-18 13:37:55] Pool UUID: 77dd8718-33b6-447b-b8f2-28453b6c7cb2, Vol: cassandra-data-cassandra-1
INFO[2022-01-18 13:37:55] Pool UUID: c634eba4-856e-41b4-b428-36344a0dea12, Vol: cassandra-data-cassandra-1
INFO[2022-01-18 13:38:16] testAndSetEndpoint failed for 10.233.29.53: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 10.233.29.53:9020: i/o timeout"
INFO[2022-01-18 13:38:16] Getting new driver.
INFO[2022-01-18 13:38:18] Using 10.13.9.199:9020 as endpoint for portworx volume driver
INFO[2022-01-18 13:38:19] Pool UUID: e8c4c390-cfad-44f9-bb41-44cd9cc0d6e2, Vol: cassandra-data-cassandra-2
INFO[2022-01-18 13:38:19] Pool UUID: c634eba4-856e-41b4-b428-36344a0dea12, Vol: cassandra-data-cassandra-2
INFO[2022-01-18 13:38:19] Initaiting pool 77dd8718-33b6-447b-b8f2-28453b6c7cb2 resize by 5 with operationtype RESIZE_TYPE_RESIZE_DISK
INFO[2022-01-18 13:38:19] Initaiting pool e8c4c390-cfad-44f9-bb41-44cd9cc0d6e2 resize by 5 with operationtype RESIZE_TYPE_RESIZE_DISK
INFO[2022-01-18 13:38:19] Initaiting pool c634eba4-856e-41b4-b428-36344a0dea12 resize by 5 with operationtype RESIZE_TYPE_RESIZE_DISK
STEP: Validate the Pool status after re-size disk
INFO[2022-01-18 13:39:20] Pool ID: e8c4c390-cfad-44f9-bb41-44cd9cc0d6e2, LastOperation: OPERATION_RESIZE, Status: OPERATION_SUCCESSFUL, Message:pool expansion to 643 GiB completed successfully
INFO[2022-01-18 13:39:20] node status: STATUS_OK
INFO[2022-01-18 13:39:20] Pool ID: e8c4c390-cfad-44f9-bb41-44cd9cc0d6e2, LastOperation: OPERATION_RESIZE, Status: OPERATION_SUCCESSFUL, Message:pool expansion to 643 GiB completed successfully
INFO[2022-01-18 13:39:20] Pool ID: c634eba4-856e-41b4-b428-36344a0dea12, LastOperation: OPERATION_RESIZE, Status: OPERATION_SUCCESSFUL, Message:pool expansion to 586 GiB completed successfully
INFO[2022-01-18 13:39:20] node status: STATUS_OK
INFO[2022-01-18 13:39:20] Pool ID: c634eba4-856e-41b4-b428-36344a0dea12, LastOperation: OPERATION_RESIZE, Status: OPERATION_SUCCESSFUL, Message:pool expansion to 586 GiB completed successfully
INFO[2022-01-18 13:39:20] Pool ID: 77dd8718-33b6-447b-b8f2-28453b6c7cb2, LastOperation: OPERATION_RESIZE, Status: OPERATION_SUCCESSFUL, Message:pool expansion to 643 GiB completed successfully
INFO[2022-01-18 13:39:20] node status: STATUS_OK
INFO[2022-01-18 13:39:20] Pool ID: 77dd8718-33b6-447b-b8f2-28453b6c7cb2, LastOperation: OPERATION_RESIZE, Status: OPERATION_SUCCESSFUL, Message:pool expansion to 643 GiB completed successfully
INFO[2022-01-18 13:39:20] Successfully released lock for trigger [poolResizeDisk]


###########Add Disk#####################
INFO[2022-01-18 16:47:00] Successfully taken lock for trigger [poolAddDisk]

STEP: get storage pools and perform add-disk by 10 percentage on it
STEP: Get StoragePool IDs from the app volumes
INFO[2022-01-18 16:48:22] testAndSetEndpoint failed for 10.233.29.53: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 10.233.29.53:9020: i/o timeout"
INFO[2022-01-18 16:48:22] Getting new driver.
INFO[2022-01-18 16:48:25] Using 10.13.9.199:9020 as endpoint for portworx volume driver
INFO[2022-01-18 16:48:26] Pool UUID: 77dd8718-33b6-447b-b8f2-28453b6c7cb2, Vol: cassandra-data-cassandra-0
INFO[2022-01-18 16:48:26] Pool UUID: e8c4c390-cfad-44f9-bb41-44cd9cc0d6e2, Vol: cassandra-data-cassandra-0
INFO[2022-01-18 16:48:47] testAndSetEndpoint failed for 10.233.29.53: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 10.233.29.53:9020: i/o timeout"
INFO[2022-01-18 16:48:47] Getting new driver.
INFO[2022-01-18 16:48:50] Using 10.13.9.215:9020 as endpoint for portworx volume driver
INFO[2022-01-18 16:48:51] Pool UUID: 77dd8718-33b6-447b-b8f2-28453b6c7cb2, Vol: cassandra-data-cassandra-1
INFO[2022-01-18 16:48:51] Pool UUID: c634eba4-856e-41b4-b428-36344a0dea12, Vol: cassandra-data-cassandra-1
INFO[2022-01-18 16:49:12] testAndSetEndpoint failed for 10.233.29.53: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 10.233.29.53:9020: i/o timeout"
INFO[2022-01-18 16:49:12] Getting new driver.
INFO[2022-01-18 16:49:15] Using 10.13.9.215:9020 as endpoint for portworx volume driver
INFO[2022-01-18 16:49:15] Pool UUID: e8c4c390-cfad-44f9-bb41-44cd9cc0d6e2, Vol: cassandra-data-cassandra-2
INFO[2022-01-18 16:49:15] Pool UUID: c634eba4-856e-41b4-b428-36344a0dea12, Vol: cassandra-data-cassandra-2
INFO[2022-01-18 16:49:15] Initiating pool e8c4c390-cfad-44f9-bb41-44cd9cc0d6e2 resize by 10 with operationtype RESIZE_TYPE_ADD_DISK
INFO[2022-01-18 16:49:16] Initiating pool c634eba4-856e-41b4-b428-36344a0dea12 resize by 10 with operationtype RESIZE_TYPE_ADD_DISK
INFO[2022-01-18 16:49:17] Initiating pool 77dd8718-33b6-447b-b8f2-28453b6c7cb2 resize by 10 with operationtype RESIZE_TYPE_ADD_DISK
INFO[2022-01-18 16:49:18] Waiting for 10 mins for add disk to finish
STEP: Validate the Pool status after add disk
INFO[2022-01-18 16:50:18] Pool ID: e8c4c390-cfad-44f9-bb41-44cd9cc0d6e2, LastOperation: OPERATION_RESIZE, Status: OPERATION_SUCCESSFUL, Message:pool expansion to 672 GiB completed successfully
INFO[2022-01-18 16:50:18] Pool ID: c634eba4-856e-41b4-b428-36344a0dea12, LastOperation: OPERATION_RESIZE, Status: OPERATION_SUCCESSFUL, Message:pool expansion to 612 GiB completed successfully
INFO[2022-01-18 16:50:18] Pool ID: 77dd8718-33b6-447b-b8f2-28453b6c7cb2, LastOperation: OPERATION_RESIZE, Status: OPERATION_SUCCESSFUL, Message:pool expansion to 672 GiB completed successfully
INFO[2022-01-18 16:50:18] Trigger Function completed for [poolAddDisk]
INFO[2022-01-18 16:50:18] Successfully released lock for trigger [poolAddDisk]


