### PR TITLE
:sparkles: auto fstrim longevity test

### DIFF
--- a/drivers/scheduler/k8s/specs/vdbench-v4-fstrim/vd-sharedv4-st.yaml
+++ b/drivers/scheduler/k8s/specs/vdbench-v4-fstrim/vd-sharedv4-st.yaml
@@ -17,7 +17,7 @@ apiVersion: v1
 metadata:
   name: vdbench-pvc-sharedv4
 spec:
-  storageClassName: vdbench-sc-sharedv4
+  storageClassName: vdbench-sc-sharedv4-fstrim
   accessModes:
     - ReadWriteMany
   resources:

--- a/drivers/volume/common.go
+++ b/drivers/volume/common.go
@@ -470,6 +470,14 @@ func (d *DefaultDriver) ExpandPool(poolUID string, operation api.SdkStoragePool_
 	}
 }
 
+// GetAutoFsTrimStatus get auto ftim status of a given volume
+func (d *DefaultDriver) GetAutoFsTrimStatus(pxEndpoint string) (map[string]api.FilesystemTrim_FilesystemTrimStatus, error) {
+	return nil, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "GetAutoFsTrimStatus()",
+	}
+}
+
 // ListStoragePools lists all existing storage pools
 func (d *DefaultDriver) ListStoragePools(labelSelector metav1.LabelSelector) (map[string]*api.StoragePool, error) {
 	return nil, &errors.ErrNotSupported{
@@ -550,6 +558,14 @@ func (d *DefaultDriver) SetClusterOpts(n node.Node, rtOpts map[string]string) er
 	return &errors.ErrNotSupported{
 		Type:      "Function",
 		Operation: "SetClusterOpts()",
+	}
+}
+
+// SetClusterRunTimeOpts sets cluster run time options
+func (d *DefaultDriver) SetClusterRunTimeOpts(n node.Node, rtOpts map[string]string) error {
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "SetClusterRunTimeOpts()",
 	}
 }
 

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -161,6 +161,7 @@ type portworx struct {
 	diagsJobManager       api.OpenStorageJobClient
 	licenseManager        pxapi.PortworxLicenseClient
 	licenseFeatureManager pxapi.PortworxLicensedFeatureClient
+	autoFsTrimManager     api.OpenStorageFilesystemTrimClient
 	schedOps              schedops.Driver
 	nodeDriver            node.Driver
 	refreshEndpoint       bool
@@ -1800,6 +1801,29 @@ func (d *portworx) getExpectedPoolSizes(listApRules *apapi.AutopilotRuleList) (m
 	return expectedPoolSizes, nil
 }
 
+//GetAutoFsTrimStatus get status of autofstrim
+func (d *portworx) GetAutoFsTrimStatus(endpoint string) (map[string]api.FilesystemTrim_FilesystemTrimStatus, error) {
+
+	sdkport, _ := getSDKPort()
+	pxEndpoint := fmt.Sprintf("%s:%d", endpoint, sdkport)
+	newConn, err := grpc.Dial(pxEndpoint, grpc.WithInsecure())
+	if err != nil {
+		logrus.Errorf("Got error while setting the connection endpoint, Error: %v", err)
+		return nil, err
+
+	}
+	d.autoFsTrimManager = api.NewOpenStorageFilesystemTrimClient(newConn)
+
+	autoFstrimResp, err := d.autoFsTrimManager.AutoFSTrimStatus(d.getContext(), &api.SdkAutoFSTrimStatusRequest{})
+	if err != nil {
+		logrus.Errorf("Got error while getting auto fstrim status : %v", err)
+		return nil, err
+
+	}
+	logrus.Infof("Trim Status is [%v]", autoFstrimResp.GetTrimStatus())
+	return autoFstrimResp.GetTrimStatus(), nil
+}
+
 // pickAlternateClusterManager returns a different node than given one, useful in case you want to skip nodes which are down
 func (d *portworx) pickAlternateClusterManager(n node.Node) (api.OpenStorageNodeClient, error) {
 	// Check if px is down on all node addresses. We don't want to keep track
@@ -2146,6 +2170,7 @@ func (d *portworx) testAndSetEndpoint(endpoint string, sdkport, apiport int32) e
 	d.diagsManager = api.NewOpenStorageDiagsClient(conn)
 	d.diagsJobManager = api.NewOpenStorageJobClient(conn)
 	d.licenseFeatureManager = pxapi.NewPortworxLicensedFeatureClient(conn)
+	d.autoFsTrimManager = api.NewOpenStorageFilesystemTrimClient(conn)
 	if legacyClusterManager, err := d.getLegacyClusterManager(endpoint, apiport); err == nil {
 		d.legacyClusterManager = legacyClusterManager
 	} else {
@@ -2572,6 +2597,14 @@ func (d *portworx) getNodeManagerByAddress(addr string) (api.OpenStorageNodeClie
 	}
 
 	return dClient, nil
+}
+
+func (d *portworx) getFilesystemTrimManager() api.OpenStorageFilesystemTrimClient {
+	if d.refreshEndpoint {
+		d.setDriver()
+	}
+	return d.autoFsTrimManager
+
 }
 
 func (d *portworx) maintenanceOp(n node.Node, op string) error {
@@ -3165,7 +3198,7 @@ func (d *portworx) GetLicenseSummary() (torpedovolume.LicenseSummary, error) {
 	return licenseSummary, nil
 }
 
-func (d *portworx) SetClusterOpts(n node.Node, rtOpts map[string]string) error {
+func (d *portworx) SetClusterRunTimeOpts(n node.Node, rtOpts map[string]string) error {
 	var err error
 
 	opts := node.ConnectionOpts{
@@ -3189,6 +3222,33 @@ func (d *portworx) SetClusterOpts(n node.Node, rtOpts map[string]string) error {
 	}
 
 	logrus.Debugf("Successfully set rt_opts")
+	return nil
+}
+
+func (d *portworx) SetClusterOpts(n node.Node, clusterOpts map[string]string) error {
+	var err error
+
+	opts := node.ConnectionOpts{
+		IgnoreError:     false,
+		TimeBeforeRetry: defaultRetryInterval,
+		Timeout:         defaultTimeout,
+		Sudo:            true,
+	}
+
+	var clusteropts string
+	for k, v := range clusterOpts {
+		clusteropts += k + "=" + v + " "
+	}
+
+	clusteropts = strings.TrimSuffix(clusteropts, " ")
+	cmd := fmt.Sprintf("%s cluster options update %s", d.getPxctlPath(n), clusteropts)
+
+	out, err := d.nodeDriver.RunCommand(n, cmd, opts)
+	if err != nil {
+		return fmt.Errorf("failed to set cluster options, Err: %v %v", err, out)
+	}
+
+	logrus.Debugf("Successfully updated Cluster Options")
 	return nil
 }
 

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -226,7 +226,10 @@ type Driver interface {
 	GetLicenseSummary() (LicenseSummary, error)
 
 	//SetClusterOpts sets cluster options
-	SetClusterOpts(n node.Node, rtOpts map[string]string) error
+	SetClusterOpts(n node.Node, clusterOpts map[string]string) error
+
+	//SetClusterRunTimeOpts sets cluster run time options
+	SetClusterRunTimeOpts(n node.Node, rtOpts map[string]string) error
 
 	//ToggleCallHome toggles Call-home
 	ToggleCallHome(n node.Node, enabled bool) error
@@ -272,6 +275,9 @@ type Driver interface {
 
 	// WaitForPxPodsToBeUp waits for px pod to be up in given node
 	WaitForPxPodsToBeUp(n node.Node) error
+
+	//GetAutoFsTrimStatus get status of autofstrim
+	GetAutoFsTrimStatus(pxEndpoint string) (map[string]api.FilesystemTrim_FilesystemTrimStatus, error)
 }
 
 // StorageProvisionerType provisioner to be used for torpedo volumes

--- a/go.sum
+++ b/go.sum
@@ -519,6 +519,7 @@ github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=

--- a/tests/common.go
+++ b/tests/common.go
@@ -3207,7 +3207,7 @@ func init() {
 //CreateJiraIssueWithLogs creates a jira issue and copy logs to nfs mount
 func CreateJiraIssueWithLogs(issueDescription, issueSummary string) {
 	issueKey, err := jirautils.CreateIssue(issueDescription, issueSummary)
-	if err == nil {
+	if err == nil && issueKey != "" {
 		collectAndCopyDiagsOnWorkerNodes(issueKey)
 		collectAndCopyStorkLogs(issueKey)
 		collectAndCopyOperatorLogs(issueKey)
@@ -3241,7 +3241,7 @@ func collectAndCopyDiagsOnWorkerNodes(issueKey string) {
 				OutputFile:    filePath,
 				ContainerName: "",
 				Profile:       false,
-				Live:          true,
+				Live:          false,
 				Upload:        false,
 				All:           true,
 				Force:         true,

--- a/tests/license/license_test.go
+++ b/tests/license/license_test.go
@@ -592,7 +592,7 @@ var _ = Describe("{DisableCallHomeTest}", func() {
 
 		currNode := node.GetWorkerNodes()[0]
 		Step(fmt.Sprintf("Set License expiry timeout to 1 hour"), func() {
-			err := Inst().V.SetClusterOpts(currNode, map[string]string{
+			err := Inst().V.SetClusterRunTimeOpts(currNode, map[string]string{
 				"metering_interval_mins":       "10",
 				"license_expiry_timeout_hours": "1",
 			})

--- a/tests/longevity/longevity_test.go
+++ b/tests/longevity/longevity_test.go
@@ -77,6 +77,7 @@ var _ = Describe("{Longevity}", func() {
 		VolumesDelete:       TriggerVolumeDelete,
 		UpgradeVolumeDriver: TriggerUpgradeVolumeDriver,
 		AppTasksDown:        TriggerAppTasksDown,
+		AutoFsTrim:          TriggerAutoFsTrim,
 	}
 	It("has to schedule app and introduce test triggers", func() {
 		Step(fmt.Sprintf("Start watch on K8S configMap [%s/%s]",
@@ -336,6 +337,7 @@ func populateIntervals() {
 	triggerInterval[DeleteLocalSnapShot] = make(map[int]time.Duration)
 	triggerInterval[UpgradeVolumeDriver] = make(map[int]time.Duration)
 	triggerInterval[AppTasksDown] = make(map[int]time.Duration)
+	triggerInterval[AutoFsTrim] = make(map[int]time.Duration)
 
 	baseInterval := 10 * time.Minute
 	triggerInterval[BackupScaleMongo][10] = 1 * baseInterval
@@ -664,6 +666,17 @@ func populateIntervals() {
 	triggerInterval[PoolResizeDisk][2] = 24 * baseInterval
 	triggerInterval[PoolResizeDisk][1] = 30 * baseInterval
 
+	triggerInterval[AutoFsTrim][10] = 1 * baseInterval
+	triggerInterval[AutoFsTrim][9] = 3 * baseInterval
+	triggerInterval[AutoFsTrim][8] = 6 * baseInterval
+	triggerInterval[AutoFsTrim][7] = 9 * baseInterval
+	triggerInterval[AutoFsTrim][6] = 12 * baseInterval
+	triggerInterval[AutoFsTrim][5] = 15 * baseInterval
+	triggerInterval[AutoFsTrim][4] = 18 * baseInterval
+	triggerInterval[AutoFsTrim][3] = 21 * baseInterval
+	triggerInterval[AutoFsTrim][2] = 24 * baseInterval
+	triggerInterval[AutoFsTrim][1] = 27 * baseInterval
+
 	baseInterval = 300 * time.Minute
 
 	triggerInterval[UpgradeStork][10] = 1 * baseInterval
@@ -724,6 +737,7 @@ func populateIntervals() {
 	triggerInterval[LocalSnapShot][0] = 0
 	triggerInterval[DeleteLocalSnapShot][0] = 0
 	triggerInterval[AppTasksDown][0] = 0
+	triggerInterval[AutoFsTrim][0] = 0
 }
 
 func isTriggerEnabled(triggerType string) (time.Duration, bool) {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Runs auto fstrim test as part of longevity

**Which issue(s) this PR fixes** (optional)
Closes #PTX-5751

**Special notes for your reviewer**:

test log

DEBU[2022-04-11 16:40:40] Running command on pod debug-xsxrj [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c sudo /usr/local/bin/pxctl cluster options update --auto-fstrim=on]]
DEBU[2022-04-11 16:40:43] Successfully updated Cluster Options
INFO[2022-04-11 16:40:43] AutoFsTrim is successfully enabled
STEP: Validate AutoFsTrim Status
INFO[2022-04-11 16:45:43] Getting info : pvc-1add61b8-6505-4193-9914-27de34c3d142
INFO[2022-04-11 16:46:04] testAndSetEndpoint failed for 10.233.0.29: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 10.233.0.29:9020: i/o timeout"
INFO[2022-04-11 16:46:04] Getting new driver.
INFO[2022-04-11 16:46:07] Using 10.13.11.83:9020 as endpoint for portworx volume driver
INFO[2022-04-11 16:46:09] Trim Status is [map[379114528754248137:FS_TRIM_INPROGRESS]]
INFO[2022-04-11 16:46:09] Autofstrim status for volume pvc-1add61b8-6505-4193-9914-27de34c3d142, status: FS_TRIM_INPROGRESS
STEP: Reboot attached node and validate AutoFsTrim Status
INFO[2022-04-11 16:46:30] testAndSetEndpoint failed for 10.233.0.29: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 10.233.0.29:9020: i/o timeout"
INFO[2022-04-11 16:46:30] Getting new driver.
INFO[2022-04-11 16:46:32] Using 10.13.11.83:9020 as endpoint for portworx volume driver
DEBU[2022-04-11 16:46:33] Volume attached on: 10.13.11.85
DEBU[2022-04-11 16:46:33] Driver management IP: 10.13.9.116
DEBU[2022-04-11 16:46:33] Driver data IP: 10.13.9.116
DEBU[2022-04-11 16:46:33] Checking if volume is on Node torpedo-long-fa-sample-test-13-1 (10.13.9.116)
DEBU[2022-04-11 16:46:33] Volume attached on: 10.13.11.85
DEBU[2022-04-11 16:46:34] Driver management IP: 10.13.11.85
INFO[2022-04-11 16:46:34] volume pvc-1add61b8-6505-4193-9914-27de34c3d142 is attached on node torpedo-long-fa-sample-test-13-2 [10.13.11.85]
INFO[2022-04-11 16:46:34] Stopping volume driver on torpedo-long-fa-sample-test-13-2.
DEBU[2022-04-11 16:46:35] Finding the debug pod to run command on node torpedo-long-fa-sample-test-13-2
DEBU[2022-04-11 16:46:36] Running command on pod debug-fv97f [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c sudo systemctl stop portworx.service]]
INFO[2022-04-11 16:47:10] Sleeping for 10s for volume driver to gracefully go down.
INFO[2022-04-11 16:47:20] Rebooting node torpedo-long-fa-sample-test-13-2

DEBU[2022-04-11 17:07:19] checking if PX pod is up on node: torpedo-long-fa-sample-test-13-2
DEBU[2022-04-11 17:07:21] px is fully operational on node: torpedo-long-fa-sample-test-13-2
INFO[2022-04-11 17:07:22] Getting info : pvc-1add61b8-6505-4193-9914-27de34c3d142
INFO[2022-04-11 17:07:43] testAndSetEndpoint failed for 10.233.0.29: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 10.233.0.29:9020: i/o timeout"
INFO[2022-04-11 17:07:43] Getting new driver.
INFO[2022-04-11 17:07:45] Using 10.13.11.83:9020 as endpoint for portworx volume driver
INFO[2022-04-11 17:07:47] Trim Status is [map[]]
INFO[2022-04-11 17:07:47] Autofstrim for volume pvc-1add61b8-6505-4193-9914-27de34c3d142 not started, retrying after 2 mins
INFO[2022-04-11 17:09:49] Trim Status is [map[]]
INFO[2022-04-11 17:09:49] Autofstrim for volume pvc-1add61b8-6505-4193-9914-27de34c3d142 not started, retrying after 2 mins
INFO[2022-04-11 17:11:50] Trim Status is [map[]]
INFO[2022-04-11 17:11:50] Autofstrim for volume pvc-1add61b8-6505-4193-9914-27de34c3d142 not started, retrying after 2 mins
INFO[2022-04-11 17:13:52] Trim Status is [map[]]
INFO[2022-04-11 17:13:52] Autofstrim for volume pvc-1add61b8-6505-4193-9914-27de34c3d142 not started, retrying after 2 mins
INFO[2022-04-11 17:15:54] Trim Status is [map[]]
INFO[2022-04-11 17:15:54] Autofstrim for volume pvc-1add61b8-6505-4193-9914-27de34c3d142 not started, retrying after 2 mins
INFO[2022-04-11 17:17:55] Trim Status is [map[]]
INFO[2022-04-11 17:17:55] Autofstrim for volume pvc-1add61b8-6505-4193-9914-27de34c3d142 not started, retrying after 2 mins
INFO[2022-04-11 17:19:56] Trim Status is [map[]]
INFO[2022-04-11 17:19:56] Autofstrim for volume pvc-1add61b8-6505-4193-9914-27de34c3d142 not started, retrying after 2 mins
INFO[2022-04-11 17:21:58] Trim Status is [map[]]
INFO[2022-04-11 17:21:58] Autofstrim for volume pvc-1add61b8-6505-4193-9914-27de34c3d142 not started, retrying after 2 mins
INFO[2022-04-11 17:23:59] Trim Status is [map[]]
INFO[2022-04-11 17:23:59] Autofstrim for volume pvc-1add61b8-6505-4193-9914-27de34c3d142 not started, retrying after 2 mins
INFO[2022-04-11 17:26:01] Trim Status is [map[]]
INFO[2022-04-11 17:26:01] Autofstrim for volume pvc-1add61b8-6505-4193-9914-27de34c3d142 not started, retrying after 2 mins
INFO[2022-04-11 17:28:02] Trim Status is [map[]]
INFO[2022-04-11 17:28:02] Autofstrim for volume pvc-1add61b8-6505-4193-9914-27de34c3d142 not started, retrying after 2 mins
INFO[2022-04-11 17:30:04] Trim Status is [map[]]
INFO[2022-04-11 17:30:04] Autofstrim for volume pvc-1add61b8-6505-4193-9914-27de34c3d142 not started, retrying after 2 mins
INFO[2022-04-11 17:32:05] Trim Status is [map[]]
INFO[2022-04-11 17:32:05] Autofstrim for volume pvc-1add61b8-6505-4193-9914-27de34c3d142 not started, retrying after 2 mins
INFO[2022-04-11 17:34:06] Trim Status is [map[]]
INFO[2022-04-11 17:34:06] Autofstrim for volume pvc-1add61b8-6505-4193-9914-27de34c3d142 not started, retrying after 2 mins
INFO[2022-04-11 17:36:08] Trim Status is [map[379114528754248137:FS_TRIM_INPROGRESS]]
INFO[2022-04-11 17:36:08] Autofstrim status for volume pvc-1add61b8-6505-4193-9914-27de34c3d142, status: FS_TRIM_INPROGRESS
INFO[2022-04-11 17:36:08] Trigger Function completed for [autoFsTrim]
INFO[2022-04-11 17:36:08] Successfully released lock for trigger [autoFsTrim]

