### PR TITLE
:hammer: Adding jira issue creation for Longevity

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -450,6 +450,9 @@ spec:
             "--testrail-host=$TESTRAIL_HOST",
             "--testrail-username=$TESTRAIL_USERNAME",
             "--testrail-password=$TESTRAIL_PASSWORD",
+            "--jira-username=$JIRA_USERNAME",
+            "--jira-token=$JIRA_TOKEN",
+            "--jira-account-id=$JIRA_ACCOUNT_ID",
             "$APP_DESTROY_TIMEOUT_ARG",
     ]
     tty: true

--- a/pkg/jirautils/jirautil.go
+++ b/pkg/jirautils/jirautil.go
@@ -30,8 +30,10 @@ func Init(username, token string) {
 	client, err = jira.NewClient(httpClient.Client(), jiraURL)
 	if err != nil {
 		isJiraConnectionSuccessful = false
-		logrus.Errorf("Testrail connection not successful, Cause: %v", err)
+		logrus.Errorf("Jira connection not successful, Cause: %v", err)
 
+	} else {
+		logrus.Info("Jira connection is successful")
 	}
 
 	isJiraConnectionSuccessful = true

--- a/tests/longevity/longevity_test.go
+++ b/tests/longevity/longevity_test.go
@@ -639,8 +639,6 @@ func populateIntervals() {
 	triggerInterval[PoolAddDisk][2] = 24 * baseInterval
 	triggerInterval[PoolAddDisk][1] = 30 * baseInterval
 
-	baseInterval = 30 * time.Minute
-
 	triggerInterval[PoolResizeDisk][10] = 1 * baseInterval
 	triggerInterval[PoolResizeDisk][9] = 3 * baseInterval
 	triggerInterval[PoolResizeDisk][8] = 6 * baseInterval


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
collects logs and raised ptx in case of any error in longevity events

**Which issue(s) this PR fixes** (optional)
Closes # PTX-5564, PTX_5537

**Special notes for your reviewer**:
Signed-Off by: lsrinivas

<img width="1152" alt="Screenshot 2022-03-25 at 12 09 01" src="https://user-images.githubusercontent.com/83946232/160068308-b897642a-c56b-42cf-9576-3e3fff9b8567.png">

logs:
looking for core files on node torpedo-long-fa-sample-test-12-0
WARN[2022-03-25 06:13:08] [/var/cores/core-px-test.log
] found on node [torpedo-long-fa-sample-test-12-0]
INFO[2022-03-25 06:13:08] Creating Jira Issue
INFO[2022-03-25 06:13:08] Event type [coreChecker] does not exists
INFO[2022-03-25 06:13:09] Resp: 201
INFO[2022-03-25 06:13:09] Successfully created new jira issue.
INFO[2022-03-25 06:13:09] Jira Issue: PTX-5645
INFO[2022-03-25 06:13:09] Creating directors logs in the node torpedo-long-fa-sample-test-12-0
INFO[2022-03-25 06:13:09] Mounting nfs diags directory
INFO[2022-03-25 06:13:09] Creating PTX PTX-5645 directory in the node torpedo-long-fa-sample-test-12-0
INFO[2022-03-25 06:13:10] collect diags on node: torpedo-long-fa-sample-test-12-0

logs copied to diags mount
[root@torpedo-long-fa-sample-test-12-0 PTX-5645]# ls
autopilot-5cf5788c57-228ch.log  portworx-operator-79cb6dd8dd-zx648.log  stork-565ff7fb9-cdcdf.log  stork-565ff7fb9-dbl2g.log  stork-565ff7fb9-nhxd4.log
