### PR TITLE
Add support for CRDs in torpedo spec decode/validate

### DIFF
--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -55,6 +55,8 @@ import (
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	storageapi "k8s.io/api/storage/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -506,6 +508,14 @@ func decodeSpec(specContents []byte) (runtime.Object, error) {
 			return nil, err
 		}
 
+		if err := apiextensionsv1beta1.AddToScheme(schemeObj); err != nil {
+			return nil, err
+		}
+
+		if err := apiextensionsv1.AddToScheme(schemeObj); err != nil {
+			return nil, err
+		}
+
 		codecs := serializer.NewCodecFactory(schemeObj)
 		obj, _, err = codecs.UniversalDeserializer().Decode([]byte(specContents), nil, nil)
 		if err != nil {
@@ -585,6 +595,10 @@ func validateSpec(in interface{}) (interface{}, error) {
 	} else if specObj, ok := in.(*monitoringv1.ServiceMonitor); ok {
 		return specObj, nil
 	} else if specObj, ok := in.(*corev1.Namespace); ok {
+		return specObj, nil
+	} else if specObj, ok := in.(*apiextensionsv1beta1.CustomResourceDefinition); ok {
+		return specObj, nil
+	} else if specObj, ok := in.(*apiextensionsv1.CustomResourceDefinition); ok {
 		return specObj, nil
 	}
 


### PR DESCRIPTION
Signed-off-by: Rohit-PX <rohit@portworx.com>


**What this PR does / why we need it**:

- Torpedo does not support CRDs currently. 
- We are planning to add operator tests in stork as well as in torpedo in the future
- These new tests will require torpedo support

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PTX-5032


**Special notes for your reviewer**:

