### PR TITLE
PWX-22804: Converted some Pure specs to use FB

### DIFF
--- a/drivers/scheduler/k8s/specs/mysql/pure/pure-storage-class.yaml
+++ b/drivers/scheduler/k8s/specs/mysql/pure/pure-storage-class.yaml
@@ -6,14 +6,7 @@ provisioner: pxd.portworx.com
 parameters:
   # Tests:
   # * FlashArray Direct Access w/ filesystem
-  # * Specifying filesystem type, creation options, and mount options
-  # * Specifying QoS
+  # * Default filesystem type (XFS), mount options and create options
+  # * No QoS
   backend: "pure_block"
-  max_iops: "30000"
-  max_bandwidth: "10G"
-  csi.storage.k8s.io/fstype: ext4
-  createoptions: -b 4096
-mountOptions:
-  - nosuid
-  - discard
 allowVolumeExpansion: true

--- a/drivers/scheduler/k8s/specs/nginx-without-enc/pure/pure-storage-class.yaml
+++ b/drivers/scheduler/k8s/specs/nginx-without-enc/pure/pure-storage-class.yaml
@@ -5,8 +5,7 @@ metadata:
   name: nginx-sc
 provisioner: pxd.portworx.com
 parameters:
-  backend: "pure_block"
-  iops_limit: "30000"
-  bandwidth_limit: "10G"
-  csi.storage.k8s.io/fstype: xfs
+  # Tests:
+  # * FlashBlade Direct Access
+  backend: "pure_file"
 allowVolumeExpansion: true

--- a/drivers/scheduler/k8s/specs/wordpress/pure/pure-storage-class.yaml
+++ b/drivers/scheduler/k8s/specs/wordpress/pure/pure-storage-class.yaml
@@ -5,8 +5,8 @@ metadata:
 provisioner: pxd.portworx.com
 parameters:
   backend: "pure_block"
-  iops_limit: "30000"
-  bandwidth_limit: "10G"
+  max_iops: "30000"
+  max_bandwidth: "10G"
   csi.storage.k8s.io/fstype: xfs
 allowVolumeExpansion: true
 ---
@@ -17,7 +17,7 @@ metadata:
 provisioner: pxd.portworx.com
 parameters:
   backend: "pure_block"
-  iops_limit: "30000"
-  bandwidth_limit: "10G"
+  max_iops: "30000"
+  max_bandwidth: "10G"
   csi.storage.k8s.io/fstype: xfs
 allowVolumeExpansion: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Quick fixup from the last PR, now that we don't have a "convert storage class" method we need to have different specs for both FA and FB. This sets up:
* Elasticsearch on FA DA with some filesystem options
* MySQL on FA DA with no extra options
* NGINX on FB DA


