### PR TITLE
Writes more data to Pure volumes using Elasticsearch

### DIFF
--- a/tests/common.go
+++ b/tests/common.go
@@ -31,6 +31,7 @@ import (
 	"github.com/portworx/sched-ops/task"
 	"github.com/portworx/torpedo/drivers/node"
 	"github.com/portworx/torpedo/pkg/testrailuttils"
+	"github.com/portworx/torpedo/pkg/units"
 	"github.com/sirupsen/logrus"
 	appsapi "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -686,13 +687,16 @@ func ValidatePureVolumeStatisticsDynamicUpdate(ctx *scheduler.Context, errChan .
 		pods, err := Inst().S.GetPodsForPVC(vols[0].Name, vols[0].Namespace)
 		processError(err, errChan...)
 
-		// write to the FB volume
-		cmdArgs := []string{"exec", "-it", pods[0].Name, "-n", pods[0].Namespace, "--", "bash", "-c", "dd bs=512 count=1048576 </dev/urandom > " + getMountPath(pods[0].Namespace) + "/myfile"}
+		mountPath, bytesToWrite := getPureAppDataDir(pods[0].Namespace)
+
+		// write to the Direct Access volume
+		ddCmd := fmt.Sprintf("dd bs=512 count=%d if=/dev/urandom of=%s/myfile", bytesToWrite/512, mountPath)
+		cmdArgs := []string{"exec", "-it", pods[0].Name, "-n", pods[0].Namespace, "--", "bash", "-c", ddCmd}
 		err = osutils.Kubectl(cmdArgs)
 		processError(err, errChan...)
 		fmt.Println("sleeping to let volume usage get reflected")
 		// wait until the backends size is reflected before making the REST call
-		time.Sleep(125 * time.Second)
+		time.Sleep(time.Minute * 2)
 
 		byteUsedAfter, err := Inst().V.ValidateGetByteUsedForVolume(vols[0].ID, make(map[string]string))
 		fmt.Printf("after writing random bytes to the file the byteUsed in volume %s is %v\n", vols[0].ID, byteUsedAfter)
@@ -708,20 +712,21 @@ func checkPureVolumeExpectedSizeChange(sizeChangeInBytes uint64) error {
 	return nil
 }
 
-// getMountPath checkts the podname prefix, and finds the mountpath.
-//	unfortunately, the mountpath for PVCs all vary among applications, so Im getting the hardcoded value here
-//	maybe there will be some improvement later
-func getMountPath(namespace string) string {
+// getPureAppDataDir checks the pod namespace prefix, and returns a path that we can
+// write data to on a volume. Because the mountpath varies so heavily between applications
+// (some have multiple PVCs, some have configmap vols, etc. etc.) this is the easiest way
+// at the moment. As more apps get added to our test suite, we should add them here.
+func getPureAppDataDir(namespace string) (string, int) {
 	if strings.HasPrefix(namespace, "nginx-without-enc") {
-		return "/usr/share/nginx/html"
+		return "/usr/share/nginx/html", units.GiB / 2
 	}
 	if strings.HasPrefix(namespace, "wordpress") {
-		return "/var/www/html"
+		return "/var/www/html", units.GiB / 2
 	}
 	if strings.HasPrefix(namespace, "elasticsearch") {
-		return "/usr/share/elasticsearch/data"
+		return "/usr/share/elasticsearch/data", units.GiB * 5
 	}
-	return ""
+	return "", 0
 }
 
 // GetVolumeParameters returns volume parameters for all volumes for given context


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, the Pure test suite runs a test where we write data to the data directory of an app, and then validate that the bytesUsed has increased. This works in general, but Elasticsearch uses the data directory quite heavily due to the esload app that's running, so sometimes we actually see the bytesUsed decrease instead of increase (due to either the load app or over-time compression?) which causes the test to fail.

I'm hoping that writing much more data (e.g. 5 GiB instead of .5 GiB) will make a more noticeable difference. I had to do some refactoring to make it so that we still only wrote a bit of data to nginx and wordpress, but I think this will be better in the long run.
