### PR TITLE
PWX-22505: sharedv4-svc failover tests by rebooting the NFS server node

### DIFF
--- a/drivers/node/ssh/ssh.go
+++ b/drivers/node/ssh/ssh.go
@@ -466,31 +466,39 @@ func (s *SSH) doCmdUsingPodWithoutRetry(n node.Node, cmd string) (string, error)
 }
 
 func (s *SSH) doCmdUsingPod(n node.Node, options node.ConnectionOpts, cmd string, ignoreErr bool) (string, error) {
-	cmds := []string{"nsenter", "--mount=/hostproc/1/ns/mnt", "/bin/bash", "-c", cmd}
+	var debugPod *v1.Pod
 
-	allPodsForNode, err := k8sCore.GetPodsByNode(n.Name, execPodDefaultNamespace)
-	if err != nil {
-		logrus.Errorf("failed to get pods in node: %s err: %v", n.Name, err)
+	findDebugPodFunc := func() (interface{}, bool, error) {
+		allPodsForNode, err := k8sCore.GetPodsByNode(n.Name, execPodDefaultNamespace)
+		if err != nil {
+			logrus.Errorf("failed to get pods in node: %s err: %v", n.Name, err)
+			return nil, true, err
+		}
+		for _, pod := range allPodsForNode.Items {
+			if pod.Labels["name"] == execPodDaemonSetLabel && k8sCore.IsPodReady(pod) {
+				debugPod = &pod
+				break
+			}
+		}
+
+		if debugPod == nil {
+			return nil, true, &node.ErrFailedToRunCommand{
+				Node:  n,
+				Cause: fmt.Sprintf("debug pod not found in node %v", n),
+			}
+		}
+		return nil, false, nil
+	}
+
+	logrus.Debugf("Finding the debug pod to run command on node %s", n.Name)
+	if _, err := task.DoRetryWithTimeout(findDebugPodFunc, options.Timeout, options.TimeBeforeRetry); err != nil {
 		return "", err
 	}
-	var debugPod *v1.Pod
-	for _, pod := range allPodsForNode.Items {
-		if pod.Labels["name"] == execPodDaemonSetLabel && k8sCore.IsPodReady(pod) {
-			debugPod = &pod
-			break
-		}
-	}
 
-	if debugPod == nil {
-		return "", &node.ErrFailedToRunCommand{
-			Node:  n,
-			Cause: fmt.Sprintf("debug pod not found in node %v", n),
-		}
-	}
-
+	cmds := []string{"nsenter", "--mount=/hostproc/1/ns/mnt", "/bin/bash", "-c", cmd}
 	t := func() (interface{}, bool, error) {
 		output, err := k8sCore.RunCommandInPod(cmds, debugPod.Name, "", debugPod.Namespace)
-		if ignoreErr == false && err != nil {
+		if !ignoreErr && err != nil {
 			return nil, true, &node.ErrFailedToRunCommand{
 				Node: n,
 				Cause: fmt.Sprintf("failed to run command in pod. command: %v , err: %v, pod: %v",

--- a/drivers/scheduler/k8s/specs/test-sv4-svc/pod.yaml
+++ b/drivers/scheduler/k8s/specs/test-sv4-svc/pod.yaml
@@ -3,7 +3,10 @@ kind: Deployment
 metadata:
   name: test-sv4-dep-svc
 spec:
-  replicas: 3
+  {{ if .Replicas }}
+  replicas: {{ .Replicas }}
+  {{ else }}
+  replicas: 3{{ end }}
   selector:
     matchLabels:
       app: test-sv4-app-svc
@@ -27,18 +30,24 @@ spec:
         image: portworx/sharedv4-test:torpedo
         imagePullPolicy: Always
         command: ["python", "/app/fileio.py"]
-        args: ["--lock", "--interval=0.25", "$(MY_FILE)"]
+        args: ["--lock", "--interval=0.25", "$(SHARED_FILE)", "$(LOCAL_FILE)"]
         env:
           - name: MY_POD_NAME
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-          - name: MY_FILE
+          - name: SHARED_FILE
             value: "/test-sv4-vol-svc/$(MY_POD_NAME)"
+          - name: LOCAL_FILE
+            value: "/local-vol/$(MY_POD_NAME)"
         volumeMounts:
         - name: test-sv4-vol-svc
           mountPath: /test-sv4-vol-svc
+        - name: local-vol
+          mountPath: /local-vol
       volumes:
       - name: test-sv4-vol-svc
         persistentVolumeClaim:
           claimName: test-sv4-pvc-svc
+      - name: local-vol
+        emptyDir: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
Automated the following test case:

C54385: Verify nfs server reboot doesn't cause app restart (with exceptions)

Also,
- added retries when getting PX pod (debug pod) after rebooting the node
- changed the test app to append to the file and use local storage to verify
  correctness (part of the test-sharedv4 repo)
- updated the app deployment to incorporate the changes to the app

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**Which issue(s) this PR fixes** (optional)
PWX-22505

**Special notes for your reviewer**:

