### PR TITLE
PWX-22976: generate a packet trace during sharedv4 svc failover test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,12 @@ ifndef PKGS
 PKGS := $(shell GOFLAGS=-mod=vendor go list ./... 2>&1 | grep -v 'github.com/portworx/torpedo/tests')
 endif
 
+# To build just one test binary, use GINKGO_BUILD_ONE=<name> e.g. GINKGO_BUILD_ONE=basic make build
+GINKGO_BUILD_DIR=.
+ifdef GINKGO_BUILD_ONE
+	GINKGO_BUILD_DIR=./tests/$(GINKGO_BUILD_ONE)
+endif
+
 ifeq ($(BUILD_TYPE),debug)
 BUILDFLAGS := -gcflags "-N -l"
 endif
@@ -60,9 +66,9 @@ build:
 
 	(mkdir -p tools && cd tools && GO111MODULE=on go get github.com/onsi/ginkgo/ginkgo@v1.16.5)
 	(mkdir -p tools && cd tools && GO111MODULE=off go get github.com/onsi/gomega)
-	ginkgo build -r
+	ginkgo build -r $(GINKGO_BUILD_DIR)
 
-	find . -name '*.test' | awk '{cmd="cp  "$$1"  $(BIN)"; system(cmd)}'
+	find $(GINKGO_BUILD_DIR) -name '*.test' | awk '{cmd="cp  "$$1"  $(BIN)"; system(cmd)}'
 	chmod -R 755 bin/*
 
 vendor-update:

--- a/drivers/node/node.go
+++ b/drivers/node/node.go
@@ -392,6 +392,7 @@ func (d *notSupportedDriver) PowerOnVMByName(vmName string) error {
 	}
 }
 
+// IsUsingSSH returns true if the command will be run using ssh
 func (d *notSupportedDriver) IsUsingSSH() bool {
 	return false
 }

--- a/drivers/node/node.go
+++ b/drivers/node/node.go
@@ -129,6 +129,9 @@ type Driver interface {
 	// CrashNode Crashes the given node
 	CrashNode(node Node, options CrashNodeOpts) error
 
+	// IsUsingSSH returns true if the command will be run using ssh
+	IsUsingSSH() bool
+
 	// RunCommand runs the given command on the node and returns the output
 	RunCommand(node Node, command string, options ConnectionOpts) (string, error)
 
@@ -387,4 +390,8 @@ func (d *notSupportedDriver) PowerOnVMByName(vmName string) error {
 		Type:      "Function",
 		Operation: "PowerOnVmByName()",
 	}
+}
+
+func (d *notSupportedDriver) IsUsingSSH() bool {
+	return false
 }

--- a/drivers/node/ssh/ssh.go
+++ b/drivers/node/ssh/ssh.go
@@ -83,6 +83,7 @@ func getKeyFile(keypath string) (ssh_pkg.Signer, error) {
 	return pubkey, nil
 }
 
+// IsUsingSSH returns true if the command will be run using ssh
 func IsUsingSSH() bool {
 	return len(os.Getenv("TORPEDO_SSH_KEY")) > 0 || len(os.Getenv("TORPEDO_SSH_PASSWORD")) > 0
 }

--- a/drivers/node/ssh/ssh.go
+++ b/drivers/node/ssh/ssh.go
@@ -83,7 +83,7 @@ func getKeyFile(keypath string) (ssh_pkg.Signer, error) {
 	return pubkey, nil
 }
 
-func useSSH() bool {
+func IsUsingSSH() bool {
 	return len(os.Getenv("TORPEDO_SSH_KEY")) > 0 || len(os.Getenv("TORPEDO_SSH_PASSWORD")) > 0
 }
 
@@ -93,7 +93,7 @@ func (s *SSH) Init(nodeOpts node.InitOptions) error {
 
 	nodes := node.GetWorkerNodes()
 	var err error
-	if useSSH() {
+	if IsUsingSSH() {
 		err = s.initSSH()
 	} else {
 		err = s.initExecPod()
@@ -200,7 +200,7 @@ func (s *SSH) TestConnection(n node.Node, options node.ConnectionOpts) error {
 	var err error
 	var cmd string
 
-	if useSSH() {
+	if IsUsingSSH() {
 		cmd = "hostname"
 	} else {
 		cmd = "date"
@@ -347,7 +347,7 @@ func (s *SSH) RunCommand(n node.Node, command string, options node.ConnectionOpt
 
 // RunCommandWithNoRetry runs given command on given node but with no retries
 func (s *SSH) RunCommandWithNoRetry(n node.Node, command string, options node.ConnectionOpts) (string, error) {
-	if useSSH() {
+	if IsUsingSSH() {
 		return s.doCmdSSH(n, options, command, options.IgnoreError)
 	}
 	return s.doCmdUsingPodWithoutRetry(n, command)
@@ -435,7 +435,7 @@ func (s *SSH) SystemctlUnitExist(n node.Node, service string, options node.Syste
 
 func (s *SSH) doCmd(n node.Node, options node.ConnectionOpts, cmd string, ignoreErr bool) (string, error) {
 
-	if useSSH() {
+	if IsUsingSSH() {
 		return s.doCmdSSH(n, options, cmd, ignoreErr)
 	}
 	return s.doCmdUsingPod(n, options, cmd, ignoreErr)


### PR DESCRIPTION
**What this PR does / why we need it**:
Run tcpdump while the failover is in progress so that we can debug the
failures better.

Also, added an env variable to Makefile to build just a single test binary.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->


**Which issue(s) this PR fixes** (optional)
PWX-22976

**Special notes for your reviewer**:

