### PR TITLE
Adding a Recycle OCP API

### DIFF
--- a/drivers/node/node.go
+++ b/drivers/node/node.go
@@ -180,6 +180,12 @@ type Driver interface {
 
 	// SystemctlUnitExist checks if a given service exists in a node
 	SystemctlUnitExist(n Node, service string, options SystemctlOpts) (bool, error)
+
+	// AddMachine adds the new machine instance to existing map
+	AddMachine(machineName string) error
+
+	// PowerOnVmByName power on the VM using the vm name
+	PowerOnVmByName(vmName string) error
 }
 
 // Register registers the given node driver
@@ -366,5 +372,19 @@ func (d *notSupportedDriver) SystemctlUnitExist(node Node, service string, optio
 	return false, &errors.ErrNotSupported{
 		Type:      "Function",
 		Operation: "SystemctlUnitExist()",
+	}
+}
+
+func (d *notSupportedDriver) AddMachine(machineName string) error {
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "AddMachine()",
+	}
+}
+
+func (d *notSupportedDriver) PowerOnVmByName(vmName string) error {
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "PowerOnVmByName()",
 	}
 }

--- a/drivers/node/node.go
+++ b/drivers/node/node.go
@@ -184,8 +184,8 @@ type Driver interface {
 	// AddMachine adds the new machine instance to existing map
 	AddMachine(machineName string) error
 
-	// PowerOnVmByName power on the VM using the vm name
-	PowerOnVmByName(vmName string) error
+	// PowerOnVMByName power on the VM using the vm name
+	PowerOnVMByName(vmName string) error
 }
 
 // Register registers the given node driver
@@ -382,7 +382,7 @@ func (d *notSupportedDriver) AddMachine(machineName string) error {
 	}
 }
 
-func (d *notSupportedDriver) PowerOnVmByName(vmName string) error {
+func (d *notSupportedDriver) PowerOnVMByName(vmName string) error {
 	return &errors.ErrNotSupported{
 		Type:      "Function",
 		Operation: "PowerOnVmByName()",

--- a/drivers/node/node_registry.go
+++ b/drivers/node/node_registry.go
@@ -35,6 +35,17 @@ func UpdateNode(n Node) error {
 	return nil
 }
 
+// DeleteNode method delete a given node if exist in the node collection
+func DeleteNode(n Node) error {
+	if n.uuid == "" {
+		return fmt.Errorf("UUID should be set to delete existing node")
+	}
+	lock.Lock()
+	defer lock.Unlock()
+	delete(nodeRegistry, n.uuid)
+	return nil
+}
+
 // GetNodes returns all the nodes from the node collection
 func GetNodes() []Node {
 	var nodeList []Node
@@ -115,6 +126,16 @@ func Contains(nodes []Node, n Node) bool {
 		}
 	}
 	return false
+}
+
+// GetNodeByName returns a node which matches with given name
+func GetNodeByName(nodeName string) (Node, error) {
+	for _, n := range nodeRegistry {
+		if n.Name == nodeName {
+			return n, nil
+		}
+	}
+	return Node{}, fmt.Errorf("FAILED: Node [%s] not found in node registry", nodeName)
 }
 
 // CleanupRegistry removes entry of all nodes from registry

--- a/drivers/node/vsphere/vsphere.go
+++ b/drivers/node/vsphere/vsphere.go
@@ -119,14 +119,14 @@ func (v *vsphere) TestConnection(n node.Node, options node.ConnectionOpts) error
 	return err
 }
 
-func (v *vsphere) connect() error {
-
+// getVMFinder return find.Finder instance
+func (v *vsphere) getVMFinder() (*find.Finder, error) {
 	login := fmt.Sprintf("%s%s:%s@%s/sdk", Protocol, v.vsphereUsername, v.vspherePassword, v.vsphereHostIP)
 	logrus.Infof("Logging in to ESXi using: %s", login)
 
 	u, err := url.Parse(login)
 	if err != nil {
-		return fmt.Errorf("error parsing url %s", login)
+		return nil, fmt.Errorf("error parsing url %s", login)
 	}
 
 	v.ctx, v.cancel = context.WithCancel(context.Background())
@@ -134,7 +134,7 @@ func (v *vsphere) connect() error {
 
 	c, err := govmomi.NewClient(v.ctx, u, true)
 	if err != nil {
-		return fmt.Errorf("logging in error: %s", err.Error())
+		return nil, fmt.Errorf("logging in error: %s", err.Error())
 	}
 	logrus.Infof("Log in successful to vsphere:  %s:\n", v.vsphereHostIP)
 
@@ -143,11 +143,24 @@ func (v *vsphere) connect() error {
 	// Find one and only datacenter
 	dc, err := f.DefaultDatacenter(v.ctx)
 	if err != nil {
-		return fmt.Errorf("Failed to find data center: %v", err)
+		return nil, fmt.Errorf("Failed to find data center: %v", err)
 	}
 
 	// Make future calls local to this datacenter
 	f.SetDatacenter(dc)
+
+	return f, nil
+
+}
+
+func (v *vsphere) connect() error {
+	var f *find.Finder
+
+	// Getting finder instance
+	f, err := v.getVMFinder()
+	if err != nil {
+		return err
+	}
 
 	// Find virtual machines in datacenter
 	vms, err := f.VirtualMachineList(v.ctx, "*")
@@ -168,10 +181,30 @@ func (v *vsphere) connect() error {
 	return nil
 }
 
+// AddVM adds a new VM object to vmMap
+func (v *vsphere) AddMachine(vmName string) error {
+	var f *find.Finder
+
+	logrus.Infof("Adding VM: %s into vmMap  ", vmName)
+
+	f, err := v.getVMFinder()
+	if err != nil {
+		return err
+	}
+
+	vm, err := f.VirtualMachine(v.ctx, vmName)
+	if err != nil {
+		return err
+	}
+
+	vmMap[vm.Name()] = vm
+	return nil
+}
+
 // RebootVM reboots vsphere VM
 func (v *vsphere) RebootNode(n node.Node, options node.RebootNodeOpts) error {
 	if _, ok := vmMap[n.Name]; !ok {
-		return fmt.Errorf("Could not fetch VM for node: %s", n.Name)
+		return fmt.Errorf("could not fetch VM for node: %s", n.Name)
 	}
 
 	vm := vmMap[n.Name]
@@ -187,23 +220,55 @@ func (v *vsphere) RebootNode(n node.Node, options node.RebootNodeOpts) error {
 	return nil
 }
 
+// powerOnVM powers on VM by providing VM object
+func (v *vsphere) powerOnVM(vm *object.VirtualMachine) error {
+	// Checking the VM state before powering it On
+	powerState, err := vm.PowerState(v.ctx)
+	if err != nil {
+		return err
+	}
+
+	if powerState == types.VirtualMachinePowerStatePoweredOn {
+		logrus.Warn("VM is already in powered-on state: ", vm.Name())
+		return nil
+	}
+
+	tsk, err := vm.PowerOn(v.ctx)
+	if err != nil {
+		return fmt.Errorf("failed to power on %s: %v", vm.Name(), err)
+	}
+	if _, err := tsk.WaitForResult(v.ctx); err != nil {
+		return fmt.Errorf("failed to reboot VM %s. cause %v", vm.Name(), err)
+	}
+	return nil
+}
+
 // PowerOnVM powers on the VM if not already on
 func (v *vsphere) PowerOnVM(n node.Node) error {
 	var err error
 	vm := vmMap[n.Name]
 
 	logrus.Infof("Powering on VM: %s  ", vm.Name())
-	tsk, err := vm.PowerOn(v.ctx)
-	if err != nil {
-		return fmt.Errorf("Failed to power on %s: %v", vm.Name(), err)
-	}
-	if _, err := tsk.WaitForResult(v.ctx); err != nil {
+	if err = v.powerOnVM(vm); err != nil {
 		return &node.ErrFailedToRebootNode{
 			Node:  n,
 			Cause: fmt.Sprintf("failed to reboot VM %s. cause %v", vm.Name(), err),
 		}
 	}
 
+	return nil
+}
+
+// PowerOnVmByName powers on VM by using name
+func (v *vsphere) PowerOnVmByName(vmName string) error {
+	// Make sure vmName is part of vmMap before using this method
+	var err error
+	vm := vmMap[vmName]
+
+	logrus.Infof("Powering on VM: %s  ", vm.Name())
+	if err = v.powerOnVM(vm); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/drivers/node/vsphere/vsphere.go
+++ b/drivers/node/vsphere/vsphere.go
@@ -259,8 +259,8 @@ func (v *vsphere) PowerOnVM(n node.Node) error {
 	return nil
 }
 
-// PowerOnVmByName powers on VM by using name
-func (v *vsphere) PowerOnVmByName(vmName string) error {
+// PowerOnVMByName powers on VM by using name
+func (v *vsphere) PowerOnVMByName(vmName string) error {
 	// Make sure vmName is part of vmMap before using this method
 	var err error
 	vm := vmMap[vmName]

--- a/drivers/scheduler/dcos/dcos.go
+++ b/drivers/scheduler/dcos/dcos.go
@@ -830,6 +830,14 @@ func (d *dcos) ParseCharts(chartDir string) (*scheduler.HelmRepo, error) {
 	}
 }
 
+func (d *dcos) RecycleNode(n node.Node) error {
+	//Recycle is not supported
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "RecycleNode()",
+	}
+}
+
 func init() {
 	d := &dcos{}
 	scheduler.Register(SchedName, d)

--- a/drivers/scheduler/errors.go
+++ b/drivers/scheduler/errors.go
@@ -395,3 +395,52 @@ type ErrFailedToGetEvents struct {
 func (e *ErrFailedToGetEvents) Error() string {
 	return fmt.Sprintf("Failed to get Events for: [%v]%v due to err: %v", e.Type, e.Name, e.Cause)
 }
+
+// ErrFailedToDeleteNode error when we are unable to delete node
+type ErrFailedToDeleteNode struct {
+	// Node which failed to delete
+	Node node.Node
+
+	// Cause is the underlying cause of the error
+	Cause string
+}
+
+func (e *ErrFailedToDeleteNode) Error() string {
+	return fmt.Sprintf("Failed to Delete a Node : [%v] due to err: %v", e.Node.Name, e.Cause)
+}
+
+// ErrFailedToGetNode error when we are unable to get a new node
+type ErrFailedToGetNode struct {
+	// Cause is the underlying cause of the error
+	Cause string
+}
+
+func (e *ErrFailedToGetNode) Error() string {
+	return fmt.Sprintf("Failed to Get a Node due to err: %v", e.Cause)
+}
+
+// ErrFailedToUpdateNodeList error when we are unable to update a new node in node list
+type ErrFailedToUpdateNodeList struct {
+	// Node which failed to update
+	Node string
+
+	// Cause is the underlying cause of the error
+	Cause string
+}
+
+func (e *ErrFailedToUpdateNodeList) Error() string {
+	return fmt.Sprintf("Failed to Update a Node : [%v] due to err: %v", e.Node, e.Cause)
+}
+
+// ErrFailedToBringUpNode error when node failed to be up
+type ErrFailedToBringUpNode struct {
+	// Node which failed to start
+	Node string
+
+	// Cause is the underlying cause of the error
+	Cause error
+}
+
+func (e *ErrFailedToBringUpNode) Error() string {
+	return fmt.Sprintf("Failed to bring up a Node : [%v] due to err: %v", e.Node, e.Cause)
+}

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -32,6 +32,7 @@ import (
 	"github.com/portworx/sched-ops/k8s/batch"
 	k8sCommon "github.com/portworx/sched-ops/k8s/common"
 	"github.com/portworx/sched-ops/k8s/core"
+	schederrors "github.com/portworx/sched-ops/k8s/errors"
 	"github.com/portworx/sched-ops/k8s/externalstorage"
 	"github.com/portworx/sched-ops/k8s/networking"
 	"github.com/portworx/sched-ops/k8s/rbac"
@@ -4511,7 +4512,7 @@ func (k *K8s) CreateAutopilotRule(apRule apapi.AutopilotRule) (*apapi.AutopilotR
 			}
 		}
 		if err != nil {
-			return nil, true, fmt.Errorf("Failed to create autopilot rule: %v. Err: %v", apRule.Name, err)
+			return nil, true, fmt.Errorf("failed to create autopilot rule: %v. Err: %v", apRule.Name, err)
 		}
 		return aRule, false, nil
 	}
@@ -4697,7 +4698,7 @@ func createDockerRegistrySecret(secretName, secretNamespace string) (*v1.Secret,
 			}
 		}
 		if err != nil {
-			return nil, fmt.Errorf("Failed to create Docker registry secret: %s. Err: %v", secretName, err)
+			return nil, fmt.Errorf("failed to create Docker registry secret: %s. Err: %v", secretName, err)
 		}
 		logrus.Infof("Created Docker registry secret: %s", secret.Name)
 		return secret, nil

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -2252,6 +2252,89 @@ func (k *K8s) WaitForDestroy(ctx *scheduler.Context, timeout time.Duration) erro
 	return nil
 }
 
+// SelectiveWaitForTermination waits for application pods to be terminated except on the nodes
+// provided in the exclude list
+func (k *K8s) SelectiveWaitForTermination(ctx *scheduler.Context, timeout time.Duration, excludeList []node.Node) error {
+	t := func() (interface{}, bool, error) {
+		podNames, err := filterPodsByNodes(ctx, excludeList)
+		if err != nil {
+			return nil, true, err
+		}
+		if len(podNames) > 0 {
+			return nil, true, fmt.Errorf("pods %s still present in the system", podNames)
+		}
+		return nil, false, nil
+	}
+
+	if _, err := task.DoRetryWithTimeout(t, timeout, DefaultRetryInterval); err != nil {
+		return err
+	}
+	return nil
+}
+
+// filterPodsByNodes returns a list of pod names started as part of the provided context
+// and not running on the nodes provided in the exclude list
+func filterPodsByNodes(ctx *scheduler.Context, excludeList []node.Node) ([]string, error) {
+	allPods := make(map[types.UID]corev1.Pod)
+	namespaces := make(map[string]string)
+	for _, specObj := range ctx.App.SpecList {
+		var pods []corev1.Pod
+		var err error
+		if obj, ok := specObj.(*appsapi.Deployment); ok {
+			if pods, err = k8sApps.GetDeploymentPods(obj); err != nil && err != schederrors.ErrPodsNotFound {
+				return nil, &scheduler.ErrFailedToGetAppStatus{
+					App:   ctx.App,
+					Cause: fmt.Sprintf("Failed to get deployment: %v. Err: %v", obj.Name, err),
+				}
+			}
+			namespaces[obj.Namespace] = ""
+
+		} else if obj, ok := specObj.(*appsapi.StatefulSet); ok {
+			if pods, err = k8sApps.GetStatefulSetPods(obj); err != nil && err != schederrors.ErrPodsNotFound {
+				return nil, &scheduler.ErrFailedToGetAppStatus{
+					App:   ctx.App,
+					Cause: fmt.Sprintf("Failed to get statefulset: %v. Err: %v", obj.Name, err),
+				}
+			}
+			namespaces[obj.Namespace] = ""
+
+		} else if obj, ok := specObj.(*corev1.Pod); ok {
+			pod, err := k8sCore.GetPodByUID(obj.UID, obj.Namespace)
+			if err != nil && err != schederrors.ErrPodsNotFound {
+				return nil, &scheduler.ErrFailedToGetAppStatus{
+					App:   ctx.App,
+					Cause: fmt.Sprintf("Failed to get pod: %v. Err: %v", obj.Name, err),
+				}
+			}
+			if pod != nil {
+				pods = []corev1.Pod{*pod}
+				namespaces[obj.Namespace] = ""
+			}
+		}
+		for _, pod := range pods {
+			allPods[pod.UID] = pod
+		}
+	}
+
+	// Compare the two pod maps. Create a list of pod names which are not running
+	// on the excluded nodes
+	var podList []string
+	for _, pod := range allPods {
+		excludePod := false
+		for _, excludedNode := range excludeList {
+			if pod.Spec.NodeName == excludedNode.Name {
+				excludePod = true
+				break
+			}
+		}
+		if !excludePod {
+			podInfo := pod.Namespace + "/" + pod.Name + " (" + pod.Spec.NodeName + ")"
+			podList = append(podList, podInfo)
+		}
+	}
+	return podList, nil
+}
+
 // DeleteTasks delete the task
 func (k *K8s) DeleteTasks(ctx *scheduler.Context, opts *scheduler.DeleteTasksOptions) error {
 	fn := "DeleteTasks"

--- a/drivers/scheduler/openshift/openshift.go
+++ b/drivers/scheduler/openshift/openshift.go
@@ -2,6 +2,8 @@ package openshift
 
 import (
 	"fmt"
+	"io/ioutil"
+	"net/http"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -530,6 +532,10 @@ func (k *openshift) UpgradeScheduler(version string) error {
 		return err
 	}
 
+	if err := ackAPIRemoval(upgradeVersion); err != nil {
+		return err
+	}
+
 	if err := startUpgrade(upgradeVersion); err != nil {
 		return err
 	}
@@ -571,6 +577,57 @@ func getCluterInfo() string {
 		return ""
 	}
 	return output.(string)
+}
+
+func ackAPIRemoval(version string) error {
+	parsedVersion, err := getParsedVersion(version)
+	if err != nil {
+		return err
+	}
+	// this issue happens on OCP 4.9
+	parsedVersion49, _ := semver.Parse("4.9.0")
+
+	if parsedVersion.GTE(parsedVersion49) {
+		t := func() (interface{}, bool, error) {
+			var output []byte
+			patchData := "{\"data\":{\"ack-4.8-kube-1.22-api-removals-in-4.9\":\"true\"}}"
+			args := []string{"-n", "openshift-config", "patch", "cm", "admin-acks", "--type=merge", "--patch", patchData}
+			if output, err = exec.Command("oc", args...).CombinedOutput(); err != nil {
+				return nil, true, fmt.Errorf("failed to ack API removal due to %s. cause: %v", string(output), err)
+			}
+			logrus.Info(string(output))
+			return nil, false, nil
+		}
+		_, err = task.DoRetryWithTimeout(t, 1*time.Minute, 5*time.Second)
+	}
+	return err
+}
+
+func getParsedVersion(version string) (semver.Version, error) {
+	if versionReg.MatchString(version) {
+		cli := &http.Client{}
+		url := fmt.Sprintf("https://mirror.openshift.com/pub/openshift-v4/clients/ocp/%s/release.txt", version)
+		resp, err := cli.Get(url)
+		if err != nil {
+			return semver.Version{}, err
+		}
+		defer resp.Body.Close()
+		output, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return semver.Version{}, err
+		}
+		var re = regexp.MustCompile(`(?m)Name:\s+([\d.]+)`)
+		match := re.FindStringSubmatch(string(output))
+		if len(match) > 1 {
+			version = match[1]
+		}
+	}
+
+	parsedVersion, err := semver.Parse(version)
+	if err != nil {
+		return semver.Version{}, err
+	}
+	return parsedVersion, nil
 }
 
 func getClientVersion() (string, error) {
@@ -810,17 +867,7 @@ func downloadOCP4Client(ocpVersion string) error {
 // workaround for https://portworx.atlassian.net/browse/PWX-20465
 func fixOCPClusterStorageOperator(version string) error {
 
-	if versionReg.MatchString(version) {
-		url := fmt.Sprintf("https://mirror.openshift.com/pub/openshift-v4/clients/ocp/%s/release.txt", version)
-		command := []string{"-c", fmt.Sprintf("curl --silent -L %s | grep \"Name:\" || true", url)}
-		stdout, err := exec.Command("bash", command...).CombinedOutput()
-		if err != nil {
-			return err
-		}
-		version = strings.TrimSpace(strings.ReplaceAll(string(stdout), "Name:", ""))
-	}
-
-	parsedVersion, err := semver.Parse(version)
+	parsedVersion, err := getParsedVersion(version)
 	if err != nil {
 		return err
 	}

--- a/drivers/scheduler/openshift/openshift.go
+++ b/drivers/scheduler/openshift/openshift.go
@@ -2,14 +2,13 @@ package openshift
 
 import (
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"os/exec"
 	"regexp"
 	"strings"
 	"time"
 
 	"github.com/blang/semver"
+	"github.com/libopenstorage/openstorage/api"
 	openshiftv1 "github.com/openshift/api/config/v1"
 	"github.com/portworx/sched-ops/k8s/apiextensions"
 	k8s "github.com/portworx/sched-ops/k8s/core"
@@ -17,9 +16,11 @@ import (
 	opnshift "github.com/portworx/sched-ops/k8s/openshift"
 	"github.com/portworx/sched-ops/task"
 	"github.com/portworx/torpedo/drivers/node"
+	"github.com/portworx/torpedo/drivers/node/vsphere"
 	"github.com/portworx/torpedo/drivers/scheduler"
 	kube "github.com/portworx/torpedo/drivers/scheduler/k8s"
 	"github.com/portworx/torpedo/drivers/scheduler/spec"
+	"github.com/portworx/torpedo/drivers/volume"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -33,6 +34,7 @@ const (
 	// OpenshiftMirror is the mirror we use do download ocp client
 	OpenshiftMirror   = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp"
 	defaultCmdTimeout = 5 * time.Minute
+	driverUpTimeout   = 10 * time.Minute
 	defaultCmdRetry   = 15 * time.Second
 )
 
@@ -106,6 +108,299 @@ func (k *openshift) StartSchedOnNode(n node.Node) error {
 			Cause:         err.Error(),
 		}
 	}
+	return nil
+}
+
+// Check for newly create OCP node and retun OCP node
+func (k *openshift) checkAndGetNewNode() (string, error) {
+	var err error
+	var newNodeName string
+
+	// Waiting for new node to be ready
+	newNodeName, err = k.getAndWaitMachineToBeReady()
+	if err != nil {
+		// This is to handle error case when newly provisioned node not ready in 10 minutes
+		// Deleting the newly provisioned node and waiting for one more time before returning error
+		if len(newNodeName) != 0 {
+			k.deleteAMachine(newNodeName)
+		}
+		// Waiting for new node to be ready
+		newNodeName, err = k.getAndWaitMachineToBeReady()
+		if err != nil {
+			return newNodeName, err
+		}
+	}
+
+	// VM is up and ready. Waiting for other services to be up and joining it to cluster.
+	err = k.waitForJoinK8sNode(newNodeName)
+	if err != nil {
+		return newNodeName, err
+	}
+
+	return newNodeName, nil
+}
+
+// Waits for newly provisioned OCP node to be ready and running
+func (k *openshift) getAndWaitMachineToBeReady() (string, error) {
+	var err error
+	var isTriedOnce bool = false
+	var provState string = "Provisioned"
+	var driverName = k.K8s.NodeDriverName
+	logrus.Info("Using Node Driver: ", driverName)
+
+	t := func() (interface{}, bool, error) {
+
+		var output []byte
+		cmd := "kubectl get machines -n openshift-machine-api"
+		cmd += " --sort-by='.metadata.creationTimestamp' | tail -1"
+
+		output, err = exec.Command("sh", "-c", cmd).CombinedOutput()
+		result := strings.Fields(string(output))
+
+		if err != nil {
+			return "", true, fmt.Errorf(
+				"FAILED: Unable to get new OCP VM:[%s] status. cause: %v", result[0], err,
+			)
+		} else if strings.ToLower(result[1]) != "running" {
+			// Observed that OCP unable to power-on VM sometimes for vSphere driver
+			// Trying to power on the new VM once
+			if result[1] == provState && driverName == vsphere.DriverName && !isTriedOnce {
+				isTriedOnce = true
+				driver, _ := node.Get(driverName)
+				if err = driver.AddMachine(result[0]); err != nil {
+					return result[0], true, err
+				}
+				if err = driver.PowerOnVmByName(result[0]); err != nil {
+					return result[0], true, err
+				}
+			}
+			return result[0], true, &scheduler.ErrFailedToBringUpNode{
+				Node:  result[0],
+				Cause: fmt.Errorf("FAILED: OCP Unable to bring up the new node"),
+			}
+		}
+		return result[0], false, nil
+	}
+
+	output, err := task.DoRetryWithTimeout(t, 10*time.Minute, 30*time.Second)
+	if err != nil {
+		if output != nil {
+			return output.(string), err
+		}
+		return "", err
+	}
+	nodeName := output.(string)
+	logrus.Infof("New OCP VM: [%s] is up now", nodeName)
+	return nodeName, nil
+}
+
+// Wait for node to join k8s cluster
+func (k *openshift) waitForJoinK8sNode(node string) error {
+	t := func() (interface{}, bool, error) {
+		if err := k8sCore.IsNodeReady(node); err != nil {
+			return "", true, fmt.Errorf(
+				"FAILED: Waiting for new node:[%s] to join k8s cluster. cause: %v", node, err,
+			)
+		}
+		return "", false, nil
+	}
+	if _, err := task.DoRetryWithTimeout(t, 5*time.Minute, 10*time.Second); err != nil {
+		return err
+	}
+	logrus.Infof("New OCP VM: [%s] came up successfully and joined k8s cluster", node)
+	return nil
+}
+
+// Delete the OCP node using kubectl command
+func (k *openshift) deleteAMachine(nodeName string) error {
+	var err error
+
+	// Delete the node from machineset using kubectl command
+	t := func() (interface{}, bool, error) {
+		cmd := "kubectl delete machines -n openshift-machine-api " + nodeName
+		if _, err = exec.Command("sh", "-c", cmd).CombinedOutput(); err != nil {
+			return "", true, fmt.Errorf("failed to delete machine. cause: %v", err)
+		}
+		return "", false, nil
+	}
+	if _, err = task.DoRetryWithTimeout(t, 2*time.Minute, 60*time.Second); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Method to recycling OCP node
+func (k *openshift) RecycleNode(n node.Node) error {
+
+	// Check if node is valid before proceeding for delete a node
+	var worker []node.Node = node.GetWorkerNodes()
+	var delNode *api.StorageNode
+	var isStoragelessNode bool = false
+	if node.Contains(worker, n) {
+
+		// Check if node is meta node and set the meta flag
+		isKVDBNode := n.IsMetadataNode
+
+		// Get node info before deleting the node
+		volDriver, err := volume.Get(k.VolDriverName)
+		if err != nil {
+			return err
+		}
+
+		if delNode, err = volDriver.GetPxNode(&n); err != nil {
+			return err
+		}
+
+		// Get storageless nodes
+		storagelessNodes, err := volDriver.GetStoragelessNodes()
+		if err != nil {
+			return err
+		}
+
+		// Checking if given node is storageless node
+		if volDriver.Contains(storagelessNodes, delNode) {
+			logrus.Infof(
+				"PX node [%s] is storageless node and pool validation is not needed",
+				delNode.Hostname,
+			)
+			isStoragelessNode = true
+		}
+
+		logrus.Infof("Before recyling a node, Node [%s] is having following pools:",
+			delNode.Hostname,
+		)
+		for _, pool := range delNode.Pools {
+			logrus.Infof("Node [%s] is having pool id: [%s]", delNode.Hostname, pool.Uuid)
+
+		}
+		logrus.Infof("Before recyling a node, Node [%s] is having disks: [%v]",
+			delNode.Hostname, delNode.Disks,
+		)
+
+		// Delete the node from machines using kubectl command
+		logrus.Infof("Recycling the node [%s] having NodeId: [%s]", delNode.Hostname, delNode.Id)
+		if isKVDBNode {
+			logrus.Infof("Node [%s] is one of the KVDB node", delNode.Hostname)
+		}
+
+		// PowerOff machine before deleting the machine for vSphere driver
+		var driverName = k.K8s.NodeDriverName
+		if driverName == vsphere.DriverName {
+			driver, _ := node.Get(driverName)
+			driver.PowerOffVM(n)
+		}
+
+		err = k.deleteAMachine(n.Name)
+		if err != nil {
+			logrus.Errorf("Failed to delete OCP node: [%s] due to err: [%v]", n.Name, err)
+			return err
+		}
+
+		// Removing the node from the nodeRegistry
+		err = node.DeleteNode(n)
+		if err != nil {
+			return &scheduler.ErrFailedToUpdateNodeList{
+				Node: n.Name,
+				Cause: fmt.Sprintf(
+					"Failed to remove OCP node [%s] from node list. Error: [%v]", n.Name, err),
+			}
+
+		}
+		logrus.Infof("Successfully deleted the OCP node: [%s] ", n.Name)
+
+		// OCP creates a new node once the desired number of worker node count goes down
+		// Wait for OCP to provision new node and update new node to the k8s node list
+		newOCPNode, err := k.checkAndGetNewNode()
+		if err != nil {
+			return &scheduler.ErrFailedToGetNode{
+				Cause: fmt.Sprintf("Failed to get newly created OCP node name. Error: [%v]", err),
+			}
+		}
+
+		// Getting k8s node
+		newNode, err := k8sCore.GetNodeByName(newOCPNode)
+		if err != nil {
+			return err
+		}
+
+		//Adding a new node to a nodeRegistry
+		if err = k.AddNewNode(*newNode); err != nil {
+			return &scheduler.ErrFailedToUpdateNodeList{
+				Node: newOCPNode,
+				Cause: fmt.Sprintf(
+					"Failed to update new OCP node [%s] in node list. Error: [%v]", newOCPNode, err),
+			}
+		}
+
+		// Getting the node object for a new node
+		newlyProvNode, err := node.GetNodeByName(newOCPNode)
+		if err != nil {
+			return err
+		}
+
+		// Waits for px pod to be up in new node
+		if err = volDriver.WaitForPxPodsToBeUp(newlyProvNode); err != nil {
+			return err
+		}
+
+		// Validation is needed only when deleted node was StorageNode
+		if err = k.validateDrivesAfterNewNodePickUptheId(delNode, volDriver,
+			storagelessNodes, isStoragelessNode,
+		); err != nil {
+			return err
+		}
+
+		// Update the new node object with storage information
+		if err = volDriver.UpdateNodeWithStorageInfo(newlyProvNode); err != nil {
+			return err
+		}
+		logrus.Infof("Successfully updated the storage info for new node: [%s] ", newlyProvNode.Name)
+
+		// Getting the new node object after storage info updated
+		newlyProvNode, err = node.GetNodeByName(newlyProvNode.Name)
+		if err != nil {
+			return err
+		}
+
+		logrus.Infof("Waiting for driver to be come up on node: [%s] ", newlyProvNode.Name)
+
+		// Waiting and make sure driver to come up successfuly on newly provisoned node
+		if err = volDriver.WaitDriverUpOnNode(newlyProvNode, driverUpTimeout); err != nil {
+			return err
+		}
+		logrus.Infof("Driver came up successfully on node: [%s] ", newlyProvNode.Name)
+
+		return nil
+	}
+	return fmt.Errorf("FAILED: Node is not a worker node")
+}
+
+func (k *openshift) validateDrivesAfterNewNodePickUptheId(delNode *api.StorageNode,
+	volDriver volume.Driver, storagelessNodes []*api.StorageNode, isStoragelessNode bool) error {
+
+	logrus.Infof("Validating the pools and drives on new node")
+	// Validation is needed only when deleted node was StorageNode
+	if !isStoragelessNode {
+		// Wait for new node to pick up the deleted node ID
+		logrus.Infof("Waiting for NodeId [%s] to be picked by another node ", delNode.Id)
+		newPXNode, err := volDriver.WaitForNodeIdToBePickedByAnotherNode(delNode)
+		if err != nil {
+			return err
+		}
+		logrus.Infof("NodeId [%s] pick up by another node: [%s]", delNode.Id, newPXNode.Hostname)
+		logrus.Infof("Validating the node: [%s] after it picked the NodeId: [%s] ",
+			newPXNode.Hostname, delNode.Id,
+		)
+
+		err = volDriver.ValidateNodeAfterPickingUpNodeId(delNode, newPXNode, storagelessNodes)
+		if err != nil {
+			return err
+		}
+		logrus.Infof("Successfully validated the pools and drives on new node")
+		return nil
+	}
+	logrus.Infof("Skipping the pool and drives validation for storageless node: [%s]", delNode.Id)
 	return nil
 }
 
@@ -205,6 +500,11 @@ func (k *openshift) updateSecurityContextConstraints(namespace string) error {
 	return nil
 }
 
+// String returns the string name of this driver.
+func (k *openshift) String() string {
+	return SchedName
+}
+
 func (k *openshift) UpgradeScheduler(version string) error {
 	var err error
 
@@ -227,10 +527,6 @@ func (k *openshift) UpgradeScheduler(version string) error {
 	}
 
 	if err := fixOCPClusterStorageOperator(upgradeVersion); err != nil {
-		return err
-	}
-
-	if err := ackAPIRemoval(upgradeVersion); err != nil {
 		return err
 	}
 
@@ -514,7 +810,17 @@ func downloadOCP4Client(ocpVersion string) error {
 // workaround for https://portworx.atlassian.net/browse/PWX-20465
 func fixOCPClusterStorageOperator(version string) error {
 
-	parsedVersion, err := getParsedVersion(version)
+	if versionReg.MatchString(version) {
+		url := fmt.Sprintf("https://mirror.openshift.com/pub/openshift-v4/clients/ocp/%s/release.txt", version)
+		command := []string{"-c", fmt.Sprintf("curl --silent -L %s | grep \"Name:\" || true", url)}
+		stdout, err := exec.Command("bash", command...).CombinedOutput()
+		if err != nil {
+			return err
+		}
+		version = strings.TrimSpace(strings.ReplaceAll(string(stdout), "Name:", ""))
+	}
+
+	parsedVersion, err := semver.Parse(version)
 	if err != nil {
 		return err
 	}
@@ -568,57 +874,6 @@ func fixOCPClusterStorageOperator(version string) error {
 		}
 	}
 	return nil
-}
-
-func ackAPIRemoval(version string) error {
-	parsedVersion, err := getParsedVersion(version)
-	if err != nil {
-		return err
-	}
-	// this issue happens on OCP 4.9
-	parsedVersion49, _ := semver.Parse("4.9.0")
-
-	if parsedVersion.GTE(parsedVersion49) {
-		t := func() (interface{}, bool, error) {
-			var output []byte
-			patchData := "{\"data\":{\"ack-4.8-kube-1.22-api-removals-in-4.9\":\"true\"}}"
-			args := []string{"-n", "openshift-config", "patch", "cm", "admin-acks", "--type=merge", "--patch", patchData}
-			if output, err = exec.Command("oc", args...).CombinedOutput(); err != nil {
-				return nil, true, fmt.Errorf("failed to ack API removal due to %s. cause: %v", string(output), err)
-			}
-			logrus.Info(string(output))
-			return nil, false, nil
-		}
-		_, err = task.DoRetryWithTimeout(t, 1*time.Minute, 5*time.Second)
-	}
-	return err
-}
-
-func getParsedVersion(version string) (semver.Version, error) {
-	if versionReg.MatchString(version) {
-		cli := &http.Client{}
-		url := fmt.Sprintf("https://mirror.openshift.com/pub/openshift-v4/clients/ocp/%s/release.txt", version)
-		resp, err := cli.Get(url)
-		if err != nil {
-			return semver.Version{}, err
-		}
-		defer resp.Body.Close()
-		output, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return semver.Version{}, err
-		}
-		var re = regexp.MustCompile(`(?m)Name:\s+([\d.]+)`)
-		match := re.FindStringSubmatch(string(output))
-		if len(match) > 1 {
-			version = match[1]
-		}
-	}
-
-	parsedVersion, err := semver.Parse(version)
-	if err != nil {
-		return semver.Version{}, err
-	}
-	return parsedVersion, nil
 }
 
 func init() {

--- a/drivers/scheduler/openshift/openshift.go
+++ b/drivers/scheduler/openshift/openshift.go
@@ -172,7 +172,7 @@ func (k *openshift) getAndWaitMachineToBeReady() (string, error) {
 				if err = driver.AddMachine(result[0]); err != nil {
 					return result[0], true, err
 				}
-				if err = driver.PowerOnVmByName(result[0]); err != nil {
+				if err = driver.PowerOnVMByName(result[0]); err != nil {
 					return result[0], true, err
 				}
 			}
@@ -273,7 +273,7 @@ func (k *openshift) RecycleNode(n node.Node) error {
 			delNode.Hostname,
 		)
 		for _, pool := range delNode.Pools {
-			logrus.Infof("Node [%s] is having pool id: [%s]", delNode.Hostname, pool.Uuid)
+			logrus.Infof("Node [%s] is having pool ID: [%s]", delNode.Hostname, pool.Uuid)
 
 		}
 		logrus.Infof("Before recyling a node, Node [%s] is having disks: [%v]",
@@ -281,7 +281,7 @@ func (k *openshift) RecycleNode(n node.Node) error {
 		)
 
 		// Delete the node from machines using kubectl command
-		logrus.Infof("Recycling the node [%s] having NodeId: [%s]", delNode.Hostname, delNode.Id)
+		logrus.Infof("Recycling the node [%s] having NodeID: [%s]", delNode.Hostname, delNode.Id)
 		if isKVDBNode {
 			logrus.Infof("Node [%s] is one of the KVDB node", delNode.Hostname)
 		}
@@ -347,7 +347,7 @@ func (k *openshift) RecycleNode(n node.Node) error {
 		}
 
 		// Validation is needed only when deleted node was StorageNode
-		if err = k.validateDrivesAfterNewNodePickUptheId(delNode, volDriver,
+		if err = k.validateDrivesAfterNewNodePickUptheID(delNode, volDriver,
 			storagelessNodes, isStoragelessNode,
 		); err != nil {
 			return err
@@ -378,20 +378,20 @@ func (k *openshift) RecycleNode(n node.Node) error {
 	return fmt.Errorf("FAILED: Node is not a worker node")
 }
 
-func (k *openshift) validateDrivesAfterNewNodePickUptheId(delNode *api.StorageNode,
+func (k *openshift) validateDrivesAfterNewNodePickUptheID(delNode *api.StorageNode,
 	volDriver volume.Driver, storagelessNodes []*api.StorageNode, isStoragelessNode bool) error {
 
 	logrus.Infof("Validating the pools and drives on new node")
 	// Validation is needed only when deleted node was StorageNode
 	if !isStoragelessNode {
 		// Wait for new node to pick up the deleted node ID
-		logrus.Infof("Waiting for NodeId [%s] to be picked by another node ", delNode.Id)
+		logrus.Infof("Waiting for NodeID [%s] to be picked by another node ", delNode.Id)
 		newPXNode, err := volDriver.WaitForNodeIDToBePickedByAnotherNode(delNode)
 		if err != nil {
 			return err
 		}
-		logrus.Infof("NodeId [%s] pick up by another node: [%s]", delNode.Id, newPXNode.Hostname)
-		logrus.Infof("Validating the node: [%s] after it picked the NodeId: [%s] ",
+		logrus.Infof("NodeID [%s] pick up by another node: [%s]", delNode.Id, newPXNode.Hostname)
+		logrus.Infof("Validating the node: [%s] after it picked the NodeID: [%s] ",
 			newPXNode.Hostname, delNode.Id,
 		)
 

--- a/drivers/scheduler/openshift/openshift.go
+++ b/drivers/scheduler/openshift/openshift.go
@@ -386,7 +386,7 @@ func (k *openshift) validateDrivesAfterNewNodePickUptheId(delNode *api.StorageNo
 	if !isStoragelessNode {
 		// Wait for new node to pick up the deleted node ID
 		logrus.Infof("Waiting for NodeId [%s] to be picked by another node ", delNode.Id)
-		newPXNode, err := volDriver.WaitForNodeIdToBePickedByAnotherNode(delNode)
+		newPXNode, err := volDriver.WaitForNodeIDToBePickedByAnotherNode(delNode)
 		if err != nil {
 			return err
 		}
@@ -395,7 +395,7 @@ func (k *openshift) validateDrivesAfterNewNodePickUptheId(delNode *api.StorageNo
 			newPXNode.Hostname, delNode.Id,
 		)
 
-		err = volDriver.ValidateNodeAfterPickingUpNodeId(delNode, newPXNode, storagelessNodes)
+		err = volDriver.ValidateNodeAfterPickingUpNodeID(delNode, newPXNode, storagelessNodes)
 		if err != nil {
 			return err
 		}

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -316,6 +316,9 @@ type Driver interface {
 
 	// DeleteSecret deletes secret with given name in given namespace
 	DeleteSecret(namespace, name string) error
+
+	//RecyleNode deletes nodes with given node
+	RecycleNode(n node.Node) error
 }
 
 var (

--- a/drivers/volume/common.go
+++ b/drivers/volume/common.go
@@ -13,7 +13,6 @@ import (
 	driver_api "github.com/portworx/torpedo/drivers/api"
 	"github.com/portworx/torpedo/drivers/node"
 	"github.com/portworx/torpedo/pkg/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // DiagRequestConfig is a request object which provides all the configuration details
@@ -203,7 +202,7 @@ func (d *DefaultDriver) ValidateCreateGroupSnapshotUsingPxctl() error {
 	}
 }
 
-// ValidateGetByteUsedForVolume validates and returns byteUsed for given volume.
+//ValidateGetByteUsedForVolume validates and returns byteUsed for given volume.
 func (d *DefaultDriver) ValidateGetByteUsedForVolume(volumeName string, params map[string]string) (uint64, error) {
 	return 0, &errors.ErrNotSupported{
 		Type:      "Function",
@@ -211,7 +210,7 @@ func (d *DefaultDriver) ValidateGetByteUsedForVolume(volumeName string, params m
 	}
 }
 
-// ValidatePureVolumesNoReplicaSets validates Pure volumes has no replicaset.
+//ValidatePureVolumesNoReplicaSets validates Pure volumes has no replicaset.
 func (d *DefaultDriver) ValidatePureVolumesNoReplicaSets(volumeName string, params map[string]string) error {
 	return &errors.ErrNotSupported{
 		Type:      "Function",
@@ -446,22 +445,6 @@ func (d *DefaultDriver) ValidateStoragePools() error {
 	}
 }
 
-// ExpandPool resizes a pool of a given ID
-func (d *DefaultDriver) ExpandPool(poolUID string, operation api.SdkStoragePool_ResizeOperationType, size uint64) error {
-	return &errors.ErrNotSupported{
-		Type:      "Function",
-		Operation: "ExpandPool()",
-	}
-}
-
-// ListStoragePools lists all existing storage pools
-func (d *DefaultDriver) ListStoragePools(labelSelector metav1.LabelSelector) (map[string]*api.StoragePool, error) {
-	return nil, &errors.ErrNotSupported{
-		Type:      "Function",
-		Operation: "ListStoragePools()",
-	}
-}
-
 // ValidateRebalanceJobs validates rebalance jobs
 func (d *DefaultDriver) ValidateRebalanceJobs() error {
 	return &errors.ErrNotSupported{
@@ -529,7 +512,7 @@ func (d *DefaultDriver) RestartDriver(n node.Node, triggerOpts *driver_api.Trigg
 	}
 }
 
-// SetClusterOpts sets cluster options
+//SetClusterOpts sets cluster options
 func (d *DefaultDriver) SetClusterOpts(n node.Node, rtOpts map[string]string) error {
 	return &errors.ErrNotSupported{
 		Type:      "Function",
@@ -537,7 +520,7 @@ func (d *DefaultDriver) SetClusterOpts(n node.Node, rtOpts map[string]string) er
 	}
 }
 
-// ToggleCallHome toggles Call-home
+//ToggleCallHome toggles Call-home
 func (d *DefaultDriver) ToggleCallHome(n node.Node, enabled bool) error {
 	return &errors.ErrNotSupported{
 		Type:      "Function",
@@ -545,10 +528,59 @@ func (d *DefaultDriver) ToggleCallHome(n node.Node, enabled bool) error {
 	}
 }
 
-// UpdateSharedv4FailoverStrategyUsingPxctl updates the sharedv4 failover strategy using pxctl
-func (d *DefaultDriver) UpdateSharedv4FailoverStrategyUsingPxctl(volumeName string, strategy api.Sharedv4FailoverStrategy_Value) error {
+// GetPxNode return api.Storage Node
+func (d *DefaultDriver) GetPxNode(n *node.Node, nManagers ...api.OpenStorageNodeClient) (*api.StorageNode, error) {
+	return &api.StorageNode{}, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "GetPxNode()",
+	}
+}
+
+// Contains return
+func (d *DefaultDriver) Contains(nodes []*api.StorageNode, n *api.StorageNode) bool {
+	return false
+}
+
+// GetStoragelessNodes return storageless node list
+func (d *DefaultDriver) GetStoragelessNodes() ([]*api.StorageNode, error) {
+	return []*api.StorageNode{}, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "GetStoragelessNodes()",
+	}
+}
+
+// UpdateNodeWithStorageInfo updates storage info in new node object
+func (d *DefaultDriver) UpdateNodeWithStorageInfo(node.Node) error {
 	return &errors.ErrNotSupported{
 		Type:      "Function",
-		Operation: "UpdateSharedv4FailoverStrategyUsingPxctl",
+		Operation: "UpdateNodeWithStorageInfo()",
 	}
+
+}
+
+// WaitForNodeIdToBePickedByAnotherNode wait for new node to pick up the drives.
+func (d *DefaultDriver) WaitForNodeIdToBePickedByAnotherNode(
+	n *api.StorageNode) (*api.StorageNode, error) {
+	return &api.StorageNode{}, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "WaitForNodeIdToBePickedByAnotherNode()",
+	}
+}
+
+// ValidateNodeAfterPickingUpNodeId validates the node.
+func (d *DefaultDriver) ValidateNodeAfterPickingUpNodeId(
+	n1 *api.StorageNode, n2 *api.StorageNode, sn []*api.StorageNode) error {
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "ValidateNodeAfterPickingUpNodeId()",
+	}
+}
+
+// WaitForPxPodsToBeUp waits for px pods to be up
+func (d *DefaultDriver) WaitForPxPodsToBeUp(n node.Node) error {
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "WaitForPxPodsToBeUp()",
+	}
+
 }

--- a/drivers/volume/common.go
+++ b/drivers/volume/common.go
@@ -13,6 +13,7 @@ import (
 	driver_api "github.com/portworx/torpedo/drivers/api"
 	"github.com/portworx/torpedo/drivers/node"
 	"github.com/portworx/torpedo/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // DiagRequestConfig is a request object which provides all the configuration details
@@ -202,7 +203,7 @@ func (d *DefaultDriver) ValidateCreateGroupSnapshotUsingPxctl() error {
 	}
 }
 
-//ValidateGetByteUsedForVolume validates and returns byteUsed for given volume.
+// ValidateGetByteUsedForVolume validates and returns byteUsed for given volume.
 func (d *DefaultDriver) ValidateGetByteUsedForVolume(volumeName string, params map[string]string) (uint64, error) {
 	return 0, &errors.ErrNotSupported{
 		Type:      "Function",
@@ -210,7 +211,7 @@ func (d *DefaultDriver) ValidateGetByteUsedForVolume(volumeName string, params m
 	}
 }
 
-//ValidatePureVolumesNoReplicaSets validates Pure volumes has no replicaset.
+// ValidatePureVolumesNoReplicaSets validates Pure volumes has no replicaset.
 func (d *DefaultDriver) ValidatePureVolumesNoReplicaSets(volumeName string, params map[string]string) error {
 	return &errors.ErrNotSupported{
 		Type:      "Function",
@@ -445,6 +446,22 @@ func (d *DefaultDriver) ValidateStoragePools() error {
 	}
 }
 
+// ExpandPool resizes a pool of a given ID
+func (d *DefaultDriver) ExpandPool(poolUID string, operation api.SdkStoragePool_ResizeOperationType, size uint64) error {
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "ExpandPool()",
+	}
+}
+
+// ListStoragePools lists all existing storage pools
+func (d *DefaultDriver) ListStoragePools(labelSelector metav1.LabelSelector) (map[string]*api.StoragePool, error) {
+	return nil, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "ListStoragePools()",
+	}
+}
+
 // ValidateRebalanceJobs validates rebalance jobs
 func (d *DefaultDriver) ValidateRebalanceJobs() error {
 	return &errors.ErrNotSupported{
@@ -512,7 +529,7 @@ func (d *DefaultDriver) RestartDriver(n node.Node, triggerOpts *driver_api.Trigg
 	}
 }
 
-//SetClusterOpts sets cluster options
+// SetClusterOpts sets cluster options
 func (d *DefaultDriver) SetClusterOpts(n node.Node, rtOpts map[string]string) error {
 	return &errors.ErrNotSupported{
 		Type:      "Function",
@@ -520,11 +537,19 @@ func (d *DefaultDriver) SetClusterOpts(n node.Node, rtOpts map[string]string) er
 	}
 }
 
-//ToggleCallHome toggles Call-home
+// ToggleCallHome toggles Call-home
 func (d *DefaultDriver) ToggleCallHome(n node.Node, enabled bool) error {
 	return &errors.ErrNotSupported{
 		Type:      "Function",
 		Operation: "ToggleCallHome()",
+	}
+}
+
+// UpdateSharedv4FailoverStrategyUsingPxctl updates the sharedv4 failover strategy using pxctl
+func (d *DefaultDriver) UpdateSharedv4FailoverStrategyUsingPxctl(volumeName string, strategy api.Sharedv4FailoverStrategy_Value) error {
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "UpdateSharedv4FailoverStrategyUsingPxctl",
 	}
 }
 

--- a/drivers/volume/common.go
+++ b/drivers/volume/common.go
@@ -583,8 +583,8 @@ func (d *DefaultDriver) UpdateNodeWithStorageInfo(node.Node) error {
 
 }
 
-// WaitForNodeIdToBePickedByAnotherNode wait for new node to pick up the drives.
-func (d *DefaultDriver) WaitForNodeIdToBePickedByAnotherNode(
+// WaitForNodeIDToBePickedByAnotherNode wait for new node to pick up the drives.
+func (d *DefaultDriver) WaitForNodeIDToBePickedByAnotherNode(
 	n *api.StorageNode) (*api.StorageNode, error) {
 	return &api.StorageNode{}, &errors.ErrNotSupported{
 		Type:      "Function",
@@ -592,8 +592,8 @@ func (d *DefaultDriver) WaitForNodeIdToBePickedByAnotherNode(
 	}
 }
 
-// ValidateNodeAfterPickingUpNodeId validates the node.
-func (d *DefaultDriver) ValidateNodeAfterPickingUpNodeId(
+// ValidateNodeAfterPickingUpNodeID validates the node.
+func (d *DefaultDriver) ValidateNodeAfterPickingUpNodeID(
 	n1 *api.StorageNode, n2 *api.StorageNode, sn []*api.StorageNode) error {
 	return &errors.ErrNotSupported{
 		Type:      "Function",

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"io"
 	"math"
 	"net/http"
@@ -15,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"gopkg.in/yaml.v2"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/hashicorp/go-version"
@@ -74,9 +75,7 @@ const (
 	formattingCommandPxctlLocalSnapshotCreate = "pxctl volume snapshot create %s --name %s"
 	formattingCommandPxctlCloudSnapCreate     = "pxctl cloudsnap backup %s"
 	pxctlGroupSnapshotCreate                  = "pxctl volume snapshot group"
-	pxctlVolumeUpdate                         = "pxctl volume update "
 	refreshEndpointParam                      = "refresh-endpoint"
-	defaultPXAPITimeout                       = 5 * time.Minute
 )
 
 const (
@@ -170,72 +169,6 @@ type metadataNode struct {
 	ID         string   `json:"ID"`
 }
 
-// ExpandPool resizes a pool of a given ID
-func (d *portworx) ExpandPool(poolUUID string, operation api.SdkStoragePool_ResizeOperationType, size uint64) error {
-
-	logrus.Infof("Initiating pool %v resize by %v with operationtype %v", poolUUID, size, operation.String())
-
-	// start a task to check if pool  resize is done
-	t := func() (interface{}, bool, error) {
-		jobListResp, err := d.storagePoolManager.Resize(d.getContext(), &api.SdkStoragePoolResizeRequest{
-			Uuid: poolUUID,
-			ResizeFactor: &api.SdkStoragePoolResizeRequest_Size{
-				Size: size,
-			},
-			OperationType: operation,
-		})
-		if err != nil {
-			return nil, true, err
-		}
-		if jobListResp.String() != "" {
-			logrus.Debugf("Resize respone: %v", jobListResp.String())
-		}
-		return nil, false, nil
-	}
-	if _, err := task.DoRetryWithTimeout(t, validateRebalanceJobsTimeout, validateRebalanceJobsInterval); err != nil {
-		return err
-	}
-	return nil
-}
-
-// ListStoragePools returns all PX storage pools
-func (d *portworx) ListStoragePools(labelSelector metav1.LabelSelector) (map[string]*api.StoragePool, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultPXAPITimeout)
-	defer cancel()
-
-	// TODO PX SDK currently does not have a way of directly getting storage pool objects.
-	// We need to list nodes and then inspect each node
-	resp, err := d.nodeManager.Enumerate(ctx, &api.SdkNodeEnumerateRequest{})
-	if err != nil {
-		return nil, err
-	}
-
-	pools := make(map[string]*api.StoragePool)
-	for _, nodeID := range resp.NodeIds {
-		logrus.Infof("<debug> NODE_ID: %s", nodeID)
-		nodeResp, err := d.nodeManager.Inspect(ctx, &api.SdkNodeInspectRequest{NodeId: nodeID})
-		if err != nil {
-			return nil, err
-		}
-
-		for _, pool := range nodeResp.Node.Pools {
-			matches := true
-			for k, v := range labelSelector.MatchLabels {
-				if v != pool.Labels[k] {
-					matches = false
-					break
-				}
-			}
-
-			if matches {
-				pools[pool.GetUuid()] = pool
-			}
-		}
-	}
-
-	return pools, nil
-}
-
 func (d *portworx) String() string {
 	return DriverName
 }
@@ -277,15 +210,8 @@ func (d *portworx) Init(sched, nodeDriver, token, storageProvisioner, csiGeneric
 		}
 	}
 
-	logrus.Infof("The following Portworx nodes are in the cluster:")
-	for _, n := range storageNodes {
-		logrus.Infof(
-			"Node UID: %v Node IP: %v Node Status: %v",
-			n.Id,
-			n.DataIp,
-			n.Status,
-		)
-	}
+	d.printNodes(storageNodes)
+
 	torpedovolume.StorageDriver = DriverName
 	// Set provisioner for torpedo
 	if storageProvisioner != "" {
@@ -328,6 +254,198 @@ func (d *portworx) updateNodes(pxNodes []*api.StorageNode) error {
 	}
 
 	return nil
+}
+
+func (d *portworx) printNodes(pxnodes []*api.StorageNode) {
+	logrus.Infof("The following Portworx nodes are in the cluster:")
+	for _, n := range pxnodes {
+		logrus.Infof(
+			"Node UID: %v Node IP: %v Node Status: %v",
+			n.Id,
+			n.DataIp,
+			n.Status,
+		)
+	}
+}
+
+// getStoragelessNode filter out storageless nodes from all px nodes and return it
+func (d *portworx) GetStoragelessNodes() ([]*api.StorageNode, error) {
+
+	storagelessNodes := make([]*api.StorageNode, 0)
+
+	pxnodes, err := d.getPxNodes()
+	if err != nil {
+		return storagelessNodes, err
+	}
+
+	for _, pxnode := range pxnodes {
+		if len(pxnode.Pools) == 0 {
+			storagelessNodes = append(storagelessNodes, pxnode)
+		}
+	}
+	return storagelessNodes, nil
+}
+
+// UpdateNodeWithStorageInfo update nthe storage info to a new node object
+func (d *portworx) UpdateNodeWithStorageInfo(n node.Node) error {
+
+	logrus.Infof("Updating the storage info for new node: [%s] ", n.Name)
+
+	// Getting all PX nodes
+	storageNodes, err := d.getPxNodes()
+	if err != nil {
+		return err
+	}
+
+	if err = d.updateNode(&n, storageNodes); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *portworx) WaitForPxPodsToBeUp(n node.Node) error {
+
+	// Check if PX pod is up
+	logrus.Debugf("checking if PX pod is up on node: %s", n.Name)
+	t := func() (interface{}, bool, error) {
+		if !d.schedOps.IsPXReadyOnNode(n) {
+			return "", true, &ErrFailedToWaitForPx{
+				Node:  n,
+				Cause: fmt.Sprintf("px pod is not ready on node: %s after %v", n.Name, validatePXStartTimeout),
+			}
+		}
+		return "", false, nil
+	}
+
+	if _, err := task.DoRetryWithTimeout(t, validatePXStartTimeout, defaultRetryInterval); err != nil {
+		return fmt.Errorf("PX pod failed to come up on node : [%s]. Error: [%v]", n.Name, err)
+	}
+	return nil
+}
+
+func (d *portworx) ValidateNodeAfterPickingUpNodeId(delNode *api.StorageNode,
+	newNode *api.StorageNode, storagelessNodes []*api.StorageNode) error {
+
+	// If node is a storageless node below validation steps not needed
+	if !d.validateNodeIdMigration(delNode, newNode, storagelessNodes) {
+		return fmt.Errorf("validation failed: NodeId:[%s] pick-up failed by new Node: [%s]",
+			delNode.Id, newNode.Hostname,
+		)
+	}
+	logrus.Infof("Pools and Disks are matching after new node:[%s] picked the NodeId: [%s]",
+		newNode.Hostname, newNode.Id,
+	)
+	logrus.Infof("After recyling a node, Node [%s] is having following pools:",
+		newNode.Hostname,
+	)
+	for _, pool := range newNode.Pools {
+		logrus.Infof("Node [%s] is having pool id: [%s]", newNode.Hostname, pool.Uuid)
+	}
+
+	logrus.Infof("After recyling a node, Node [%s] is having disks: [%v]",
+		newNode.Hostname, newNode.Disks,
+	)
+
+	return nil
+}
+
+// Contains checks if px node is present in the given list of px nodes
+func (d *portworx) Contains(nodes []*api.StorageNode, n *api.StorageNode) bool {
+	for _, value := range nodes {
+		if value.Hostname == n.Hostname {
+			return true
+		}
+	}
+	return false
+}
+
+// comparePoolsAndDisks compares pools and disks between two StorageNode objects
+func (d *portworx) comparePoolsAndDisks(srcNode *api.StorageNode,
+	dstNode *api.StorageNode) bool {
+	srcPools := srcNode.Pools
+	dstPools := dstNode.Pools
+
+	// comparing pool ids
+	if len(srcPools) != len(dstPools) {
+		return false
+	}
+
+	for x, pool := range srcPools {
+		if pool.Uuid != dstPools[x].Uuid {
+			logrus.Errorf("Source pools: [%v] not macthing with Destination pools: [%v]",
+				srcPools, dstPools)
+			return false
+		}
+	}
+
+	// Comparing disks
+	srcDisks := srcNode.Disks
+	dstDisks := dstNode.Disks
+
+	for disk, value := range srcDisks {
+		if !srcDisks[disk].Metadata && !dstDisks[disk].Metadata {
+			if value.Id != dstDisks[disk].Id {
+				return false
+			}
+		} else if srcDisks[disk].Metadata && dstDisks[disk].Metadata {
+			if value.Id != dstDisks[disk].Id {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// validateNodeIdMigration validate the nodeID is picked by another storageless node
+func (d *portworx) validateNodeIdMigration(delNode *api.StorageNode, newNode *api.StorageNode,
+	storagelessNodes []*api.StorageNode) bool {
+	// delNode is a deleted node and newNode is a node which picked the NodeId from delNode
+
+	// Validate that nodeID is picked up by the storage-less node
+	if len(storagelessNodes) != 0 && !d.Contains(storagelessNodes, newNode) {
+		logrus.Errorf("Delete NodeId [%s] is not pick up by storageless node", delNode.Id)
+		return false
+	}
+
+	// Validate that dirves and pool IDs are same after picking up by storage-less node
+	if !d.comparePoolsAndDisks(delNode, newNode) {
+		logrus.Errorf(
+			"Pools [%v] in deleted node are not macthing with new node pools [%v]",
+			delNode.Pools, newNode.Pools,
+		)
+		return false
+	}
+	return true
+}
+
+// waitForNodeIdToBePickedByAnotherNode Waits for a given nodeID to be picked up by another node
+func (d *portworx) WaitForNodeIdToBePickedByAnotherNode(
+	delNode *api.StorageNode) (*api.StorageNode, error) {
+
+	t := func() (interface{}, bool, error) {
+		nNode, err := d.getPxNodeById(delNode.Id)
+		if err != nil {
+			return nil, true, err
+		}
+		if nNode.Hostname == delNode.Hostname {
+			return nil, true, fmt.Errorf("waiting for NodeId %v to be picked by another node", delNode.Id)
+		}
+		if len(nNode.Pools) == 0 {
+			return nil, true, fmt.Errorf("waiting for storage to be up in node: [%s]", nNode.Hostname)
+		}
+		return nNode, false, nil
+	}
+
+	result, err := task.DoRetryWithTimeout(t, asyncTimeout, validateStoragePoolSizeInterval)
+	if err != nil {
+		return nil, err
+	}
+
+	if result == nil {
+		return nil, fmt.Errorf("failed to pick NodeId: [%s] by PX nodes in a cluster", delNode.Id)
+	}
+
+	return result.(*api.StorageNode), nil
 }
 
 func (d *portworx) updateNode(n *node.Node, pxNodes []*api.StorageNode) error {
@@ -531,7 +649,7 @@ func (d *portworx) CleanupVolume(volumeName string) error {
 	return nil
 }
 
-func (d *portworx) getPxNode(n *node.Node, nManager ...api.OpenStorageNodeClient) (*api.StorageNode, error) {
+func (d *portworx) GetPxNode(n *node.Node, nManager ...api.OpenStorageNodeClient) (*api.StorageNode, error) {
 	if len(nManager) == 0 {
 		nManager = []api.OpenStorageNodeClient{d.getNodeManager()}
 	}
@@ -542,7 +660,7 @@ func (d *portworx) getPxNode(n *node.Node, nManager ...api.OpenStorageNodeClient
 			logrus.Warnf("node %s with ID %s not found, trying to update node ID...", n.Name, n.VolDriverNodeID)
 			n, err = d.updateNodeID(n, nManager...)
 			if err == nil {
-				return d.getPxNode(n, nManager...)
+				return d.GetPxNode(n, nManager...)
 			}
 		}
 		return &api.StorageNode{Status: api.Status_STATUS_NONE}, err
@@ -570,7 +688,7 @@ func (d *portworx) getPxVersionOnNode(n node.Node, nodeManager ...api.OpenStorag
 
 	t := func() (interface{}, bool, error) {
 		logrus.Debugf("Getting PX Version on node [%s]", n.Name)
-		pxNode, err := d.getPxNode(&n, nodeManager...)
+		pxNode, err := d.GetPxNode(&n, nodeManager...)
 		if err != nil {
 			return "", false, err
 		}
@@ -589,7 +707,7 @@ func (d *portworx) getPxVersionOnNode(n node.Node, nodeManager ...api.OpenStorag
 }
 
 func (d *portworx) GetStorageDevices(n node.Node) ([]string, error) {
-	pxNode, err := d.getPxNode(&n)
+	pxNode, err := d.GetPxNode(&n)
 	if err != nil {
 		return nil, err
 	}
@@ -614,7 +732,7 @@ func (d *portworx) RecoverDriver(n node.Node) error {
 		return err
 	}
 	t = func() (interface{}, bool, error) {
-		apiNode, err := d.getPxNode(&n)
+		apiNode, err := d.GetPxNode(&n)
 		if err != nil {
 			return nil, true, err
 		}
@@ -642,7 +760,7 @@ func (d *portworx) RecoverDriver(n node.Node) error {
 	}
 
 	t = func() (interface{}, bool, error) {
-		apiNode, err := d.getPxNode(&n)
+		apiNode, err := d.GetPxNode(&n)
 		if err != nil {
 			return nil, true, err
 		}
@@ -866,31 +984,6 @@ func (d *portworx) ValidateCreateSnapshotUsingPxctl(volumeName string) error {
 		Timeout:         crashDriverTimeout,
 		TimeBeforeRetry: defaultRetryInterval,
 	})
-	if err != nil {
-		logrus.WithError(err).Error("error when creating local snapshot using PXCTL")
-		return err
-	}
-	return nil
-}
-
-func (d *portworx) UpdateSharedv4FailoverStrategyUsingPxctl(volumeName string, strategy api.Sharedv4FailoverStrategy_Value) error {
-	nodes := node.GetStorageDriverNodes()
-	var strategyStr string
-	if strategy == api.Sharedv4FailoverStrategy_NORMAL {
-		strategyStr = "normal"
-	} else if strategy == api.Sharedv4FailoverStrategy_AGGRESSIVE {
-		strategyStr = "aggressive"
-	} else {
-		return fmt.Errorf("invalid failover strategy: %v", strategy)
-	}
-	cmd := fmt.Sprintf("%s %s --sharedv4_failover_strategy %s", pxctlVolumeUpdate, volumeName, strategyStr)
-	_, err := d.nodeDriver.RunCommandWithNoRetry(
-		nodes[0],
-		cmd,
-		node.ConnectionOpts{
-			Timeout:         crashDriverTimeout,
-			TimeBeforeRetry: defaultRetryInterval,
-		})
 	if err != nil {
 		logrus.WithError(err).Error("error when creating local snapshot using PXCTL")
 		return err
@@ -1131,7 +1224,7 @@ func (d *portworx) StopDriver(nodes []node.Node, force bool, triggerOpts *driver
 	return driver_api.PerformTask(stopFn, triggerOpts)
 }
 
-// GetNodeForVolume returns the node on which volume is attached
+//GetNodeForVolume returns the node on which volume is attached
 func (d *portworx) GetNodeForVolume(vol *torpedovolume.Volume, timeout time.Duration, retryInterval time.Duration) (*node.Node, error) {
 	volumeName := d.schedOps.GetVolumeName(vol)
 	t := func() (interface{}, bool, error) {
@@ -1258,6 +1351,23 @@ func (d *portworx) getStorageNodesOnStart() ([]*api.StorageNode, error) {
 	return d.getPxNodes()
 }
 
+// getPxNodeById return px node by provding node id
+func (d *portworx) getPxNodeById(nodeId string) (*api.StorageNode, error) {
+
+	logrus.Infof("Getting the node using nodeId: [%s]", nodeId)
+	var nodeManager api.OpenStorageNodeClient = d.getNodeManager()
+
+	nodeResponse, err := nodeManager.Inspect(d.getContext(), &api.SdkNodeInspectRequest{NodeId: nodeId})
+	if err != nil {
+		return nil, err
+	}
+
+	if nodeResponse.Node.MgmtIp == "" {
+		return nil, fmt.Errorf("got an empty MgmtIp from SdkNodeInspectRequest")
+	}
+	return nodeResponse.Node, nil
+}
+
 func (d *portworx) getPxNodes(nManagers ...api.OpenStorageNodeClient) ([]*api.StorageNode, error) {
 	var nodeManager api.OpenStorageNodeClient
 	if nManagers == nil {
@@ -1293,7 +1403,7 @@ func (d *portworx) getPxNodes(nManagers ...api.OpenStorageNodeClient) ([]*api.St
 func (d *portworx) WaitDriverUpOnNode(n node.Node, timeout time.Duration) error {
 	logrus.Debugf("waiting for PX node to be up: %s", n.Name)
 	t := func() (interface{}, bool, error) {
-		logrus.Debugf("Getting node info: %s", n.Name)
+		logrus.Debugf("Getting node info for node: [%s]", n.Name)
 		nodeInspectResponse, err := d.getNodeManager().Inspect(d.getContext(), &api.SdkNodeInspectRequest{NodeId: n.VolDriverNodeID})
 
 		if err != nil {
@@ -2536,7 +2646,7 @@ func (d *portworx) CollectDiags(n node.Node, config *torpedovolume.DiagRequestCo
 func collectDiags(n node.Node, config *torpedovolume.DiagRequestConfig, diagOps torpedovolume.DiagOps, d *portworx) error {
 	var err error
 
-	pxNode, err := d.getPxNode(&n)
+	pxNode, err := d.GetPxNode(&n)
 	if err != nil {
 		return err
 	}
@@ -2606,7 +2716,7 @@ func collectAsyncDiags(n node.Node, config *torpedovolume.DiagRequestConfig, dia
 	diagsMgr := d.getDiagsManager()
 	jobMgr := d.getDiagsJobManager()
 
-	pxNode, err := d.getPxNode(&n)
+	pxNode, err := d.GetPxNode(&n)
 	if err != nil {
 		return err
 	}
@@ -2652,9 +2762,9 @@ func collectAsyncDiags(n node.Node, config *torpedovolume.DiagRequestConfig, dia
 		time.Sleep(5 * time.Second)
 	}
 
-	// TODO: Verify we can see the files once we return a filename
+	//TODO: Verify we can see the files once we return a filename
 	if diagOps.Validate {
-		pxNode, err := d.getPxNode(&n)
+		pxNode, err := d.GetPxNode(&n)
 		if err != nil {
 			return err
 		}

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -396,7 +396,7 @@ func (d *portworx) ValidateNodeAfterPickingUpNodeID(delNode *api.StorageNode,
 	newNode *api.StorageNode, storagelessNodes []*api.StorageNode) error {
 
 	// If node is a storageless node below validation steps not needed
-	if !d.validateNodeIdMigration(delNode, newNode, storagelessNodes) {
+	if !d.validateNodeIDMigration(delNode, newNode, storagelessNodes) {
 		return fmt.Errorf("validation failed: NodeId:[%s] pick-up failed by new Node: [%s]",
 			delNode.Id, newNode.Hostname,
 		)
@@ -465,8 +465,8 @@ func (d *portworx) comparePoolsAndDisks(srcNode *api.StorageNode,
 	return true
 }
 
-// validateNodeIdMigration validate the nodeID is picked by another storageless node
-func (d *portworx) validateNodeIdMigration(delNode *api.StorageNode, newNode *api.StorageNode,
+// validateNodeIDMigration validate the nodeID is picked by another storageless node
+func (d *portworx) validateNodeIDMigration(delNode *api.StorageNode, newNode *api.StorageNode,
 	storagelessNodes []*api.StorageNode) bool {
 	// delNode is a deleted node and newNode is a node which picked the NodeId from delNode
 
@@ -492,7 +492,7 @@ func (d *portworx) WaitForNodeIDToBePickedByAnotherNode(
 	delNode *api.StorageNode) (*api.StorageNode, error) {
 
 	t := func() (interface{}, bool, error) {
-		nNode, err := d.getPxNodeById(delNode.Id)
+		nNode, err := d.getPxNodeByID(delNode.Id)
 		if err != nil {
 			return nil, true, err
 		}
@@ -1445,13 +1445,13 @@ func (d *portworx) getStorageNodesOnStart() ([]*api.StorageNode, error) {
 	return d.getPxNodes()
 }
 
-// getPxNodeById return px node by provding node id
-func (d *portworx) getPxNodeById(nodeId string) (*api.StorageNode, error) {
+// getPxNodeByID return px node by provding node id
+func (d *portworx) getPxNodeByID(nodeID string) (*api.StorageNode, error) {
 
-	logrus.Infof("Getting the node using nodeId: [%s]", nodeId)
+	logrus.Infof("Getting the node using nodeId: [%s]", nodeID)
 	var nodeManager api.OpenStorageNodeClient = d.getNodeManager()
 
-	nodeResponse, err := nodeManager.Inspect(d.getContext(), &api.SdkNodeInspectRequest{NodeId: nodeId})
+	nodeResponse, err := nodeManager.Inspect(d.getContext(), &api.SdkNodeInspectRequest{NodeId: nodeID})
 	if err != nil {
 		return nil, err
 	}

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -391,7 +391,8 @@ func (d *portworx) WaitForPxPodsToBeUp(n node.Node) error {
 	return nil
 }
 
-func (d *portworx) ValidateNodeAfterPickingUpNodeId(delNode *api.StorageNode,
+// ValidateNodeAfterPickingUpNodeID validates the pools and drives
+func (d *portworx) ValidateNodeAfterPickingUpNodeID(delNode *api.StorageNode,
 	newNode *api.StorageNode, storagelessNodes []*api.StorageNode) error {
 
 	// If node is a storageless node below validation steps not needed
@@ -486,8 +487,8 @@ func (d *portworx) validateNodeIdMigration(delNode *api.StorageNode, newNode *ap
 	return true
 }
 
-// waitForNodeIdToBePickedByAnotherNode Waits for a given nodeID to be picked up by another node
-func (d *portworx) WaitForNodeIdToBePickedByAnotherNode(
+// waitForNodeIDToBePickedByAnotherNode Waits for a given nodeID to be picked up by another node
+func (d *portworx) WaitForNodeIDToBePickedByAnotherNode(
 	delNode *api.StorageNode) (*api.StorageNode, error) {
 
 	t := func() (interface{}, bool, error) {

--- a/drivers/volume/portworx/schedops/ocp-schedops.go
+++ b/drivers/volume/portworx/schedops/ocp-schedops.go
@@ -1,0 +1,12 @@
+package schedops
+
+// This is a subclass of k8sSchedOps
+// This is needed to differentiate k8s and OCP scheduler
+type ocpSchedOps struct {
+	k8sSchedOps
+}
+
+func init() {
+	k := &ocpSchedOps{}
+	Register("openshift", k)
+}

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -247,16 +247,16 @@ type Driver interface {
 	Contains([]*api.StorageNode, *api.StorageNode) bool
 
 	// UpdateNodeWithStorageInfo update a new node object
-	UpdateNodeWithStorageInfo(node.Node) error
+	UpdateNodeWithStorageInfo(n node.Node) error
 
 	// WaitForNodeIdToBePickedByAnotherNode wait for another node to pick the down node nodeId
-	WaitForNodeIdToBePickedByAnotherNode(*api.StorageNode) (*api.StorageNode, error)
+	WaitForNodeIDToBePickedByAnotherNode(n *api.StorageNode) (*api.StorageNode, error)
 
 	// ValidateNodeAfterPickingUpNodeId validates the new node pick the correct drives and pools
-	ValidateNodeAfterPickingUpNodeId(*api.StorageNode, *api.StorageNode, []*api.StorageNode) error
+	ValidateNodeAfterPickingUpNodeID(n1 *api.StorageNode, n2 *api.StorageNode, snList []*api.StorageNode) error
 
 	// WaitForPxPodsToBeUp waits for px pod to be up in given node
-	WaitForPxPodsToBeUp(node.Node) error
+	WaitForPxPodsToBeUp(n node.Node) error
 }
 
 // StorageProvisionerType provisioner to be used for torpedo volumes

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -10,6 +10,7 @@ import (
 	driver_api "github.com/portworx/torpedo/drivers/api"
 	"github.com/portworx/torpedo/drivers/node"
 	"github.com/portworx/torpedo/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Volume is a generic struct encapsulating volumes in the cluster
@@ -221,8 +222,17 @@ type Driver interface {
 	//ToggleCallHome toggles Call-home
 	ToggleCallHome(n node.Node, enabled bool) error
 
+	// UpdateSharedv4FailoverStrategyUsingPxctl updates the sharedv4 failover strategy using pxctl
+	UpdateSharedv4FailoverStrategyUsingPxctl(volumeName string, strategy api.Sharedv4FailoverStrategy_Value) error
+
 	// ValidateStorageCluster validates all the storage cluster components
 	ValidateStorageCluster(endpointURL, endpointVersion string) error
+
+	// ExpandPool resizes a pool of a given ID
+	ExpandPool(poolUID string, operation api.SdkStoragePool_ResizeOperationType, size uint64) error
+
+	// ListStoragePools lists all existing storage pools
+	ListStoragePools(labelSelector metav1.LabelSelector) (map[string]*api.StoragePool, error)
 
 	// GetPxNode return api.StorageNode
 	GetPxNode(*node.Node, ...api.OpenStorageNodeClient) (*api.StorageNode, error)

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -249,10 +249,10 @@ type Driver interface {
 	// UpdateNodeWithStorageInfo update a new node object
 	UpdateNodeWithStorageInfo(n node.Node) error
 
-	// WaitForNodeIdToBePickedByAnotherNode wait for another node to pick the down node nodeId
+	// WaitForNodeIDToBePickedByAnotherNode wait for another node to pick the down node nodeID
 	WaitForNodeIDToBePickedByAnotherNode(n *api.StorageNode) (*api.StorageNode, error)
 
-	// ValidateNodeAfterPickingUpNodeId validates the new node pick the correct drives and pools
+	// ValidateNodeAfterPickingUpNodeID validates the new node pick the correct drives and pools
 	ValidateNodeAfterPickingUpNodeID(n1 *api.StorageNode, n2 *api.StorageNode, snList []*api.StorageNode) error
 
 	// WaitForPxPodsToBeUp waits for px pod to be up in given node

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -10,7 +10,6 @@ import (
 	driver_api "github.com/portworx/torpedo/drivers/api"
 	"github.com/portworx/torpedo/drivers/node"
 	"github.com/portworx/torpedo/pkg/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Volume is a generic struct encapsulating volumes in the cluster
@@ -216,23 +215,38 @@ type Driver interface {
 	// GetLicenseSummary returns the activated license SKU and Features
 	GetLicenseSummary() (LicenseSummary, error)
 
-	// SetClusterOpts sets cluster options
+	//SetClusterOpts sets cluster options
 	SetClusterOpts(n node.Node, rtOpts map[string]string) error
 
-	// ToggleCallHome toggles Call-home
+	//ToggleCallHome toggles Call-home
 	ToggleCallHome(n node.Node, enabled bool) error
-
-	// UpdateSharedv4FailoverStrategyUsingPxctl updates the sharedv4 failover strategy using pxctl
-	UpdateSharedv4FailoverStrategyUsingPxctl(volumeName string, strategy api.Sharedv4FailoverStrategy_Value) error
 
 	// ValidateStorageCluster validates all the storage cluster components
 	ValidateStorageCluster(endpointURL, endpointVersion string) error
 
-	// ExpandPool resizes a pool of a given ID
-	ExpandPool(poolUID string, operation api.SdkStoragePool_ResizeOperationType, size uint64) error
+	// GetPxNode return api.StorageNode
+	GetPxNode(*node.Node, ...api.OpenStorageNodeClient) (*api.StorageNode, error)
 
-	// ListStoragePools lists all existing storage pools
-	ListStoragePools(labelSelector metav1.LabelSelector) (map[string]*api.StoragePool, error)
+	// GetStoragelessNodes() return list of storageless nodes
+	GetStoragelessNodes() ([]*api.StorageNode, error)
+
+	// RecyclePXHost Recycle a node and validate the storageless node picked all it drives
+	//RecyclePXHost(*node.Node) error
+
+	// Contains check if StorageNode list conatins a give node or not
+	Contains([]*api.StorageNode, *api.StorageNode) bool
+
+	// UpdateNodeWithStorageInfo update a new node object
+	UpdateNodeWithStorageInfo(node.Node) error
+
+	// WaitForNodeIdToBePickedByAnotherNode wait for another node to pick the down node nodeId
+	WaitForNodeIdToBePickedByAnotherNode(*api.StorageNode) (*api.StorageNode, error)
+
+	// ValidateNodeAfterPickingUpNodeId validates the new node pick the correct drives and pools
+	ValidateNodeAfterPickingUpNodeId(*api.StorageNode, *api.StorageNode, []*api.StorageNode) error
+
+	// WaitForPxPodsToBeUp waits for px pod to be up in given node
+	WaitForPxPodsToBeUp(node.Node) error
 }
 
 // StorageProvisionerType provisioner to be used for torpedo volumes

--- a/tests/openshift/ocp_node_recycle_test.go
+++ b/tests/openshift/ocp_node_recycle_test.go
@@ -1,0 +1,78 @@
+package tests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
+	. "github.com/onsi/gomega"
+	"github.com/portworx/torpedo/drivers/node"
+	. "github.com/portworx/torpedo/tests"
+	"github.com/sirupsen/logrus"
+)
+
+func TestOCPRecylceNode(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	var specReporters []Reporter
+	junitReporter := reporters.NewJUnitReporter("/testresults/junit_recycle.xml")
+	specReporters = append(specReporters, junitReporter)
+	RunSpecsWithDefaultAndCustomReporters(t, "Torpedo : Recycle", specReporters)
+}
+
+var _ = BeforeSuite(func() {
+	InitInstance()
+})
+
+// Sanity test for OCP Recycle method
+var _ = Describe("{RecycleOCPNode}", func() {
+
+	if Inst().S.String() != "openshift" {
+		fmt.Printf("Failed: This test is not supported for scheduler: [%s]", Inst().S.String())
+		Expect(Inst().S.String()).To(Equal("openshift"))
+	}
+
+	It("Validing the drives and pools after recyling a node", func() {
+		Step("Get the storage nodes and delete it", func() {
+			workerNodes := node.GetStorageDriverNodes()
+			var delNode = workerNodes[0]
+			Step(
+				fmt.Sprintf("Listing all nodes before recycling a storage node %s", delNode.Name),
+				func() {
+					workerNodes := node.GetWorkerNodes()
+					for x, wNode := range workerNodes {
+						logrus.Infof("WorkerNode[%d] is: [%s] and volDriverID is [%s]", x, wNode.Name, wNode.VolDriverNodeID)
+					}
+				})
+			Step(
+				fmt.Sprintf("Recycle a node: %s", delNode.Name),
+				func() {
+					err := Inst().S.RecycleNode(delNode)
+					Expect(err).NotTo(HaveOccurred(),
+						fmt.Sprintf("Failed to recycle a node [%s]. Error: [%v]", delNode.Name, err))
+
+				})
+			Step(
+				fmt.Sprintf("Listing all nodes after recycle a storage node %s", delNode.Name),
+				func() {
+					workerNodes := node.GetWorkerNodes()
+					for x, wNode := range workerNodes {
+						logrus.Infof("WorkerNode[%d] is: [%s] and volDriverID is [%s]", x, wNode.Name, wNode.VolDriverNodeID)
+					}
+				})
+		})
+	})
+})
+
+var _ = AfterSuite(func() {
+	PerformSystemCheck()
+	//ValidateCleanup()
+})
+
+func TestMain(m *testing.M) {
+	// call flag.Parse() here if TestMain uses flags
+	ParseFlags()
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Recycle a OCP Node from OCP cluster and wait for it to create new node.

Recycle OCP Node API performs followings steps:

1. Make sure node is a worker node before proceeding
2. Check the node is storage node or storage-less node
3. Collect the pools and drives information
4. Delete a OCP node from a OCP cluster
5. Remove the node from node list
6. Waits for OCP to provision  a new node
7. Waits for OCP VM to be ready
8. Waits for OCP node to join k8s cluster
9. Update the  new node to the node list (nodeRegistry node)
10. Wait for deleted node NodeId to be picked up by another node
11. Validate the another PX storage-less node picks the nodeID properly by validating the drives and pools ID later
12. Update the new nodeObject with storage info
13. Waits for volume driver to come up in a new node 
14. Added the ocp-schedops.go file for openshift 
15. Added a tests to validate RecycleAPI

**Which issue(s) this PR fixes** (optional)
Closes # PTX-4704 PTX-5034

**Special notes for your reviewer**:

DEV Test Job link: https://jenkins.portworx.dev/job/Torpedo/job/tp-dev-test/986/

LOGS:

`{RecycleOCPNode} 
  Validing the drives and pools after recyling a node
  /go/src/github.com/portworx/torpedo/tests/openshift/ocp_node_recycle_test.go:37
STEP: Get the storage nodes and delete it
STEP: Listing all nodes before recycling a storage node ocp-airgapfafbst02-q2v4g-worker-tzbrk
INFO[2022-02-06 20:09:29] WorkerNode[0] is: [ocp-airgapfafbst02-q2v4g-worker-x57z8] and volDriverID is [aacb720a-def1-4bc1-9218-5cb90e85f011] 
INFO[2022-02-06 20:09:29] WorkerNode[1] is: [ocp-airgapfafbst02-q2v4g-worker-t6rlf] and volDriverID is [1335afcf-2ae5-4d25-b469-85a95a7e1261] 
INFO[2022-02-06 20:09:29] WorkerNode[2] is: [ocp-airgapfafbst02-q2v4g-worker-n8zzx] and volDriverID is [dbee9cdd-e3fe-4ae2-9d2c-fc2e7db0d555] 
INFO[2022-02-06 20:09:29] WorkerNode[3] is: [ocp-airgapfafbst02-q2v4g-worker-qz8lq] and volDriverID is [0a39d1e2-b142-4f6d-9cc7-206c92105508] 
INFO[2022-02-06 20:09:29] WorkerNode[4] is: [ocp-airgapfafbst02-q2v4g-worker-tzbrk] and volDriverID is [f750eb93-cc47-4699-8510-d56c65d5d9eb] 
INFO[2022-02-06 20:09:29] WorkerNode[5] is: [ocp-airgapfafbst02-q2v4g-worker-5n9jz] and volDriverID is [49fbd4d5-d706-45b8-81a2-bfb0900ec656] 
INFO[2022-02-06 20:09:29] WorkerNode[6] is: [ocp-airgapfafbst02-q2v4g-worker-hj6s5] and volDriverID is [8abdff52-fe7e-4687-aaf2-6a6d1161ceae] 
STEP: Recycle a node: ocp-airgapfafbst02-q2v4g-worker-tzbrk

INFO[2022-02-06 20:09:49] testAndSetEndpoint failed for 172.30.18.185: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 172.30.18.185:9020: i/o timeout" 
INFO[2022-02-06 20:09:49] Getting new driver.                          
INFO[2022-02-06 20:09:49] Using 10.13.30.161:17017 as endpoint for portworx volume driver 
DEBU[2022-02-06 20:09:49] Inspecting node [ocp-airgapfafbst02-q2v4g-worker-tzbrk] with volume driver node id [f750eb93-cc47-4699-8510-d56c65d5d9eb] 
INFO[2022-02-06 20:10:09] testAndSetEndpoint failed for 172.30.18.185: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 172.30.18.185:9020: i/o timeout" 
INFO[2022-02-06 20:10:09] Getting new driver.                          
INFO[2022-02-06 20:10:11] Using 10.13.30.161:17017 as endpoint for portworx volume driver 
INFO[2022-02-06 20:10:11] Before recyling a node, Node [ocp-airgapfafbst02-q2v4g-worker-tzbrk] is having following pools: 
INFO[2022-02-06 20:10:11] Node [ocp-airgapfafbst02-q2v4g-worker-tzbrk] is having pool id: [edfa0275-e39f-4d4e-aa8c-f7ab0c77c27f] 
INFO[2022-02-06 20:10:11] Node [ocp-airgapfafbst02-q2v4g-worker-tzbrk] is having pool id: [d4b666cf-7c49-4a06-bd39-327fb9f1242b] 
INFO[2022-02-06 20:10:11] Before recyling a node, Node [ocp-airgapfafbst02-q2v4g-worker-tzbrk] is having disks: [map[/dev/mapper/3624a93702e5c57e44f014def000139c7p1:id:"1"  path:"/dev/mapper/3624a93702e5c57e44f014def000139c7p1"  medium:STORAGE_MEDIUM_SSD  online:true  size:3219128320  metadata:true /dev/mapper/3624a93702e5c57e44f014def000139c7p2:id:"1"  path:"/dev/mapper/3624a93702e5c57e44f014def000139c7p2"  medium:STORAGE_MEDIUM_SSD  online:true  seq_write:1.57493e+08  size:157841076224  used:7524581376  last_scan:{seconds:1643997114  nanos:672395340} /dev/mapper/3624a93702e5c57e44f014def000139c9:id:"2"  path:"/dev/mapper/3624a93702e5c57e44f014def000139c9"  medium:STORAGE_MEDIUM_SSD  online:true  size:161061273600  used:7524581376  last_scan:{seconds:1643997114  nanos:672413337} /dev/mapper/3624a93702e5c57e44f014def000139cb:id:"1"  path:"/dev/mapper/3624a93702e5c57e44f014def000139cb"  medium:STORAGE_MEDIUM_SSD  online:true  seq_write:1.69689e+08  size:268435456000  used:11832131584  last_scan:{seconds:1643997114  nanos:666866808}]] 
INFO[2022-02-06 20:10:11] Recycling the node [ocp-airgapfafbst02-q2v4g-worker-tzbrk] having NodeId: [f750eb93-cc47-4699-8510-d56c65d5d9eb] 
INFO[2022-02-06 20:10:11] 
Powering off VM: ocp-airgapfafbst02-q2v4g-worker-tzbrk   
INFO[2022-02-06 20:11:05] Successfully deleted the OCP node: [ocp-airgapfafbst02-q2v4g-worker-tzbrk] 

INFO[2022-02-06 20:11:05] Using Node Driver: vsphere                   
2022/02/06 20:11:06 Failed to bring up a Node : [ocp-airgapfafbst02-q2v4g-worker-wx2tm] due to err: FAILED: OCP Unable to bring up the new node Next retry in: 30s
INFO[2022-02-06 20:11:36] Adding VM: ocp-airgapfafbst02-q2v4g-worker-wx2tm into vmMap   
INFO[2022-02-06 20:11:36] Logging in to ESXi using: https://administrator@vsphere.local:P@$$w0rd!@vcsa.pwx.dev.purestorage.com/sdk 
INFO[2022-02-06 20:11:36] Log in successful to vsphere:  vcsa.pwx.dev.purestorage.com: 
INFO[2022-02-06 20:11:43] Powering on VM: ocp-airgapfafbst02-q2v4g-worker-wx2tm   
WARN[2022-02-06 20:11:43] VM: [%s] is already in powered-on state 
2022/02/06 20:11:43 Failed to bring up a Node : [ocp-airgapfafbst02-q2v4g-worker-wx2tm] due to err: FAILED: OCP Unable to bring up the new node Next retry in: 30s
2022/02/06 20:12:13 Failed to bring up a Node : [ocp-airgapfafbst02-q2v4g-worker-wx2tm] due to err: FAILED: OCP Unable to bring up the new node Next retry in: 30s
2022/02/06 20:12:44 Failed to bring up a Node : [ocp-airgapfafbst02-q2v4g-worker-wx2tm] due to err: FAILED: OCP Unable to bring up the new node Next retry in: 30s
2022/02/06 20:13:15 Failed to bring up a Node : [ocp-airgapfafbst02-q2v4g-worker-wx2tm] due to err: FAILED: OCP Unable to bring up the new node Next retry in: 30s
2022/02/06 20:13:45 Failed to bring up a Node : [ocp-airgapfafbst02-q2v4g-worker-wx2tm] due to err: FAILED: OCP Unable to bring up the new node Next retry in: 30s
2022/02/06 20:14:16 Failed to bring up a Node : [ocp-airgapfafbst02-q2v4g-worker-wx2tm] due to err: FAILED: OCP Unable to bring up the new node Next retry in: 30s
2022/02/06 20:14:47 Failed to bring up a Node : [ocp-airgapfafbst02-q2v4g-worker-wx2tm] due to err: FAILED: OCP Unable to bring up the new node Next retry in: 30s
2022/02/06 20:15:18 Failed to bring up a Node : [ocp-airgapfafbst02-q2v4g-worker-wx2tm] due to err: FAILED: OCP Unable to bring up the new node Next retry in: 30s

INFO[2022-02-06 20:15:48] New OCP VM: [ocp-airgapfafbst02-q2v4g-worker-wx2tm] is up now 

2022/02/06 20:15:48 FAILED: Waiting for new node:[ocp-airgapfafbst02-q2v4g-worker-wx2tm] to join k8s cluster. cause: node: ocp-airgapfafbst02-q2v4g-worker-wx2tm is not ready as condition: Ready ([container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?, Failed to initialize CSINode: error updating CSINode annotation: timed out waiting for the condition; caused by: nodes "ocp-airgapfafbst02-q2v4g-worker-wx2tm" not found]) is False. Reason: KubeletNotReady Next retry in: 10s
2022/02/06 20:15:58 FAILED: Waiting for new node:[ocp-airgapfafbst02-q2v4g-worker-wx2tm] to join k8s cluster. cause: node: ocp-airgapfafbst02-q2v4g-worker-wx2tm is not ready as condition: Ready (container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?) is False. Reason: KubeletNotReady Next retry in: 10s
2022/02/06 20:16:08 FAILED: Waiting for new node:[ocp-airgapfafbst02-q2v4g-worker-wx2tm] to join k8s cluster. cause: node: ocp-airgapfafbst02-q2v4g-worker-wx2tm is not ready as condition: Ready (container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?) is False. Reason: KubeletNotReady Next retry in: 10s
2022/02/06 20:16:18 FAILED: Waiting for new node:[ocp-airgapfafbst02-q2v4g-worker-wx2tm] to join k8s cluster. cause: node: ocp-airgapfafbst02-q2v4g-worker-wx2tm is not ready as condition: Ready (container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?) is False. Reason: KubeletNotReady Next retry in: 10s
2022/02/06 20:16:29 FAILED: Waiting for new node:[ocp-airgapfafbst02-q2v4g-worker-wx2tm] to join k8s cluster. cause: node: ocp-airgapfafbst02-q2v4g-worker-wx2tm is not ready as condition: Ready (container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?) is False. Reason: KubeletNotReady Next retry in: 10s

INFO[2022-02-06 20:16:39] New OCP VM: [ocp-airgapfafbst02-q2v4g-worker-wx2tm] came up successfully and joined k8s cluster 

INFO[2022-02-06 20:16:39] Parsed node [ocp-airgapfafbst02-q2v4g-worker-wx2tm] as Type: Worker, Zone: , Region  
DEBU[2022-02-06 20:16:39] checking if PX pod is up on node: ocp-airgapfafbst02-q2v4g-worker-wx2tm
 
INFO[2022-02-06 20:16:39] Validating the pools and drives on new node  
INFO[2022-02-06 20:16:39] Waiting for NodeId [f750eb93-cc47-4699-8510-d56c65d5d9eb] to be picked by another node  

INFO[2022-02-06 20:16:39] Getting the node using nodeId: [f750eb93-cc47-4699-8510-d56c65d5d9eb] 
INFO[2022-02-06 20:17:00] testAndSetEndpoint failed for 172.30.18.185: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 172.30.18.185:9020: i/o timeout" 
INFO[2022-02-06 20:17:00] Getting new driver.                          
INFO[2022-02-06 20:17:00] Using 10.13.31.109:17017 as endpoint for portworx volume driver 
2022/02/06 20:17:00 waiting for NodeId f750eb93-cc47-4699-8510-d56c65d5d9eb to be picked by another node Next retry in: 30s
INFO[2022-02-06 20:17:30] Getting the node using nodeId: [f750eb93-cc47-4699-8510-d56c65d5d9eb] 
INFO[2022-02-06 20:17:50] testAndSetEndpoint failed for 172.30.18.185: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 172.30.18.185:9020: i/o timeout" 
INFO[2022-02-06 20:17:50] Getting new driver.                          
INFO[2022-02-06 20:17:50] Using 10.13.30.116:17017 as endpoint for portworx volume driver 
2022/02/06 20:17:50 waiting for NodeId f750eb93-cc47-4699-8510-d56c65d5d9eb to be picked by another node Next retry in: 30s
INFO[2022-02-06 20:18:20] Getting the node using nodeId: [f750eb93-cc47-4699-8510-d56c65d5d9eb] 
INFO[2022-02-06 20:18:41] testAndSetEndpoint failed for 172.30.18.185: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 172.30.18.185:9020: i/o timeout" 
INFO[2022-02-06 20:18:41] Getting new driver.                          
INFO[2022-02-06 20:18:42] testAndSetEndpoint failed for 172.30.18.185: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 10.13.30.162:17017: connect: connection refused" 
INFO[2022-02-06 20:18:43] testAndSetEndpoint failed for 172.30.18.185: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 10.13.30.162:17017: connect: connection refused" 
INFO[2022-02-06 20:18:46] Using 10.13.31.109:17017 as endpoint for portworx volume driver 
2022/02/06 20:18:46 waiting for NodeId f750eb93-cc47-4699-8510-d56c65d5d9eb to be picked by another node Next retry in: 30s
INFO[2022-02-06 20:19:16] Getting the node using nodeId: [f750eb93-cc47-4699-8510-d56c65d5d9eb] 
INFO[2022-02-06 20:19:38] testAndSetEndpoint failed for 172.30.18.185: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 172.30.18.185:9020: i/o timeout" 
INFO[2022-02-06 20:19:38] Getting new driver.                          
INFO[2022-02-06 20:19:38] Using 10.13.30.161:17017 as endpoint for portworx volume driver 
2022/02/06 20:19:38 waiting for NodeId f750eb93-cc47-4699-8510-d56c65d5d9eb to be picked by another node Next retry in: 30s
INFO[2022-02-06 20:20:08] Getting the node using nodeId: [f750eb93-cc47-4699-8510-d56c65d5d9eb] 
INFO[2022-02-06 20:20:29] testAndSetEndpoint failed for 172.30.18.185: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 172.30.18.185:9020: i/o timeout" 
INFO[2022-02-06 20:20:29] Getting new driver.                          
INFO[2022-02-06 20:20:29] Using 10.13.31.109:17017 as endpoint for portworx volume driver

INFO[2022-02-06 20:20:29] NodeId [f750eb93-cc47-4699-8510-d56c65d5d9eb] pick up by another node: [ocp-airgapfafbst02-q2v4g-worker-wx2tm] 

INFO[2022-02-06 20:20:29] Validating the node: [ocp-airgapfafbst02-q2v4g-worker-wx2tm] after it picked the NodeId: [f750eb93-cc47-4699-8510-d56c65d5d9eb]  
INFO[2022-02-06 20:20:29] Pools and Disks are matching after new node:[ocp-airgapfafbst02-q2v4g-worker-wx2tm] picked the NodeId: [f750eb93-cc47-4699-8510-d56c65d5d9eb] 
INFO[2022-02-06 20:20:29] After recyling a node, Node [ocp-airgapfafbst02-q2v4g-worker-wx2tm] is having following pools: 
INFO[2022-02-06 20:20:29] Node [ocp-airgapfafbst02-q2v4g-worker-wx2tm] is having pool id: [edfa0275-e39f-4d4e-aa8c-f7ab0c77c27f] 
INFO[2022-02-06 20:20:29] Node [ocp-airgapfafbst02-q2v4g-worker-wx2tm] is having pool id: [d4b666cf-7c49-4a06-bd39-327fb9f1242b] 
INFO[2022-02-06 20:20:29] After recyling a node, Node [ocp-airgapfafbst02-q2v4g-worker-wx2tm] is having disks: [map[/dev/mapper/3624a93702e5c57e44f014def000139c7p1:id:"1"  path:"/dev/mapper/3624a93702e5c57e44f014def000139c7p1"  medium:STORAGE_MEDIUM_SSD  online:true  size:3219128320  metadata:true /dev/mapper/3624a93702e5c57e44f014def000139c7p2:id:"1"  path:"/dev/mapper/3624a93702e5c57e44f014def000139c7p2"  medium:STORAGE_MEDIUM_SSD  online:true  seq_write:1.57493e+08  size:157841076224  used:7524581376  last_scan:{seconds:1644178820  nanos:658463555} /dev/mapper/3624a93702e5c57e44f014def000139c9:id:"2"  path:"/dev/mapper/3624a93702e5c57e44f014def000139c9"  medium:STORAGE_MEDIUM_SSD  online:true  size:161061273600  used:7524581376  last_scan:{seconds:1644178820  nanos:658489412} /dev/mapper/3624a93702e5c57e44f014def000139cb:id:"1"  path:"/dev/mapper/3624a93702e5c57e44f014def000139cb"  medium:STORAGE_MEDIUM_SSD  online:true  seq_write:1.69689e+08  size:268435456000  used:11832131584  last_scan:{seconds:1644178820  nanos:652112472}]] 

INFO[2022-02-06 20:20:29] Successfully validated the pools and drives on new node

INFO[2022-02-06 20:20:29] Updating the storage info for new node: [ocp-airgapfafbst02-q2v4g-worker-wx2tm] 

INFO[2022-02-06 20:20:49] testAndSetEndpoint failed for 172.30.18.185: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 172.30.18.185:9020: i/o timeout" 
INFO[2022-02-06 20:20:49] Getting new driver.                          
INFO[2022-02-06 20:20:49] Using 10.13.30.161:17017 as endpoint for portworx volume driver 
INFO[2022-02-06 20:20:50] Updating node: <nil>                         
INFO[2022-02-06 20:20:50] PX is enabled on node ocp-airgapfafbst02-q2v4g-worker-wx2tm. 
INFO[2022-02-06 20:20:50] Checking PX node id:"f750eb93-cc47-4699-8510-d56c65d5d9eb"  cpu:4.242614707730986  mem_total:33711661056  mem_used:2030882816  mem_free:31680778240  status:STATUS_OK  disks:{key:"/dev/mapper/3624a93702e5c57e44f014def000139c7p1"  value:{id:"1"  path:"/dev/mapper/3624a93702e5c57e44f014def000139c7p1"  medium:STORAGE_MEDIUM_SSD  online:true  size:3219128320  metadata:true}}  disks:{key:"/dev/mapper/3624a93702e5c57e44f014def000139c7p2"  value:{id:"1"  path:"/dev/mapper/3624a93702e5c57e44f014def000139c7p2"  medium:STORAGE_MEDIUM_SSD  online:true  seq_write:1.57493e+08  size:157841076224  used:7524581376  last_scan:{seconds:1644178820  nanos:658463555}}}  disks:{key:"/dev/mapper/3624a93702e5c57e44f014def000139c9"  value:{id:"2"  path:"/dev/mapper/3624a93702e5c57e44f014def000139c9"  medium:STORAGE_MEDIUM_SSD  online:true  size:161061273600  used:7524581376  last_scan:{seconds:1644178820  nanos:658489412}}}  disks:{key:"/dev/mapper/3624a93702e5c57e44f014def000139cb"  value:{id:"1"  path:"/dev/mapper/3624a93702e5c57e44f014def000139cb"  medium:STORAGE_MEDIUM_SSD  online:true  seq_write:1.69689e+08  size:268435456000  used:11832131584  last_scan:{seconds:1644178820  nanos:652112472}}}  pools:{Cos:HIGH  Medium:STORAGE_MEDIUM_SSD  RaidLevel:"raid0"  TotalSize:268435456000  Used:11832131584  labels:{key:"beta.kubernetes.io/arch"  value:"amd64"}  labels:{key:"beta.kubernetes.io/os"  value:"linux"}  labels:{key:"iopriority"  value:"HIGH"}  labels:{key:"kubernetes.io/arch"  value:"amd64"}  labels:{key:"kubernetes.io/hostname"  value:"ocp-airgapfafbst02-q2v4g-worker-wx2tm"}  labels:{key:"kubernetes.io/os"  value:"linux"}  labels:{key:"medium"  value:"STORAGE_MEDIUM_SSD"}  labels:{key:"node-role.kubernetes.io/worker"  value:""}  labels:{key:"node.openshift.io/os_id"  value:"rhcos"}  uuid:"edfa0275-e39f-4d4e-aa8c-f7ab0c77c27f"}  pools:{ID:1  Cos:HIGH  Medium:STORAGE_MEDIUM_SSD  RaidLevel:"raid0"  TotalSize:318902349824  Used:15049162752  labels:{key:"beta.kubernetes.io/arch"  value:"amd64"}  labels:{key:"beta.kubernetes.io/os"  value:"linux"}  labels:{key:"iopriority"  value:"HIGH"}  labels:{key:"kubernetes.io/arch"  value:"amd64"}  labels:{key:"kubernetes.io/hostname"  value:"ocp-airgapfafbst02-q2v4g-worker-wx2tm"}  labels:{key:"kubernetes.io/os"  value:"linux"}  labels:{key:"medium"  value:"STORAGE_MEDIUM_SSD"}  labels:{key:"node-role.kubernetes.io/worker"  value:""}  labels:{key:"node.openshift.io/os_id"  value:"rhcos"}  uuid:"d4b666cf-7c49-4a06-bd39-327fb9f1242b"}  mgmt_ip:"10.13.30.162"  data_ip:"10.13.30.162"  hostname:"ocp-airgapfafbst02-q2v4g-worker-wx2tm"  node_labels:{key:"Data IP"  value:"10.13.30.162"}  node_labels:{key:"Kernel Version"  value:"4.18.0-305.28.1.el8_4.x86_64"}  node_labels:{key:"Management IP"  value:"10.13.30.162"}  node_labels:{key:"OS"  value:"Red Hat Enterprise Linux CoreOS 48.84.202111222303-0 (Ootpa)"}  node_labels:{key:"PX Version"  value:"2.9.1.1-1bb6c1a"}  scheduler_node_name:"ocp-airgapfafbst02-q2v4g-worker-wx2tm"  HWType:VirtualMachine  security_status:UNSECURED for address 10.13.30.162 
INFO[2022-02-06 20:20:50] Url to call http://172.30.18.185:9001        
WARN[2022-02-06 20:21:00] can not check if id:"f750eb93-cc47-4699-8510-d56c65d5d9eb"  cpu:4.242614707730986  mem_total:33711661056  mem_used:2030882816  mem_free:31680778240  status:STATUS_OK  disks:{key:"/dev/mapper/3624a93702e5c57e44f014def000139c7p1"  value:{id:"1"  path:"/dev/mapper/3624a93702e5c57e44f014def000139c7p1"  medium:STORAGE_MEDIUM_SSD  online:true  size:3219128320  metadata:true}}  disks:{key:"/dev/mapper/3624a93702e5c57e44f014def000139c7p2"  value:{id:"1"  path:"/dev/mapper/3624a93702e5c57e44f014def000139c7p2"  medium:STORAGE_MEDIUM_SSD  online:true  seq_write:1.57493e+08  size:157841076224  used:7524581376  last_scan:{seconds:1644178820  nanos:658463555}}}  disks:{key:"/dev/mapper/3624a93702e5c57e44f014def000139c9"  value:{id:"2"  path:"/dev/mapper/3624a93702e5c57e44f014def000139c9"  medium:STORAGE_MEDIUM_SSD  online:true  size:161061273600  used:7524581376  last_scan:{seconds:1644178820  nanos:658489412}}}  disks:{key:"/dev/mapper/3624a93702e5c57e44f014def000139cb"  value:{id:"1"  path:"/dev/mapper/3624a93702e5c57e44f014def000139cb"  medium:STORAGE_MEDIUM_SSD  online:true  seq_write:1.69689e+08  size:268435456000  used:11832131584  last_scan:{seconds:1644178820  nanos:652112472}}}  pools:{Cos:HIGH  Medium:STORAGE_MEDIUM_SSD  RaidLevel:"raid0"  TotalSize:268435456000  Used:11832131584  labels:{key:"beta.kubernetes.io/arch"  value:"amd64"}  labels:{key:"beta.kubernetes.io/os"  value:"linux"}  labels:{key:"iopriority"  value:"HIGH"}  labels:{key:"kubernetes.io/arch"  value:"amd64"}  labels:{key:"kubernetes.io/hostname"  value:"ocp-airgapfafbst02-q2v4g-worker-wx2tm"}  labels:{key:"kubernetes.io/os"  value:"linux"}  labels:{key:"medium"  value:"STORAGE_MEDIUM_SSD"}  labels:{key:"node-role.kubernetes.io/worker"  value:""}  labels:{key:"node.openshift.io/os_id"  value:"rhcos"}  uuid:"edfa0275-e39f-4d4e-aa8c-f7ab0c77c27f"}  pools:{ID:1  Cos:HIGH  Medium:STORAGE_MEDIUM_SSD  RaidLevel:"raid0"  TotalSize:318902349824  Used:15049162752  labels:{key:"beta.kubernetes.io/arch"  value:"amd64"}  labels:{key:"beta.kubernetes.io/os"  value:"linux"}  labels:{key:"iopriority"  value:"HIGH"}  labels:{key:"kubernetes.io/arch"  value:"amd64"}  labels:{key:"kubernetes.io/hostname"  value:"ocp-airgapfafbst02-q2v4g-worker-wx2tm"}  labels:{key:"kubernetes.io/os"  value:"linux"}  labels:{key:"medium"  value:"STORAGE_MEDIUM_SSD"}  labels:{key:"node-role.kubernetes.io/worker"  value:""}  labels:{key:"node.openshift.io/os_id"  value:"rhcos"}  uuid:"d4b666cf-7c49-4a06-bd39-327fb9f1242b"}  mgmt_ip:"10.13.30.162"  data_ip:"10.13.30.162"  hostname:"ocp-airgapfafbst02-q2v4g-worker-wx2tm"  node_labels:{key:"Data IP"  value:"10.13.30.162"}  node_labels:{key:"Kernel Version"  value:"4.18.0-305.28.1.el8_4.x86_64"}  node_labels:{key:"Management IP"  value:"10.13.30.162"}  node_labels:{key:"OS"  value:"Red Hat Enterprise Linux CoreOS 48.84.202111222303-0 (Ootpa)"}  node_labels:{key:"PX Version"  value:"2.9.1.1-1bb6c1a"}  scheduler_node_name:"ocp-airgapfafbst02-q2v4g-worker-wx2tm"  HWType:VirtualMachine  security_status:UNSECURED is metadata node 
INFO[2022-02-06 20:21:00] Successfully updated the storage info for new node: [ocp-airgapfafbst02-q2v4g-worker-wx2tm]  
INFO[2022-02-06 20:21:00] Waiting for driver to be come up on node: [ocp-airgapfafbst02-q2v4g-worker-wx2tm]  
DEBU[2022-02-06 20:21:00] waiting for PX node to be up: ocp-airgapfafbst02-q2v4g-worker-wx2tm 
DEBU[2022-02-06 20:21:00] Getting node info for node: [ocp-airgapfafbst02-q2v4g-worker-wx2tm] 
INFO[2022-02-06 20:21:20] testAndSetEndpoint failed for 172.30.18.185: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 172.30.18.185:9020: i/o timeout" 
INFO[2022-02-06 20:21:20] Getting new driver.                          
INFO[2022-02-06 20:21:20] Using 10.13.31.109:17017 as endpoint for portworx volume driver 
DEBU[2022-02-06 20:21:20] checking PX status on node: ocp-airgapfafbst02-q2v4g-worker-wx2tm 
INFO[2022-02-06 20:21:21] px on node: ocp-airgapfafbst02-q2v4g-worker-wx2tm is now up. status: STATUS_OK 
DEBU[2022-02-06 20:21:21] checking if PX pod is up on node: ocp-airgapfafbst02-q2v4g-worker-wx2tm 
DEBU[2022-02-06 20:21:21] px is fully operational on node: ocp-airgapfafbst02-q2v4g-worker-wx2tm 
INFO[2022-02-06 20:21:21] Driver came up successfully on node: [ocp-airgapfafbst02-q2v4g-worker-wx2tm]  
STEP: Listing all nodes after recycle a storage node ocp-airgapfafbst02-q2v4g-worker-tzbrk
INFO[2022-02-06 20:21:21] WorkerNode[0] is: [ocp-airgapfafbst02-q2v4g-worker-5n9jz] and volDriverID is [49fbd4d5-d706-45b8-81a2-bfb0900ec656] 
INFO[2022-02-06 20:21:21] WorkerNode[1] is: [ocp-airgapfafbst02-q2v4g-worker-hj6s5] and volDriverID is [8abdff52-fe7e-4687-aaf2-6a6d1161ceae] 
INFO[2022-02-06 20:21:21] WorkerNode[2] is: [ocp-airgapfafbst02-q2v4g-worker-n8zzx] and volDriverID is [dbee9cdd-e3fe-4ae2-9d2c-fc2e7db0d555] 
INFO[2022-02-06 20:21:21] WorkerNode[3] is: [ocp-airgapfafbst02-q2v4g-worker-qz8lq] and volDriverID is [0a39d1e2-b142-4f6d-9cc7-206c92105508] 
INFO[2022-02-06 20:21:21] WorkerNode[4] is: [ocp-airgapfafbst02-q2v4g-worker-wx2tm] and volDriverID is [f750eb93-cc47-4699-8510-d56c65d5d9eb] 
INFO[2022-02-06 20:21:21] WorkerNode[5] is: [ocp-airgapfafbst02-q2v4g-worker-t6rlf] and volDriverID is [1335afcf-2ae5-4d25-b469-85a95a7e1261] 
INFO[2022-02-06 20:21:21] WorkerNode[6] is: [ocp-airgapfafbst02-q2v4g-worker-x57z8] and volDriverID is [aacb720a-def1-4bc1-9218-5cb90e85f011] 

• [SLOW TEST:713.769 seconds]
{RecycleOCPNode}
/go/src/github.com/portworx/torpedo/tests/openshift/ocp_node_recycle_test.go:30
  Validing the drives and pools after recyling a node
  /go/src/github.com/portworx/torpedo/tests/openshift/ocp_node_recycle_test.go:37
------------------------------
STEP: verifying if core files are present on each node
INFO[2022-02-06 20:21:21] looking for core files on node ocp-airgapfafbst02-q2v4g-worker-5n9jz 
INFO[2022-02-06 20:21:22] looking for core files on node ocp-airgapfafbst02-q2v4g-worker-hj6s5 
INFO[2022-02-06 20:21:22] looking for core files on node ocp-airgapfafbst02-q2v4g-worker-n8zzx 
INFO[2022-02-06 20:21:23] looking for core files on node ocp-airgapfafbst02-q2v4g-worker-qz8lq 
INFO[2022-02-06 20:21:23] looking for core files on node ocp-airgapfafbst02-q2v4g-worker-wx2tm 
INFO[2022-02-06 20:21:24] looking for core files on node ocp-airgapfafbst02-q2v4g-worker-t6rlf 
INFO[2022-02-06 20:21:24] looking for core files on node ocp-airgapfafbst02-q2v4g-worker-x57z8 

JUnit report was created: /testresults/junit_recycle.xml

Ran 1 of 1 Specs in 1013.667 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
`