### PR TITLE
PWX-22988: wait for pod termination and increase the timeouts

### DIFF
--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -2133,7 +2133,7 @@ func (k *K8s) WaitForRunning(ctx *scheduler.Context, timeout, retryInterval time
 		}
 	}
 
-	t := func() (interface{}, bool, error) {
+	isPodTerminating := func() (interface{}, bool, error) {
 		var terminatingPods []string
 		pods, err := k.getPodsForApp(ctx)
 		// sadly, getPodsForApp returns an error if there are no pods
@@ -2153,7 +2153,7 @@ func (k *K8s) WaitForRunning(ctx *scheduler.Context, timeout, retryInterval time
 		return nil, false, nil
 	}
 
-	_, err := task.DoRetryWithTimeout(t, k8sDestroyTimeout, DefaultRetryInterval)
+	_, err := task.DoRetryWithTimeout(isPodTerminating, k8sDestroyTimeout, DefaultRetryInterval)
 	if err != nil {
 		logrus.Warnf("Timed out waiting for app %v's pods to terminate: %v", ctx.App.Key, err)
 		return err

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -101,7 +101,7 @@ const (
 	k8sNodeReadyTimeout    = 5 * time.Minute
 	volDirCleanupTimeout   = 5 * time.Minute
 	k8sObjectCreateTimeout = 2 * time.Minute
-	k8sDestroyTimeout      = 2 * time.Minute
+	k8sDestroyTimeout      = 5 * time.Minute
 	// FindFilesOnWorkerTimeout timeout for find files on worker
 	FindFilesOnWorkerTimeout = 1 * time.Minute
 	deleteTasksWaitTimeout   = 3 * time.Minute
@@ -2133,6 +2133,28 @@ func (k *K8s) WaitForRunning(ctx *scheduler.Context, timeout, retryInterval time
 		}
 	}
 
+	t := func() (interface{}, bool, error) {
+		var terminatingPods []string
+		pods, err := k.getPodsForApp(ctx)
+		if err != nil {
+			return nil, true, fmt.Errorf("failed to get pods for app %v: %w", ctx.App.Key, err)
+		}
+		for _, pod := range pods {
+			if !pod.DeletionTimestamp.IsZero() {
+				terminatingPods = append(terminatingPods, fmt.Sprintf("%s/%s", pod.Namespace, pod.Name))
+			}
+		}
+		if len(terminatingPods) > 0 {
+			return nil, true, fmt.Errorf("terminating pods: %v", terminatingPods)
+		}
+		return nil, false, nil
+	}
+
+	_, err := task.DoRetryWithTimeout(t, k8sDestroyTimeout, DefaultRetryInterval)
+	if err != nil {
+		logrus.Warnf("Timed out waiting for app %v's pods to terminate: %v", ctx.App.Key, err)
+		return err
+	}
 	return nil
 }
 

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -2136,7 +2136,10 @@ func (k *K8s) WaitForRunning(ctx *scheduler.Context, timeout, retryInterval time
 	t := func() (interface{}, bool, error) {
 		var terminatingPods []string
 		pods, err := k.getPodsForApp(ctx)
-		if err != nil {
+		// sadly, getPodsForApp returns an error if there are no pods
+		if err != schederrors.ErrPodsNotFound {
+			return nil, false, nil
+		} else if err != nil {
 			return nil, true, fmt.Errorf("failed to get pods for app %v: %w", ctx.App.Key, err)
 		}
 		for _, pod := range pods {

--- a/tests/sharedv4/sharedv4_test.go
+++ b/tests/sharedv4/sharedv4_test.go
@@ -49,41 +49,17 @@ var _ = Describe("{MultiVolumeMountsForSharedV4}", func() {
 		// set frequency mins depending on the chaos level
 		var frequency int
 		var timeout time.Duration
-		switch Inst().ChaosLevel {
-		case 10:
-			frequency = 100
-			timeout = 10 * time.Minute
-		case 9:
-			frequency = 90
-			timeout = 9 * time.Minute
-		case 8:
-			frequency = 80
-			timeout = 8 * time.Minute
-		case 7:
-			frequency = 70
-			timeout = 7 * time.Minute
-		case 6:
-			frequency = 60
-			timeout = 6 * time.Minute
-		case 5:
-			frequency = 50
-			timeout = 5 * time.Minute
-		case 4:
-			frequency = 40
-			timeout = 4 * time.Minute
-		case 3:
-			frequency = 30
-			timeout = 3 * time.Minute
-		case 2:
-			frequency = 20
-			timeout = 2 * time.Minute
-		case 1:
-			frequency = 10
-			timeout = 1 * time.Minute
-		default:
+
+		chaosLevel := Inst().ChaosLevel
+		if chaosLevel != 0 {
+			frequency = 10 * chaosLevel
+			timeout = (15 * time.Duration(chaosLevel) * time.Minute) / 10
+		} else {
 			frequency = 10
 			timeout = 1 * time.Minute
 		}
+		logrus.Infof("setting number of volumes=%v and app readiness timeout=%v for chaos level %v",
+			frequency, timeout, chaosLevel)
 
 		customAppConfig := scheduler.AppConfig{
 			ClaimsCount: frequency,


### PR DESCRIPTION
**What this PR does / why we need it**:
Added a new check in WaitForRunning() function to wait for the deleted
pods to terminate fully. This helps with debugging the test failures
by catching the pods stuck terminating state earlier and avoids
secondary issues such as "device or resource busy" errors during
sharedv4 failover.

Increased the app readiness timeouts by 50% in MultiVolumeMountsForSharedV4
test.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->



**Which issue(s) this PR fixes** (optional)
PWX-22988

**Special notes for your reviewer**:

