### PR TITLE
Reenables pxctl groupsnap tests now that exit code bug is fixed

### DIFF
--- a/tests/common.go
+++ b/tests/common.go
@@ -641,16 +641,13 @@ func ValidatePureSnapshotsPXCTL(ctx *scheduler.Context, errChan ...*chan error) 
 				}
 			})
 		}
-		// TODO: This is broken for now, doesn't properly return an error
-		//       Output error message is correct, but returns exit code 0
-		//       See https://portworx.atlassian.net/browse/PWX-22950
-		//Step("validating groupsnap for using pxctl", func() {
-		//	err = Inst().V.ValidateCreateGroupSnapshotUsingPxctl()
-		//	expect(err).NotTo(beNil())
-		//	if err != nil {
-		//		expect(err.Error()).To(contain(errPureFileSnapshotNotSupported.Error()))
-		//	}
-		//})
+		Step("validating groupsnap for using pxctl", func() {
+			err = Inst().V.ValidateCreateGroupSnapshotUsingPxctl()
+			expect(err).NotTo(beNil())
+			if err != nil {
+				expect(err.Error()).To(contain(errPureFileSnapshotNotSupported.Error()))
+			}
+		})
 	})
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously this part of the tests was disabled as even though it failed correctly, the exit code was wrong. Now this is fixed so we can reenable this check.

