### PR TITLE
Add Validation after restart to stablize sharedv4test

### DIFF
--- a/tests/basic/sharedv4_test.go
+++ b/tests/basic/sharedv4_test.go
@@ -122,6 +122,7 @@ var _ = Describe("{Sharedv4Functional}", func() {
 
 				Step(fmt.Sprintf("restart vol driver %s", ctx.App.Key), func() {
 					restartVolumeDriverOnNode(attachedNode)
+					ValidateContext(ctx)
 				})
 
 				Step(fmt.Sprintf("validate counter are active for %s", ctx.App.Key), func() {


### PR DESCRIPTION
Signed-off-by: dahuang <dahuang@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
We were seeing instability in running the sharedv4 test. This PR adds validation after restarting the vol driver.

**Which issue(s) this PR fixes** (optional)
Closes # PWX-23108

**Special notes for your reviewer**:
Tested locally, no more length mismatch issue. 
