### PR TITLE
PTX-4846: use one encrypted volume for vdbench

### DIFF
--- a/drivers/scheduler/k8s/specs/vdbench-sharedv4/px-vdbench-app.yml
+++ b/drivers/scheduler/k8s/specs/vdbench-sharedv4/px-vdbench-app.yml
@@ -32,14 +32,14 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
           volumeMounts:
-            - name: vdbench-persistent-storage
+            - name: vdbench-persistent-storage-enc
               mountPath: /tmp
             - name: vdbench-output-persistent-storage
               mountPath: /output
       volumes:
-        - name: vdbench-persistent-storage
+        - name: vdbench-persistent-storage-enc
           persistentVolumeClaim:
-            claimName: vdbench-pvc-sharedv4
+            claimName: vdbench-pvc-enc-sharedv4
         - name: vdbench-output-persistent-storage
           persistentVolumeClaim:
             claimName: vdbench-pvc-output-sv4

--- a/drivers/scheduler/k8s/specs/vdbench-sharedv4/px-vdbench-storage.yml
+++ b/drivers/scheduler/k8s/specs/vdbench-sharedv4/px-vdbench-storage.yml
@@ -1,3 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: volume-secrets
+type: Opaque
+data:
+  vdbench-secret: dmRiZW5jaCBzaGFyZWR2NCByb2NrcyEK
 ---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
@@ -13,7 +20,12 @@ allowVolumeExpansion: true
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: vdbench-pvc-sharedv4
+  name: vdbench-pvc-enc-sharedv4
+  annotations:
+    px/secret-name: volume-secrets
+    px/secret-namespace: "_NAMESPACE_"
+    px/secret-key: vdbench-secret
+    px/secure: "true"
 spec:
   storageClassName: vdbench-sc-sharedv4
   accessModes:

--- a/drivers/scheduler/k8s/specs/vdbench-sv4-svc/px-vdbench-app.yml
+++ b/drivers/scheduler/k8s/specs/vdbench-sv4-svc/px-vdbench-app.yml
@@ -17,6 +17,13 @@ spec:
         - name: vdbench
           image: portworx/vdbench:torpedo
           imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 500Mi
+            requests:
+              memory: 256Mi
+              cpu: 100m
           command: ["./bench_runner.sh"]
           args: ["Basic", "5400", "$(POD_NAME)", "output/$(POD_NAME)"]
           env:
@@ -25,18 +32,14 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
           volumeMounts:
-            - name: vdbench-persistent-storage
+            - name: vdbench-persistent-storage-enc
               mountPath: /tmp
             - name: vdbench-output-persistent-storage
               mountPath: /output
-          resources:
-            limits:
-              cpu: "200m"
-              memory: "500Mi"
       volumes:
-        - name: vdbench-persistent-storage
+        - name: vdbench-persistent-storage-enc
           persistentVolumeClaim:
-            claimName: vdbench-pvc-sv4-svc
+            claimName: vdbench-pvc-enc-sv4-svc
         - name: vdbench-output-persistent-storage
           persistentVolumeClaim:
             claimName: vdbench-pvc-output-sv4-svc

--- a/drivers/scheduler/k8s/specs/vdbench-sv4-svc/px-vdbench-storage.yml
+++ b/drivers/scheduler/k8s/specs/vdbench-sv4-svc/px-vdbench-storage.yml
@@ -1,3 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: volume-secrets
+type: Opaque
+data:
+  vdbench-secret: dmRiZW5jaCBzaGFyZWR2NCBzdmMgcm9ja3MhCg==
 ---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
@@ -14,7 +21,12 @@ allowVolumeExpansion: true
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: vdbench-pvc-sv4-svc
+  name: vdbench-pvc-enc-sv4-svc
+  annotations:
+    px/secret-name: volume-secrets
+    px/secret-namespace: "_NAMESPACE_"
+    px/secret-key: vdbench-secret
+    px/secure: "true"
 spec:
   storageClassName: vdbench-sc-sv4-svc
   accessModes:


### PR DESCRIPTION
**What this PR does / why we need it**:
Changed the vdbench app to use one encrypted volume for both
sharedv4 and sharedv4-svc deployments.

Signed-off-by: Neelesh Thakur <neelesh.thakur@purestorage.com>

**Which issue(s) this PR fixes** (optional)
PTX-4846

**Special notes for your reviewer**:
Verified the deployments by running the dev job:
https://jenkins.pwx.dev.purestorage.com/job/Dev/job/torpedo-dev03/12
