### PR TITLE
PWX-19763 Add IPv6 test for pxctl status

### DIFF
--- a/drivers/volume/common.go
+++ b/drivers/volume/common.go
@@ -665,3 +665,11 @@ func (d *DefaultDriver) GetPxVersionOnNode(n node.Node) (string, error) {
 		Operation: "GetPxVersionOnNode()",
 	}
 }
+
+//GetPxctlStatus retruns GetPxctlStatus on the given node
+func (d *DefaultDriver) GetPxctlStatus(n node.Node, isJson bool) (string, error) {
+	return "", &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "GetPxctlStatus()",
+	}
+}

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -1578,7 +1578,7 @@ func (d *portworx) WaitDriverUpOnNode(n node.Node, timeout time.Duration) error 
 		switch pxNode.Status {
 		case api.Status_STATUS_DECOMMISSION: // do nothing
 		case api.Status_STATUS_OK:
-			pxStatus, err := d.getPxctlStatus(n)
+			pxStatus, err := d.GetPxctlStatus(n, true)
 			if err != nil {
 				return "", true, &ErrFailedToWaitForPx{
 					Node:  n,
@@ -3364,7 +3364,7 @@ func (d *portworx) getPxctlPath(n node.Node) string {
 	return strings.TrimSpace(out)
 }
 
-func (d *portworx) getPxctlStatus(n node.Node) (string, error) {
+func (d *portworx) GetPxctlStatus(n node.Node, isJson bool) (string, error) {
 	opts := node.ConnectionOpts{
 		IgnoreError:     false,
 		TimeBeforeRetry: defaultRetryInterval,
@@ -3381,6 +3381,13 @@ func (d *portworx) getPxctlStatus(n node.Node) (string, error) {
 		}
 	}
 
+	if !isJson {
+		out, err := d.nodeDriver.RunCommand(n, fmt.Sprintf("%s status", pxctlPath), opts)
+		if err != nil {
+			return "", fmt.Errorf("failed to get pxctl status. cause: %v", err)
+		}
+		return out, nil
+	}
 	out, err := d.nodeDriver.RunCommand(n, fmt.Sprintf("%s -j status", pxctlPath), opts)
 	if err != nil {
 		return "", fmt.Errorf("failed to get pxctl status. cause: %v", err)

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -278,6 +278,9 @@ type Driver interface {
 
 	//GetAutoFsTrimStatus get status of autofstrim
 	GetAutoFsTrimStatus(pxEndpoint string) (map[string]api.FilesystemTrim_FilesystemTrimStatus, error)
+
+	// GetPxctlStatus returns the status of pxctl
+	GetPxctlStatus(n node.Node, isJson bool) (string, error)
 }
 
 // StorageProvisionerType provisioner to be used for torpedo volumes

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Azure/azure-storage-blob-go v0.9.0
 	github.com/LINBIT/golinstor v0.27.0
 	github.com/andygrunwald/go-jira v1.15.0
+	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/aws/aws-sdk-go v1.35.37
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible

--- a/pkg/ipv6util/ipv6util.go
+++ b/pkg/ipv6util/ipv6util.go
@@ -1,0 +1,59 @@
+package ipv6util
+
+import (
+	"bufio"
+	"strings"
+
+	"github.com/asaskevich/govalidator"
+)
+
+// ParseIpv6AddressInPxctlStatus takes output of `pxctl status` and return the list of IPs parsed
+func ParseIpv6AddressInPxctlStatus(status string, nodeCount int) []string {
+	ips := []string{}
+	scanner := bufio.NewScanner(strings.NewReader(status))
+	// iterate each line to check for two conditions where IPs are printed:
+	// 1. `IP: <addr>`
+	//    ex: IP: 0000:111:2222:3333:444:5555:6666:777
+	// 2. (number of nodes) lines after `IP \t ID...`
+	//    ex: IP					ID					SchedulerNodeName	Auth		StorageNode	Used	Capacity	Status	StorageStatus	Version		Kernel			OS
+	//		0000:111:2222:3333:444:5555:6666:777	f703597a-9772-4bdb-b630-6395b3c98658	...	...
+	// 		0000:111:2222:3333:444:5555:6666:777	cedc897f-a489-4c28-9c20-12b8b4c3d1d8	...	...
+	for scanner.Scan() {
+		line := scanner.Text()
+		line = strings.TrimPrefix(line, "\t")
+
+		if strings.HasPrefix(line, "IP") {
+			// check for the first condition
+			if strings.HasPrefix(line, "IP:") {
+				ips = append(ips, strings.Split(line, " ")[1])
+				continue
+			}
+
+			// check for the second condition
+			for i := 0; i < nodeCount; i++ {
+				if !scanner.Scan() {
+					break
+				}
+				line := scanner.Text()
+				line = strings.TrimPrefix(line, "\t")
+				ips = append(ips, strings.Split(line, "\t")[0])
+			}
+		}
+	}
+	return ips
+}
+
+// IsAddressIPv6 checks the given address is a valid Ipv6 address
+func IsAddressIPv6(addr string) bool {
+	return govalidator.IsIPv6(addr)
+}
+
+// AreAddressesIPv6 checks the given addresses are valid Ipv6 addresses
+func AreAddressesIPv6(addrs []string) bool {
+	isIpv6 := true
+
+	for _, addr := range addrs {
+		isIpv6 = isIpv6 && IsAddressIPv6(addr)
+	}
+	return isIpv6
+}

--- a/pkg/ipv6util/ipv6util_test.go
+++ b/pkg/ipv6util/ipv6util_test.go
@@ -1,0 +1,89 @@
+package ipv6util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	sampleIpv6PxctlStatusOutput = `
+Status: PX is operational
+Telemetry: Disabled or Unhealthy
+License: Trial
+Node ID: f703597a-9772-4bdb-b630-6395b3c98658
+	IP: 0000:111:2222:3333:444:5555:6666:777
+ 	Local Storage Pool: 1 pool
+	POOL	IO_PRIORITY	RAID_LEVEL	USABLE	USED	STATUS	ZONE	REGION
+	0	HIGH		raid0		100 GiB	6.2 GiB	Online	default	default
+	Local Storage Devices: 1 device
+	Device	Path		Media Type		Size		Last-Scan
+	0:1	/dev/sdb	STORAGE_MEDIUM_SSD	100 GiB		some time
+	* Internal kvdb on this node is sharing this storage device /dev/sdb  to store its data.
+	total		-	100 GiB
+	Cache Devices:
+	 * No cache devices
+Cluster Summary
+	Cluster ID: px-cluster-2c8df3fc-a2b9-4c31-8b9d-5fddcb4646e1
+	Cluster UUID: f2c71ae5-c076-4e33-be1c-001c0d558274
+	Scheduler: kubernetes
+	Nodes: 6 node(s) with storage (6 online)
+	IP					ID					SchedulerNodeName	Auth		StorageNode	Used	Capacity	Status	StorageStatus	Version		Kernel			OS
+	0000:111:2222:3333:444:5555:6666:666	f703597a-9772-4bdb-b630-6395b3c98658	node05			Disabled	Yes		6.2 GiB	100 GiB		Online	Up (This node)	2.11.0-5fbb8c2	3.10.0-1160.53.1.el7.x86_64	CentOS Linux 7 (Core)
+	0000:111:2222:3333:444:5555:6666:555	cedc897f-a489-4c28-9c20-12b8b4c3d1d8	node01			Disabled	Yes		6.7 GiB	100 GiB		Online	Up		2.11.0-5fbb8c2	3.10.0-1160.53.1.el7.x86_64	CentOS Linux 7 (Core)
+	0000:111:2222:3333:444:5555:6666:444	956aafc1-a52d-41f3-afb1-6427e2a3b0ef	node04			Disabled	Yes		6.3 GiB	100 GiB		Online	Up		2.11.0-5fbb8c2	3.10.0-1160.53.1.el7.x86_64	CentOS Linux 7 (Core)
+	0000:111:2222:3333:444:5555:6666:333	6d801e0f-a7e7-4063-8f2f-50b43c1d9608	node03			Disabled	Yes		6.6 GiB	100 GiB		Online	Up		2.11.0-5fbb8c2	3.10.0-1160.53.1.el7.x86_64	CentOS Linux 7 (Core)
+	0000:111:2222:3333:444:5555:6666:222	28dee5d4-7724-41eb-a86d-929a3f88456e	node06			Disabled	Yes		6.3 GiB	100 GiB		Online	Up		2.11.0-5fbb8c2	3.10.0-1160.53.1.el7.x86_64	CentOS Linux 7 (Core)
+	0000:111:2222:3333:444:5555:6666:111	0e88d11f-6fb1-4898-b76a-e38c200fa7ae	node02			Disabled	Yes		6.1 GiB	100 GiB		Online	Up		2.11.0-5fbb8c2	3.10.0-1160.53.1.el7.x86_64	CentOS Linux 7 (Core)
+	Warnings:
+		 WARNING: Internal Kvdb is not using dedicated drive on nodes [0000:111:2222:3333:444:5555:6666:666 0000:111:2222:3333:444:5555:6666:444 0000:111:2222:3333:444:5555:6666:333]. This configuration is not recommended for production clusters.
+Global Storage Pool
+	Total Used    	:  38 GiB
+	Total Capacity	:  600 GiB
+`
+	sampleIpv4PxctlStatusOutput = `
+Status: PX is operational
+Telemetry: Disabled or Unhealthy
+License: Trial
+Node ID: f703597a-9772-4bdb-b630-6395b3c98658
+	IP: 192.168.121.111
+ 	Local Storage Pool: 1 pool
+	POOL	IO_PRIORITY	RAID_LEVEL	USABLE	USED	STATUS	ZONE	REGION
+	0	HIGH		raid0		100 GiB	6.2 GiB	Online	default	default
+	Local Storage Devices: 1 device
+	Device	Path		Media Type		Size		Last-Scan
+	0:1	/dev/sdb	STORAGE_MEDIUM_SSD	100 GiB		some time
+	* Internal kvdb on this node is sharing this storage device /dev/sdb  to store its data.
+	total		-	100 GiB
+	Cache Devices:
+	 * No cache devices
+Cluster Summary
+	Cluster ID: px-cluster-2c8df3fc-a2b9-4c31-8b9d-5fddcb4646e1
+	Cluster UUID: f2c71ae5-c076-4e33-be1c-001c0d558274
+	Scheduler: kubernetes
+	Nodes: 6 node(s) with storage (6 online)
+	IP					ID					SchedulerNodeName	Auth		StorageNode	Used	Capacity	Status	StorageStatus	Version		Kernel			OS
+	192.168.121.111	f703597a-9772-4bdb-b630-6395b3c98658	node05			Disabled	Yes		6.2 GiB	100 GiB		Online	Up (This node)	2.11.0-5fbb8c2	3.10.0-1160.53.1.el7.x86_64	CentOS Linux 7 (Core)
+	192.168.121.222	cedc897f-a489-4c28-9c20-12b8b4c3d1d8	node01			Disabled	Yes		6.7 GiB	100 GiB		Online	Up		2.11.0-5fbb8c2	3.10.0-1160.53.1.el7.x86_64	CentOS Linux 7 (Core)
+	192.168.121.333	956aafc1-a52d-41f3-afb1-6427e2a3b0ef	node04			Disabled	Yes		6.3 GiB	100 GiB		Online	Up		2.11.0-5fbb8c2	3.10.0-1160.53.1.el7.x86_64	CentOS Linux 7 (Core)
+	192.168.121.444	6d801e0f-a7e7-4063-8f2f-50b43c1d9608	node03			Disabled	Yes		6.6 GiB	100 GiB		Online	Up		2.11.0-5fbb8c2	3.10.0-1160.53.1.el7.x86_64	CentOS Linux 7 (Core)
+	192.168.121.555	28dee5d4-7724-41eb-a86d-929a3f88456e	node06			Disabled	Yes		6.3 GiB	100 GiB		Online	Up		2.11.0-5fbb8c2	3.10.0-1160.53.1.el7.x86_64	CentOS Linux 7 (Core)
+	192.168.121.666	0e88d11f-6fb1-4898-b76a-e38c200fa7ae	node02			Disabled	Yes		6.1 GiB	100 GiB		Online	Up		2.11.0-5fbb8c2	3.10.0-1160.53.1.el7.x86_64	CentOS Linux 7 (Core)
+Global Storage Pool
+	Total Used    	:  38 GiB
+	Total Capacity	:  600 GiB
+`
+
+	nodeCount = 6
+)
+
+func TestValidIpv6Address(t *testing.T) {
+	addrs := ParseIpv6AddressInPxctlStatus(sampleIpv6PxctlStatusOutput, nodeCount)
+	isIpv6 := AreAddressesIPv6(addrs)
+	assert.True(t, isIpv6, "addresses are expected to be ipv6")
+
+	addrs = ParseIpv6AddressInPxctlStatus(sampleIpv4PxctlStatusOutput, nodeCount)
+	isIpv6 = AreAddressesIPv6(addrs)
+	assert.False(t, isIpv6, "addresses are expected to be ipv4")
+
+}

--- a/tests/ipv6/ipv6_test.go
+++ b/tests/ipv6/ipv6_test.go
@@ -1,0 +1,79 @@
+package tests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
+	. "github.com/onsi/gomega"
+	"github.com/portworx/torpedo/drivers/node"
+	"github.com/portworx/torpedo/drivers/scheduler"
+	"github.com/portworx/torpedo/pkg/ipv6util"
+	"github.com/portworx/torpedo/pkg/testrailuttils"
+	. "github.com/portworx/torpedo/tests"
+)
+
+func TestBasic(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	var specReporters []Reporter
+	junitReporter := reporters.NewJUnitReporter("/testresults/junit_ipv6.xml")
+	specReporters = append(specReporters, junitReporter)
+	RunSpecsWithDefaultAndCustomReporters(t, "Torpedo : Ipv6", specReporters)
+}
+
+var _ = BeforeSuite(func() {
+	InitInstance()
+})
+
+// Simple single test
+var _ = Describe("{PxctlStatusTest}", func() {
+	// update the testrailID with your test
+	var testrailID = 9695443
+	// testrailID corresponds to: https://portworx.testrail.net/index.php?/tests/view/9695443
+	var runID int
+	JustBeforeEach(func() {
+		runID = testrailuttils.AddRunsToMilestone(testrailID)
+	})
+	var contexts []*scheduler.Context
+
+	It("has to run pxctl status and checks for valid ipv6 addresses", func() {
+		var status string
+		var err error
+		var ips []string
+
+		nodes := node.GetWorkerNodes()
+		Step(fmt.Sprintln("run pxctl status"), func() {
+			status, err = Inst().V.GetPxctlStatus(nodes[0], false)
+			Expect(err).NotTo(HaveOccurred(), status)
+		})
+
+		Step(fmt.Sprintln("parse address from pxctl status"), func() {
+			ips = ipv6util.ParseIpv6AddressInPxctlStatus(status, len(nodes))
+			// number of ips are the number of nodes + 1 (the node IP where the status command is run on)
+			Expect(len(ips)).To(Equal(len(nodes)+1), "unexpected ip count, should be one more than to number of worker nodes")
+		})
+
+		Step(fmt.Sprintln("validate the address are ipv6"), func() {
+			isIpv6 := ipv6util.AreAddressesIPv6(ips)
+			Expect(isIpv6).To(BeTrue(), "addresses in pxctl status are expected to be IPv6, parsed ips: %v", ips)
+		})
+
+	})
+	JustAfterEach(func() {
+		AfterEachTest(contexts, testrailID, runID)
+	})
+})
+
+var _ = AfterSuite(func() {
+	PerformSystemCheck()
+	ValidateCleanup()
+})
+
+func TestMain(m *testing.M) {
+	// call flag.Parse() here if TestMain uses flags
+	ParseFlags()
+	os.Exit(m.Run())
+}


### PR DESCRIPTION


Signed-off-by: dahuang <dahuang@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR adds test for checking the output address of `pxctl status` are IPv6. The changes includes: 
- add GetPxctlStatus  in volume driver for both json and stdout options
- Add helper file `ipv6utils` for parsing and validating ipv6 addrs

**Which issue(s) this PR fixes** (optional)
Closes # PWX-19763

**Special notes for your reviewer**:

