### PR TITLE
PWX-22789 Remove using service Endpoints for maintainOp

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -2340,25 +2340,14 @@ func (d *portworx) getNodeManagerByAddress(addr string) (api.OpenStorageNodeClie
 
 func (d *portworx) maintenanceOp(n node.Node, op string) error {
 	var err error
-	// TODO replace by sdk call whenever it is available
-	pxdRestPort, err := getRestPort()
+
+	logrus.Warnf("unable to get service endpoint falling back to node addr: err=%v, skipPXSvcEndpoint=%v", err, d.skipPXSvcEndpoint)
+	pxdRestPort, err := getRestContainerPort()
 	if err != nil {
 		return err
 	}
-	var url, endpoint string
-	if !d.skipPXSvcEndpoint {
-		endpoint, err = d.schedOps.GetServiceEndpoint()
-	}
-	if err != nil || endpoint == "" {
-		logrus.Warnf("unable to get service endpoint falling back to node addr: err=%v, skipPXSvcEndpoint=%v", err, d.skipPXSvcEndpoint)
-		pxdRestPort, err = getRestContainerPort()
-		if err != nil {
-			return err
-		}
-		url = fmt.Sprintf("http://%s:%d", n.Addresses[0], pxdRestPort)
-	} else {
-		url = fmt.Sprintf("http://%s:%d", endpoint, pxdRestPort)
-	}
+	url := fmt.Sprintf("http://%s:%d", n.Addresses[0], pxdRestPort)
+
 	c, err := client.NewClient(url, "", "")
 	if err != nil {
 		return err

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -2340,8 +2340,9 @@ func (d *portworx) getNodeManagerByAddress(addr string) (api.OpenStorageNodeClie
 
 func (d *portworx) maintenanceOp(n node.Node, op string) error {
 	var err error
-
-	logrus.Warnf("unable to get service endpoint falling back to node addr: err=%v, skipPXSvcEndpoint=%v", err, d.skipPXSvcEndpoint)
+	// we are removing using service endpoint because services would
+	// return a random node endpoint the service chooses and puts it in maintenance.
+	// this would fail the status check in `EnterMaintenanc` and `ExitMaintenance`
 	pxdRestPort, err := getRestContainerPort()
 	if err != nil {
 		return err


### PR DESCRIPTION
In Enter/Exit Maintenance Mode, we make two calls: `maintenanceOp` for
putting the node in maintenance mode, and `getPxNode` for checking the
status of the node.

The issue with `maintenanceOp` with using serviceEndpoint was that it
calls to the services and return a random node endpoint the service choose.
Therefore, putting a random node in maintenance and failing the status check.

This PR aims to resolve the issue. For now, we remove getting the service
endpoint and use the node's address. If there's any concern or better way to do this,
feel free to comment.

Signed-off-by: dahuang <dahuang@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**Which issue(s) this PR fixes** (optional)
Closes # PWX22798

**Special notes for your reviewer**:
Testing note:
Tested with Shared4SvcMaintainNode
`ginkgo --focus Shared4SvcMaintainNode -v bin/basic.test -- -spec-dir `pwd`/drivers/scheduler/k8s/specs --app-list test-sv4-svc`
