### PR TITLE
Fixing the App scale Up factor and timeout for AppScaleUpAndDown Test

### DIFF
--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -2673,7 +2673,12 @@ func (k *K8s) ValidateVolumes(ctx *scheduler.Context, timeout, retryInterval tim
 					Cause: fmt.Sprintf("Failed to get StatefulSet: %v. Err: %v", obj.Name, err),
 				}
 			}
-			if err := k8sApps.ValidatePVCsForStatefulSet(ss, timeout*time.Duration(*obj.Spec.Replicas), retryInterval); err != nil {
+			//Providing the scaling factor in timeout
+			scalingFactor := *obj.Spec.Replicas
+			if *ss.Spec.Replicas > *obj.Spec.Replicas {
+				scalingFactor = int32(*ss.Spec.Replicas - *obj.Spec.Replicas)
+			}
+			if err := k8sApps.ValidatePVCsForStatefulSet(ss, timeout*time.Duration(scalingFactor), retryInterval); err != nil {
 				return &scheduler.ErrFailedToValidateStorage{
 					App:   ctx.App,
 					Cause: fmt.Sprintf("Failed to validate PVCs for statefulset: %v. Err: %v", ss.Name, err),

--- a/tests/basic/basic_test.go
+++ b/tests/basic/basic_test.go
@@ -405,11 +405,12 @@ var _ = Describe("{AppScaleUpAndDown}", func() {
 				Step(fmt.Sprintf("scale up app: %s by %d ", ctx.App.Key, len(node.GetWorkerNodes())), func() {
 					applicationScaleUpMap, err := Inst().S.GetScaleFactorMap(ctx)
 					Expect(err).NotTo(HaveOccurred())
-					workerNodes := int32(len(node.GetWorkerNodes()))
+					//Scaling up by number of storage-nodes
+					workerStorageNodes := int32(len(node.GetStorageNodes()))
 					for name, scale := range applicationScaleUpMap {
 						// limit scale up to the number of worker nodes
-						if scale < workerNodes {
-							applicationScaleUpMap[name] = workerNodes
+						if scale < workerStorageNodes {
+							applicationScaleUpMap[name] = workerStorageNodes
 						}
 					}
 					err = Inst().S.ScaleApplication(ctx, applicationScaleUpMap)

--- a/tests/common.go
+++ b/tests/common.go
@@ -191,6 +191,7 @@ const (
 const (
 	waitResourceCleanup       = 2 * time.Minute
 	defaultTimeout            = 5 * time.Minute
+	defaultVolScaleTimeout    = 2 * time.Minute
 	defaultRetryInterval      = 10 * time.Second
 	defaultCmdTimeout         = 20 * time.Second
 	defaultCmdRetryInterval   = 5 * time.Second
@@ -530,7 +531,7 @@ func ValidateVolumes(ctx *scheduler.Context, errChan ...*chan error) {
 		var err error
 		Step(fmt.Sprintf("inspect %s app's volumes", ctx.App.Key), func() {
 			appScaleFactor := time.Duration(Inst().GlobalScaleFactor)
-			err = Inst().S.ValidateVolumes(ctx, appScaleFactor*defaultTimeout, defaultRetryInterval, nil)
+			err = Inst().S.ValidateVolumes(ctx, appScaleFactor*defaultVolScaleTimeout, defaultRetryInterval, nil)
 			processError(err, errChan...)
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixing the App scale up factor and timeout value for scaling up the Apps

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
Tested the methods in eks job run. Please find the test result below

`13:31:43  ------------------------------

13:31:43  {AppScaleUpAndDown} 
13:31:43    has to scale up and scale down the app
13:31:43    /go/src/github.com/portworx/torpedo/tests/basic/basic_test.go:394
13:31:43  STEP: schedule applications
13:31:43  INFO[2022-04-08 20:31:43] Setting provisioner of elasticsearch-sc to kubernetes.io/portworx-volume 
13:31:43  INFO[2022-04-08 20:31:43] [elasticsearch] Found existing storage class: elasticsearch-sc 
13:31:43  INFO[2022-04-08 20:31:43] [elasticsearch] Created Service: elasticsearch-cluster 
13:31:43  INFO[2022-04-08 20:31:43] [elasticsearch] Created Service: elasticsearch-api 
13:31:43  INFO[2022-04-08 20:31:43] [elasticsearch] Created Config Map: es-config 
13:31:44  INFO[2022-04-08 20:31:43] [elasticsearch] Created StatefulSet: esnode  
13:31:44  INFO[2022-04-08 20:31:43] [elasticsearch] Created deployment: es-load  
13:31:44  INFO[2022-04-08 20:31:43] Setting provisioner of postgres-sc to kubernetes.io/portworx-volume 
13:31:44  INFO[2022-04-08 20:31:43] [postgres] Found existing storage class: postgres-sc 
13:31:44  INFO[2022-04-08 20:31:43] [postgres] Created PVC: postgres-data        
13:31:44  INFO[2022-04-08 20:31:44] [postgres] Created deployment: postgres      
13:31:44  INFO[2022-04-08 20:31:44] [sysbench] Created PVC: sysbench-mysql-data  
13:31:44  INFO[2022-04-08 20:31:44] Setting provisioner of sysbench-sc to kubernetes.io/portworx-volume 
13:31:44  INFO[2022-04-08 20:31:44] [sysbench] Found existing storage class: sysbench-sc 
13:31:44  INFO[2022-04-08 20:31:44] [sysbench] Created deployment: sysbench      
13:31:44  INFO[2022-04-08 20:31:44] Setting provisioner of px-nginx-sc-v4 to kubernetes.io/portworx-volume 
13:31:44  INFO[2022-04-08 20:31:44] [nginx-sharedv4] Found existing storage class: px-nginx-sc-v4 
13:31:44  INFO[2022-04-08 20:31:44] [nginx-sharedv4] Created PVC: px-nginx-pvc-sharedv4 
13:31:44  INFO[2022-04-08 20:31:44] [nginx-sharedv4] Created PVC: px-nginx-pvc-enc-sharedv4 
13:31:45  INFO[2022-04-08 20:31:44] [nginx-sharedv4] Created Service: nginx-service 
13:31:45  INFO[2022-04-08 20:31:45] [nginx-sharedv4] Created deployment: nginx   
13:31:45  INFO[2022-04-08 20:31:45] [nginx-sharedv4] Created Secret: volume-secrets 
13:31:45  INFO[2022-04-08 20:31:45] Setting provisioner of px-nginx-sc-sharedv4-svc to kubernetes.io/portworx-volume 
13:31:45  INFO[2022-04-08 20:31:45] [nginx-sv4-svc] Found existing storage class: px-nginx-sc-sharedv4-svc 
13:31:45  INFO[2022-04-08 20:31:45] [nginx-sv4-svc] Created PVC: px-nginx-pvc-sharedv4 
13:31:45  INFO[2022-04-08 20:31:45] [nginx-sv4-svc] Created PVC: px-nginx-pvc-enc-sharedv4 
13:31:46  INFO[2022-04-08 20:31:45] [nginx-sv4-svc] Created Service: nginx-service 
13:31:47  INFO[2022-04-08 20:31:46] [nginx-sv4-svc] Created deployment: nginx    
13:31:47  INFO[2022-04-08 20:31:46] [nginx-sv4-svc] Created Secret: volume-secrets 

13:31:47  STEP: validate applications
13:31:47  STEP: validate elasticsearch app's volumes
13:31:47  STEP: inspect elasticsearch app's volumes
13:31:47  2022/04/08 20:31:46 Expected PVCs: 3, Actual: 1 Next retry in: 10s
13:31:57  2022/04/08 20:31:56 Expected PVCs: 3, Actual: 1 Next retry in: 10s
13:32:07  2022/04/08 20:32:06 Expected PVCs: 3, Actual: 1 Next retry in: 10s
13:32:16  2022/04/08 20:32:16 Expected PVCs: 3, Actual: 1 Next retry in: 10s
13:32:26  2022/04/08 20:32:26 Expected PVCs: 3, Actual: 1 Next retry in: 10s
13:32:39  2022/04/08 20:32:36 Expected PVCs: 3, Actual: 2 Next retry in: 10s
13:32:47  2022/04/08 20:32:46 Expected PVCs: 3, Actual: 2 Next retry in: 10s
13:32:57  2022/04/08 20:32:56 Expected PVCs: 3, Actual: 2 Next retry in: 10s
13:33:07  2022/04/08 20:33:06 Expected PVCs: 3, Actual: 2 Next retry in: 10s
13:33:17  2022/04/08 20:33:16 Expected PVCs: 3, Actual: 2 Next retry in: 10s
13:33:27  2022/04/08 20:33:27 Expected PVCs: 3, Actual: 2 Next retry in: 10s
13:33:37  2022/04/08 20:33:37 PVC es-data-esnode-2 is not ready yet. Cause: PVC expected status: Bound PVC actual status: Pending Next retry in: 10s
13:33:49  2022/04/08 20:33:47 PVC es-data-esnode-2 is not ready yet. Cause: PVC expected status: Bound PVC actual status: Pending Next retry in: 10s
13:33:57  INFO[2022-04-08 20:33:57] [elasticsearch] Validated PVCs from StatefulSet: esnode 

13:33:57  STEP: get elasticsearch app's volume's custom parameters
13:33:57  STEP: get elasticsearch app's volume: pvc-4b4e73dc-9dcf-4c7c-b1b5-b3adb6a074ab inspected by the volume driver

13:33:57  INFO[2022-04-08 20:33:57] Successfully inspected volume: pvc-4b4e73dc-9dcf-4c7c-b1b5-b3adb6a074ab (960018057512770722) 
13:33:57  STEP: get elasticsearch app's volume: pvc-a5b71539-84d9-4734-92a9-c3781615d0ff inspected by the volume driver
13:33:57  INFO[2022-04-08 20:33:57] Successfully inspected volume: pvc-a5b71539-84d9-4734-92a9-c3781615d0ff (636662019148048391) 
13:33:57  STEP: get elasticsearch app's volume: pvc-6d3b7d0b-0a7e-46f7-a2ec-aa13bbd84644 inspected by the volume driver
13:33:57  INFO[2022-04-08 20:33:57] Successfully inspected volume: pvc-6d3b7d0b-0a7e-46f7-a2ec-aa13bbd84644 (502488237817609476) 

13:33:57  STEP: wait for elasticsearch app to start running
13:33:57  INFO[2022-04-08 20:33:57] [elasticsearch] Validated Service: elasticsearch-cluster 
13:33:57  INFO[2022-04-08 20:33:57] [elasticsearch] Validated Service: elasticsearch-api 
13:33:57  2022/04/08 20:33:57 app esnode is not ready yet. Cause: Expected replicas: 3 Ready replicas: 2 Current pods overview:
13:33:57    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.39.135
13:33:57    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109
13:33:57    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.30.222
13:33:57   Next retry in: 10s
13:34:07  2022/04/08 20:34:07 app esnode is not ready yet. Cause: Expected replicas: 3 Ready replicas: 2 Current pods overview:
13:34:07    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.39.135
13:34:07    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109
13:34:07    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:false node:192.168.30.222
13:34:07   Next retry in: 10s
13:34:17  2022/04/08 20:34:17 app esnode is not ready yet. Cause: Expected replicas: 3 Ready replicas: 2 Current pods overview:
13:34:17    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.39.135
13:34:17    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109
13:34:17    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:false node:192.168.30.222
13:34:17   Next retry in: 10s

13:34:29  2022/04/08 20:34:27 app esnode is not ready yet. Cause: Expected replicas: 3 Ready replicas: 2 Current pods overview:
13:34:29    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.39.135
13:34:29    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109
13:34:29    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:false node:192.168.30.222
13:34:29   Next retry in: 10s
13:34:37  INFO[2022-04-08 20:34:37] [elasticsearch] Validated statefulset: esnode 


13:34:37  INFO[2022-04-08 20:34:37] [elasticsearch] Validated deployment: es-load 
13:34:37  STEP: validate if elasticsearch app's volumes are setup
13:34:37  STEP: validate if elasticsearch app's volume: es-data-esnode-0 is setup

13:34:37  INFO[2022-04-08 20:34:37] Pod [elasticsearch-applicationscaleupdown-0-04-08-20h17m34s] esnode-0 ready on node ip-192-168-39-135.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  
13:34:37  DEBU[2022-04-08 20:34:37] validating the mounts in pod elasticsearch-applicationscaleupdown-0-04-08-20h17m34s/esnode-0 
13:34:37  DEBU[2022-04-08 20:34:37] pod: [elasticsearch-applicationscaleupdown-0-04-08-20h17m34s] esnode-0 has PX mount: [/dev/pxd/pxd960018057512770722 /usr/share/elasticsearch/data  /dev/pxd/pxd960018057512770722] 
13:34:37  DEBU[2022-04-08 20:34:37] Finding the debug pod to run command on node ip-192-168-39-135.us-west-2.compute.internal 
13:34:37  DEBU[2022-04-08 20:34:37] Running command on pod debug-7x9dp [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-4b4e73dc-9dcf-4c7c-b1b5-b3adb6a074ab]] 
13:34:37  STEP: validate if elasticsearch app's volume: es-data-esnode-1 is setup
13:34:37  INFO[2022-04-08 20:34:37] Pod [elasticsearch-applicationscaleupdown-0-04-08-20h17m34s] esnode-1 ready on node ip-192-168-79-109.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:34:38  DEBU[2022-04-08 20:34:37] validating the mounts in pod elasticsearch-applicationscaleupdown-0-04-08-20h17m34s/esnode-1 

13:34:38  DEBU[2022-04-08 20:34:37] pod: [elasticsearch-applicationscaleupdown-0-04-08-20h17m34s] esnode-1 has PX mount: [/dev/pxd/pxd636662019148048391 /usr/share/elasticsearch/data  /dev/pxd/pxd636662019148048391] 

13:34:38  DEBU[2022-04-08 20:34:37] Finding the debug pod to run command on node ip-192-168-79-109.us-west-2.compute.internal 

13:34:38  DEBU[2022-04-08 20:34:37] Running command on pod debug-v9r4k [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-a5b71539-84d9-4734-92a9-c3781615d0ff]] 

13:34:38  STEP: validate if elasticsearch app's volume: es-data-esnode-2 is setup

13:34:38  INFO[2022-04-08 20:34:38] Pod [elasticsearch-applicationscaleupdown-0-04-08-20h17m34s] esnode-2 ready on node ip-192-168-30-222.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:34:38  DEBU[2022-04-08 20:34:38] validating the mounts in pod elasticsearch-applicationscaleupdown-0-04-08-20h17m34s/esnode-2 

13:34:38  DEBU[2022-04-08 20:34:38] pod: [elasticsearch-applicationscaleupdown-0-04-08-20h17m34s] esnode-2 has PX mount: [/dev/pxd/pxd502488237817609476 /usr/share/elasticsearch/data  /dev/pxd/pxd502488237817609476] 

13:34:38  DEBU[2022-04-08 20:34:38] Finding the debug pod to run command on node ip-192-168-30-222.us-west-2.compute.internal 

13:34:38  DEBU[2022-04-08 20:34:38] Running command on pod debug-7pftt [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-6d3b7d0b-0a7e-46f7-a2ec-aa13bbd84644]] 

13:34:39  STEP: validate postgres app's volumes

13:34:39  STEP: inspect postgres app's volumes

13:34:39  INFO[2022-04-08 20:34:39] [postgres] Validated PVC: postgres-data, Namespace: postgres-applicationscaleupdown-0-04-08-20h17m34s 

13:34:39  STEP: get postgres app's volume's custom parameters

13:34:39  STEP: get postgres app's volume: pvc-83ea1fc0-b511-4cbc-b99e-b7bb49ed2308 inspected by the volume driver

13:34:39  INFO[2022-04-08 20:34:39] Successfully inspected volume: pvc-83ea1fc0-b511-4cbc-b99e-b7bb49ed2308 (419169834960255864) 

13:34:39  STEP: wait for postgres app to start running

13:34:39  INFO[2022-04-08 20:34:39] [postgres] Validated deployment: postgres 

13:34:39  STEP: validate if postgres app's volumes are setup

13:34:39  STEP: validate if postgres app's volume: postgres-data is setup

13:34:40  INFO[2022-04-08 20:34:40] Pod [postgres-applicationscaleupdown-0-04-08-20h17m34s] postgres-c88c5898f-l94j6 ready on node ip-192-168-79-109.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:34:40  INFO[2022-04-08 20:34:40] Pod [postgres-applicationscaleupdown-0-04-08-20h17m34s] postgres-c88c5898f-pfhqc not ready on node ip-192-168-30-222.us-west-2.compute.internal - Initialized: True Ready: False Scheduled: True  

13:34:40  DEBU[2022-04-08 20:34:40] validating the mounts in pod postgres-applicationscaleupdown-0-04-08-20h17m34s/postgres-c88c5898f-l94j6 

13:34:40  DEBU[2022-04-08 20:34:40] pod: [postgres-applicationscaleupdown-0-04-08-20h17m34s] postgres-c88c5898f-l94j6 has PX mount: [/dev/pxd/pxd419169834960255864 /var/lib/postgresql/data  /dev/pxd/pxd419169834960255864] 

13:34:40  DEBU[2022-04-08 20:34:40] Finding the debug pod to run command on node ip-192-168-79-109.us-west-2.compute.internal 

13:34:41  DEBU[2022-04-08 20:34:40] Running command on pod debug-v9r4k [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-83ea1fc0-b511-4cbc-b99e-b7bb49ed2308]] 

13:34:41  INFO[2022-04-08 20:34:41] Pod [postgres-applicationscaleupdown-0-04-08-20h17m34s] postgres-c88c5898f-pfhqc not ready on node ip-192-168-30-222.us-west-2.compute.internal - Initialized: True Ready: False Scheduled: True  

13:34:41  STEP: validate sysbench app's volumes

13:34:41  STEP: inspect sysbench app's volumes

13:34:41  INFO[2022-04-08 20:34:41] [sysbench] Validated PVC: sysbench-mysql-data, Namespace: sysbench-applicationscaleupdown-0-04-08-20h17m34s 

13:34:41  STEP: get sysbench app's volume's custom parameters

13:34:42  STEP: get sysbench app's volume: pvc-5ca91fca-edee-4144-8a1a-853b9a234a1e inspected by the volume driver

13:34:42  INFO[2022-04-08 20:34:41] Successfully inspected volume: pvc-5ca91fca-edee-4144-8a1a-853b9a234a1e (72582932534895790) 

13:34:42  STEP: wait for sysbench app to start running

13:34:42  INFO[2022-04-08 20:34:41] [sysbench] Validated deployment: sysbench 

13:34:42  STEP: validate if sysbench app's volumes are setup

13:34:42  STEP: validate if sysbench app's volume: sysbench-mysql-data is setup

13:34:42  INFO[2022-04-08 20:34:42] Pod [sysbench-applicationscaleupdown-0-04-08-20h17m34s] sysbench-79868f4546-fpwld ready on node ip-192-168-74-103.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:34:42  DEBU[2022-04-08 20:34:42] validating the mounts in pod sysbench-applicationscaleupdown-0-04-08-20h17m34s/sysbench-79868f4546-fpwld 

13:34:43  DEBU[2022-04-08 20:34:42] pod: [sysbench-applicationscaleupdown-0-04-08-20h17m34s] sysbench-79868f4546-fpwld has PX mount: [/dev/pxd/pxd72582932534895790 /var/lib/mysql  /dev/pxd/pxd72582932534895790] 

13:34:43  DEBU[2022-04-08 20:34:42] Finding the debug pod to run command on node ip-192-168-74-103.us-west-2.compute.internal 

13:34:43  DEBU[2022-04-08 20:34:43] Running command on pod debug-g2m5l [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-5ca91fca-edee-4144-8a1a-853b9a234a1e]] 

13:34:43  STEP: validate nginx-sharedv4 app's volumes

13:34:43  STEP: inspect nginx-sharedv4 app's volumes

13:34:43  INFO[2022-04-08 20:34:43] [nginx-sharedv4] Validated PVC: px-nginx-pvc-sharedv4, Namespace: nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s 

13:34:43  INFO[2022-04-08 20:34:43] [nginx-sharedv4] Validated PVC: px-nginx-pvc-enc-sharedv4, Namespace: nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s 

13:34:43  STEP: get nginx-sharedv4 app's volume's custom parameters

13:34:44  STEP: get nginx-sharedv4 app's volume: pvc-610c8fbf-34f7-45a3-93b0-41079cbf9419 inspected by the volume driver

13:34:44  INFO[2022-04-08 20:34:44] Successfully inspected volume: pvc-610c8fbf-34f7-45a3-93b0-41079cbf9419 (671567044016503101) 

13:34:44  STEP: get nginx-sharedv4 app's volume: pvc-5d3abcb1-355d-44aa-a121-382165bf72c6 inspected by the volume driver

13:34:44  INFO[2022-04-08 20:34:44] Successfully inspected volume: pvc-5d3abcb1-355d-44aa-a121-382165bf72c6 (1003972371003177018) 

13:34:44  STEP: wait for nginx-sharedv4 app to start running

13:34:44  INFO[2022-04-08 20:34:44] [nginx-sharedv4] Validated Service: nginx-service 

13:34:44  INFO[2022-04-08 20:34:44] [nginx-sharedv4] Validated deployment: nginx 

13:34:44  STEP: validate if nginx-sharedv4 app's volumes are setup

13:34:45  STEP: validate if nginx-sharedv4 app's volume: px-nginx-pvc-sharedv4 is setup

13:34:45  INFO[2022-04-08 20:34:45] Pod [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-2m5pj ready on node ip-192-168-79-109.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:34:45  INFO[2022-04-08 20:34:45] Pod [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-lsftw ready on node ip-192-168-20-251.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:34:45  INFO[2022-04-08 20:34:45] Pod [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-qmtgg ready on node ip-192-168-39-135.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:34:45  DEBU[2022-04-08 20:34:45] validating the mounts in pod nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-2m5pj 

13:34:45  DEBU[2022-04-08 20:34:45] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-2m5pj has PX mount: [/dev/pxd/pxd671567044016503101 /usr/share/nginx/html  /dev/pxd/pxd671567044016503101] 

13:34:45  DEBU[2022-04-08 20:34:45] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-2m5pj has PX mount: [/dev/mapper/pxd-enc1003972371003177018 /usr/share/nginx/html-enc  /dev/mapper/pxd-enc1003972371003177018] 

13:34:45  DEBU[2022-04-08 20:34:45] Finding the debug pod to run command on node ip-192-168-79-109.us-west-2.compute.internal 

13:34:46  DEBU[2022-04-08 20:34:46] Running command on pod debug-v9r4k [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-610c8fbf-34f7-45a3-93b0-41079cbf9419]] 

13:34:46  DEBU[2022-04-08 20:34:46] validating the mounts in pod nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-lsftw 

13:34:47  DEBU[2022-04-08 20:34:46] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-lsftw has PX mount: [192.168.79.109:/var/lib/osd/pxns/671567044016503101 /usr/share/nginx/html  192.168.79.109:/var/lib/osd/pxns/671567044016503101] 

13:34:47  DEBU[2022-04-08 20:34:46] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-lsftw has PX mount: [192.168.79.109:/var/lib/osd/pxns/1003972371003177018 /usr/share/nginx/html-enc  192.168.79.109:/var/lib/osd/pxns/1003972371003177018] 

13:34:47  DEBU[2022-04-08 20:34:46] Finding the debug pod to run command on node ip-192-168-20-251.us-west-2.compute.internal 

13:34:47  DEBU[2022-04-08 20:34:46] Running command on pod debug-5svpb [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-610c8fbf-34f7-45a3-93b0-41079cbf9419]] 

13:34:47  DEBU[2022-04-08 20:34:47] validating the mounts in pod nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-qmtgg 

13:34:47  DEBU[2022-04-08 20:34:47] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-qmtgg has PX mount: [192.168.79.109:/var/lib/osd/pxns/671567044016503101 /usr/share/nginx/html  192.168.79.109:/var/lib/osd/pxns/671567044016503101] 

13:34:47  DEBU[2022-04-08 20:34:47] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-qmtgg has PX mount: [192.168.79.109:/var/lib/osd/pxns/1003972371003177018 /usr/share/nginx/html-enc  192.168.79.109:/var/lib/osd/pxns/1003972371003177018] 

13:34:47  DEBU[2022-04-08 20:34:47] Finding the debug pod to run command on node ip-192-168-39-135.us-west-2.compute.internal 

13:34:47  DEBU[2022-04-08 20:34:47] Running command on pod debug-7x9dp [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-610c8fbf-34f7-45a3-93b0-41079cbf9419]] 

13:34:48  STEP: validate if nginx-sharedv4 app's volume: px-nginx-pvc-enc-sharedv4 is setup

13:34:48  INFO[2022-04-08 20:34:48] Pod [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-2m5pj ready on node ip-192-168-79-109.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:34:48  INFO[2022-04-08 20:34:48] Pod [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-lsftw ready on node ip-192-168-20-251.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:34:48  INFO[2022-04-08 20:34:48] Pod [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-qmtgg ready on node ip-192-168-39-135.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:34:48  DEBU[2022-04-08 20:34:48] validating the mounts in pod nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-2m5pj 

13:34:48  DEBU[2022-04-08 20:34:48] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-2m5pj has PX mount: [/dev/pxd/pxd671567044016503101 /usr/share/nginx/html  /dev/pxd/pxd671567044016503101] 

13:34:48  DEBU[2022-04-08 20:34:48] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-2m5pj has PX mount: [/dev/mapper/pxd-enc1003972371003177018 /usr/share/nginx/html-enc  /dev/mapper/pxd-enc1003972371003177018] 

13:34:48  DEBU[2022-04-08 20:34:48] Finding the debug pod to run command on node ip-192-168-79-109.us-west-2.compute.internal 

13:34:49  DEBU[2022-04-08 20:34:48] Running command on pod debug-v9r4k [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-5d3abcb1-355d-44aa-a121-382165bf72c6]] 

13:34:49  DEBU[2022-04-08 20:34:49] validating the mounts in pod nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-lsftw 

13:34:49  DEBU[2022-04-08 20:34:49] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-lsftw has PX mount: [192.168.79.109:/var/lib/osd/pxns/671567044016503101 /usr/share/nginx/html  192.168.79.109:/var/lib/osd/pxns/671567044016503101] 

13:34:49  DEBU[2022-04-08 20:34:49] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-lsftw has PX mount: [192.168.79.109:/var/lib/osd/pxns/1003972371003177018 /usr/share/nginx/html-enc  192.168.79.109:/var/lib/osd/pxns/1003972371003177018] 

13:34:49  DEBU[2022-04-08 20:34:49] Finding the debug pod to run command on node ip-192-168-20-251.us-west-2.compute.internal 

13:34:49  DEBU[2022-04-08 20:34:49] Running command on pod debug-5svpb [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-5d3abcb1-355d-44aa-a121-382165bf72c6]] 

13:34:50  DEBU[2022-04-08 20:34:49] validating the mounts in pod nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-qmtgg 

13:34:50  DEBU[2022-04-08 20:34:50] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-qmtgg has PX mount: [192.168.79.109:/var/lib/osd/pxns/671567044016503101 /usr/share/nginx/html  192.168.79.109:/var/lib/osd/pxns/671567044016503101] 

13:34:50  DEBU[2022-04-08 20:34:50] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-qmtgg has PX mount: [192.168.79.109:/var/lib/osd/pxns/1003972371003177018 /usr/share/nginx/html-enc  192.168.79.109:/var/lib/osd/pxns/1003972371003177018] 

13:34:50  DEBU[2022-04-08 20:34:50] Finding the debug pod to run command on node ip-192-168-39-135.us-west-2.compute.internal 

13:34:50  DEBU[2022-04-08 20:34:50] Running command on pod debug-7x9dp [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-5d3abcb1-355d-44aa-a121-382165bf72c6]] 

13:34:50  STEP: validate nginx-sv4-svc app's volumes

13:34:50  STEP: inspect nginx-sv4-svc app's volumes

13:34:50  INFO[2022-04-08 20:34:50] [nginx-sv4-svc] Validated PVC: px-nginx-pvc-sharedv4, Namespace: nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s 

13:34:51  INFO[2022-04-08 20:34:50] [nginx-sv4-svc] Validated PVC: px-nginx-pvc-enc-sharedv4, Namespace: nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s 

13:34:51  STEP: get nginx-sv4-svc app's volume's custom parameters

13:34:52  STEP: get nginx-sv4-svc app's volume: pvc-27d112aa-8a2a-4f11-9c6a-eaabd715fea9 inspected by the volume driver

13:34:52  INFO[2022-04-08 20:34:51] Successfully inspected volume: pvc-27d112aa-8a2a-4f11-9c6a-eaabd715fea9 (16920407505374329) 

13:34:52  STEP: get nginx-sv4-svc app's volume: pvc-09a526d7-1625-40a9-806a-b7be48e40610 inspected by the volume driver

13:34:52  INFO[2022-04-08 20:34:51] Successfully inspected volume: pvc-09a526d7-1625-40a9-806a-b7be48e40610 (741489761887231960) 

13:34:52  STEP: wait for nginx-sv4-svc app to start running

13:34:52  INFO[2022-04-08 20:34:51] [nginx-sv4-svc] Validated Service: nginx-service 

13:34:52  INFO[2022-04-08 20:34:52] [nginx-sv4-svc] Validated deployment: nginx 

13:34:52  STEP: validate if nginx-sv4-svc app's volumes are setup

13:34:52  STEP: validate if nginx-sv4-svc app's volume: px-nginx-pvc-sharedv4 is setup

13:34:52  INFO[2022-04-08 20:34:52] Pod [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-5zphv ready on node ip-192-168-20-251.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:34:52  INFO[2022-04-08 20:34:52] Pod [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-h8d82 ready on node ip-192-168-39-135.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:34:52  INFO[2022-04-08 20:34:52] Pod [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-ltzc7 ready on node ip-192-168-20-251.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:34:53  DEBU[2022-04-08 20:34:52] validating the mounts in pod nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-5zphv 

13:34:53  DEBU[2022-04-08 20:34:53] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-5zphv has PX mount: [/dev/pxd/pxd16920407505374329 /usr/share/nginx/html  /dev/pxd/pxd16920407505374329] 

13:34:53  DEBU[2022-04-08 20:34:53] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-5zphv has PX mount: [/dev/mapper/pxd-enc741489761887231960 /usr/share/nginx/html-enc  /dev/mapper/pxd-enc741489761887231960] 

13:34:53  DEBU[2022-04-08 20:34:53] Finding the debug pod to run command on node ip-192-168-20-251.us-west-2.compute.internal 

13:34:53  DEBU[2022-04-08 20:34:53] Running command on pod debug-5svpb [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-27d112aa-8a2a-4f11-9c6a-eaabd715fea9]] 

13:34:53  DEBU[2022-04-08 20:34:53] validating the mounts in pod nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-h8d82 

13:34:54  DEBU[2022-04-08 20:34:54] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-h8d82 has PX mount: [10.100.254.112:/var/lib/osd/pxns/16920407505374329 /usr/share/nginx/html  10.100.254.112:/var/lib/osd/pxns/16920407505374329] 

13:34:54  DEBU[2022-04-08 20:34:54] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-h8d82 has PX mount: [10.100.100.90:/var/lib/osd/pxns/741489761887231960 /usr/share/nginx/html-enc  10.100.100.90:/var/lib/osd/pxns/741489761887231960] 

13:34:54  DEBU[2022-04-08 20:34:54] Finding the debug pod to run command on node ip-192-168-39-135.us-west-2.compute.internal 

13:34:54  DEBU[2022-04-08 20:34:54] Running command on pod debug-7x9dp [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-27d112aa-8a2a-4f11-9c6a-eaabd715fea9]] 

13:34:54  DEBU[2022-04-08 20:34:54] validating the mounts in pod nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-ltzc7 

13:34:54  DEBU[2022-04-08 20:34:54] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-ltzc7 has PX mount: [/dev/pxd/pxd16920407505374329 /usr/share/nginx/html  /dev/pxd/pxd16920407505374329] 

13:34:54  DEBU[2022-04-08 20:34:54] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-ltzc7 has PX mount: [/dev/mapper/pxd-enc741489761887231960 /usr/share/nginx/html-enc  /dev/mapper/pxd-enc741489761887231960] 

13:34:54  DEBU[2022-04-08 20:34:54] Finding the debug pod to run command on node ip-192-168-20-251.us-west-2.compute.internal 

13:34:55  DEBU[2022-04-08 20:34:55] Running command on pod debug-5svpb [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-27d112aa-8a2a-4f11-9c6a-eaabd715fea9]] 

13:34:55  STEP: validate if nginx-sv4-svc app's volume: px-nginx-pvc-enc-sharedv4 is setup

13:34:55  INFO[2022-04-08 20:34:55] Pod [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-5zphv ready on node ip-192-168-20-251.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:34:55  INFO[2022-04-08 20:34:55] Pod [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-h8d82 ready on node ip-192-168-39-135.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:34:55  INFO[2022-04-08 20:34:55] Pod [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-ltzc7 ready on node ip-192-168-20-251.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:34:55  DEBU[2022-04-08 20:34:55] validating the mounts in pod nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-5zphv 

13:34:56  DEBU[2022-04-08 20:34:56] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-5zphv has PX mount: [/dev/pxd/pxd16920407505374329 /usr/share/nginx/html  /dev/pxd/pxd16920407505374329] 

13:34:56  DEBU[2022-04-08 20:34:56] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-5zphv has PX mount: [/dev/mapper/pxd-enc741489761887231960 /usr/share/nginx/html-enc  /dev/mapper/pxd-enc741489761887231960] 

13:34:56  DEBU[2022-04-08 20:34:56] Finding the debug pod to run command on node ip-192-168-20-251.us-west-2.compute.internal 

13:34:56  DEBU[2022-04-08 20:34:56] Running command on pod debug-5svpb [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-09a526d7-1625-40a9-806a-b7be48e40610]] 

13:34:56  DEBU[2022-04-08 20:34:56] validating the mounts in pod nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-h8d82 

13:34:56  DEBU[2022-04-08 20:34:56] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-h8d82 has PX mount: [10.100.254.112:/var/lib/osd/pxns/16920407505374329 /usr/share/nginx/html  10.100.254.112:/var/lib/osd/pxns/16920407505374329] 

13:34:56  DEBU[2022-04-08 20:34:56] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-h8d82 has PX mount: [10.100.100.90:/var/lib/osd/pxns/741489761887231960 /usr/share/nginx/html-enc  10.100.100.90:/var/lib/osd/pxns/741489761887231960] 

13:34:56  DEBU[2022-04-08 20:34:56] Finding the debug pod to run command on node ip-192-168-39-135.us-west-2.compute.internal 

13:34:57  DEBU[2022-04-08 20:34:57] Running command on pod debug-7x9dp [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-09a526d7-1625-40a9-806a-b7be48e40610]] 

13:34:57  DEBU[2022-04-08 20:34:57] validating the mounts in pod nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-ltzc7 

13:34:57  DEBU[2022-04-08 20:34:57] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-ltzc7 has PX mount: [/dev/pxd/pxd16920407505374329 /usr/share/nginx/html  /dev/pxd/pxd16920407505374329] 

13:34:57  DEBU[2022-04-08 20:34:57] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-ltzc7 has PX mount: [/dev/mapper/pxd-enc741489761887231960 /usr/share/nginx/html-enc  /dev/mapper/pxd-enc741489761887231960] 

13:34:57  DEBU[2022-04-08 20:34:57] Finding the debug pod to run command on node ip-192-168-20-251.us-west-2.compute.internal 

13:34:58  DEBU[2022-04-08 20:34:57] Running command on pod debug-5svpb [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-09a526d7-1625-40a9-806a-b7be48e40610]] 

13:34:58  STEP: Scale up and down all app

13:34:58  STEP: scale up app: elasticsearch by 10 

13:34:58  INFO[2022-04-08 20:34:58] Scale all Stateful sets                      

13:34:58  INFO[2022-04-08 20:34:58] StatefulSet esnode scaled to 6 successfully. 

13:34:58  INFO[2022-04-08 20:34:58] Scale all Deployments                        

13:34:58  INFO[2022-04-08 20:34:58] Deployment es-load scaled to 6 successfully. 

13:34:58  STEP: Giving few seconds for scaled up applications to stabilize

13:35:08  STEP: validate elasticsearch app's volumes

13:35:08  STEP: inspect elasticsearch app's volumes

13:35:08  2022/04/08 20:35:08 Expected PVCs: 6, Actual: 4 Next retry in: 10s

13:35:18  2022/04/08 20:35:18 Expected PVCs: 6, Actual: 4 Next retry in: 10s

13:35:28  2022/04/08 20:35:28 Expected PVCs: 6, Actual: 4 Next retry in: 10s

13:35:38  2022/04/08 20:35:38 Expected PVCs: 6, Actual: 4 Next retry in: 10s

13:35:50  2022/04/08 20:35:48 Expected PVCs: 6, Actual: 4 Next retry in: 10s

13:35:58  2022/04/08 20:35:58 Expected PVCs: 6, Actual: 4 Next retry in: 10s

13:36:08  2022/04/08 20:36:08 Expected PVCs: 6, Actual: 4 Next retry in: 10s

13:36:18  2022/04/08 20:36:18 Expected PVCs: 6, Actual: 5 Next retry in: 10s

13:36:28  2022/04/08 20:36:28 Expected PVCs: 6, Actual: 5 Next retry in: 10s

13:36:40  2022/04/08 20:36:38 Expected PVCs: 6, Actual: 5 Next retry in: 10s

13:36:48  2022/04/08 20:36:48 Expected PVCs: 6, Actual: 5 Next retry in: 10s

13:36:58  2022/04/08 20:36:58 Expected PVCs: 6, Actual: 5 Next retry in: 10s

13:37:08  2022/04/08 20:37:08 Expected PVCs: 6, Actual: 5 Next retry in: 10s

13:37:18  2022/04/08 20:37:18 Expected PVCs: 6, Actual: 5 Next retry in: 10s

13:37:30  2022/04/08 20:37:28 Expected PVCs: 6, Actual: 5 Next retry in: 10s

13:37:38  2022/04/08 20:37:38 Expected PVCs: 6, Actual: 5 Next retry in: 10s

13:37:48  2022/04/08 20:37:48 Expected PVCs: 6, Actual: 5 Next retry in: 10s

13:37:58  2022/04/08 20:37:58 Expected PVCs: 6, Actual: 5 Next retry in: 10s

13:38:08  2022/04/08 20:38:08 Expected PVCs: 6, Actual: 5 Next retry in: 10s

13:38:20  2022/04/08 20:38:18 PVC es-data-esnode-5 is not ready yet. Cause: PVC expected status: Bound PVC actual status: Pending Next retry in: 10s

13:38:28  INFO[2022-04-08 20:38:28] [elasticsearch] Validated PVCs from StatefulSet: esnode 

13:38:28  STEP: get elasticsearch app's volume's custom parameters

13:38:28  STEP: get elasticsearch app's volume: pvc-2c7139a5-004f-489e-bf94-cfdaf46afa35 inspected by the volume driver

13:38:28  INFO[2022-04-08 20:38:28] Successfully inspected volume: pvc-2c7139a5-004f-489e-bf94-cfdaf46afa35 (42602268803135413) 

13:38:28  STEP: get elasticsearch app's volume: pvc-24423d75-f9fe-4e1a-a2b6-c3ed755499d7 inspected by the volume driver

13:38:28  INFO[2022-04-08 20:38:28] Successfully inspected volume: pvc-24423d75-f9fe-4e1a-a2b6-c3ed755499d7 (1133554559821467282) 

13:38:28  STEP: get elasticsearch app's volume: pvc-c55d7ca3-18db-48d1-876f-517e88db39e7 inspected by the volume driver

13:38:28  INFO[2022-04-08 20:38:28] Successfully inspected volume: pvc-c55d7ca3-18db-48d1-876f-517e88db39e7 (915222410459126561) 

13:38:28  STEP: get elasticsearch app's volume: pvc-4b4e73dc-9dcf-4c7c-b1b5-b3adb6a074ab inspected by the volume driver

13:38:28  INFO[2022-04-08 20:38:28] Successfully inspected volume: pvc-4b4e73dc-9dcf-4c7c-b1b5-b3adb6a074ab (960018057512770722) 

13:38:28  STEP: get elasticsearch app's volume: pvc-a5b71539-84d9-4734-92a9-c3781615d0ff inspected by the volume driver

13:38:28  INFO[2022-04-08 20:38:28] Successfully inspected volume: pvc-a5b71539-84d9-4734-92a9-c3781615d0ff (636662019148048391) 

13:38:28  STEP: get elasticsearch app's volume: pvc-6d3b7d0b-0a7e-46f7-a2ec-aa13bbd84644 inspected by the volume driver

13:38:28  INFO[2022-04-08 20:38:28] Successfully inspected volume: pvc-6d3b7d0b-0a7e-46f7-a2ec-aa13bbd84644 (502488237817609476) 

13:38:28  STEP: wait for elasticsearch app to start running

13:38:28  INFO[2022-04-08 20:38:28] [elasticsearch] Validated Service: elasticsearch-cluster 

13:38:28  INFO[2022-04-08 20:38:28] [elasticsearch] Validated Service: elasticsearch-api 

13:38:28  2022/04/08 20:38:28 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 4 Current pods overview:

13:38:28    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:38:28    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:38:28    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:38:28    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:38:28    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:38:28    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.30.222

13:38:28   Next retry in: 10s

13:38:38  2022/04/08 20:38:38 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 4 Current pods overview:

13:38:38    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:38:38    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:38:38    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:38:38    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:38:38    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:38:38    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:false node:192.168.30.222

13:38:38   Next retry in: 10s

13:38:51  2022/04/08 20:38:48 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 4 Current pods overview:

13:38:51    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:38:51    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:38:51    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:38:51    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:38:51    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:38:51    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:false node:192.168.30.222

13:38:51   Next retry in: 10s

13:38:59  2022/04/08 20:38:58 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:38:59    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:38:59    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:38:59    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:38:59    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:38:59    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:38:59    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:38:59   Next retry in: 10s

13:39:09  2022/04/08 20:39:08 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:39:09    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:false node:192.168.39.135

13:39:09    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:39:09    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:39:09    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:39:09    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:39:09    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:39:09   Next retry in: 10s

13:39:19  2022/04/08 20:39:18 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:39:19    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:false node:192.168.39.135

13:39:19    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:39:19    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:39:19    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:39:19    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:39:19    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:39:19   Next retry in: 10s

13:39:31  2022/04/08 20:39:29 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:39:31    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:false node:192.168.39.135

13:39:31    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:39:31    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:39:31    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:39:31    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:39:31    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:39:31   Next retry in: 10s

13:39:39  2022/04/08 20:39:39 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:39:39    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:39:39    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:39:39    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:39:39    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:39:39    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:39:39    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:39:39   Next retry in: 10s

13:39:49  2022/04/08 20:39:49 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:39:49    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:39:49    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:39:49    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:39:49    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:39:49    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:39:49    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:39:49   Next retry in: 10s

13:39:59  2022/04/08 20:39:59 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:39:59    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:39:59    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:39:59    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:39:59    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:39:59    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:39:59    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:39:59   Next retry in: 10s

13:40:11  2022/04/08 20:40:09 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:40:11    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:40:11    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:40:11    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:40:11    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:40:11    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:40:11    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:40:11   Next retry in: 10s

13:40:19  2022/04/08 20:40:19 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:40:19    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:40:19    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:40:19    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:40:19    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:40:19    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:40:19    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:40:19   Next retry in: 10s

13:40:29  2022/04/08 20:40:29 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:40:29    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:40:29    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:40:29    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:40:29    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:40:29    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:40:29    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:40:29   Next retry in: 10s

13:40:39  2022/04/08 20:40:39 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:40:39    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:40:39    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:40:39    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:40:39    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:40:39    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:40:39    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:40:39   Next retry in: 10s

13:40:51  2022/04/08 20:40:49 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:40:51    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:40:51    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:40:51    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:40:51    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:40:51    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:40:51    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:40:51   Next retry in: 10s

13:40:59  2022/04/08 20:40:59 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:40:59    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:40:59    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:40:59    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:40:59    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:40:59    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:40:59    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:40:59   Next retry in: 10s

13:41:09  2022/04/08 20:41:09 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:41:09    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:false node:192.168.39.135

13:41:09    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:41:09    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:41:09    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:41:09    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:41:09    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:41:09   Next retry in: 10s

13:41:19  2022/04/08 20:41:19 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:41:19    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:false node:192.168.39.135

13:41:19    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:41:19    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:41:19    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:41:19    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:41:19    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:41:19   Next retry in: 10s

13:41:31  2022/04/08 20:41:29 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:41:31    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:false node:192.168.39.135

13:41:31    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:41:31    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:41:31    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:41:31    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:41:31    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:41:31   Next retry in: 10s

13:41:39  2022/04/08 20:41:39 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:41:39    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:41:39    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:41:39    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:41:39    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:41:39    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:41:39    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:41:39   Next retry in: 10s

13:41:49  2022/04/08 20:41:49 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:41:49    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:41:49    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:41:49    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:41:49    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:41:49    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:41:49    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:41:49   Next retry in: 10s

13:41:59  2022/04/08 20:41:59 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:41:59    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:41:59    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:41:59    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:41:59    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:41:59    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:41:59    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:41:59   Next retry in: 10s

13:42:11  2022/04/08 20:42:09 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:42:11    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:42:11    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:42:11    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:42:11    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:42:11    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:42:11    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:42:11   Next retry in: 10s

13:42:19  2022/04/08 20:42:19 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:42:19    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:42:19    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:42:19    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:42:19    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:42:19    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:42:19    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:42:19   Next retry in: 10s

13:42:29  2022/04/08 20:42:29 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:42:29    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:42:29    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:42:29    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:42:29    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:42:29    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:42:29    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:42:29   Next retry in: 10s

13:42:40  2022/04/08 20:42:39 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:42:40    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:42:40    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:42:40    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:42:40    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:42:40    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:42:40    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:42:40   Next retry in: 10s

13:42:50  2022/04/08 20:42:49 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:42:50    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:42:50    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:42:50    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:42:50    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:42:50    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:42:50    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:42:50   Next retry in: 10s

13:43:00  2022/04/08 20:42:59 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:43:00    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:43:00    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:43:00    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:43:00    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:43:00    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:43:00    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:43:00   Next retry in: 10s

13:43:10  2022/04/08 20:43:09 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:43:10    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:43:10    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:43:10    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:43:10    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:43:10    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:43:10    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:43:10   Next retry in: 10s

13:43:20  2022/04/08 20:43:19 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:43:20    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:43:20    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:43:20    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:43:20    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:43:20    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:43:20    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:43:20   Next retry in: 10s

13:43:32  2022/04/08 20:43:30 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:43:32    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:43:32    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:43:32    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:43:32    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:43:32    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:43:32    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:43:32   Next retry in: 10s

13:43:40  2022/04/08 20:43:40 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:43:40    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:43:40    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:43:40    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:43:40    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:43:40    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:43:40    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:43:40   Next retry in: 10s

13:43:50  2022/04/08 20:43:50 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:43:50    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:43:50    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:43:50    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:43:50    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:43:50    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:43:50    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:43:50   Next retry in: 10s

13:44:00  2022/04/08 20:44:00 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:44:00    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:44:00    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:44:00    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:44:00    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:44:00    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:44:00    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:44:00   Next retry in: 10s

13:44:12  2022/04/08 20:44:10 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:44:12    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:44:12    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:44:12    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:44:12    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:44:12    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:44:12    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:44:12   Next retry in: 10s

13:44:20  2022/04/08 20:44:20 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:44:20    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:44:20    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:44:20    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:44:20    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:44:20    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:44:20    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:44:20   Next retry in: 10s

13:44:30  2022/04/08 20:44:30 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:44:30    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:false node:192.168.39.135

13:44:30    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:44:30    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:44:30    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:44:30    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:44:30    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:44:30   Next retry in: 10s

13:44:40  2022/04/08 20:44:40 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:44:40    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:false node:192.168.39.135

13:44:40    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:44:40    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:44:40    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:44:40    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:44:40    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:44:40   Next retry in: 10s

13:44:52  2022/04/08 20:44:50 app esnode is not ready yet. Cause: Expected replicas: 6 Ready replicas: 5 Current pods overview:

13:44:52    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:false node:192.168.39.135

13:44:52    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:44:52    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:44:52    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:44:52    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:44:52    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:44:52   Next retry in: 10s

13:45:00  INFO[2022-04-08 20:45:00] [elasticsearch] Validated statefulset: esnode 

13:45:00  INFO[2022-04-08 20:45:00] [elasticsearch] Validated deployment: es-load 

13:45:00  STEP: validate if elasticsearch app's volumes are setup

13:45:00  STEP: validate if elasticsearch app's volume: es-data-esnode-0 is setup

13:45:00  INFO[2022-04-08 20:45:00] Pod [elasticsearch-applicationscaleupdown-0-04-08-20h17m34s] esnode-0 ready on node ip-192-168-39-135.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:45:00  DEBU[2022-04-08 20:45:00] validating the mounts in pod elasticsearch-applicationscaleupdown-0-04-08-20h17m34s/esnode-0 

13:45:00  DEBU[2022-04-08 20:45:00] pod: [elasticsearch-applicationscaleupdown-0-04-08-20h17m34s] esnode-0 has PX mount: [/dev/pxd/pxd960018057512770722 /usr/share/elasticsearch/data  /dev/pxd/pxd960018057512770722] 

13:45:00  DEBU[2022-04-08 20:45:00] Finding the debug pod to run command on node ip-192-168-39-135.us-west-2.compute.internal 

13:45:00  DEBU[2022-04-08 20:45:00] Running command on pod debug-7x9dp [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-4b4e73dc-9dcf-4c7c-b1b5-b3adb6a074ab]] 

13:45:01  STEP: validate if elasticsearch app's volume: es-data-esnode-1 is setup

13:45:01  INFO[2022-04-08 20:45:00] Pod [elasticsearch-applicationscaleupdown-0-04-08-20h17m34s] esnode-1 ready on node ip-192-168-79-109.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:45:01  DEBU[2022-04-08 20:45:00] validating the mounts in pod elasticsearch-applicationscaleupdown-0-04-08-20h17m34s/esnode-1 

13:45:01  DEBU[2022-04-08 20:45:01] pod: [elasticsearch-applicationscaleupdown-0-04-08-20h17m34s] esnode-1 has PX mount: [/dev/pxd/pxd636662019148048391 /usr/share/elasticsearch/data  /dev/pxd/pxd636662019148048391] 

13:45:01  DEBU[2022-04-08 20:45:01] Finding the debug pod to run command on node ip-192-168-79-109.us-west-2.compute.internal 

13:45:01  DEBU[2022-04-08 20:45:01] Running command on pod debug-v9r4k [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-a5b71539-84d9-4734-92a9-c3781615d0ff]] 

13:45:01  STEP: validate if elasticsearch app's volume: es-data-esnode-2 is setup

13:45:01  INFO[2022-04-08 20:45:01] Pod [elasticsearch-applicationscaleupdown-0-04-08-20h17m34s] esnode-2 ready on node ip-192-168-30-222.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:45:01  DEBU[2022-04-08 20:45:01] validating the mounts in pod elasticsearch-applicationscaleupdown-0-04-08-20h17m34s/esnode-2 

13:45:01  DEBU[2022-04-08 20:45:01] pod: [elasticsearch-applicationscaleupdown-0-04-08-20h17m34s] esnode-2 has PX mount: [/dev/pxd/pxd502488237817609476 /usr/share/elasticsearch/data  /dev/pxd/pxd502488237817609476] 

13:45:01  DEBU[2022-04-08 20:45:01] Finding the debug pod to run command on node ip-192-168-30-222.us-west-2.compute.internal 

13:45:01  DEBU[2022-04-08 20:45:01] Running command on pod debug-7pftt [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-6d3b7d0b-0a7e-46f7-a2ec-aa13bbd84644]] 

13:45:02  STEP: validate if elasticsearch app's volume: es-data-esnode-3 is setup

13:45:02  INFO[2022-04-08 20:45:02] Pod [elasticsearch-applicationscaleupdown-0-04-08-20h17m34s] esnode-3 ready on node ip-192-168-74-103.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:45:02  DEBU[2022-04-08 20:45:02] validating the mounts in pod elasticsearch-applicationscaleupdown-0-04-08-20h17m34s/esnode-3 

13:45:03  DEBU[2022-04-08 20:45:02] pod: [elasticsearch-applicationscaleupdown-0-04-08-20h17m34s] esnode-3 has PX mount: [/dev/pxd/pxd42602268803135413 /usr/share/elasticsearch/data  /dev/pxd/pxd42602268803135413] 

13:45:03  DEBU[2022-04-08 20:45:02] Finding the debug pod to run command on node ip-192-168-74-103.us-west-2.compute.internal 

13:45:03  DEBU[2022-04-08 20:45:03] Running command on pod debug-g2m5l [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-2c7139a5-004f-489e-bf94-cfdaf46afa35]] 

13:45:03  STEP: validate if elasticsearch app's volume: es-data-esnode-4 is setup

13:45:03  INFO[2022-04-08 20:45:03] Pod [elasticsearch-applicationscaleupdown-0-04-08-20h17m34s] esnode-4 ready on node ip-192-168-59-82.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:45:04  DEBU[2022-04-08 20:45:03] validating the mounts in pod elasticsearch-applicationscaleupdown-0-04-08-20h17m34s/esnode-4 

13:45:04  DEBU[2022-04-08 20:45:04] pod: [elasticsearch-applicationscaleupdown-0-04-08-20h17m34s] esnode-4 has PX mount: [/dev/pxd/pxd1133554559821467282 /usr/share/elasticsearch/data  /dev/pxd/pxd1133554559821467282] 

13:45:04  DEBU[2022-04-08 20:45:04] Finding the debug pod to run command on node ip-192-168-59-82.us-west-2.compute.internal 

13:45:04  DEBU[2022-04-08 20:45:04] Running command on pod debug-nr86p [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-24423d75-f9fe-4e1a-a2b6-c3ed755499d7]] 

13:45:04  STEP: validate if elasticsearch app's volume: es-data-esnode-5 is setup

13:45:05  INFO[2022-04-08 20:45:04] Pod [elasticsearch-applicationscaleupdown-0-04-08-20h17m34s] esnode-5 ready on node ip-192-168-30-222.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:45:05  DEBU[2022-04-08 20:45:05] validating the mounts in pod elasticsearch-applicationscaleupdown-0-04-08-20h17m34s/esnode-5 

13:45:05  DEBU[2022-04-08 20:45:05] pod: [elasticsearch-applicationscaleupdown-0-04-08-20h17m34s] esnode-5 has PX mount: [/dev/pxd/pxd915222410459126561 /usr/share/elasticsearch/data  /dev/pxd/pxd915222410459126561] 

13:45:05  DEBU[2022-04-08 20:45:05] Finding the debug pod to run command on node ip-192-168-30-222.us-west-2.compute.internal 

13:45:05  DEBU[2022-04-08 20:45:05] Running command on pod debug-7pftt [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-c55d7ca3-18db-48d1-876f-517e88db39e7]] 

13:45:05  STEP: scale down app elasticsearch by 1

13:45:05  INFO[2022-04-08 20:45:05] Scale all Stateful sets                      

13:45:05  INFO[2022-04-08 20:45:05] StatefulSet esnode scaled to 5 successfully. 

13:45:05  INFO[2022-04-08 20:45:05] Scale all Deployments                        

13:45:05  INFO[2022-04-08 20:45:05] Deployment es-load scaled to 5 successfully. 

13:45:05  STEP: Giving few seconds for scaled down applications to stabilize

13:45:15  STEP: validate elasticsearch app's volumes

13:45:15  STEP: inspect elasticsearch app's volumes

13:45:15  INFO[2022-04-08 20:45:15] [elasticsearch] Validated PVCs from StatefulSet: esnode 

13:45:15  STEP: get elasticsearch app's volume's custom parameters

13:45:16  STEP: get elasticsearch app's volume: pvc-6d3b7d0b-0a7e-46f7-a2ec-aa13bbd84644 inspected by the volume driver

13:45:16  INFO[2022-04-08 20:45:15] Successfully inspected volume: pvc-6d3b7d0b-0a7e-46f7-a2ec-aa13bbd84644 (502488237817609476) 

13:45:16  STEP: get elasticsearch app's volume: pvc-2c7139a5-004f-489e-bf94-cfdaf46afa35 inspected by the volume driver

13:45:16  INFO[2022-04-08 20:45:15] Successfully inspected volume: pvc-2c7139a5-004f-489e-bf94-cfdaf46afa35 (42602268803135413) 

13:45:16  STEP: get elasticsearch app's volume: pvc-24423d75-f9fe-4e1a-a2b6-c3ed755499d7 inspected by the volume driver

13:45:16  INFO[2022-04-08 20:45:15] Successfully inspected volume: pvc-24423d75-f9fe-4e1a-a2b6-c3ed755499d7 (1133554559821467282) 

13:45:16  STEP: get elasticsearch app's volume: pvc-c55d7ca3-18db-48d1-876f-517e88db39e7 inspected by the volume driver

13:45:16  INFO[2022-04-08 20:45:15] Successfully inspected volume: pvc-c55d7ca3-18db-48d1-876f-517e88db39e7 (915222410459126561) 

13:45:16  STEP: get elasticsearch app's volume: pvc-4b4e73dc-9dcf-4c7c-b1b5-b3adb6a074ab inspected by the volume driver

13:45:16  INFO[2022-04-08 20:45:15] Successfully inspected volume: pvc-4b4e73dc-9dcf-4c7c-b1b5-b3adb6a074ab (960018057512770722) 

13:45:16  STEP: get elasticsearch app's volume: pvc-a5b71539-84d9-4734-92a9-c3781615d0ff inspected by the volume driver

13:45:16  INFO[2022-04-08 20:45:15] Successfully inspected volume: pvc-a5b71539-84d9-4734-92a9-c3781615d0ff (636662019148048391) 

13:45:16  STEP: wait for elasticsearch app to start running

13:45:16  INFO[2022-04-08 20:45:15] [elasticsearch] Validated Service: elasticsearch-cluster 

13:45:16  INFO[2022-04-08 20:45:16] [elasticsearch] Validated Service: elasticsearch-api 

13:45:16  2022/04/08 20:45:16 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:45:16    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:45:16    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:45:16    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:45:16    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:45:16    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:45:16    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:45:16   Next retry in: 10s

13:45:26  2022/04/08 20:45:26 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:45:26    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:45:26    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:45:26    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:45:26    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:45:26    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:45:26    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:45:26   Next retry in: 10s

13:45:38  2022/04/08 20:45:36 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:45:38    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:45:38    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:45:38    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:45:38    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:45:38    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:45:38    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:45:38   Next retry in: 10s

13:45:46  2022/04/08 20:45:46 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:45:46    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:45:46    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:45:46    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:45:46    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:45:46    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:45:46    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:45:46   Next retry in: 10s

13:45:56  2022/04/08 20:45:56 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:45:56    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:45:56    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:45:56    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:45:56    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:45:56    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:45:56    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:45:56   Next retry in: 10s

13:46:06  2022/04/08 20:46:06 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:46:06    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:46:06    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:46:06    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:46:06    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:46:06    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:46:06    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:46:06   Next retry in: 10s

13:46:16  2022/04/08 20:46:16 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:46:16    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:46:16    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:46:16    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:46:16    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:46:16    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:46:16    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:46:16   Next retry in: 10s

13:46:26  2022/04/08 20:46:26 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:46:26    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:46:26    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:46:26    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:46:26    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:46:26    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:46:26    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:46:26   Next retry in: 10s

13:46:38  2022/04/08 20:46:36 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:46:38    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:46:38    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:46:38    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:46:38    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:46:38    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:46:38    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:46:38   Next retry in: 10s

13:46:46  2022/04/08 20:46:46 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:46:46    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:46:46    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:46:46    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:46:46    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:46:46    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:46:46    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:46:46   Next retry in: 10s

13:46:56  2022/04/08 20:46:56 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:46:56    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:46:56    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:46:56    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:46:56    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:46:56    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:46:56    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:46:56   Next retry in: 10s

13:47:06  2022/04/08 20:47:06 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:47:06    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:47:06    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:47:06    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:47:06    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:47:06    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:47:06    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:47:06   Next retry in: 10s

13:47:16  2022/04/08 20:47:16 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:47:16    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:47:16    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:47:16    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:47:16    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:47:16    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:47:16    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:47:16   Next retry in: 10s

13:47:26  2022/04/08 20:47:26 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:47:26    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:47:26    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:47:26    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:47:26    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:47:26    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:47:26    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:47:26   Next retry in: 10s

13:47:38  2022/04/08 20:47:36 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:47:38    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:47:38    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:47:38    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:47:38    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:47:38    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:47:38    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:47:38   Next retry in: 10s

13:47:46  2022/04/08 20:47:46 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:47:46    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:47:46    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:47:46    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:47:46    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:47:46    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:47:46    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:47:46   Next retry in: 10s

13:47:56  2022/04/08 20:47:56 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:47:56    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:47:56    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:47:56    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:47:56    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:47:56    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:47:56    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:47:56   Next retry in: 10s

13:48:06  2022/04/08 20:48:06 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:48:06    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:48:06    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:48:06    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:48:06    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:48:06    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:48:06    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:48:06   Next retry in: 10s

13:48:18  2022/04/08 20:48:16 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:48:18    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:48:18    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:48:18    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:48:18    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:48:18    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:48:18    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:48:18   Next retry in: 10s

13:48:26  2022/04/08 20:48:26 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:48:26    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:48:26    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:48:26    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:48:26    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:48:26    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:48:26    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:48:26   Next retry in: 10s

13:48:36  2022/04/08 20:48:36 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:48:36    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:48:36    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:48:36    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:48:36    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:48:36    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:48:36    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:48:36   Next retry in: 10s

13:48:46  2022/04/08 20:48:46 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:48:46    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:48:46    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:48:46    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:48:46    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:48:46    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:48:46    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:48:46   Next retry in: 10s

13:48:56  2022/04/08 20:48:56 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:48:56    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:48:56    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:48:56    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:48:56    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:48:56    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:48:56    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:48:56   Next retry in: 10s

13:49:08  2022/04/08 20:49:06 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:49:08    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:49:08    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:49:08    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:49:08    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:49:08    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:49:08    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:49:08   Next retry in: 10s

13:49:16  2022/04/08 20:49:16 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:49:16    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:49:16    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:49:16    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:49:16    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:49:16    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:49:16    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:49:16   Next retry in: 10s

13:49:26  2022/04/08 20:49:26 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:49:26    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:49:26    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:49:26    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:49:26    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:49:26    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:49:26    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:49:26   Next retry in: 10s

13:49:36  2022/04/08 20:49:36 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:49:36    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:49:36    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:49:36    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:49:36    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:49:36    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:49:36    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:49:36   Next retry in: 10s

13:49:46  2022/04/08 20:49:46 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:49:46    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:49:46    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:49:46    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:49:46    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:49:46    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:49:46    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:49:46   Next retry in: 10s

13:49:59  2022/04/08 20:49:56 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:49:59    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:49:59    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:49:59    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:49:59    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:49:59    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:49:59    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:49:59   Next retry in: 10s

13:50:07  2022/04/08 20:50:06 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:50:07    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:50:07    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:50:07    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:50:07    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:50:07    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:50:07    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:50:07   Next retry in: 10s

13:50:17  2022/04/08 20:50:16 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:50:17    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:false node:192.168.39.135

13:50:17    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:50:17    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:50:17    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:50:17    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:50:17    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:50:17   Next retry in: 10s

13:50:27  2022/04/08 20:50:26 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:50:27    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:false node:192.168.39.135

13:50:27    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:50:27    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:50:27    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:50:27    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:50:27    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:50:27   Next retry in: 10s

13:50:37  2022/04/08 20:50:36 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:50:37    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:false node:192.168.39.135

13:50:37    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:50:37    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:50:37    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:50:37    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:50:37    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:50:37   Next retry in: 10s

13:50:49  2022/04/08 20:50:46 app esnode is not ready yet. Cause: Expected replicas: 5 Observed replicas: 6. Current pods overview:

13:50:49    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.39.135

13:50:49    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:50:49    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:50:49    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:50:49    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:50:49    pod name:esnode-5 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.30.222

13:50:49   Next retry in: 10s

13:50:57  2022/04/08 20:50:57 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:50:57    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:50:57    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:50:57    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:50:57    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:50:57    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:50:57   Next retry in: 10s

13:51:07  2022/04/08 20:51:07 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:51:07    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:51:07    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:51:07    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:51:07    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:51:07    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:51:07   Next retry in: 10s

13:51:17  2022/04/08 20:51:17 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:51:17    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:51:17    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:51:17    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:51:17    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:51:17    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:51:17   Next retry in: 10s

13:51:27  2022/04/08 20:51:27 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:51:27    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:51:27    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:51:27    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:51:27    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:51:27    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:51:27   Next retry in: 10s

13:51:39  2022/04/08 20:51:37 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:51:39    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:51:39    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:51:39    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:51:39    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:51:39    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:51:39   Next retry in: 10s

13:51:47  2022/04/08 20:51:47 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:51:47    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:51:47    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:51:47    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:51:47    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:51:47    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:51:47   Next retry in: 10s

13:51:57  2022/04/08 20:51:57 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:51:57    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:51:57    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:51:57    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:51:57    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:51:57    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:51:57   Next retry in: 10s

13:52:07  2022/04/08 20:52:07 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:52:07    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:52:07    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:52:07    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:52:07    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:52:07    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:52:07   Next retry in: 10s

13:52:17  2022/04/08 20:52:17 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:52:17    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:52:17    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:52:17    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:52:17    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:52:17    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:52:17   Next retry in: 10s

13:52:29  2022/04/08 20:52:27 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:52:29    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:52:29    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:52:29    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:52:29    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:52:29    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:52:29   Next retry in: 10s

13:52:37  2022/04/08 20:52:37 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:52:37    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:52:37    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:52:37    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:52:37    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:52:37    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:52:37   Next retry in: 10s

13:52:47  2022/04/08 20:52:47 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:52:47    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:52:47    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:52:47    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:52:47    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:52:47    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:52:47   Next retry in: 10s

13:52:57  2022/04/08 20:52:57 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:52:57    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:52:57    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:52:57    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:52:57    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:52:57    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:52:57   Next retry in: 10s

13:53:09  2022/04/08 20:53:07 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:53:09    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:53:09    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:53:09    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:53:09    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:53:09    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:53:09   Next retry in: 10s

13:53:17  2022/04/08 20:53:17 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:53:17    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:53:17    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:53:17    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:53:17    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:53:17    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:53:17   Next retry in: 10s

13:53:27  2022/04/08 20:53:27 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:53:27    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:53:27    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:53:27    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:53:27    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:53:27    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:53:27   Next retry in: 10s

13:53:37  2022/04/08 20:53:37 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:53:37    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:53:37    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:53:37    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:53:37    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:53:37    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:53:37   Next retry in: 10s

13:53:47  2022/04/08 20:53:47 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:53:47    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:53:47    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:53:47    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:53:47    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:53:47    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:53:47   Next retry in: 10s

13:53:59  2022/04/08 20:53:57 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:53:59    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:53:59    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:53:59    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:53:59    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:53:59    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:53:59   Next retry in: 10s

13:54:07  2022/04/08 20:54:07 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:54:07    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:54:07    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:54:07    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:54:07    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:54:07    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:54:07   Next retry in: 10s

13:54:17  2022/04/08 20:54:17 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:54:17    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:54:17    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:54:17    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:54:17    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:54:17    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:54:17   Next retry in: 10s

13:54:27  2022/04/08 20:54:27 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:54:27    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:54:27    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:54:27    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:54:27    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:54:27    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:54:27   Next retry in: 10s

13:54:37  2022/04/08 20:54:37 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:54:37    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:54:37    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:54:37    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:54:37    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:54:37    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:54:37   Next retry in: 10s

13:54:49  2022/04/08 20:54:47 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:54:49    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:54:49    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:54:49    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:54:49    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:54:49    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:54:49   Next retry in: 10s

13:54:57  2022/04/08 20:54:57 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:54:57    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:54:57    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:54:57    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:54:57    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:54:57    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:54:57   Next retry in: 10s

13:55:07  2022/04/08 20:55:07 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:55:07    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:55:07    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:55:07    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:55:07    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:55:07    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:55:07   Next retry in: 10s

13:55:17  2022/04/08 20:55:17 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:55:17    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:55:17    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:55:17    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:55:17    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:55:17    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:55:17   Next retry in: 10s

13:55:27  2022/04/08 20:55:27 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:55:27    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:55:27    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:55:27    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:55:27    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:55:27    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:55:27   Next retry in: 10s

13:55:39  2022/04/08 20:55:37 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:55:39    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:55:39    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:55:39    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:55:39    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:55:39    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:55:39   Next retry in: 10s

13:55:48  2022/04/08 20:55:47 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:55:48    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:55:48    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:55:48    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:55:48    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:55:48    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:55:48   Next retry in: 10s

13:55:58  2022/04/08 20:55:57 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:55:58    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:false ready:false node:192.168.39.135

13:55:58    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:55:58    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:55:58    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:55:58    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:55:58   Next retry in: 10s

13:56:07  2022/04/08 20:56:07 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:56:07    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:false node:192.168.39.135

13:56:07    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:56:07    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:56:07    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:56:07    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:56:07   Next retry in: 10s

13:56:20  2022/04/08 20:56:17 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:56:20    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:false node:192.168.39.135

13:56:20    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:56:20    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:56:20    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:56:20    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:56:20   Next retry in: 10s

13:56:28  2022/04/08 20:56:27 app esnode is not ready yet. Cause: Expected replicas: 5 Ready replicas: 4 Current pods overview:

13:56:28    pod name:esnode-0 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:false node:192.168.39.135

13:56:28    pod name:esnode-1 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.79.109

13:56:28    pod name:esnode-2 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.30.222

13:56:28    pod name:esnode-3 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.74.103

13:56:28    pod name:esnode-4 namespace:elasticsearch-applicationscaleupdown-0-04-08-20h17m34s running:true ready:true node:192.168.59.82

13:56:28   Next retry in: 10s

13:56:38  INFO[2022-04-08 20:56:37] [elasticsearch] Validated statefulset: esnode 

13:56:38  INFO[2022-04-08 20:56:38] [elasticsearch] Validated deployment: es-load 

13:56:38  STEP: validate if elasticsearch app's volumes are setup

13:56:38  STEP: validate if elasticsearch app's volume: es-data-esnode-0 is setup

13:56:38  INFO[2022-04-08 20:56:38] Pod [elasticsearch-applicationscaleupdown-0-04-08-20h17m34s] esnode-0 ready on node ip-192-168-39-135.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:56:38  DEBU[2022-04-08 20:56:38] validating the mounts in pod elasticsearch-applicationscaleupdown-0-04-08-20h17m34s/esnode-0 

13:56:38  DEBU[2022-04-08 20:56:38] pod: [elasticsearch-applicationscaleupdown-0-04-08-20h17m34s] esnode-0 has PX mount: [/dev/pxd/pxd960018057512770722 /usr/share/elasticsearch/data  /dev/pxd/pxd960018057512770722] 

13:56:38  DEBU[2022-04-08 20:56:38] Finding the debug pod to run command on node ip-192-168-39-135.us-west-2.compute.internal 

13:56:38  DEBU[2022-04-08 20:56:38] Running command on pod debug-7x9dp [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-4b4e73dc-9dcf-4c7c-b1b5-b3adb6a074ab]] 

13:56:38  STEP: validate if elasticsearch app's volume: es-data-esnode-1 is setup

13:56:38  INFO[2022-04-08 20:56:38] Pod [elasticsearch-applicationscaleupdown-0-04-08-20h17m34s] esnode-1 ready on node ip-192-168-79-109.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:56:38  DEBU[2022-04-08 20:56:38] validating the mounts in pod elasticsearch-applicationscaleupdown-0-04-08-20h17m34s/esnode-1 

13:56:38  DEBU[2022-04-08 20:56:38] pod: [elasticsearch-applicationscaleupdown-0-04-08-20h17m34s] esnode-1 has PX mount: [/dev/pxd/pxd636662019148048391 /usr/share/elasticsearch/data  /dev/pxd/pxd636662019148048391] 

13:56:38  DEBU[2022-04-08 20:56:38] Finding the debug pod to run command on node ip-192-168-79-109.us-west-2.compute.internal 

13:56:38  DEBU[2022-04-08 20:56:38] Running command on pod debug-v9r4k [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-a5b71539-84d9-4734-92a9-c3781615d0ff]] 

13:56:38  STEP: validate if elasticsearch app's volume: es-data-esnode-2 is setup

13:56:38  INFO[2022-04-08 20:56:38] Pod [elasticsearch-applicationscaleupdown-0-04-08-20h17m34s] esnode-2 ready on node ip-192-168-30-222.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:56:39  DEBU[2022-04-08 20:56:39] validating the mounts in pod elasticsearch-applicationscaleupdown-0-04-08-20h17m34s/esnode-2 

13:56:39  DEBU[2022-04-08 20:56:39] pod: [elasticsearch-applicationscaleupdown-0-04-08-20h17m34s] esnode-2 has PX mount: [/dev/pxd/pxd502488237817609476 /usr/share/elasticsearch/data  /dev/pxd/pxd502488237817609476] 

13:56:39  DEBU[2022-04-08 20:56:39] Finding the debug pod to run command on node ip-192-168-30-222.us-west-2.compute.internal 

13:56:39  DEBU[2022-04-08 20:56:39] Running command on pod debug-7pftt [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-6d3b7d0b-0a7e-46f7-a2ec-aa13bbd84644]] 

13:56:39  STEP: validate if elasticsearch app's volume: es-data-esnode-3 is setup

13:56:40  INFO[2022-04-08 20:56:40] Pod [elasticsearch-applicationscaleupdown-0-04-08-20h17m34s] esnode-3 ready on node ip-192-168-74-103.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:56:40  DEBU[2022-04-08 20:56:40] validating the mounts in pod elasticsearch-applicationscaleupdown-0-04-08-20h17m34s/esnode-3 

13:56:40  DEBU[2022-04-08 20:56:40] pod: [elasticsearch-applicationscaleupdown-0-04-08-20h17m34s] esnode-3 has PX mount: [/dev/pxd/pxd42602268803135413 /usr/share/elasticsearch/data  /dev/pxd/pxd42602268803135413] 

13:56:40  DEBU[2022-04-08 20:56:40] Finding the debug pod to run command on node ip-192-168-74-103.us-west-2.compute.internal 

13:56:40  DEBU[2022-04-08 20:56:40] Running command on pod debug-g2m5l [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-2c7139a5-004f-489e-bf94-cfdaf46afa35]] 

13:56:41  STEP: validate if elasticsearch app's volume: es-data-esnode-4 is setup

13:56:41  INFO[2022-04-08 20:56:41] Pod [elasticsearch-applicationscaleupdown-0-04-08-20h17m34s] esnode-4 ready on node ip-192-168-59-82.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:56:41  DEBU[2022-04-08 20:56:41] validating the mounts in pod elasticsearch-applicationscaleupdown-0-04-08-20h17m34s/esnode-4 

13:56:41  DEBU[2022-04-08 20:56:41] pod: [elasticsearch-applicationscaleupdown-0-04-08-20h17m34s] esnode-4 has PX mount: [/dev/pxd/pxd1133554559821467282 /usr/share/elasticsearch/data  /dev/pxd/pxd1133554559821467282] 

13:56:41  DEBU[2022-04-08 20:56:41] Finding the debug pod to run command on node ip-192-168-59-82.us-west-2.compute.internal 

13:56:42  DEBU[2022-04-08 20:56:41] Running command on pod debug-nr86p [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-24423d75-f9fe-4e1a-a2b6-c3ed755499d7]] 

13:56:42  STEP: validate if elasticsearch app's volume: es-data-esnode-5 is setup

13:56:42  STEP: scale up app: postgres by 10 

13:56:42  STEP: Giving few seconds for scaled up applications to stabilize

13:56:52  STEP: validate postgres app's volumes

13:56:52  STEP: inspect postgres app's volumes

13:56:52  INFO[2022-04-08 20:56:52] [postgres] Validated PVC: postgres-data, Namespace: postgres-applicationscaleupdown-0-04-08-20h17m34s 

13:56:52  STEP: get postgres app's volume's custom parameters

13:56:52  STEP: get postgres app's volume: pvc-83ea1fc0-b511-4cbc-b99e-b7bb49ed2308 inspected by the volume driver

13:56:52  INFO[2022-04-08 20:56:52] Successfully inspected volume: pvc-83ea1fc0-b511-4cbc-b99e-b7bb49ed2308 (419169834960255864) 

13:56:52  STEP: wait for postgres app to start running

13:56:52  INFO[2022-04-08 20:56:52] [postgres] Validated deployment: postgres 

13:56:52  STEP: validate if postgres app's volumes are setup

13:56:52  STEP: validate if postgres app's volume: postgres-data is setup

13:56:53  INFO[2022-04-08 20:56:52] Pod [postgres-applicationscaleupdown-0-04-08-20h17m34s] postgres-c88c5898f-l94j6 ready on node ip-192-168-79-109.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:56:53  INFO[2022-04-08 20:56:52] Pod [postgres-applicationscaleupdown-0-04-08-20h17m34s] postgres-c88c5898f-pfhqc not ready on node ip-192-168-30-222.us-west-2.compute.internal - Initialized: True Ready: False Scheduled: True  

13:56:53  DEBU[2022-04-08 20:56:52] validating the mounts in pod postgres-applicationscaleupdown-0-04-08-20h17m34s/postgres-c88c5898f-l94j6 

13:56:53  DEBU[2022-04-08 20:56:52] pod: [postgres-applicationscaleupdown-0-04-08-20h17m34s] postgres-c88c5898f-l94j6 has PX mount: [/dev/pxd/pxd419169834960255864 /var/lib/postgresql/data  /dev/pxd/pxd419169834960255864] 

13:56:53  DEBU[2022-04-08 20:56:52] Finding the debug pod to run command on node ip-192-168-79-109.us-west-2.compute.internal 

13:56:53  DEBU[2022-04-08 20:56:52] Running command on pod debug-v9r4k [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-83ea1fc0-b511-4cbc-b99e-b7bb49ed2308]] 

13:56:53  INFO[2022-04-08 20:56:52] Pod [postgres-applicationscaleupdown-0-04-08-20h17m34s] postgres-c88c5898f-pfhqc not ready on node ip-192-168-30-222.us-west-2.compute.internal - Initialized: True Ready: False Scheduled: True  

13:56:53  STEP: scale down app postgres by 1

13:56:53  STEP: Giving few seconds for scaled down applications to stabilize

13:57:03  STEP: validate postgres app's volumes

13:57:03  STEP: inspect postgres app's volumes

13:57:03  INFO[2022-04-08 20:57:03] [postgres] Validated PVC: postgres-data, Namespace: postgres-applicationscaleupdown-0-04-08-20h17m34s 

13:57:03  STEP: get postgres app's volume's custom parameters

13:57:03  STEP: get postgres app's volume: pvc-83ea1fc0-b511-4cbc-b99e-b7bb49ed2308 inspected by the volume driver

13:57:03  INFO[2022-04-08 20:57:03] Successfully inspected volume: pvc-83ea1fc0-b511-4cbc-b99e-b7bb49ed2308 (419169834960255864) 

13:57:03  STEP: wait for postgres app to start running

13:57:03  INFO[2022-04-08 20:57:03] [postgres] Validated deployment: postgres 

13:57:03  STEP: validate if postgres app's volumes are setup

13:57:03  STEP: validate if postgres app's volume: postgres-data is setup

13:57:03  INFO[2022-04-08 20:57:03] Pod [postgres-applicationscaleupdown-0-04-08-20h17m34s] postgres-c88c5898f-l94j6 ready on node ip-192-168-79-109.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:57:03  INFO[2022-04-08 20:57:03] Pod [postgres-applicationscaleupdown-0-04-08-20h17m34s] postgres-c88c5898f-pfhqc not ready on node ip-192-168-30-222.us-west-2.compute.internal - Initialized: True Ready: False Scheduled: True  

13:57:03  DEBU[2022-04-08 20:57:03] validating the mounts in pod postgres-applicationscaleupdown-0-04-08-20h17m34s/postgres-c88c5898f-l94j6 

13:57:03  DEBU[2022-04-08 20:57:03] pod: [postgres-applicationscaleupdown-0-04-08-20h17m34s] postgres-c88c5898f-l94j6 has PX mount: [/dev/pxd/pxd419169834960255864 /var/lib/postgresql/data  /dev/pxd/pxd419169834960255864] 

13:57:03  DEBU[2022-04-08 20:57:03] Finding the debug pod to run command on node ip-192-168-79-109.us-west-2.compute.internal 

13:57:03  DEBU[2022-04-08 20:57:03] Running command on pod debug-v9r4k [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-83ea1fc0-b511-4cbc-b99e-b7bb49ed2308]] 

13:57:03  INFO[2022-04-08 20:57:03] Pod [postgres-applicationscaleupdown-0-04-08-20h17m34s] postgres-c88c5898f-pfhqc not ready on node ip-192-168-30-222.us-west-2.compute.internal - Initialized: True Ready: False Scheduled: True  

13:57:03  STEP: scale up app: sysbench by 10 

13:57:03  STEP: Giving few seconds for scaled up applications to stabilize

13:57:13  STEP: validate sysbench app's volumes

13:57:13  STEP: inspect sysbench app's volumes

13:57:13  INFO[2022-04-08 20:57:13] [sysbench] Validated PVC: sysbench-mysql-data, Namespace: sysbench-applicationscaleupdown-0-04-08-20h17m34s 

13:57:13  STEP: get sysbench app's volume's custom parameters

13:57:13  STEP: get sysbench app's volume: pvc-5ca91fca-edee-4144-8a1a-853b9a234a1e inspected by the volume driver

13:57:13  INFO[2022-04-08 20:57:13] Successfully inspected volume: pvc-5ca91fca-edee-4144-8a1a-853b9a234a1e (72582932534895790) 

13:57:13  STEP: wait for sysbench app to start running

13:57:13  INFO[2022-04-08 20:57:13] [sysbench] Validated deployment: sysbench 

13:57:13  STEP: validate if sysbench app's volumes are setup

13:57:13  STEP: validate if sysbench app's volume: sysbench-mysql-data is setup

13:57:13  INFO[2022-04-08 20:57:13] Pod [sysbench-applicationscaleupdown-0-04-08-20h17m34s] sysbench-79868f4546-fpwld ready on node ip-192-168-74-103.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:57:13  DEBU[2022-04-08 20:57:13] validating the mounts in pod sysbench-applicationscaleupdown-0-04-08-20h17m34s/sysbench-79868f4546-fpwld 

13:57:13  DEBU[2022-04-08 20:57:13] pod: [sysbench-applicationscaleupdown-0-04-08-20h17m34s] sysbench-79868f4546-fpwld has PX mount: [/dev/pxd/pxd72582932534895790 /var/lib/mysql  /dev/pxd/pxd72582932534895790] 

13:57:13  DEBU[2022-04-08 20:57:13] Finding the debug pod to run command on node ip-192-168-74-103.us-west-2.compute.internal 

13:57:13  DEBU[2022-04-08 20:57:13] Running command on pod debug-g2m5l [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-5ca91fca-edee-4144-8a1a-853b9a234a1e]] 

13:57:13  STEP: scale down app sysbench by 1

13:57:13  STEP: Giving few seconds for scaled down applications to stabilize

13:57:26  STEP: validate sysbench app's volumes

13:57:26  STEP: inspect sysbench app's volumes

13:57:26  INFO[2022-04-08 20:57:23] [sysbench] Validated PVC: sysbench-mysql-data, Namespace: sysbench-applicationscaleupdown-0-04-08-20h17m34s 

13:57:26  STEP: get sysbench app's volume's custom parameters

13:57:26  STEP: get sysbench app's volume: pvc-5ca91fca-edee-4144-8a1a-853b9a234a1e inspected by the volume driver

13:57:26  INFO[2022-04-08 20:57:23] Successfully inspected volume: pvc-5ca91fca-edee-4144-8a1a-853b9a234a1e (72582932534895790) 

13:57:26  STEP: wait for sysbench app to start running

13:57:26  INFO[2022-04-08 20:57:23] [sysbench] Validated deployment: sysbench 

13:57:26  STEP: validate if sysbench app's volumes are setup

13:57:26  STEP: validate if sysbench app's volume: sysbench-mysql-data is setup

13:57:26  INFO[2022-04-08 20:57:23] Pod [sysbench-applicationscaleupdown-0-04-08-20h17m34s] sysbench-79868f4546-fpwld ready on node ip-192-168-74-103.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:57:26  DEBU[2022-04-08 20:57:23] validating the mounts in pod sysbench-applicationscaleupdown-0-04-08-20h17m34s/sysbench-79868f4546-fpwld 

13:57:26  DEBU[2022-04-08 20:57:24] pod: [sysbench-applicationscaleupdown-0-04-08-20h17m34s] sysbench-79868f4546-fpwld has PX mount: [/dev/pxd/pxd72582932534895790 /var/lib/mysql  /dev/pxd/pxd72582932534895790] 

13:57:26  DEBU[2022-04-08 20:57:24] Finding the debug pod to run command on node ip-192-168-74-103.us-west-2.compute.internal 

13:57:26  DEBU[2022-04-08 20:57:24] Running command on pod debug-g2m5l [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-5ca91fca-edee-4144-8a1a-853b9a234a1e]] 

13:57:26  STEP: scale up app: nginx-sharedv4 by 10 

13:57:26  INFO[2022-04-08 20:57:24] Scale all Deployments                        

13:57:26  INFO[2022-04-08 20:57:24] Deployment nginx scaled to 6 successfully. 

13:57:26  STEP: Giving few seconds for scaled up applications to stabilize

13:57:36  STEP: validate nginx-sharedv4 app's volumes

13:57:36  STEP: inspect nginx-sharedv4 app's volumes

13:57:36  INFO[2022-04-08 20:57:34] [nginx-sharedv4] Validated PVC: px-nginx-pvc-sharedv4, Namespace: nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s 

13:57:36  INFO[2022-04-08 20:57:34] [nginx-sharedv4] Validated PVC: px-nginx-pvc-enc-sharedv4, Namespace: nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s 

13:57:36  STEP: get nginx-sharedv4 app's volume's custom parameters

13:57:36  STEP: get nginx-sharedv4 app's volume: pvc-610c8fbf-34f7-45a3-93b0-41079cbf9419 inspected by the volume driver

13:57:36  INFO[2022-04-08 20:57:34] Successfully inspected volume: pvc-610c8fbf-34f7-45a3-93b0-41079cbf9419 (671567044016503101) 

13:57:36  STEP: get nginx-sharedv4 app's volume: pvc-5d3abcb1-355d-44aa-a121-382165bf72c6 inspected by the volume driver

13:57:36  INFO[2022-04-08 20:57:34] Successfully inspected volume: pvc-5d3abcb1-355d-44aa-a121-382165bf72c6 (1003972371003177018) 

13:57:36  STEP: wait for nginx-sharedv4 app to start running

13:57:36  INFO[2022-04-08 20:57:34] [nginx-sharedv4] Validated Service: nginx-service 

13:57:36  INFO[2022-04-08 20:57:34] [nginx-sharedv4] Validated deployment: nginx 

13:57:36  STEP: validate if nginx-sharedv4 app's volumes are setup

13:57:36  STEP: validate if nginx-sharedv4 app's volume: px-nginx-pvc-sharedv4 is setup

13:57:36  INFO[2022-04-08 20:57:34] Pod [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-2m5pj ready on node ip-192-168-79-109.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:57:36  INFO[2022-04-08 20:57:34] Pod [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-gcpj8 ready on node ip-192-168-79-109.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:57:36  INFO[2022-04-08 20:57:34] Pod [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-h87sz ready on node ip-192-168-20-251.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:57:36  INFO[2022-04-08 20:57:34] Pod [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-lsftw ready on node ip-192-168-20-251.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:57:36  INFO[2022-04-08 20:57:34] Pod [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-qmtgg ready on node ip-192-168-39-135.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:57:36  INFO[2022-04-08 20:57:34] Pod [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-t2f4r ready on node ip-192-168-39-135.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:57:36  DEBU[2022-04-08 20:57:34] validating the mounts in pod nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-2m5pj 

13:57:36  DEBU[2022-04-08 20:57:35] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-2m5pj has PX mount: [/dev/pxd/pxd671567044016503101 /usr/share/nginx/html  /dev/pxd/pxd671567044016503101] 

13:57:36  DEBU[2022-04-08 20:57:35] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-2m5pj has PX mount: [/dev/mapper/pxd-enc1003972371003177018 /usr/share/nginx/html-enc  /dev/mapper/pxd-enc1003972371003177018] 

13:57:36  DEBU[2022-04-08 20:57:35] Finding the debug pod to run command on node ip-192-168-79-109.us-west-2.compute.internal 

13:57:36  DEBU[2022-04-08 20:57:35] Running command on pod debug-v9r4k [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-610c8fbf-34f7-45a3-93b0-41079cbf9419]] 

13:57:36  DEBU[2022-04-08 20:57:35] validating the mounts in pod nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-gcpj8 

13:57:36  DEBU[2022-04-08 20:57:35] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-gcpj8 has PX mount: [/dev/pxd/pxd671567044016503101 /usr/share/nginx/html  /dev/pxd/pxd671567044016503101] 

13:57:36  DEBU[2022-04-08 20:57:35] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-gcpj8 has PX mount: [/dev/mapper/pxd-enc1003972371003177018 /usr/share/nginx/html-enc  /dev/mapper/pxd-enc1003972371003177018] 

13:57:36  DEBU[2022-04-08 20:57:35] Finding the debug pod to run command on node ip-192-168-79-109.us-west-2.compute.internal 

13:57:36  DEBU[2022-04-08 20:57:35] Running command on pod debug-v9r4k [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-610c8fbf-34f7-45a3-93b0-41079cbf9419]] 

13:57:36  DEBU[2022-04-08 20:57:36] validating the mounts in pod nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-h87sz 

13:57:36  DEBU[2022-04-08 20:57:36] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-h87sz has PX mount: [192.168.79.109:/var/lib/osd/pxns/671567044016503101 /usr/share/nginx/html  192.168.79.109:/var/lib/osd/pxns/671567044016503101] 

13:57:36  DEBU[2022-04-08 20:57:36] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-h87sz has PX mount: [192.168.79.109:/var/lib/osd/pxns/1003972371003177018 /usr/share/nginx/html-enc  192.168.79.109:/var/lib/osd/pxns/1003972371003177018] 

13:57:36  DEBU[2022-04-08 20:57:36] Finding the debug pod to run command on node ip-192-168-20-251.us-west-2.compute.internal 

13:57:36  DEBU[2022-04-08 20:57:36] Running command on pod debug-5svpb [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-610c8fbf-34f7-45a3-93b0-41079cbf9419]] 

13:57:37  DEBU[2022-04-08 20:57:37] validating the mounts in pod nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-lsftw 

13:57:37  DEBU[2022-04-08 20:57:37] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-lsftw has PX mount: [192.168.79.109:/var/lib/osd/pxns/671567044016503101 /usr/share/nginx/html  192.168.79.109:/var/lib/osd/pxns/671567044016503101] 

13:57:37  DEBU[2022-04-08 20:57:37] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-lsftw has PX mount: [192.168.79.109:/var/lib/osd/pxns/1003972371003177018 /usr/share/nginx/html-enc  192.168.79.109:/var/lib/osd/pxns/1003972371003177018] 

13:57:37  DEBU[2022-04-08 20:57:37] Finding the debug pod to run command on node ip-192-168-20-251.us-west-2.compute.internal 

13:57:37  DEBU[2022-04-08 20:57:37] Running command on pod debug-5svpb [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-610c8fbf-34f7-45a3-93b0-41079cbf9419]] 

13:57:37  DEBU[2022-04-08 20:57:37] validating the mounts in pod nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-qmtgg 

13:57:38  DEBU[2022-04-08 20:57:38] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-qmtgg has PX mount: [192.168.79.109:/var/lib/osd/pxns/671567044016503101 /usr/share/nginx/html  192.168.79.109:/var/lib/osd/pxns/671567044016503101] 

13:57:38  DEBU[2022-04-08 20:57:38] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-qmtgg has PX mount: [192.168.79.109:/var/lib/osd/pxns/1003972371003177018 /usr/share/nginx/html-enc  192.168.79.109:/var/lib/osd/pxns/1003972371003177018] 

13:57:38  DEBU[2022-04-08 20:57:38] Finding the debug pod to run command on node ip-192-168-39-135.us-west-2.compute.internal 

13:57:38  DEBU[2022-04-08 20:57:38] Running command on pod debug-7x9dp [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-610c8fbf-34f7-45a3-93b0-41079cbf9419]] 

13:57:38  DEBU[2022-04-08 20:57:38] validating the mounts in pod nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-t2f4r 

13:57:39  DEBU[2022-04-08 20:57:39] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-t2f4r has PX mount: [192.168.79.109:/var/lib/osd/pxns/671567044016503101 /usr/share/nginx/html  192.168.79.109:/var/lib/osd/pxns/671567044016503101] 

13:57:39  DEBU[2022-04-08 20:57:39] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-t2f4r has PX mount: [192.168.79.109:/var/lib/osd/pxns/1003972371003177018 /usr/share/nginx/html-enc  192.168.79.109:/var/lib/osd/pxns/1003972371003177018] 

13:57:39  DEBU[2022-04-08 20:57:39] Finding the debug pod to run command on node ip-192-168-39-135.us-west-2.compute.internal 

13:57:39  DEBU[2022-04-08 20:57:39] Running command on pod debug-7x9dp [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-610c8fbf-34f7-45a3-93b0-41079cbf9419]] 

13:57:39  STEP: validate if nginx-sharedv4 app's volume: px-nginx-pvc-enc-sharedv4 is setup

13:57:39  INFO[2022-04-08 20:57:39] Pod [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-2m5pj ready on node ip-192-168-79-109.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:57:39  INFO[2022-04-08 20:57:39] Pod [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-gcpj8 ready on node ip-192-168-79-109.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:57:39  INFO[2022-04-08 20:57:39] Pod [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-h87sz ready on node ip-192-168-20-251.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:57:39  INFO[2022-04-08 20:57:39] Pod [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-lsftw ready on node ip-192-168-20-251.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:57:39  INFO[2022-04-08 20:57:39] Pod [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-qmtgg ready on node ip-192-168-39-135.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:57:39  INFO[2022-04-08 20:57:39] Pod [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-t2f4r ready on node ip-192-168-39-135.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:57:40  DEBU[2022-04-08 20:57:39] validating the mounts in pod nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-2m5pj 

13:57:40  DEBU[2022-04-08 20:57:40] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-2m5pj has PX mount: [/dev/pxd/pxd671567044016503101 /usr/share/nginx/html  /dev/pxd/pxd671567044016503101] 

13:57:40  DEBU[2022-04-08 20:57:40] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-2m5pj has PX mount: [/dev/mapper/pxd-enc1003972371003177018 /usr/share/nginx/html-enc  /dev/mapper/pxd-enc1003972371003177018] 

13:57:40  DEBU[2022-04-08 20:57:40] Finding the debug pod to run command on node ip-192-168-79-109.us-west-2.compute.internal 

13:57:40  DEBU[2022-04-08 20:57:40] Running command on pod debug-v9r4k [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-5d3abcb1-355d-44aa-a121-382165bf72c6]] 

13:57:40  DEBU[2022-04-08 20:57:40] validating the mounts in pod nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-gcpj8 

13:57:41  DEBU[2022-04-08 20:57:41] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-gcpj8 has PX mount: [/dev/pxd/pxd671567044016503101 /usr/share/nginx/html  /dev/pxd/pxd671567044016503101] 

13:57:41  DEBU[2022-04-08 20:57:41] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-gcpj8 has PX mount: [/dev/mapper/pxd-enc1003972371003177018 /usr/share/nginx/html-enc  /dev/mapper/pxd-enc1003972371003177018] 

13:57:41  DEBU[2022-04-08 20:57:41] Finding the debug pod to run command on node ip-192-168-79-109.us-west-2.compute.internal 

13:57:41  DEBU[2022-04-08 20:57:41] Running command on pod debug-v9r4k [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-5d3abcb1-355d-44aa-a121-382165bf72c6]] 

13:57:41  DEBU[2022-04-08 20:57:41] validating the mounts in pod nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-h87sz 

13:57:42  DEBU[2022-04-08 20:57:41] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-h87sz has PX mount: [192.168.79.109:/var/lib/osd/pxns/671567044016503101 /usr/share/nginx/html  192.168.79.109:/var/lib/osd/pxns/671567044016503101] 

13:57:42  DEBU[2022-04-08 20:57:41] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-h87sz has PX mount: [192.168.79.109:/var/lib/osd/pxns/1003972371003177018 /usr/share/nginx/html-enc  192.168.79.109:/var/lib/osd/pxns/1003972371003177018] 

13:57:42  DEBU[2022-04-08 20:57:41] Finding the debug pod to run command on node ip-192-168-20-251.us-west-2.compute.internal 

13:57:42  DEBU[2022-04-08 20:57:41] Running command on pod debug-5svpb [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-5d3abcb1-355d-44aa-a121-382165bf72c6]] 

13:57:42  DEBU[2022-04-08 20:57:42] validating the mounts in pod nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-lsftw 

13:57:42  DEBU[2022-04-08 20:57:42] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-lsftw has PX mount: [192.168.79.109:/var/lib/osd/pxns/671567044016503101 /usr/share/nginx/html  192.168.79.109:/var/lib/osd/pxns/671567044016503101] 

13:57:42  DEBU[2022-04-08 20:57:42] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-lsftw has PX mount: [192.168.79.109:/var/lib/osd/pxns/1003972371003177018 /usr/share/nginx/html-enc  192.168.79.109:/var/lib/osd/pxns/1003972371003177018] 

13:57:42  DEBU[2022-04-08 20:57:42] Finding the debug pod to run command on node ip-192-168-20-251.us-west-2.compute.internal 

13:57:42  DEBU[2022-04-08 20:57:42] Running command on pod debug-5svpb [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-5d3abcb1-355d-44aa-a121-382165bf72c6]] 

13:57:43  DEBU[2022-04-08 20:57:43] validating the mounts in pod nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-qmtgg 

13:57:43  DEBU[2022-04-08 20:57:43] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-qmtgg has PX mount: [192.168.79.109:/var/lib/osd/pxns/671567044016503101 /usr/share/nginx/html  192.168.79.109:/var/lib/osd/pxns/671567044016503101] 

13:57:43  DEBU[2022-04-08 20:57:43] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-qmtgg has PX mount: [192.168.79.109:/var/lib/osd/pxns/1003972371003177018 /usr/share/nginx/html-enc  192.168.79.109:/var/lib/osd/pxns/1003972371003177018] 

13:57:43  DEBU[2022-04-08 20:57:43] Finding the debug pod to run command on node ip-192-168-39-135.us-west-2.compute.internal 

13:57:43  DEBU[2022-04-08 20:57:43] Running command on pod debug-7x9dp [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-5d3abcb1-355d-44aa-a121-382165bf72c6]] 

13:57:44  DEBU[2022-04-08 20:57:43] validating the mounts in pod nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-t2f4r 

13:57:44  DEBU[2022-04-08 20:57:44] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-t2f4r has PX mount: [192.168.79.109:/var/lib/osd/pxns/671567044016503101 /usr/share/nginx/html  192.168.79.109:/var/lib/osd/pxns/671567044016503101] 

13:57:44  DEBU[2022-04-08 20:57:44] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-t2f4r has PX mount: [192.168.79.109:/var/lib/osd/pxns/1003972371003177018 /usr/share/nginx/html-enc  192.168.79.109:/var/lib/osd/pxns/1003972371003177018] 

13:57:44  DEBU[2022-04-08 20:57:44] Finding the debug pod to run command on node ip-192-168-39-135.us-west-2.compute.internal 

13:57:44  DEBU[2022-04-08 20:57:44] Running command on pod debug-7x9dp [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-5d3abcb1-355d-44aa-a121-382165bf72c6]] 

13:57:44  STEP: scale down app nginx-sharedv4 by 1

13:57:45  INFO[2022-04-08 20:57:44] Scale all Deployments                        

13:57:45  INFO[2022-04-08 20:57:44] Deployment nginx scaled to 5 successfully. 

13:57:45  STEP: Giving few seconds for scaled down applications to stabilize

13:57:55  STEP: validate nginx-sharedv4 app's volumes

13:57:55  STEP: inspect nginx-sharedv4 app's volumes

13:57:55  INFO[2022-04-08 20:57:54] [nginx-sharedv4] Validated PVC: px-nginx-pvc-sharedv4, Namespace: nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s 

13:57:55  INFO[2022-04-08 20:57:54] [nginx-sharedv4] Validated PVC: px-nginx-pvc-enc-sharedv4, Namespace: nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s 

13:57:55  STEP: get nginx-sharedv4 app's volume's custom parameters

13:57:55  STEP: get nginx-sharedv4 app's volume: pvc-610c8fbf-34f7-45a3-93b0-41079cbf9419 inspected by the volume driver

13:57:55  INFO[2022-04-08 20:57:55] Successfully inspected volume: pvc-610c8fbf-34f7-45a3-93b0-41079cbf9419 (671567044016503101) 

13:57:55  STEP: get nginx-sharedv4 app's volume: pvc-5d3abcb1-355d-44aa-a121-382165bf72c6 inspected by the volume driver

13:57:55  INFO[2022-04-08 20:57:55] Successfully inspected volume: pvc-5d3abcb1-355d-44aa-a121-382165bf72c6 (1003972371003177018) 

13:57:55  STEP: wait for nginx-sharedv4 app to start running

13:57:55  INFO[2022-04-08 20:57:55] [nginx-sharedv4] Validated Service: nginx-service 

13:57:55  INFO[2022-04-08 20:57:55] [nginx-sharedv4] Validated deployment: nginx 

13:57:55  STEP: validate if nginx-sharedv4 app's volumes are setup

13:57:55  STEP: validate if nginx-sharedv4 app's volume: px-nginx-pvc-sharedv4 is setup

13:57:55  INFO[2022-04-08 20:57:55] Pod [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-2m5pj ready on node ip-192-168-79-109.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:57:55  INFO[2022-04-08 20:57:55] Pod [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-gcpj8 ready on node ip-192-168-79-109.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:57:55  INFO[2022-04-08 20:57:55] Pod [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-h87sz ready on node ip-192-168-20-251.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:57:55  INFO[2022-04-08 20:57:55] Pod [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-lsftw ready on node ip-192-168-20-251.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:57:55  INFO[2022-04-08 20:57:55] Pod [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-qmtgg ready on node ip-192-168-39-135.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:57:55  DEBU[2022-04-08 20:57:55] validating the mounts in pod nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-2m5pj 

13:57:55  DEBU[2022-04-08 20:57:55] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-2m5pj has PX mount: [/dev/pxd/pxd671567044016503101 /usr/share/nginx/html  /dev/pxd/pxd671567044016503101] 

13:57:55  DEBU[2022-04-08 20:57:55] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-2m5pj has PX mount: [/dev/mapper/pxd-enc1003972371003177018 /usr/share/nginx/html-enc  /dev/mapper/pxd-enc1003972371003177018] 

13:57:55  DEBU[2022-04-08 20:57:55] Finding the debug pod to run command on node ip-192-168-79-109.us-west-2.compute.internal 

13:57:56  DEBU[2022-04-08 20:57:55] Running command on pod debug-v9r4k [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-610c8fbf-34f7-45a3-93b0-41079cbf9419]] 

13:57:56  DEBU[2022-04-08 20:57:56] validating the mounts in pod nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-gcpj8 

13:57:56  DEBU[2022-04-08 20:57:56] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-gcpj8 has PX mount: [/dev/pxd/pxd671567044016503101 /usr/share/nginx/html  /dev/pxd/pxd671567044016503101] 

13:57:56  DEBU[2022-04-08 20:57:56] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-gcpj8 has PX mount: [/dev/mapper/pxd-enc1003972371003177018 /usr/share/nginx/html-enc  /dev/mapper/pxd-enc1003972371003177018] 

13:57:56  DEBU[2022-04-08 20:57:56] Finding the debug pod to run command on node ip-192-168-79-109.us-west-2.compute.internal 

13:57:56  DEBU[2022-04-08 20:57:56] Running command on pod debug-v9r4k [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-610c8fbf-34f7-45a3-93b0-41079cbf9419]] 

13:57:57  DEBU[2022-04-08 20:57:56] validating the mounts in pod nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-h87sz 

13:57:57  DEBU[2022-04-08 20:57:57] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-h87sz has PX mount: [192.168.79.109:/var/lib/osd/pxns/671567044016503101 /usr/share/nginx/html  192.168.79.109:/var/lib/osd/pxns/671567044016503101] 

13:57:57  DEBU[2022-04-08 20:57:57] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-h87sz has PX mount: [192.168.79.109:/var/lib/osd/pxns/1003972371003177018 /usr/share/nginx/html-enc  192.168.79.109:/var/lib/osd/pxns/1003972371003177018] 

13:57:57  DEBU[2022-04-08 20:57:57] Finding the debug pod to run command on node ip-192-168-20-251.us-west-2.compute.internal 

13:57:57  DEBU[2022-04-08 20:57:57] Running command on pod debug-5svpb [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-610c8fbf-34f7-45a3-93b0-41079cbf9419]] 

13:57:57  DEBU[2022-04-08 20:57:57] validating the mounts in pod nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-lsftw 

13:57:58  DEBU[2022-04-08 20:57:58] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-lsftw has PX mount: [192.168.79.109:/var/lib/osd/pxns/671567044016503101 /usr/share/nginx/html  192.168.79.109:/var/lib/osd/pxns/671567044016503101] 

13:57:58  DEBU[2022-04-08 20:57:58] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-lsftw has PX mount: [192.168.79.109:/var/lib/osd/pxns/1003972371003177018 /usr/share/nginx/html-enc  192.168.79.109:/var/lib/osd/pxns/1003972371003177018] 

13:57:58  DEBU[2022-04-08 20:57:58] Finding the debug pod to run command on node ip-192-168-20-251.us-west-2.compute.internal 

13:57:58  DEBU[2022-04-08 20:57:58] Running command on pod debug-5svpb [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-610c8fbf-34f7-45a3-93b0-41079cbf9419]] 

13:57:58  DEBU[2022-04-08 20:57:58] validating the mounts in pod nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-qmtgg 

13:57:59  DEBU[2022-04-08 20:57:58] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-qmtgg has PX mount: [192.168.79.109:/var/lib/osd/pxns/671567044016503101 /usr/share/nginx/html  192.168.79.109:/var/lib/osd/pxns/671567044016503101] 

13:57:59  DEBU[2022-04-08 20:57:58] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-qmtgg has PX mount: [192.168.79.109:/var/lib/osd/pxns/1003972371003177018 /usr/share/nginx/html-enc  192.168.79.109:/var/lib/osd/pxns/1003972371003177018] 

13:57:59  DEBU[2022-04-08 20:57:58] Finding the debug pod to run command on node ip-192-168-39-135.us-west-2.compute.internal 

13:57:59  DEBU[2022-04-08 20:57:58] Running command on pod debug-7x9dp [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-610c8fbf-34f7-45a3-93b0-41079cbf9419]] 

13:57:59  STEP: validate if nginx-sharedv4 app's volume: px-nginx-pvc-enc-sharedv4 is setup

13:57:59  INFO[2022-04-08 20:57:59] Pod [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-2m5pj ready on node ip-192-168-79-109.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:57:59  INFO[2022-04-08 20:57:59] Pod [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-gcpj8 ready on node ip-192-168-79-109.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:57:59  INFO[2022-04-08 20:57:59] Pod [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-h87sz ready on node ip-192-168-20-251.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:57:59  INFO[2022-04-08 20:57:59] Pod [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-lsftw ready on node ip-192-168-20-251.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:57:59  INFO[2022-04-08 20:57:59] Pod [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-qmtgg ready on node ip-192-168-39-135.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:57:59  DEBU[2022-04-08 20:57:59] validating the mounts in pod nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-2m5pj 

13:58:00  DEBU[2022-04-08 20:58:00] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-2m5pj has PX mount: [/dev/pxd/pxd671567044016503101 /usr/share/nginx/html  /dev/pxd/pxd671567044016503101] 

13:58:00  DEBU[2022-04-08 20:58:00] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-2m5pj has PX mount: [/dev/mapper/pxd-enc1003972371003177018 /usr/share/nginx/html-enc  /dev/mapper/pxd-enc1003972371003177018] 

13:58:00  DEBU[2022-04-08 20:58:00] Finding the debug pod to run command on node ip-192-168-79-109.us-west-2.compute.internal 

13:58:00  DEBU[2022-04-08 20:58:00] Running command on pod debug-v9r4k [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-5d3abcb1-355d-44aa-a121-382165bf72c6]] 

13:58:00  DEBU[2022-04-08 20:58:00] validating the mounts in pod nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-gcpj8 

13:58:00  DEBU[2022-04-08 20:58:00] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-gcpj8 has PX mount: [/dev/pxd/pxd671567044016503101 /usr/share/nginx/html  /dev/pxd/pxd671567044016503101] 

13:58:00  DEBU[2022-04-08 20:58:00] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-gcpj8 has PX mount: [/dev/mapper/pxd-enc1003972371003177018 /usr/share/nginx/html-enc  /dev/mapper/pxd-enc1003972371003177018] 

13:58:00  DEBU[2022-04-08 20:58:00] Finding the debug pod to run command on node ip-192-168-79-109.us-west-2.compute.internal 

13:58:01  DEBU[2022-04-08 20:58:00] Running command on pod debug-v9r4k [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-5d3abcb1-355d-44aa-a121-382165bf72c6]] 

13:58:01  DEBU[2022-04-08 20:58:01] validating the mounts in pod nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-h87sz 

13:58:01  DEBU[2022-04-08 20:58:01] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-h87sz has PX mount: [192.168.79.109:/var/lib/osd/pxns/671567044016503101 /usr/share/nginx/html  192.168.79.109:/var/lib/osd/pxns/671567044016503101] 

13:58:01  DEBU[2022-04-08 20:58:01] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-h87sz has PX mount: [192.168.79.109:/var/lib/osd/pxns/1003972371003177018 /usr/share/nginx/html-enc  192.168.79.109:/var/lib/osd/pxns/1003972371003177018] 

13:58:01  DEBU[2022-04-08 20:58:01] Finding the debug pod to run command on node ip-192-168-20-251.us-west-2.compute.internal 

13:58:01  DEBU[2022-04-08 20:58:01] Running command on pod debug-5svpb [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-5d3abcb1-355d-44aa-a121-382165bf72c6]] 

13:58:02  DEBU[2022-04-08 20:58:02] validating the mounts in pod nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-lsftw 

13:58:02  DEBU[2022-04-08 20:58:02] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-lsftw has PX mount: [192.168.79.109:/var/lib/osd/pxns/671567044016503101 /usr/share/nginx/html  192.168.79.109:/var/lib/osd/pxns/671567044016503101] 

13:58:02  DEBU[2022-04-08 20:58:02] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-lsftw has PX mount: [192.168.79.109:/var/lib/osd/pxns/1003972371003177018 /usr/share/nginx/html-enc  192.168.79.109:/var/lib/osd/pxns/1003972371003177018] 

13:58:02  DEBU[2022-04-08 20:58:02] Finding the debug pod to run command on node ip-192-168-20-251.us-west-2.compute.internal 

13:58:02  DEBU[2022-04-08 20:58:02] Running command on pod debug-5svpb [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-5d3abcb1-355d-44aa-a121-382165bf72c6]] 

13:58:02  DEBU[2022-04-08 20:58:02] validating the mounts in pod nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-qmtgg 

13:58:03  DEBU[2022-04-08 20:58:03] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-qmtgg has PX mount: [192.168.79.109:/var/lib/osd/pxns/671567044016503101 /usr/share/nginx/html  192.168.79.109:/var/lib/osd/pxns/671567044016503101] 

13:58:03  DEBU[2022-04-08 20:58:03] pod: [nginx-sharedv4-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-qmtgg has PX mount: [192.168.79.109:/var/lib/osd/pxns/1003972371003177018 /usr/share/nginx/html-enc  192.168.79.109:/var/lib/osd/pxns/1003972371003177018] 

13:58:03  DEBU[2022-04-08 20:58:03] Finding the debug pod to run command on node ip-192-168-39-135.us-west-2.compute.internal 

13:58:03  DEBU[2022-04-08 20:58:03] Running command on pod debug-7x9dp [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-5d3abcb1-355d-44aa-a121-382165bf72c6]] 

13:58:03  STEP: scale up app: nginx-sv4-svc by 10 

13:58:04  INFO[2022-04-08 20:58:03] Scale all Deployments                        

13:58:04  INFO[2022-04-08 20:58:03] Deployment nginx scaled to 6 successfully. 

13:58:04  STEP: Giving few seconds for scaled up applications to stabilize

13:58:14  STEP: validate nginx-sv4-svc app's volumes

13:58:14  STEP: inspect nginx-sv4-svc app's volumes

13:58:14  INFO[2022-04-08 20:58:13] [nginx-sv4-svc] Validated PVC: px-nginx-pvc-sharedv4, Namespace: nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s 

13:58:14  INFO[2022-04-08 20:58:13] [nginx-sv4-svc] Validated PVC: px-nginx-pvc-enc-sharedv4, Namespace: nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s 

13:58:14  STEP: get nginx-sv4-svc app's volume's custom parameters

13:58:14  STEP: get nginx-sv4-svc app's volume: pvc-27d112aa-8a2a-4f11-9c6a-eaabd715fea9 inspected by the volume driver

13:58:14  INFO[2022-04-08 20:58:14] Successfully inspected volume: pvc-27d112aa-8a2a-4f11-9c6a-eaabd715fea9 (16920407505374329) 

13:58:14  STEP: get nginx-sv4-svc app's volume: pvc-09a526d7-1625-40a9-806a-b7be48e40610 inspected by the volume driver

13:58:14  INFO[2022-04-08 20:58:14] Successfully inspected volume: pvc-09a526d7-1625-40a9-806a-b7be48e40610 (741489761887231960) 

13:58:14  STEP: wait for nginx-sv4-svc app to start running

13:58:14  INFO[2022-04-08 20:58:14] [nginx-sv4-svc] Validated Service: nginx-service 

13:58:14  INFO[2022-04-08 20:58:14] [nginx-sv4-svc] Validated deployment: nginx 

13:58:14  STEP: validate if nginx-sv4-svc app's volumes are setup

13:58:14  STEP: validate if nginx-sv4-svc app's volume: px-nginx-pvc-sharedv4 is setup

13:58:14  INFO[2022-04-08 20:58:14] Pod [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-5zphv ready on node ip-192-168-20-251.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:58:14  INFO[2022-04-08 20:58:14] Pod [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-cs74k ready on node ip-192-168-39-135.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:58:14  INFO[2022-04-08 20:58:14] Pod [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-dfwm7 ready on node ip-192-168-20-251.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:58:14  INFO[2022-04-08 20:58:14] Pod [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-h8d82 ready on node ip-192-168-39-135.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:58:14  INFO[2022-04-08 20:58:14] Pod [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-ltzc7 ready on node ip-192-168-20-251.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:58:14  INFO[2022-04-08 20:58:14] Pod [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-sp7cm ready on node ip-192-168-39-135.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:58:14  DEBU[2022-04-08 20:58:14] validating the mounts in pod nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-5zphv 

13:58:14  DEBU[2022-04-08 20:58:14] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-5zphv has PX mount: [/dev/pxd/pxd16920407505374329 /usr/share/nginx/html  /dev/pxd/pxd16920407505374329] 

13:58:14  DEBU[2022-04-08 20:58:14] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-5zphv has PX mount: [/dev/mapper/pxd-enc741489761887231960 /usr/share/nginx/html-enc  /dev/mapper/pxd-enc741489761887231960] 

13:58:14  DEBU[2022-04-08 20:58:14] Finding the debug pod to run command on node ip-192-168-20-251.us-west-2.compute.internal 

13:58:15  DEBU[2022-04-08 20:58:14] Running command on pod debug-5svpb [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-27d112aa-8a2a-4f11-9c6a-eaabd715fea9]] 

13:58:15  DEBU[2022-04-08 20:58:15] validating the mounts in pod nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-cs74k 

13:58:15  DEBU[2022-04-08 20:58:15] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-cs74k has PX mount: [10.100.254.112:/var/lib/osd/pxns/16920407505374329 /usr/share/nginx/html  10.100.254.112:/var/lib/osd/pxns/16920407505374329] 

13:58:15  DEBU[2022-04-08 20:58:15] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-cs74k has PX mount: [10.100.100.90:/var/lib/osd/pxns/741489761887231960 /usr/share/nginx/html-enc  10.100.100.90:/var/lib/osd/pxns/741489761887231960] 

13:58:15  DEBU[2022-04-08 20:58:15] Finding the debug pod to run command on node ip-192-168-39-135.us-west-2.compute.internal 

13:58:15  DEBU[2022-04-08 20:58:15] Running command on pod debug-7x9dp [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-27d112aa-8a2a-4f11-9c6a-eaabd715fea9]] 

13:58:16  DEBU[2022-04-08 20:58:15] validating the mounts in pod nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-dfwm7 

13:58:16  DEBU[2022-04-08 20:58:16] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-dfwm7 has PX mount: [/dev/pxd/pxd16920407505374329 /usr/share/nginx/html  /dev/pxd/pxd16920407505374329] 
13:58:16  DEBU[2022-04-08 20:58:16] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-dfwm7 has PX mount: [/dev/mapper/pxd-enc741489761887231960 /usr/share/nginx/html-enc  /dev/mapper/pxd-enc741489761887231960] 
13:58:16  DEBU[2022-04-08 20:58:16] Finding the debug pod to run command on node ip-192-168-20-251.us-west-2.compute.internal 
13:58:16  DEBU[2022-04-08 20:58:16] Running command on pod debug-5svpb [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-27d112aa-8a2a-4f11-9c6a-eaabd715fea9]] 

13:58:16  DEBU[2022-04-08 20:58:16] validating the mounts in pod nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-h8d82 
13:58:17  DEBU[2022-04-08 20:58:17] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-h8d82 has PX mount: [10.100.254.112:/var/lib/osd/pxns/16920407505374329 /usr/share/nginx/html  10.100.254.112:/var/lib/osd/pxns/16920407505374329] 
13:58:17  DEBU[2022-04-08 20:58:17] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-h8d82 has PX mount: [10.100.100.90:/var/lib/osd/pxns/741489761887231960 /usr/share/nginx/html-enc  10.100.100.90:/var/lib/osd/pxns/741489761887231960] 
13:58:17  DEBU[2022-04-08 20:58:17] Finding the debug pod to run command on node ip-192-168-39-135.us-west-2.compute.internal 
13:58:17  DEBU[2022-04-08 20:58:17] Running command on pod debug-7x9dp [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-27d112aa-8a2a-4f11-9c6a-eaabd715fea9]] 

13:58:17  DEBU[2022-04-08 20:58:17] validating the mounts in pod nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-ltzc7 

13:58:18  DEBU[2022-04-08 20:58:17] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-ltzc7 has PX mount: [/dev/pxd/pxd16920407505374329 /usr/share/nginx/html  /dev/pxd/pxd16920407505374329] 

13:58:18  DEBU[2022-04-08 20:58:17] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-ltzc7 has PX mount: [/dev/mapper/pxd-enc741489761887231960 /usr/share/nginx/html-enc  /dev/mapper/pxd-enc741489761887231960] 

13:58:18  DEBU[2022-04-08 20:58:17] Finding the debug pod to run command on node ip-192-168-20-251.us-west-2.compute.internal 

13:58:18  DEBU[2022-04-08 20:58:18] Running command on pod debug-5svpb [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-27d112aa-8a2a-4f11-9c6a-eaabd715fea9]] 

13:58:18  DEBU[2022-04-08 20:58:18] validating the mounts in pod nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-sp7cm 

13:58:18  DEBU[2022-04-08 20:58:18] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-sp7cm has PX mount: [10.100.254.112:/var/lib/osd/pxns/16920407505374329 /usr/share/nginx/html  10.100.254.112:/var/lib/osd/pxns/16920407505374329] 

13:58:18  DEBU[2022-04-08 20:58:18] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-sp7cm has PX mount: [10.100.100.90:/var/lib/osd/pxns/741489761887231960 /usr/share/nginx/html-enc  10.100.100.90:/var/lib/osd/pxns/741489761887231960] 

13:58:18  DEBU[2022-04-08 20:58:18] Finding the debug pod to run command on node ip-192-168-39-135.us-west-2.compute.internal 

13:58:18  DEBU[2022-04-08 20:58:18] Running command on pod debug-7x9dp [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-27d112aa-8a2a-4f11-9c6a-eaabd715fea9]] 

13:58:19  STEP: validate if nginx-sv4-svc app's volume: px-nginx-pvc-enc-sharedv4 is setup

13:58:19  INFO[2022-04-08 20:58:19] Pod [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-5zphv ready on node ip-192-168-20-251.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:58:19  INFO[2022-04-08 20:58:19] Pod [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-cs74k ready on node ip-192-168-39-135.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:58:19  INFO[2022-04-08 20:58:19] Pod [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-dfwm7 ready on node ip-192-168-20-251.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:58:19  INFO[2022-04-08 20:58:19] Pod [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-h8d82 ready on node ip-192-168-39-135.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:58:19  INFO[2022-04-08 20:58:19] Pod [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-ltzc7 ready on node ip-192-168-20-251.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:58:19  INFO[2022-04-08 20:58:19] Pod [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-sp7cm ready on node ip-192-168-39-135.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:58:19  DEBU[2022-04-08 20:58:19] validating the mounts in pod nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-5zphv 

13:58:19  DEBU[2022-04-08 20:58:19] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-5zphv has PX mount: [/dev/pxd/pxd16920407505374329 /usr/share/nginx/html  /dev/pxd/pxd16920407505374329] 

13:58:19  DEBU[2022-04-08 20:58:19] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-5zphv has PX mount: [/dev/mapper/pxd-enc741489761887231960 /usr/share/nginx/html-enc  /dev/mapper/pxd-enc741489761887231960] 

13:58:19  DEBU[2022-04-08 20:58:19] Finding the debug pod to run command on node ip-192-168-20-251.us-west-2.compute.internal 

13:58:20  DEBU[2022-04-08 20:58:20] Running command on pod debug-5svpb [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-09a526d7-1625-40a9-806a-b7be48e40610]] 

13:58:20  DEBU[2022-04-08 20:58:20] validating the mounts in pod nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-cs74k 

13:58:20  DEBU[2022-04-08 20:58:20] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-cs74k has PX mount: [10.100.254.112:/var/lib/osd/pxns/16920407505374329 /usr/share/nginx/html  10.100.254.112:/var/lib/osd/pxns/16920407505374329] 

13:58:20  DEBU[2022-04-08 20:58:20] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-cs74k has PX mount: [10.100.100.90:/var/lib/osd/pxns/741489761887231960 /usr/share/nginx/html-enc  10.100.100.90:/var/lib/osd/pxns/741489761887231960] 

13:58:20  DEBU[2022-04-08 20:58:20] Finding the debug pod to run command on node ip-192-168-39-135.us-west-2.compute.internal 

13:58:21  DEBU[2022-04-08 20:58:20] Running command on pod debug-7x9dp [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-09a526d7-1625-40a9-806a-b7be48e40610]] 

13:58:21  DEBU[2022-04-08 20:58:21] validating the mounts in pod nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-dfwm7 

13:58:21  DEBU[2022-04-08 20:58:21] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-dfwm7 has PX mount: [/dev/pxd/pxd16920407505374329 /usr/share/nginx/html  /dev/pxd/pxd16920407505374329] 

13:58:21  DEBU[2022-04-08 20:58:21] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-dfwm7 has PX mount: [/dev/mapper/pxd-enc741489761887231960 /usr/share/nginx/html-enc  /dev/mapper/pxd-enc741489761887231960] 

13:58:21  DEBU[2022-04-08 20:58:21] Finding the debug pod to run command on node ip-192-168-20-251.us-west-2.compute.internal 

13:58:21  DEBU[2022-04-08 20:58:21] Running command on pod debug-5svpb [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-09a526d7-1625-40a9-806a-b7be48e40610]] 

13:58:22  DEBU[2022-04-08 20:58:21] validating the mounts in pod nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-h8d82 

13:58:22  DEBU[2022-04-08 20:58:22] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-h8d82 has PX mount: [10.100.254.112:/var/lib/osd/pxns/16920407505374329 /usr/share/nginx/html  10.100.254.112:/var/lib/osd/pxns/16920407505374329] 

13:58:22  DEBU[2022-04-08 20:58:22] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-h8d82 has PX mount: [10.100.100.90:/var/lib/osd/pxns/741489761887231960 /usr/share/nginx/html-enc  10.100.100.90:/var/lib/osd/pxns/741489761887231960] 

13:58:22  DEBU[2022-04-08 20:58:22] Finding the debug pod to run command on node ip-192-168-39-135.us-west-2.compute.internal 

13:58:22  DEBU[2022-04-08 20:58:22] Running command on pod debug-7x9dp [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-09a526d7-1625-40a9-806a-b7be48e40610]] 

13:58:22  DEBU[2022-04-08 20:58:22] validating the mounts in pod nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-ltzc7 

13:58:23  DEBU[2022-04-08 20:58:23] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-ltzc7 has PX mount: [/dev/pxd/pxd16920407505374329 /usr/share/nginx/html  /dev/pxd/pxd16920407505374329] 

13:58:23  DEBU[2022-04-08 20:58:23] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-ltzc7 has PX mount: [/dev/mapper/pxd-enc741489761887231960 /usr/share/nginx/html-enc  /dev/mapper/pxd-enc741489761887231960] 

13:58:23  DEBU[2022-04-08 20:58:23] Finding the debug pod to run command on node ip-192-168-20-251.us-west-2.compute.internal 

13:58:23  DEBU[2022-04-08 20:58:23] Running command on pod debug-5svpb [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-09a526d7-1625-40a9-806a-b7be48e40610]] 

13:58:23  DEBU[2022-04-08 20:58:23] validating the mounts in pod nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-sp7cm 

13:58:23  DEBU[2022-04-08 20:58:23] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-sp7cm has PX mount: [10.100.254.112:/var/lib/osd/pxns/16920407505374329 /usr/share/nginx/html  10.100.254.112:/var/lib/osd/pxns/16920407505374329] 

13:58:23  DEBU[2022-04-08 20:58:23] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-sp7cm has PX mount: [10.100.100.90:/var/lib/osd/pxns/741489761887231960 /usr/share/nginx/html-enc  10.100.100.90:/var/lib/osd/pxns/741489761887231960] 

13:58:23  DEBU[2022-04-08 20:58:23] Finding the debug pod to run command on node ip-192-168-39-135.us-west-2.compute.internal 

13:58:24  DEBU[2022-04-08 20:58:24] Running command on pod debug-7x9dp [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-09a526d7-1625-40a9-806a-b7be48e40610]] 

13:58:24  STEP: scale down app nginx-sv4-svc by 1

13:58:24  INFO[2022-04-08 20:58:24] Scale all Deployments                        

13:58:24  INFO[2022-04-08 20:58:24] Deployment nginx scaled to 5 successfully. 

13:58:24  STEP: Giving few seconds for scaled down applications to stabilize

13:58:34  STEP: validate nginx-sv4-svc app's volumes

13:58:34  STEP: inspect nginx-sv4-svc app's volumes

13:58:34  INFO[2022-04-08 20:58:34] [nginx-sv4-svc] Validated PVC: px-nginx-pvc-sharedv4, Namespace: nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s 

13:58:34  INFO[2022-04-08 20:58:34] [nginx-sv4-svc] Validated PVC: px-nginx-pvc-enc-sharedv4, Namespace: nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s 

13:58:34  STEP: get nginx-sv4-svc app's volume's custom parameters

13:58:34  STEP: get nginx-sv4-svc app's volume: pvc-27d112aa-8a2a-4f11-9c6a-eaabd715fea9 inspected by the volume driver

13:58:34  INFO[2022-04-08 20:58:34] Successfully inspected volume: pvc-27d112aa-8a2a-4f11-9c6a-eaabd715fea9 (16920407505374329) 

13:58:34  STEP: get nginx-sv4-svc app's volume: pvc-09a526d7-1625-40a9-806a-b7be48e40610 inspected by the volume driver

13:58:34  INFO[2022-04-08 20:58:34] Successfully inspected volume: pvc-09a526d7-1625-40a9-806a-b7be48e40610 (741489761887231960) 

13:58:34  STEP: wait for nginx-sv4-svc app to start running

13:58:34  INFO[2022-04-08 20:58:34] [nginx-sv4-svc] Validated Service: nginx-service 

13:58:34  INFO[2022-04-08 20:58:34] [nginx-sv4-svc] Validated deployment: nginx 

13:58:34  STEP: validate if nginx-sv4-svc app's volumes are setup

13:58:34  STEP: validate if nginx-sv4-svc app's volume: px-nginx-pvc-sharedv4 is setup

13:58:34  INFO[2022-04-08 20:58:34] Pod [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-5zphv ready on node ip-192-168-20-251.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:58:34  INFO[2022-04-08 20:58:34] Pod [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-dfwm7 ready on node ip-192-168-20-251.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:58:34  INFO[2022-04-08 20:58:34] Pod [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-h8d82 ready on node ip-192-168-39-135.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:58:34  INFO[2022-04-08 20:58:34] Pod [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-ltzc7 ready on node ip-192-168-20-251.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:58:34  INFO[2022-04-08 20:58:34] Pod [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-sp7cm ready on node ip-192-168-39-135.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:58:35  DEBU[2022-04-08 20:58:35] validating the mounts in pod nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-5zphv 

13:58:35  DEBU[2022-04-08 20:58:35] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-5zphv has PX mount: [/dev/pxd/pxd16920407505374329 /usr/share/nginx/html  /dev/pxd/pxd16920407505374329] 

13:58:35  DEBU[2022-04-08 20:58:35] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-5zphv has PX mount: [/dev/mapper/pxd-enc741489761887231960 /usr/share/nginx/html-enc  /dev/mapper/pxd-enc741489761887231960] 

13:58:35  DEBU[2022-04-08 20:58:35] Finding the debug pod to run command on node ip-192-168-20-251.us-west-2.compute.internal 

13:58:35  DEBU[2022-04-08 20:58:35] Running command on pod debug-5svpb [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-27d112aa-8a2a-4f11-9c6a-eaabd715fea9]] 

13:58:36  DEBU[2022-04-08 20:58:35] validating the mounts in pod nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-dfwm7 

13:58:36  DEBU[2022-04-08 20:58:36] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-dfwm7 has PX mount: [/dev/pxd/pxd16920407505374329 /usr/share/nginx/html  /dev/pxd/pxd16920407505374329] 

13:58:36  DEBU[2022-04-08 20:58:36] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-dfwm7 has PX mount: [/dev/mapper/pxd-enc741489761887231960 /usr/share/nginx/html-enc  /dev/mapper/pxd-enc741489761887231960] 

13:58:36  DEBU[2022-04-08 20:58:36] Finding the debug pod to run command on node ip-192-168-20-251.us-west-2.compute.internal 

13:58:36  DEBU[2022-04-08 20:58:36] Running command on pod debug-5svpb [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-27d112aa-8a2a-4f11-9c6a-eaabd715fea9]] 

13:58:36  DEBU[2022-04-08 20:58:36] validating the mounts in pod nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-h8d82 

13:58:37  DEBU[2022-04-08 20:58:36] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-h8d82 has PX mount: [10.100.254.112:/var/lib/osd/pxns/16920407505374329 /usr/share/nginx/html  10.100.254.112:/var/lib/osd/pxns/16920407505374329] 

13:58:37  DEBU[2022-04-08 20:58:36] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-h8d82 has PX mount: [10.100.100.90:/var/lib/osd/pxns/741489761887231960 /usr/share/nginx/html-enc  10.100.100.90:/var/lib/osd/pxns/741489761887231960] 

13:58:37  DEBU[2022-04-08 20:58:36] Finding the debug pod to run command on node ip-192-168-39-135.us-west-2.compute.internal 

13:58:37  DEBU[2022-04-08 20:58:37] Running command on pod debug-7x9dp [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-27d112aa-8a2a-4f11-9c6a-eaabd715fea9]] 

13:58:37  DEBU[2022-04-08 20:58:37] validating the mounts in pod nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-ltzc7 

13:58:37  DEBU[2022-04-08 20:58:37] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-ltzc7 has PX mount: [/dev/pxd/pxd16920407505374329 /usr/share/nginx/html  /dev/pxd/pxd16920407505374329] 

13:58:37  DEBU[2022-04-08 20:58:37] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-ltzc7 has PX mount: [/dev/mapper/pxd-enc741489761887231960 /usr/share/nginx/html-enc  /dev/mapper/pxd-enc741489761887231960] 

13:58:37  DEBU[2022-04-08 20:58:37] Finding the debug pod to run command on node ip-192-168-20-251.us-west-2.compute.internal 

13:58:37  DEBU[2022-04-08 20:58:37] Running command on pod debug-5svpb [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-27d112aa-8a2a-4f11-9c6a-eaabd715fea9]] 

13:58:38  DEBU[2022-04-08 20:58:38] validating the mounts in pod nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-sp7cm 

13:58:38  DEBU[2022-04-08 20:58:38] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-sp7cm has PX mount: [10.100.254.112:/var/lib/osd/pxns/16920407505374329 /usr/share/nginx/html  10.100.254.112:/var/lib/osd/pxns/16920407505374329] 

13:58:38  DEBU[2022-04-08 20:58:38] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-sp7cm has PX mount: [10.100.100.90:/var/lib/osd/pxns/741489761887231960 /usr/share/nginx/html-enc  10.100.100.90:/var/lib/osd/pxns/741489761887231960] 

13:58:38  DEBU[2022-04-08 20:58:38] Finding the debug pod to run command on node ip-192-168-39-135.us-west-2.compute.internal 

13:58:38  DEBU[2022-04-08 20:58:38] Running command on pod debug-7x9dp [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-27d112aa-8a2a-4f11-9c6a-eaabd715fea9]] 

13:58:39  STEP: validate if nginx-sv4-svc app's volume: px-nginx-pvc-enc-sharedv4 is setup

13:58:39  INFO[2022-04-08 20:58:39] Pod [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-5zphv ready on node ip-192-168-20-251.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:58:39  INFO[2022-04-08 20:58:39] Pod [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-dfwm7 ready on node ip-192-168-20-251.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:58:39  INFO[2022-04-08 20:58:39] Pod [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-h8d82 ready on node ip-192-168-39-135.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:58:39  INFO[2022-04-08 20:58:39] Pod [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-ltzc7 ready on node ip-192-168-20-251.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:58:39  INFO[2022-04-08 20:58:39] Pod [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-sp7cm ready on node ip-192-168-39-135.us-west-2.compute.internal - Initialized: True Ready: True Scheduled: True  

13:58:39  DEBU[2022-04-08 20:58:39] validating the mounts in pod nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-5zphv 

13:58:39  DEBU[2022-04-08 20:58:39] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-5zphv has PX mount: [/dev/pxd/pxd16920407505374329 /usr/share/nginx/html  /dev/pxd/pxd16920407505374329] 

13:58:39  DEBU[2022-04-08 20:58:39] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-5zphv has PX mount: [/dev/mapper/pxd-enc741489761887231960 /usr/share/nginx/html-enc  /dev/mapper/pxd-enc741489761887231960] 

13:58:39  DEBU[2022-04-08 20:58:39] Finding the debug pod to run command on node ip-192-168-20-251.us-west-2.compute.internal 

13:58:40  DEBU[2022-04-08 20:58:39] Running command on pod debug-5svpb [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-09a526d7-1625-40a9-806a-b7be48e40610]] 

13:58:40  DEBU[2022-04-08 20:58:40] validating the mounts in pod nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-dfwm7 

13:58:40  DEBU[2022-04-08 20:58:40] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-dfwm7 has PX mount: [/dev/pxd/pxd16920407505374329 /usr/share/nginx/html  /dev/pxd/pxd16920407505374329] 

13:58:40  DEBU[2022-04-08 20:58:40] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-dfwm7 has PX mount: [/dev/mapper/pxd-enc741489761887231960 /usr/share/nginx/html-enc  /dev/mapper/pxd-enc741489761887231960] 

13:58:40  DEBU[2022-04-08 20:58:40] Finding the debug pod to run command on node ip-192-168-20-251.us-west-2.compute.internal 

13:58:40  DEBU[2022-04-08 20:58:40] Running command on pod debug-5svpb [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-09a526d7-1625-40a9-806a-b7be48e40610]] 

13:58:41  DEBU[2022-04-08 20:58:41] validating the mounts in pod nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-h8d82 

13:58:41  DEBU[2022-04-08 20:58:41] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-h8d82 has PX mount: [10.100.254.112:/var/lib/osd/pxns/16920407505374329 /usr/share/nginx/html  10.100.254.112:/var/lib/osd/pxns/16920407505374329] 

13:58:41  DEBU[2022-04-08 20:58:41] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-h8d82 has PX mount: [10.100.100.90:/var/lib/osd/pxns/741489761887231960 /usr/share/nginx/html-enc  10.100.100.90:/var/lib/osd/pxns/741489761887231960] 

13:58:41  DEBU[2022-04-08 20:58:41] Finding the debug pod to run command on node ip-192-168-39-135.us-west-2.compute.internal 

13:58:41  DEBU[2022-04-08 20:58:41] Running command on pod debug-7x9dp [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-09a526d7-1625-40a9-806a-b7be48e40610]] 

13:58:41  DEBU[2022-04-08 20:58:41] validating the mounts in pod nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-ltzc7 

13:58:42  DEBU[2022-04-08 20:58:42] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-ltzc7 has PX mount: [/dev/pxd/pxd16920407505374329 /usr/share/nginx/html  /dev/pxd/pxd16920407505374329] 

13:58:42  DEBU[2022-04-08 20:58:42] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-ltzc7 has PX mount: [/dev/mapper/pxd-enc741489761887231960 /usr/share/nginx/html-enc  /dev/mapper/pxd-enc741489761887231960] 

13:58:42  DEBU[2022-04-08 20:58:42] Finding the debug pod to run command on node ip-192-168-20-251.us-west-2.compute.internal 

13:58:42  DEBU[2022-04-08 20:58:42] Running command on pod debug-5svpb [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-09a526d7-1625-40a9-806a-b7be48e40610]] 

13:58:42  DEBU[2022-04-08 20:58:42] validating the mounts in pod nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s/nginx-578db87f68-sp7cm 

13:58:43  DEBU[2022-04-08 20:58:43] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-sp7cm has PX mount: [10.100.254.112:/var/lib/osd/pxns/16920407505374329 /usr/share/nginx/html  10.100.254.112:/var/lib/osd/pxns/16920407505374329] 

13:58:43  DEBU[2022-04-08 20:58:43] pod: [nginx-sv4-svc-applicationscaleupdown-0-04-08-20h17m34s] nginx-578db87f68-sp7cm has PX mount: [10.100.100.90:/var/lib/osd/pxns/741489761887231960 /usr/share/nginx/html-enc  10.100.100.90:/var/lib/osd/pxns/741489761887231960] 

13:58:43  DEBU[2022-04-08 20:58:43] Finding the debug pod to run command on node ip-192-168-39-135.us-west-2.compute.internal 

13:58:43  DEBU[2022-04-08 20:58:43] Running command on pod debug-7x9dp [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-09a526d7-1625-40a9-806a-b7be48e40610]] 

13:58:43  STEP: teardown all apps

13:58:43  STEP: destroy the elasticsearch app's volumes

13:58:46  INFO[2022-04-08 20:58:45] [elasticsearch] Destroyed PVCs for StatefulSet: esnode 

13:58:46  STEP: start destroying elasticsearch app

13:58:46  INFO[2022-04-08 20:58:45] [elasticsearch] Destroyed Service: elasticsearch-cluster 

13:58:46  INFO[2022-04-08 20:58:46] [elasticsearch] Destroyed Service: elasticsearch-api 

13:58:46  INFO[2022-04-08 20:58:46] [elasticsearch] Destroyed Config Map: es-config 

13:58:46  STEP: validate elasticsearch app's volume es-data-esnode-0 has been deleted in the volume driver

13:58:46  2022/04/08 20:58:46 Volume pvc-4b4e73dc-9dcf-4c7c-b1b5-b3adb6a074ab is not yet removed from the system Next retry in: 10s

13:58:58  STEP: validate elasticsearch app's volume es-data-esnode-1 has been deleted in the volume driver

13:58:58  2022/04/08 20:58:56 Volume pvc-a5b71539-84d9-4734-92a9-c3781615d0ff is not yet removed from the system Next retry in: 10s

13:59:06  STEP: validate elasticsearch app's volume es-data-esnode-2 has been deleted in the volume driver

13:59:06  STEP: validate elasticsearch app's volume es-data-esnode-3 has been deleted in the volume driver

13:59:06  STEP: validate elasticsearch app's volume es-data-esnode-4 has been deleted in the volume driver

13:59:06  STEP: validate elasticsearch app's volume es-data-esnode-5 has been deleted in the volume driver

13:59:06  STEP: destroy the elasticsearch app's volumes

13:59:06  INFO[2022-04-08 20:59:06] [elasticsearch] Destroyed storage class: elasticsearch-sc 

13:59:06  INFO[2022-04-08 20:59:06] [elasticsearch] Destroyed PVCs for StatefulSet: esnode 

13:59:06  STEP: destroy the postgres app's volumes

13:59:06  INFO[2022-04-08 20:59:06] [postgres] Destroyed PVC: postgres-data      

13:59:06  STEP: start destroying postgres app

13:59:06  STEP: validate postgres app's volume postgres-data has been deleted in the volume driver

13:59:06  2022/04/08 20:59:06 Volume pvc-83ea1fc0-b511-4cbc-b99e-b7bb49ed2308 is not yet removed from the system Next retry in: 10s

13:59:16  2022/04/08 20:59:16 Volume pvc-83ea1fc0-b511-4cbc-b99e-b7bb49ed2308 is not yet removed from the system Next retry in: 10s

13:59:26  STEP: destroy the postgres app's volumes

13:59:26  INFO[2022-04-08 20:59:26] [postgres] Destroyed storage class: postgres-sc 

13:59:26  INFO[2022-04-08 20:59:26] [postgres] PVC is not found: postgres-data, skipping deletion 

13:59:26  STEP: destroy the sysbench app's volumes

13:59:26  INFO[2022-04-08 20:59:26] [sysbench] Destroyed PVC: sysbench-mysql-data 

13:59:26  STEP: start destroying sysbench app

13:59:26  STEP: validate sysbench app's volume sysbench-mysql-data has been deleted in the volume driver

13:59:26  2022/04/08 20:59:26 Volume pvc-5ca91fca-edee-4144-8a1a-853b9a234a1e is not yet removed from the system Next retry in: 10s

13:59:36  2022/04/08 20:59:36 Volume pvc-5ca91fca-edee-4144-8a1a-853b9a234a1e is not yet removed from the system Next retry in: 10s

13:59:48  2022/04/08 20:59:46 Volume pvc-5ca91fca-edee-4144-8a1a-853b9a234a1e is not yet removed from the system Next retry in: 10s

13:59:56  2022/04/08 20:59:56 Volume pvc-5ca91fca-edee-4144-8a1a-853b9a234a1e is not yet removed from the system Next retry in: 10s

14:00:06  STEP: destroy the sysbench app's volumes

14:00:06  INFO[2022-04-08 21:00:06] [sysbench] PVC is not found: sysbench-mysql-data, skipping deletion 

14:00:06  INFO[2022-04-08 21:00:06] [sysbench] Destroyed storage class: sysbench-sc 

14:00:06  STEP: destroy the nginx-sharedv4 app's volumes

14:00:06  INFO[2022-04-08 21:00:06] [nginx-sharedv4] Destroyed PVC: px-nginx-pvc-sharedv4 

14:00:06  INFO[2022-04-08 21:00:06] [nginx-sharedv4] Destroyed PVC: px-nginx-pvc-enc-sharedv4 

14:00:06  STEP: start destroying nginx-sharedv4 app

14:00:06  INFO[2022-04-08 21:00:06] [nginx-sharedv4] Destroyed Service: nginx-service 
14:00:06  STEP: validate nginx-sharedv4 app's volume px-nginx-pvc-sharedv4 has been deleted in the volume driver
14:00:06  STEP: validate nginx-sharedv4 app's volume px-nginx-pvc-enc-sharedv4 has been deleted in the volume driver
14:00:06  STEP: destroy the nginx-sharedv4 app's volumes
14:00:06  INFO[2022-04-08 21:00:06] [nginx-sharedv4] Destroyed storage class: px-nginx-sc-v4 
14:00:06  INFO[2022-04-08 21:00:06] [nginx-sharedv4] Destroyed PVC: px-nginx-pvc-sharedv4 
14:00:06  INFO[2022-04-08 21:00:06] [nginx-sharedv4] Destroyed PVC: px-nginx-pvc-enc-sharedv4 
14:00:06  STEP: destroy the nginx-sv4-svc app's volumes
14:00:06  INFO[2022-04-08 21:00:06] [nginx-sv4-svc] Destroyed PVC: px-nginx-pvc-sharedv4 
14:00:07  INFO[2022-04-08 21:00:07] [nginx-sv4-svc] Destroyed PVC: px-nginx-pvc-enc-sharedv4 
14:00:07  STEP: start destroying nginx-sv4-svc app
14:00:07  INFO[2022-04-08 21:00:07] [nginx-sv4-svc] Destroyed Service: nginx-service 
14:00:07  STEP: validate nginx-sv4-svc app's volume px-nginx-pvc-sharedv4 has been deleted in the volume driver
14:00:07  STEP: validate nginx-sv4-svc app's volume px-nginx-pvc-enc-sharedv4 has been deleted in the volume driver
14:00:07  STEP: destroy the nginx-sv4-svc app's volumes
14:00:07  INFO[2022-04-08 21:00:07] [nginx-sv4-svc] Destroyed storage class: px-nginx-sc-sharedv4-svc 
14:00:07  INFO[2022-04-08 21:00:07] [nginx-sv4-svc] Destroyed PVC: px-nginx-pvc-sharedv4 
14:00:08  INFO[2022-04-08 21:00:08] [nginx-sv4-svc] Destroyed PVC: px-nginx-pvc-enc-sharedv4 
14:00:08  DEBU[2022-04-08 21:00:08] contexts: [0xc0003fbb80 0xc000a42b00 0xc0007978c0 0xc000a43080 0xc0003aadc0] 
14:00:08  DEBU[2022-04-08 21:00:08] Getting PX Version on node [ip-192-168-92-44.us-west-2.compute.internal] 
14:00:08  DEBU[2022-04-08 21:00:08] Inspecting node [ip-192-168-92-44.us-west-2.compute.internal] with volume driver node id [b736efb2-3143-42ad-bc91-0526af6c8b94] 
14:00:08  
14:00:08  • [SLOW TEST:1704.429 seconds]
14:00:08  {AppScaleUpAndDown}`
