### PR TITLE
Openshift - Fix for apps getting deployed in the same namespace

### DIFF
--- a/drivers/scheduler/openshift/openshift.go
+++ b/drivers/scheduler/openshift/openshift.go
@@ -122,13 +122,13 @@ func (k *openshift) Schedule(instanceID string, options scheduler.ScheduleOption
 	}
 
 	var contexts []*scheduler.Context
+	oldOptionsNamespace := options.Namespace
 	for _, app := range apps {
 
-		var appNamespace string
+		appNamespace := app.GetID(instanceID)
 		if options.Namespace != "" {
 			appNamespace = options.Namespace
 		} else {
-			appNamespace = app.GetID(instanceID)
 			options.Namespace = appNamespace
 		}
 
@@ -159,6 +159,7 @@ func (k *openshift) Schedule(instanceID string, options scheduler.ScheduleOption
 		}
 
 		contexts = append(contexts, ctx)
+		options.Namespace = oldOptionsNamespace
 	}
 
 	return contexts, nil


### PR DESCRIPTION
Signed-off-by: Rohit-PX <rohit@portworx.com>


**What this PR does / why we need it**:
There was an earlier fix for this same issue for k8s: https://github.com/portworx/torpedo/pull/662
Adding the same fix for openshift.

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PTX-4579

**Special notes for your reviewer**:
Running the original job that failed here, to test the fix: http://jenkins.pwx.dev.purestorage.com/job/Torpedo/view/Torpedo%20NextPX/job/tp-ocp-stable-sv4-svc/ 


