### PR TITLE
Adding nodiscard option where mount_options with nodiscard is true

### DIFF
--- a/drivers/scheduler/k8s/specs/bonnie-sharedv4/px-bonnie-storage.yml
+++ b/drivers/scheduler/k8s/specs/bonnie-sharedv4/px-bonnie-storage.yml
@@ -8,6 +8,7 @@ parameters:
   repl: "3"
   priority_io: "high"
   sharedv4: "true"
+  nodiscard: "true"
   mount_options: "nodiscard=true"
 allowVolumeExpansion: true
 ---

--- a/drivers/scheduler/k8s/specs/bonnie-sv4-svc/px-bonnie-storage.yml
+++ b/drivers/scheduler/k8s/specs/bonnie-sv4-svc/px-bonnie-storage.yml
@@ -7,6 +7,7 @@ provisioner: kubernetes.io/portworx-volume
 parameters:
   repl: "3"
   priority_io: "high"
+  nodiscard: "true"
   mount_options: "nodiscard=true"
   sharedv4: "true"
   sharedv4_svc_type: "ClusterIP"

--- a/drivers/scheduler/k8s/specs/vdbench-heavyload/px-vdbench-storage.yml
+++ b/drivers/scheduler/k8s/specs/vdbench-heavyload/px-vdbench-storage.yml
@@ -7,6 +7,7 @@ provisioner: kubernetes.io/portworx-volume
 parameters:
   repl: "3"
   shared: "true"
+  nodiscard: "true"
   mount_options: "nodiscard=true"
 allowVolumeExpansion: true
 ---

--- a/drivers/scheduler/k8s/specs/vdbench-sharedv4/px-vdbench-storage.yml
+++ b/drivers/scheduler/k8s/specs/vdbench-sharedv4/px-vdbench-storage.yml
@@ -14,6 +14,7 @@ provisioner: kubernetes.io/portworx-volume
 parameters:
   repl: "3"
   sharedv4: "true"
+  nodiscard: "true"
   mount_options: "nodiscard=true"
 allowVolumeExpansion: true
 ---

--- a/drivers/scheduler/k8s/specs/vdbench-sv4-multivol/px-vdbench-storage.yml
+++ b/drivers/scheduler/k8s/specs/vdbench-sv4-multivol/px-vdbench-storage.yml
@@ -7,5 +7,6 @@ provisioner: kubernetes.io/portworx-volume
 parameters:
   repl: "3"
   sharedv4: "true"
+  nodiscard: "true"
   mount_options: "nodiscard=true"
 allowVolumeExpansion: true

--- a/drivers/scheduler/k8s/specs/vdbench-sv4-r2-mvol/px-vdbench-storage.yml
+++ b/drivers/scheduler/k8s/specs/vdbench-sv4-r2-mvol/px-vdbench-storage.yml
@@ -7,6 +7,7 @@ provisioner: kubernetes.io/portworx-volume
 parameters:
   repl: "2"
   sharedv4: "true"
+  nodiscard: "true"
   mount_options: "nodiscard=true"
 allowVolumeExpansion: true
 ---

--- a/drivers/scheduler/k8s/specs/vdbench-sv4-svc-multivol/px-vdbench-storage.yml
+++ b/drivers/scheduler/k8s/specs/vdbench-sv4-svc-multivol/px-vdbench-storage.yml
@@ -7,6 +7,7 @@ provisioner: kubernetes.io/portworx-volume
 parameters:
   repl: "3"
   sharedv4: "true"
+  nodiscard: "true"
   mount_options: "nodiscard=true"
   sharedv4_svc_type: "ClusterIP"
 allowVolumeExpansion: true

--- a/drivers/scheduler/k8s/specs/vdbench-sv4-svc/px-vdbench-storage.yml
+++ b/drivers/scheduler/k8s/specs/vdbench-sv4-svc/px-vdbench-storage.yml
@@ -15,6 +15,7 @@ parameters:
   repl: "3"
   sharedv4: "true"
   mount_options: "nodiscard=true"
+  nodiscard: "true"
   sharedv4_svc_type: "ClusterIP"
 allowVolumeExpansion: true
 ---


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is adding a 'nodiscard' option in storage class for volume creation. So that volume create type and mount type matches in volume/PV creation.

Below type error message will not be present in px logs for a volume.
`@px-system-test-ocp-qbvxp-worker-pgmkv portworx[2883509]: time="2022-03-18T18:21:35Z" level=info msg="Volume vol3 (969875466026985382) : Op VolumeCreate - VolumeSpec.Nodiscard(false) and VolumeSpec.MountOptions(map[nodiscard:true]) do not match. VolumeSpec.Nodiscard setting takes precedence. Effective Mountoptions map[discard:]. Please use pxctl volume update to fix the volume spec" file="proto_driver.go:1590" component=porx/storage/driver/volume
@px-system-test-ocp-qbvxp-worker-pgmkv portworx[2883509]: time="2022-03-18T18:22:46Z" level=info msg="Volume vol3 (969875466026985382) : Op VolumeMount - VolumeSpec.Nodiscard(false) and VolumeSpec.MountOptions(map[nodiscard:true]) do not match. VolumeSpec.Nodiscard setting takes precedence. Effective Mountoptions map[discard:]. Please use pxctl volume update to fix the volume spec" file="proto_driver.go:1590" component=porx/storage/driver/volume`

**Which issue(s) this PR fixes** (optional)
Closes # PTX-5548

**Special notes for your reviewer**:
Minor changes..

