### PR TITLE
PWX-23093 Validates all app counter is active before going into failover

### DIFF
--- a/tests/basic/sharedv4_svc_test.go
+++ b/tests/basic/sharedv4_svc_test.go
@@ -411,8 +411,8 @@ var _ = Describe("{Sharedv4SvcFunctional}", func() {
 										}
 										return (activeKeys == numPods)
 									}, 3*time.Minute, 10*time.Second).Should(BeTrue(),
-										"number of active keys did not match %v/%vfor volume %v (%v) for app %v",
-										activeKeys, len(countersBefore), vol.ID, apiVol.Id, ctx.App.Key)
+										"number of active keys did not match for volume %v (%v) for app %v. countersBefore map: %v",
+										vol.ID, apiVol.Id, ctx.App.Key, countersBefore)
 
 								})
 


### PR DESCRIPTION
Signed-off-by: dahuang <dahuang@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Reboot tests were sometimes failing because tests are not stable before going into the failover stage. This PR makes sure the number of active pods are the same as expected number of running pods before going into failover stage.

**Which issue(s) this PR fixes** (optional)
Closes # PWX-23093

**Special notes for your reviewer**:
Testing notes: 
Ran torpedo test locally and passed. 
