### PR TITLE
Add stork upgrade trigger to longevity

### DIFF
--- a/drivers/volume/common.go
+++ b/drivers/volume/common.go
@@ -334,6 +334,14 @@ func (d *DefaultDriver) UpgradeDriver(endpointURL string, endpointVersion string
 	}
 }
 
+// UpgradeStork upgrades the stork driver from the given link and checks if it was upgraded to endpointVersion
+func (d *DefaultDriver) UpgradeStork(endpointURL string, endpointVersion string) error {
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "UpgradeDriver()",
+	}
+}
+
 // GetClusterPairingInfo returns cluster pair information
 func (d *DefaultDriver) GetClusterPairingInfo(kubeConfigPath string) (map[string]string, error) {
 	pairInfo := make(map[string]string)

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -1748,7 +1748,7 @@ func (d *portworx) UpgradeDriver(endpointURL string, endpointVersion string, ena
 	}
 
 	if enableStork {
-		if err := d.upgradeStork(endpointURL, endpointVersion); err != nil {
+		if err := d.UpgradeStork(endpointURL, endpointVersion); err != nil {
 			return err
 		}
 	} else {
@@ -1810,8 +1810,8 @@ func (d *portworx) upgradePortworx(endpointURL string, endpointVersion string) e
 	return nil
 }
 
-// upgradeStork upgrades stork
-func (d *portworx) upgradeStork(endpointURL string, endpointVersion string) error {
+// UpgradeStork upgrades stork
+func (d *portworx) UpgradeStork(endpointURL string, endpointVersion string) error {
 	storkSpecFileName := "/stork.yaml"
 	nodeList := node.GetStorageDriverNodes()
 	pxNode := nodeList[0]

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -124,6 +124,9 @@ type Driver interface {
 	// UpgradeDriver upgrades the volume driver from the given link and checks if it was upgraded to endpointVersion
 	UpgradeDriver(endpointURL string, endpointVersion string, enableStork bool) error
 
+	// UpgradeStork upgrades the stork driver from the given link and checks if it was upgraded to endpointVersion
+	UpgradeStork(endpointURL string, endpointVersion string) error
+
 	// RandomizeVolumeName randomizes the volume name from the given name
 	RandomizeVolumeName(name string) string
 

--- a/tests/longevity/longevity_test.go
+++ b/tests/longevity/longevity_test.go
@@ -70,6 +70,7 @@ var _ = Describe("{Longevity}", func() {
 		CloudSnapShot:    TriggerCloudSnapShot,
 		PoolResizeDisk:   TriggerPoolResizeDisk,
 		PoolAddDisk:      TriggerPoolAddDisk,
+		UpgradeStork:     TriggerUpgradeStork,
 	}
 	It("has to schedule app and introduce test triggers", func() {
 		Step(fmt.Sprintf("Start watch on K8S configMap [%s/%s]",
@@ -321,6 +322,7 @@ func populateIntervals() {
 	triggerInterval[BackupDeleteBackupPod] = map[int]time.Duration{}
 	triggerInterval[BackupScaleMongo] = map[int]time.Duration{}
 	triggerInterval[CloudSnapShot] = make(map[int]time.Duration)
+	triggerInterval[UpgradeStork] = make(map[int]time.Duration)
 
 	baseInterval := 10 * time.Minute
 	triggerInterval[BackupScaleMongo][10] = 1 * baseInterval
@@ -607,6 +609,15 @@ func populateIntervals() {
 	triggerInterval[PoolResizeDisk][2] = 24 * baseInterval
 	triggerInterval[PoolResizeDisk][1] = 30 * baseInterval
 
+	baseInterval = 300 * time.Minute
+
+	triggerInterval[UpgradeStork][10] = 1 * baseInterval
+	triggerInterval[UpgradeStork][9] = 2 * baseInterval
+	triggerInterval[UpgradeStork][8] = 3 * baseInterval
+	triggerInterval[UpgradeStork][7] = 4 * baseInterval
+	triggerInterval[UpgradeStork][6] = 5 * baseInterval
+	triggerInterval[UpgradeStork][5] = 6 * baseInterval
+
 	// Chaos Level of 0 means disable test trigger
 	triggerInterval[DeployApps][0] = 0
 	triggerInterval[RebootNode][0] = 0
@@ -634,6 +645,8 @@ func populateIntervals() {
 	triggerInterval[BackupDeleteBackupPod][0] = 0
 	triggerInterval[BackupScaleMongo][0] = 0
 	triggerInterval[CloudSnapShot][0] = 0
+	triggerInterval[UpgradeStork][0] = 0
+
 }
 
 func isTriggerEnabled(triggerType string) (time.Duration, bool) {


### PR DESCRIPTION
Signed-off-by: Rohit-PX <rohit@portworx.com>

**What this PR does / why we need it**:
Longevity currently does not have an event that does stork upgrades. This PR fixes that.

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PTX-4734

**Special notes for your reviewer**:
Added simple torpedo test to test this change, but will also monitor longevity once merged.
