### PR TITLE
PWX-22507 deploy apps on storageless nodes

### DIFF
--- a/drivers/node/node.go
+++ b/drivers/node/node.go
@@ -54,11 +54,6 @@ type Node struct {
 	StoragePools             []StoragePool
 }
 
-// IsStorageNode returns true if the node is a storage node, false otherwise
-func IsStorageNode(n Node) bool {
-	return len(n.StoragePools) > 0
-}
-
 // ConnectionOpts provide basic options for all operations and can be embedded by other options
 type ConnectionOpts struct {
 	Timeout         time.Duration

--- a/drivers/node/node.go
+++ b/drivers/node/node.go
@@ -54,6 +54,10 @@ type Node struct {
 	StoragePools             []StoragePool
 }
 
+func IsStorageNode(n Node) bool {
+	return len(n.StoragePools) > 0
+}
+
 // ConnectionOpts provide basic options for all operations and can be embedded by other options
 type ConnectionOpts struct {
 	Timeout         time.Duration

--- a/drivers/node/node.go
+++ b/drivers/node/node.go
@@ -54,6 +54,7 @@ type Node struct {
 	StoragePools             []StoragePool
 }
 
+// IsStorageNode returns true if the node is a storage node, false otherwise
 func IsStorageNode(n Node) bool {
 	return len(n.StoragePools) > 0
 }

--- a/drivers/node/node_registry.go
+++ b/drivers/node/node_registry.go
@@ -78,6 +78,22 @@ func GetStorageDriverNodes() []Node {
 	return nodeList
 }
 
+// IsStorageNode returns true if the node is a storage node, false otherwise
+func IsStorageNode(n Node) bool {
+	return len(n.StoragePools) > 0
+}
+
+// GetStorageNodes gets all the nodes with non-empty StoragePools
+func GetStorageNodes() []Node {
+	var nodeList []Node
+	for _, n := range nodeRegistry {
+		if IsStorageNode(n) {
+			nodeList = append(nodeList, n)
+		}
+	}
+	return nodeList
+}
+
 // GetMetadataNodes gets all the nodes which serves as internal kvdb metadata node
 func GetMetadataNodes() []Node {
 	var nodeList []Node

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	helm.sh/helm/v3 v3.0.0-00010101000000-000000000000
 	k8s.io/api v0.20.4
+	k8s.io/apiextensions-apiserver v0.20.4
 	k8s.io/apimachinery v0.20.4
 	k8s.io/client-go v12.0.0+incompatible
 )

--- a/tests/basic/basic_test.go
+++ b/tests/basic/basic_test.go
@@ -494,9 +494,9 @@ var _ = Describe("{CordonStorageNodesDeployDestroy}", func() {
 
 		Step("Cordon all storage nodes", func() {
 			nodes := node.GetWorkerNodes()
-			for _, node := range nodes {
-				if node.IsStorageDriverInstalled {
-					err := Inst().S.DisableSchedulingOnNode(node)
+			for _, n := range nodes {
+				if node.IsStorageNode(n) {
+					err := Inst().S.DisableSchedulingOnNode(n)
 					Expect(err).NotTo(HaveOccurred())
 				}
 			}

--- a/tests/basic/basic_test.go
+++ b/tests/basic/basic_test.go
@@ -493,12 +493,14 @@ var _ = Describe("{CordonStorageNodesDeployDestroy}", func() {
 	It("has to cordon all storage nodes, deploy and destroy app", func() {
 
 		Step("Cordon all storage nodes", func() {
-			nodes := node.GetWorkerNodes()
-			for _, n := range nodes {
-				if node.IsStorageNode(n) {
-					err := Inst().S.DisableSchedulingOnNode(n)
-					Expect(err).NotTo(HaveOccurred())
-				}
+			nodes := node.GetNodes()
+			storageNodes := node.GetStorageNodes()
+			if len(nodes) == len(storageNodes) {
+				Skip("No storageless nodes detected. Skipping..")
+			}
+			for _, n := range storageNodes {
+				err := Inst().S.DisableSchedulingOnNode(n)
+				Expect(err).NotTo(HaveOccurred())
 			}
 		})
 		Step("Deploy applications", func() {

--- a/tests/basic/basic_test.go
+++ b/tests/basic/basic_test.go
@@ -505,7 +505,7 @@ var _ = Describe("{CordonStorageNodesDeployDestroy}", func() {
 			contexts = make([]*scheduler.Context, 0)
 
 			for i := 0; i < Inst().GlobalScaleFactor; i++ {
-				contexts = append(contexts, ScheduleApplications(fmt.Sprintf("cordonstoragenodesdeploydestroy-%d", i))...)
+				contexts = append(contexts, ScheduleApplications(fmt.Sprintf("cordondeploydestroy-%d", i))...)
 			}
 			ValidateApplications(contexts)
 

--- a/tests/basic/basic_test.go
+++ b/tests/basic/basic_test.go
@@ -487,6 +487,62 @@ var _ = Describe("{CordonDeployDestroy}", func() {
 	})
 })
 
+var _ = Describe("{CordonStorageNodesDeployDestroy}", func() {
+	var contexts []*scheduler.Context
+
+	It("has to cordon all storage nodes, deploy and destroy app", func() {
+
+		Step("Cordon all storage nodes", func() {
+			nodes := node.GetWorkerNodes()
+			for _, node := range nodes {
+				if node.IsStorageDriverInstalled {
+					err := Inst().S.DisableSchedulingOnNode(node)
+					Expect(err).NotTo(HaveOccurred())
+				}
+			}
+		})
+		Step("Deploy applications", func() {
+			contexts = make([]*scheduler.Context, 0)
+
+			for i := 0; i < Inst().GlobalScaleFactor; i++ {
+				contexts = append(contexts, ScheduleApplications(fmt.Sprintf("cordonstoragenodesdeploydestroy-%d", i))...)
+			}
+			ValidateApplications(contexts)
+
+		})
+		Step("Destroy apps", func() {
+			opts := make(map[string]bool)
+			opts[scheduler.OptionsWaitForDestroy] = false
+			opts[scheduler.OptionsWaitForResourceLeakCleanup] = false
+			for _, ctx := range contexts {
+				err := Inst().S.Destroy(ctx, opts)
+				Expect(err).NotTo(HaveOccurred())
+			}
+		})
+		Step("Validate destroy", func() {
+			for _, ctx := range contexts {
+				err := Inst().S.WaitForDestroy(ctx, Inst().DestroyAppTimeout)
+				Expect(err).NotTo(HaveOccurred())
+			}
+		})
+		Step("teardown all apps", func() {
+			for _, ctx := range contexts {
+				TearDownContext(ctx, nil)
+			}
+		})
+		Step("Uncordon all nodes", func() {
+			nodes := node.GetWorkerNodes()
+			for _, node := range nodes {
+				err := Inst().S.EnableSchedulingOnNode(node)
+				Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	})
+	JustAfterEach(func() {
+		AfterEachTest(contexts)
+	})
+})
+
 var _ = AfterSuite(func() {
 	PerformSystemCheck()
 	ValidateCleanup()


### PR DESCRIPTION
We want to be able to run sharedv4 (or any apps) on storageless nodes for automation. This PR adds a new job that cordon all the storage nodes and then schedule applications on top of the rest of (storage less) nodes.

Signed-off-by: dahuang <dahuang@purestorage.com>


**What this PR does / why we need it**:
PWX-22507

**Which issue(s) this PR fixes** (optional)
This adds an additional test that cordon all storage nodes and runs the app on storageless nodes. Allowing automation for SharedV4 and SharedV4-svc.

**Special notes for your reviewer**:
Tested with Jenkins: http://jenkins.pwx.dev.purestorage.com/view/Control%20Plane/job/Torpedo/job/tp-eks-sharedv4-svc/12/

after refactoring: http://jenkins.pwx.dev.purestorage.com/view/Control%20Plane/job/Torpedo/job/tp-eks-sharedv4-svc/13/ 
