### PR TITLE
PWX 22789 failover test for maintenance mode

### DIFF
--- a/drivers/volume/common.go
+++ b/drivers/volume/common.go
@@ -141,6 +141,22 @@ func (d *DefaultDriver) RecoverDriver(n node.Node) error {
 	}
 }
 
+// EnterMaintenance puts the given node in maintenance mode
+func (d *DefaultDriver) EnterMaintenance(n node.Node) error {
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "EnterMaintenance()",
+	}
+}
+
+// ExitMaintenance exits the given node from maintenance mode
+func (d *DefaultDriver) ExitMaintenance(n node.Node) error {
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "ExitMaintenance()",
+	}
+}
+
 // GetDriverVersion Returns the pxctl version
 func (d *DefaultDriver) GetDriverVersion() (string, error) {
 	return "", &errors.ErrNotSupported{

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -620,6 +620,18 @@ func (d *portworx) GetStorageDevices(n node.Node) ([]string, error) {
 
 func (d *portworx) RecoverDriver(n node.Node) error {
 
+	if err := d.EnterMaintenance(n); err != nil {
+		return err
+	}
+
+	if err := d.ExitMaintenance(n); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *portworx) EnterMaintenance(n node.Node) error {
 	t := func() (interface{}, bool, error) {
 		if err := d.maintenanceOp(n, enterMaintenancePath); err != nil {
 			return nil, true, err
@@ -647,11 +659,11 @@ func (d *portworx) RecoverDriver(n node.Node) error {
 			Cause: err.Error(),
 		}
 	}
-	// TODO: refactor the function into two pieces, entermaintenance and exitmaintenance. So we don't need to have
-	// random sleep interval in the middle.
-	time.Sleep(30 * time.Second)
+	return nil
+}
 
-	t = func() (interface{}, bool, error) {
+func (d *portworx) ExitMaintenance(n node.Node) error {
+	t := func() (interface{}, bool, error) {
 		if err := d.maintenanceOp(n, exitMaintenancePath); err != nil {
 			return nil, true, err
 		}

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -124,7 +124,7 @@ var provisioners = map[torpedovolume.StorageProvisionerType]torpedovolume.Storag
 }
 
 var csiProvisionerOnly = map[torpedovolume.StorageProvisionerType]torpedovolume.StorageProvisionerType{
-	PortworxCsi:     "pxd.portworx.com",
+	PortworxCsi: "pxd.portworx.com",
 }
 
 var deleteVolumeLabelList = []string{
@@ -638,7 +638,7 @@ func (d *portworx) RecoverDriver(n node.Node) error {
 		if apiNode.Status == api.Status_STATUS_MAINTENANCE {
 			return nil, false, nil
 		}
-		return nil, true, fmt.Errorf("Node %v is not in Maintenance mode", n.Name)
+		return nil, true, fmt.Errorf("node %v is not in Maintenance mode", n.Name)
 	}
 
 	if _, err := task.DoRetryWithTimeout(t, maintenanceWaitTimeout, defaultRetryInterval); err != nil {
@@ -647,6 +647,10 @@ func (d *portworx) RecoverDriver(n node.Node) error {
 			Cause: err.Error(),
 		}
 	}
+	// TODO: refactor the function into two pieces, entermaintenance and exitmaintenance. So we don't need to have
+	// random sleep interval in the middle.
+	time.Sleep(30 * time.Second)
+
 	t = func() (interface{}, bool, error) {
 		if err := d.maintenanceOp(n, exitMaintenancePath); err != nil {
 			return nil, true, err

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -149,6 +149,12 @@ type Driver interface {
 	// failure.
 	RecoverDriver(n node.Node) error
 
+	// EnterMaintenance puts the given node in maintenance mode
+	EnterMaintenance(n node.Node) error
+
+	// ExitMaintenance exits the given node from maintenance mode
+	ExitMaintenance(n node.Node) error
+
 	// GetDriverVersion will return the pxctl version from the node
 	GetDriverVersion() (string, error)
 

--- a/tests/basic/sharedv4_svc_test.go
+++ b/tests/basic/sharedv4_svc_test.go
@@ -276,7 +276,7 @@ func (fm *failoverMethodRecover) doFailover(attachedNode *node.Node) {
 }
 
 func (fm *failoverMethodRecover) String() string {
-	return "reboot"
+	return "recover"
 }
 
 func (fm *failoverMethodRecover) getExpectedPodDeletions() []int {
@@ -1260,9 +1260,12 @@ func restartVolumeDriverOnNode(nodeObj *node.Node) {
 }
 
 func recoverVolumeDriverOnNode(nodeObj *node.Node) {
-	logrus.Infof("Stopping volume driver on node %s", nodeObj.Name)
+	logrus.Infof("Recovering volume driver on node %s", nodeObj.Name)
 	err := Inst().V.RecoverDriver(*nodeObj)
 	Expect(err).NotTo(HaveOccurred())
+
+	logrus.Infof("Sleep to allow the failover before restarting the volume driver on node %s", nodeObj.Name)
+	time.Sleep(60 * time.Second)
 
 	err = Inst().V.WaitDriverUpOnNode(*nodeObj, Inst().DriverStartTimeout)
 	Expect(err).NotTo(HaveOccurred())

--- a/tests/basic/sharedv4_svc_test.go
+++ b/tests/basic/sharedv4_svc_test.go
@@ -272,24 +272,24 @@ func (fm *failoverMethodReboot) sleepBetweenFailovers() time.Duration {
 	return 2 * time.Minute
 }
 
-type failoverMethodRecover struct {
+type failoverMethodMaintenance struct {
 }
 
-func (fm *failoverMethodRecover) doFailover(attachedNode *node.Node) {
+func (fm *failoverMethodMaintenance) doFailover(attachedNode *node.Node) {
 	recoverVolumeDriverOnNode(attachedNode)
 }
 
-func (fm *failoverMethodRecover) String() string {
+func (fm *failoverMethodMaintenance) String() string {
 	return "recover"
 }
 
-func (fm *failoverMethodRecover) getExpectedPodDeletions() []int {
+func (fm *failoverMethodMaintenance) getExpectedPodDeletions() []int {
 	// 1 or 2 pods may get deleted depending on what kubelet does on the rebooted node.
 	// The kubelet could set up the mount for the same pod or it could create a new pod.
-	return []int{1, 2}
+	return []int{2}
 }
 
-func (fm *failoverMethodRecover) sleepBetweenFailovers() time.Duration {
+func (fm *failoverMethodMaintenance) sleepBetweenFailovers() time.Duration {
 	return 30 * time.Second
 }
 
@@ -446,7 +446,7 @@ var _ = Describe("{Sharedv4SvcFunctional}", func() {
 		Context("{Shared4SvcRecoverNode}", func() {
 			BeforeEach(func() {
 				namespacePrefix = "recovernode-"
-				fm = &failoverMethodRecover{}
+				fm = &failoverMethodMaintenance{}
 				testrailID = 54375
 			})
 			testFailoverFailback()

--- a/tests/basic/sharedv4_svc_test.go
+++ b/tests/basic/sharedv4_svc_test.go
@@ -442,10 +442,10 @@ var _ = Describe("{Sharedv4SvcFunctional}", func() {
 			testFailoverFailback()
 		})
 
-		// test failover/failback by recover the node
-		Context("{Shared4SvcRecoverNode}", func() {
+		// test failover/failback by putting the node in maintenance mode
+		Context("{Shared4SvcMaintainNode}", func() {
 			BeforeEach(func() {
-				namespacePrefix = "recovernode-"
+				namespacePrefix = "maintainnode-"
 				fm = &failoverMethodMaintenance{}
 				testrailID = 54375
 			})

--- a/tests/basic/sharedv4_svc_test.go
+++ b/tests/basic/sharedv4_svc_test.go
@@ -284,8 +284,7 @@ func (fm *failoverMethodMaintenance) String() string {
 }
 
 func (fm *failoverMethodMaintenance) getExpectedPodDeletions() []int {
-	// 1 or 2 pods may get deleted depending on what kubelet does on the rebooted node.
-	// The kubelet could set up the mount for the same pod or it could create a new pod.
+	// 2 pods, one on the old NFS server and one on the new NFS server should be deleted.
 	return []int{2}
 }
 
@@ -445,7 +444,7 @@ var _ = Describe("{Sharedv4SvcFunctional}", func() {
 		// test failover/failback by putting the node in maintenance mode
 		Context("{Shared4SvcMaintainNode}", func() {
 			BeforeEach(func() {
-				namespacePrefix = "maintainnode-"
+				namespacePrefix = "maintainnode"
 				fm = &failoverMethodMaintenance{}
 				testrailID = 54375
 			})

--- a/tests/basic/sharedv4_svc_test.go
+++ b/tests/basic/sharedv4_svc_test.go
@@ -268,6 +268,10 @@ func (fm *failoverMethodReboot) getExpectedPodDeletions() []int {
 	return []int{1, 2}
 }
 
+func (fm *failoverMethodReboot) sleepBetweenFailovers() time.Duration {
+	return 2 * time.Minute
+}
+
 type failoverMethodRecover struct {
 }
 
@@ -285,8 +289,8 @@ func (fm *failoverMethodRecover) getExpectedPodDeletions() []int {
 	return []int{1, 2}
 }
 
-func (fm *failoverMethodReboot) sleepBetweenFailovers() time.Duration {
-	return 2 * time.Minute
+func (fm *failoverMethodRecover) sleepBetweenFailovers() time.Duration {
+	return 30 * time.Second
 }
 
 var _ = Describe("{Sharedv4SvcFunctional}", func() {
@@ -1263,9 +1267,6 @@ func recoverVolumeDriverOnNode(nodeObj *node.Node) {
 	logrus.Infof("Recovering volume driver on node %s", nodeObj.Name)
 	err := Inst().V.RecoverDriver(*nodeObj)
 	Expect(err).NotTo(HaveOccurred())
-
-	logrus.Infof("Sleep to allow the failover before restarting the volume driver on node %s", nodeObj.Name)
-	time.Sleep(60 * time.Second)
 
 	err = Inst().V.WaitDriverUpOnNode(*nodeObj, Inst().DriverStartTimeout)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR adds failover test for maintenance mode.
- We added a 30 sec sleep in the recover mode for the failover mode to operate. We should refactor this out later and put the sleep in the test instead of the driver function. 

**Which issue(s) this PR fixes** (optional)
Closes # PWX-22798

**Special notes for your reviewer**:
Testing note:
run with local torpedo with PX version 2.10.0-4c8fb75
```ginkgo --focus Shared4SvcRecoverNode  -v bin/basic.test -- -spec-dir `pwd`/drivers/scheduler/k8s/specs --app-list test-sv4-svc```
