### PR TITLE
PTX-6088: wait for the context to stabilize

### DIFF
--- a/tests/basic/sharedv4_svc_test.go
+++ b/tests/basic/sharedv4_svc_test.go
@@ -520,6 +520,10 @@ var _ = Describe("{Sharedv4SvcFunctional}", func() {
 
 		It("has to schedule apps, stop volume driver on node where volume is attached, teardown the application", func() {
 			for _, ctx := range testSv4Contexts {
+				Step(fmt.Sprintf("validate app %s", ctx.App.Key), func() {
+					ValidateContext(ctx)
+				})
+
 				Step(
 					fmt.Sprintf("stop the volume driver on attached node and verify app %s teardown succeeds", ctx.App.Key),
 					func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
We should wait for the context to stabilize before starting a new
iteration of the for loop since the context may have become unstable
due to the node down and up for the previous context.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**Which issue(s) this PR fixes** (optional)
PTX-6088

**Special notes for your reviewer**:

