### PR TITLE
PWX-22505: implement sharedv4-svc failover test cases

### DIFF
--- a/drivers/scheduler/dcos/dcos.go
+++ b/drivers/scheduler/dcos/dcos.go
@@ -484,6 +484,15 @@ func (d *dcos) GetPodsForPVC(pvcname, namespace string) ([]corev1.Pod, error) {
 	}
 }
 
+// GetPodLog returns logs for all the pods in the specified context
+func (d *dcos) GetPodLog(ctx *scheduler.Context, sinceSeconds int64) (map[string]string, error) {
+	// TODO: Add implementation
+	return nil, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "GetPodLog()",
+	}
+}
+
 func (d *dcos) ResizeVolume(cxt *scheduler.Context, configMap string) ([]*volume.Volume, error) {
 	// TODO implement this method
 	return nil, &errors.ErrNotSupported{

--- a/drivers/scheduler/k8s/specs/test-sv4-svc/pod.yaml
+++ b/drivers/scheduler/k8s/specs/test-sv4-svc/pod.yaml
@@ -27,7 +27,7 @@ spec:
         image: portworx/sharedv4-test:torpedo
         imagePullPolicy: Always
         command: ["python", "/app/fileio.py"]
-        args: ["--lock", "--interval=0.1", "$(MY_FILE)"]
+        args: ["--lock", "--interval=0.25", "$(MY_FILE)"]
         env:
           - name: MY_POD_NAME
             valueFrom:

--- a/drivers/scheduler/k8s/specs/test-sv4-svc/pod.yaml
+++ b/drivers/scheduler/k8s/specs/test-sv4-svc/pod.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-sv4-dep-svc
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: test-sv4-app-svc
+  template:
+    metadata:
+      labels:
+        app: test-sv4-app-svc
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - test-sv4-app-svc
+            topologyKey: "kubernetes.io/hostname"
+      containers:
+      - name: sv4test
+        image: portworx/sharedv4-test:torpedo
+        imagePullPolicy: Always
+        command: ["python", "/app/fileio.py"]
+        args: ["--lock", "$(MY_FILE)"]
+        env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_FILE
+            value: "/test-sv4-vol-svc/$(MY_POD_NAME)"
+        volumeMounts:
+        - name: test-sv4-vol-svc
+          mountPath: /test-sv4-vol-svc
+      volumes:
+      - name: test-sv4-vol-svc
+        persistentVolumeClaim:
+          claimName: test-sv4-pvc-svc

--- a/drivers/scheduler/k8s/specs/test-sv4-svc/pod.yaml
+++ b/drivers/scheduler/k8s/specs/test-sv4-svc/pod.yaml
@@ -27,7 +27,7 @@ spec:
         image: portworx/sharedv4-test:torpedo
         imagePullPolicy: Always
         command: ["python", "/app/fileio.py"]
-        args: ["--lock", "$(MY_FILE)"]
+        args: ["--lock", "--interval=0.1", "$(MY_FILE)"]
         env:
           - name: MY_POD_NAME
             valueFrom:

--- a/drivers/scheduler/k8s/specs/test-sv4-svc/pvc.yaml
+++ b/drivers/scheduler/k8s/specs/test-sv4-svc/pvc.yaml
@@ -1,0 +1,25 @@
+##### Portworx storage class
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: test-sv4-sc-svc
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  repl: "3"
+  sharedv4: "true"
+  sharedv4_svc_type: "ClusterIP"
+allowVolumeExpansion: true
+---
+##### Portworx persistent volume claim
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: test-sv4-pvc-svc
+spec:
+  storageClassName: test-sv4-sc-svc
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 50Gi
+

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -189,6 +189,9 @@ type Driver interface {
 	// GetPodsForPVC returns pods using the pvc
 	GetPodsForPVC(pvcname, namespace string) ([]corev1.Pod, error)
 
+	// GetPodLog returns logs for all the pods in the specified context
+	GetPodLog(ctx *Context, sinceSeconds int64) (map[string]string, error)
+
 	// ResizeVolume resizes all the volumes of a given context
 	ResizeVolume(*Context, string) ([]*volume.Volume, error)
 

--- a/drivers/volume/common.go
+++ b/drivers/volume/common.go
@@ -94,6 +94,7 @@ func (d *DefaultDriver) CleanupVolume(name string) error {
 	}
 }
 
+// InspectVolume inspects the volume with the given name
 func (d *DefaultDriver) InspectVolume(name string) (*api.Volume, error) {
 	return nil, &errors.ErrNotSupported{
 		Type:      "Function",

--- a/drivers/volume/common.go
+++ b/drivers/volume/common.go
@@ -94,6 +94,13 @@ func (d *DefaultDriver) CleanupVolume(name string) error {
 	}
 }
 
+func (d *DefaultDriver) InspectVolume(name string) (*api.Volume, error) {
+	return nil, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "InspectVolume()",
+	}
+}
+
 // GetStorageDevices returns the list of storage devices used by the given node.
 func (d *DefaultDriver) GetStorageDevices(n node.Node) ([]string, error) {
 	// TODO: Implement

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -328,6 +328,18 @@ func (d *portworx) isMetadataNode(node node.Node, address string) (bool, error) 
 	return false, nil
 }
 
+func (d *portworx) InspectVolume(name string) (*api.Volume, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), inspectVolumeTimeout)
+	defer cancel()
+
+	response, err := d.getVolDriver().Inspect(ctx, &api.SdkVolumeInspectRequest{VolumeId: name})
+	if err != nil {
+		return nil, err
+	}
+
+	return response.Volume, nil
+}
+
 func (d *portworx) CleanupVolume(volumeName string) error {
 	volDriver := d.getVolDriver()
 	volumes, err := volDriver.Enumerate(d.getContext(), &api.SdkVolumeEnumerateRequest{}, nil)

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -53,6 +53,9 @@ type Driver interface {
 	// String returns the string name of this driver.
 	String() string
 
+	// InspectVolume inspects the volume with the given name
+	InspectVolume(name string) (*api.Volume, error)
+
 	// CleanupVolume forcefully unmounts/detaches and deletes a storage volume.
 	// This is only called by Torpedo during cleanup operations, it is not
 	// used during orchestration simulations.

--- a/tests/basic/basic_test.go
+++ b/tests/basic/basic_test.go
@@ -163,7 +163,7 @@ var _ = Describe("{VolumeDriverDownAttachedNode}", func() {
 						time.Sleep(20 * time.Second)
 					})
 
-					Step(fmt.Sprintf("validate app %s", appNode.Name), func() {
+					Step(fmt.Sprintf("validate app %s", ctx.App.Key), func() {
 						ValidateContext(ctx)
 					})
 				}

--- a/tests/basic/sharedv4_svc_test.go
+++ b/tests/basic/sharedv4_svc_test.go
@@ -212,7 +212,7 @@ var _ = Describe("{Shared4SvcFailoverIO}", func() {
 	It("has to schedule apps and stop volume driver on nodes where volumes are attached", func() {
 		contexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
-			contexts = append(contexts, ScheduleApplications(fmt.Sprintf("sv4-svc-failover-io-%d", i))...)
+			contexts = append(contexts, ScheduleApplications(fmt.Sprintf("failover-io-%d", i))...)
 		}
 
 		Step("scale the test-sv4-svc apps so that one pod runs on each worker node", func() {
@@ -451,6 +451,8 @@ func validateAppLogs(ctx *scheduler.Context, numPods int) {
 		for _, line := range lines {
 			if strings.Contains(line, "ERROR") {
 				errors = append(errors, fmt.Sprintf("pod %s: %s", podName, line))
+			} else if strings.Contains(line, "WARNING") {
+				logrus.Warnf("pod %s: %s", podName, line)
 			}
 		}
 	}

--- a/tests/basic/sharedv4_svc_test.go
+++ b/tests/basic/sharedv4_svc_test.go
@@ -2,12 +2,16 @@ package tests
 
 import (
 	"fmt"
+	"path"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/portworx/sched-ops/k8s/core"
 	"github.com/portworx/torpedo/drivers/node"
 	"github.com/portworx/torpedo/drivers/scheduler"
 	"github.com/portworx/torpedo/drivers/volume"
+	"github.com/portworx/torpedo/pkg/testrailuttils"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 
@@ -19,6 +23,8 @@ import (
 const (
 	defaultCommandRetry   = 5 * time.Second
 	defaultCommandTimeout = 1 * time.Minute
+	exportPathPrefix      = "/var/lib/osd/pxns"
+	pxctlPath             = "/opt/pwx/bin/pxctl"
 )
 
 var _ = Describe("{NFSServerFailover}", func() {
@@ -171,11 +177,294 @@ var _ = Describe("{NFSServerFailover}", func() {
 	})
 })
 
-func contains(arr []string, str string) bool {
-	for _, a := range arr {
-		if a == str {
-			return true
+// Test below uses test-sharedv4 app https://github.com/portworx/test-sharedv4 .
+//
+// The test-sharedv4 app has the following properties:
+// - uses node anti-affinity to ensure that each pod is on a different node
+// - one sharedv4 svc volume is exposed to all the pods
+// - each pod creates its own file named same as the pod name and keeps incrementing a counter in that file
+//
+// Struct appCounter below captures the state of a pod that is part of that app.
+type appCounter struct {
+	// podName is same as the name of the file that this pod is storing its counter into.
+	// Since this info is gathered from the volume, the pod may or may not exist currently.
+	podName string
+
+	// counter value in the file
+	counter int
+
+	// active, if true, indicates that the pod is actively incrementing the counter in the file
+	active bool
+}
+
+// Bring PX down on the node where the volume is attached. Verify that there is no I/O disruption.
+var _ = Describe("{Shared4SvcFailoverIO}", func() {
+	var testrailID = 54374
+	// testrailID corresponds to: https://portworx.testrail.net/index.php?/cases/view/54374
+	var runID int
+	var contexts, testSv4Contexts []*scheduler.Context
+	var numPods int
+
+	JustBeforeEach(func() {
+		runID = testrailuttils.AddRunsToMilestone(testrailID)
+	})
+
+	It("has to schedule apps and stop volume driver on nodes where volumes are attached", func() {
+		contexts = make([]*scheduler.Context, 0)
+		for i := 0; i < Inst().GlobalScaleFactor; i++ {
+			contexts = append(contexts, ScheduleApplications(fmt.Sprintf("sv4-svc-failover-io-%d", i))...)
+		}
+
+		Step("scale the test-sv4-svc apps so that one pod runs on each worker node", func() {
+			testSv4Contexts = getTestSv4Contexts(contexts)
+			if len(testSv4Contexts) == 0 {
+				Skip("No test-sv4-svc apps were found")
+			}
+			numPods = len(node.GetWorkerNodes())
+			for _, ctx := range testSv4Contexts {
+				Step(fmt.Sprintf("scale up app %s to %d", ctx.App.Key, numPods), func() {
+					applicationScaleUpMap, err := Inst().S.GetScaleFactorMap(ctx)
+					Expect(err).NotTo(HaveOccurred())
+					for name := range applicationScaleUpMap {
+						applicationScaleUpMap[name] = int32(numPods)
+					}
+					err = Inst().S.ScaleApplication(ctx, applicationScaleUpMap)
+					Expect(err).NotTo(HaveOccurred())
+				})
+			}
+		})
+
+		ValidateApplications(contexts)
+
+		Step("set HA level to 2 to verify failover and failback to the same node", func() {
+			for _, ctx := range testSv4Contexts {
+				vols, err := Inst().S.GetVolumes(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Step(
+					fmt.Sprintf("set HA level to 2 on app %s's volume %v", ctx.App.Key, vols[0]),
+					func() {
+						err := Inst().V.SetReplicationFactor(vols[0], 2, nil)
+						Expect(err).NotTo(HaveOccurred())
+					})
+				Step(
+					fmt.Sprintf("validate successful update of HA level on app %s's volume %v", ctx.App.Key, vols[0]),
+					func() {
+						newRepl, err := Inst().V.GetReplicationFactor(vols[0])
+						Expect(err).NotTo(HaveOccurred())
+						Expect(newRepl).To(BeNumerically("==", 2))
+						// ValidateContext() will fail with error "volume has invalid repl value. Expected:3 Actual:2"
+						// without the line below.
+						ctx.SkipVolumeValidation = true
+					})
+			}
+		})
+
+		Step("for each context, restart volume driver on NFS server node and verify I/O", func() {
+			for _, ctx := range testSv4Contexts {
+				var countersBefore, countersAfter map[string]appCounter
+				vols, err := Inst().S.GetVolumes(ctx)
+				Expect(err).NotTo(HaveOccurred())
+
+				// verify failover and failback by repeating the steps below
+				for i := 0; i < 2; i++ {
+					// get the attached node before the failover
+					attachedNodeBefore, err := Inst().V.GetNodeForVolume(vols[0],
+						defaultCommandTimeout, defaultCommandRetry)
+					Expect(err).NotTo(HaveOccurred())
+
+					Step(
+						fmt.Sprintf("get counter values from node %v for app %s's volume before failover",
+							attachedNodeBefore.Name, ctx.App.Key),
+						func() {
+							countersBefore = getAppCounters(vols[0], attachedNodeBefore,
+								3*time.Duration(numPods)*time.Second)
+						})
+
+					Step(
+						fmt.Sprintf("failover #%d for app %s by stopping the volume driver on node %s",
+							i, ctx.App.Key, attachedNodeBefore.Name),
+						func() {
+							StopVolDriverAndWait([]node.Node{*attachedNodeBefore})
+						})
+
+					Step(
+						fmt.Sprintf("start volume driver %s on node where app %s's volume was attached: %s",
+							Inst().V.String(), ctx.App.Key, attachedNodeBefore.Name),
+						func() {
+							StartVolDriverAndWait([]node.Node{*attachedNodeBefore})
+						})
+
+					Step("Giving few seconds for volume driver and the app pods to stabilize",
+						func() {
+							time.Sleep(60 * time.Second)
+						})
+
+					Step(fmt.Sprintf("validate app %s", ctx.App.Key),
+						func() {
+							ValidateContext(ctx)
+						})
+
+					Step(
+						fmt.Sprintf("get counter values for app %s's volume after failover #%d", ctx.App.Key, 0),
+						func() {
+							attachedNodeAfter, err := Inst().V.GetNodeForVolume(vols[0],
+								defaultCommandTimeout, defaultCommandRetry)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(attachedNodeAfter.Name).NotTo(Equal(attachedNodeBefore.Name))
+							countersAfter = getAppCounters(vols[0], attachedNodeAfter,
+								3*time.Duration(numPods)*time.Second)
+						})
+
+					Step(fmt.Sprintf("validate no I/O disruption for app %s after failover #%d", ctx.App.Key, i),
+						func() {
+							// 2 pods (1 on the old NFS server and 1 on the new NFS server) should get restarted,
+							// others should not be interrupted
+							validateAppCounters(ctx, countersBefore, countersAfter, numPods, 2)
+							validateAppLogs(ctx, numPods)
+						})
+				}
+			}
+		})
+
+		Step("destroy apps", func() {
+			opts := make(map[string]bool)
+			opts[scheduler.OptionsWaitForResourceLeakCleanup] = true
+			for _, ctx := range contexts {
+				TearDownContext(ctx, opts)
+			}
+		})
+	})
+	JustAfterEach(func() {
+		AfterEachTest(contexts, testrailID, runID)
+	})
+})
+
+// returns the contexts that are running test-sv4-svc* apps
+func getTestSv4Contexts(contexts []*scheduler.Context) []*scheduler.Context {
+	var testSv4Contexts []*scheduler.Context
+	for _, ctx := range contexts {
+		if !strings.HasPrefix(ctx.App.Key, "test-sv4-svc") {
+			continue
+		}
+		testSv4Contexts = append(testSv4Contexts, ctx)
+	}
+	return testSv4Contexts
+}
+
+// returns the appCounter structs for the app pods by scanning the export path on the NFS server
+func getAppCounters(vol *volume.Volume, attachedNode *node.Node, sleepInterval time.Duration) map[string]appCounter {
+	snap1 := getAppCountersSnapshot(vol, attachedNode)
+	time.Sleep(sleepInterval)
+	snap2 := getAppCountersSnapshot(vol, attachedNode)
+	Expect(len(snap1)).To(Equal(len(snap2)), "unexpected change in the number of pods when collecting counters")
+
+	ret := map[string]appCounter{}
+	for podName, counter1 := range snap1 {
+		counter2, ok := snap2[podName]
+		Expect(ok).To(BeTrue(), "pod %v counter not found in the second snap", podName)
+		Expect(counter2).To(BeNumerically(">=", counter1), "counter for pod %v decreased unexpectedly", podName)
+		ret[podName] = appCounter{podName: podName, counter: counter2, active: counter2 > counter1}
+	}
+	return ret
+}
+
+func getAppCountersSnapshot(vol *volume.Volume, attachedNode *node.Node) map[string]int {
+	counterByPodName := map[string]int{}
+	// We find all the files in the root dir where the pods are writing their counters.
+	// Exclude the common file, tmp files. Use grep '' to get the lines in "fileName:counter" format.
+	// The volume.ID contains PV name. We need the PX volume id to contruct the export path. So, we use
+	// backticks to run "pxctl volume list | grep <PV name> | awk {print $1}" to fill in the PX volume ID.
+	// Example:
+	// # find /var/lib/osd/pxns/`pxctl v l | grep pvc-28b994b6-74a9-422f-939f-dd5631b3c581 | awk '{print $1}'` -maxdepth 1 -type f | grep -v -e common -e tmp | xargs grep ''
+	// /var/lib/osd/pxns/283170809327294682/sv4test-88d78b767-n5gkc:478941
+	// /var/lib/osd/pxns/283170809327294682/sv4test-88d78b767-5bgxn:5437
+	// /var/lib/osd/pxns/283170809327294682/sv4test-88d78b767-48br7:521419
+	//
+	cmd := fmt.Sprintf("find %s/`%s volume list | grep %s | awk '{print $1}'` -maxdepth 1 -type f "+
+		"| grep -v -e common -e tmp | xargs grep ''", exportPathPrefix, pxctlPath, vol.ID)
+	output, err := runCmd(cmd, *attachedNode)
+	Expect(err).NotTo(HaveOccurred())
+	for _, line := range strings.Split(output, "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.Split(line, ":")
+		Expect(len(parts)).To(Equal(2))
+
+		val, err := strconv.Atoi(parts[1])
+		Expect(err).NotTo(HaveOccurred())
+
+		podName := path.Base(parts[0])
+		counterByPodName[podName] = val
+	}
+	return counterByPodName
+}
+
+// Validate the app counters after the failover.
+// - counters for all pods (with some exceptions) should continue incrementing
+// - the specified number of pods should have stopped incrementing their counters and the same number of
+//   new pods should have started incrementing the counters
+func validateAppCounters(ctx *scheduler.Context, countersBefore, countersAfter map[string]appCounter,
+	numPods, expectedPodRestarts int) {
+
+	var survivingPods []string
+	var terminatedPods []string
+	var newPods []string
+
+	for podName, counterBefore := range countersBefore {
+		// pod was not active even before the failover. This can happen when there are multiple failovers.
+		if !counterBefore.active {
+			continue
+		}
+		counterAfter, ok := countersAfter[podName]
+		// Since we don't delete the files for the terminated pods, the file should still be there on the volume
+		Expect(ok).To(BeTrue())
+		if counterAfter.active {
+			Expect(counterAfter.counter).To(BeNumerically(">", counterBefore.counter))
+			survivingPods = append(survivingPods, podName)
+		} else {
+			terminatedPods = append(terminatedPods, podName)
 		}
 	}
-	return false
+	// check for the new pods
+	for podName, counterAfter := range countersAfter {
+		if _, ok := countersBefore[podName]; !ok {
+			// a new pod must be active
+			Expect(counterAfter.active).To(BeTrue(), "pod %v is not active", podName)
+			newPods = append(newPods, podName)
+		}
+	}
+	// pods on old and new NFS server should have been terminated and new ones should have replaced them
+	Expect(len(terminatedPods)).To(Equal(expectedPodRestarts))
+	Expect(len(newPods)).To(Equal(expectedPodRestarts))
+	Expect(len(survivingPods) + len(newPods)).To(Equal(numPods))
+}
+
+// There should not be any errors in the pod logs.
+func validateAppLogs(ctx *scheduler.Context, numPods int) {
+	logsByPodName, err := Inst().S.GetPodLog(ctx, 0)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(len(logsByPodName)).To(Equal(numPods))
+	var errors []string
+	for podName, output := range logsByPodName {
+		lines := strings.Split(output, "\n")
+		for _, line := range lines {
+			if strings.Contains(line, "ERROR") {
+				errors = append(errors, fmt.Sprintf("pod %s: %s", podName, line))
+			}
+		}
+	}
+	Expect(errors).To(BeNil(), "Errors found in the pod logs: %v", errors)
+}
+
+func runCmd(cmd string, n node.Node) (string, error) {
+	output, err := Inst().N.RunCommand(n, cmd, node.ConnectionOpts{
+		Timeout:         defaultCommandTimeout,
+		TimeBeforeRetry: defaultCommandRetry,
+		Sudo:            true,
+	})
+	if err != nil {
+		logrus.Warnf("failed to run cmd: %s. err: %v", cmd, err)
+	}
+	return output, err
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Added test-sharedv4 app to Torpedo.

Added the following sharedv4 service test cases:

C54374: Verify failover by stopping the node where sharedv4 volume is attached (with i/o)
C54377: Verify previously written data after failover
C54382: Verify failback by stopping failover node

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->



**Which issue(s) this PR fixes** (optional)
PWX-22505

**Special notes for your reviewer**:

