### PR TITLE
PWX-23197: increase the timeout when waiting for the app destroy

### DIFF
--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -2231,14 +2231,14 @@ func (k *K8s) Destroy(ctx *scheduler.Context, opts map[string]bool) error {
 	}
 
 	if value, ok := opts[scheduler.OptionsWaitForResourceLeakCleanup]; ok && value {
-		if err := k.WaitForDestroy(ctx, DefaultTimeout); err != nil {
+		if err := k.WaitForDestroy(ctx, k8sDestroyTimeout); err != nil {
 			return err
 		}
 		if err := k.waitForCleanup(ctx, podList); err != nil {
 			return err
 		}
 	} else if value, ok = opts[scheduler.OptionsWaitForDestroy]; ok && value {
-		if err := k.WaitForDestroy(ctx, DefaultTimeout); err != nil {
+		if err := k.WaitForDestroy(ctx, k8sDestroyTimeout); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
We were using 3 min timeout while waiting for the app to get destroyed. This
was not enough in some cases when the app can legitimately take longer
to go away. Moreover, a few other tests are already using 5 min timeout
for destroy. Changed the code in k8s.go to use the 5 min timeout as well.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->



**Which issue(s) this PR fixes** (optional)
PWX-23197

**Special notes for your reviewer**:

