### PR TITLE
Updating the node drivers for eks

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -325,6 +325,7 @@ if [ -n "${K8S_VENDOR}" ]; then
             K8S_VENDOR_KEY=px/enabled
             K8S_VENDOR_OPERATOR="In"
             K8S_VENDOR_VALUE='values: ["false"]'
+            NODE_DRIVER="aws"
             ;;
     esac
 else


### PR DESCRIPTION

**What this PR does / why we need it**:
Updating the node driver for eks scheduler. All eks test should use `aws` node driver

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
Minor change..

