### PR TITLE
Adding code to check if node is rebooted before checking px to go down

### DIFF
--- a/drivers/node/node.go
+++ b/drivers/node/node.go
@@ -189,6 +189,9 @@ type Driver interface {
 
 	// PowerOnVMByName power on the VM using the vm name
 	PowerOnVMByName(vmName string) error
+
+	// IsNodeRebootedInGivenTimeRange check if node is rebooted within given time range
+	IsNodeRebootedInGivenTimeRange(Node, time.Duration) (bool, error)
 }
 
 // Register registers the given node driver
@@ -395,4 +398,12 @@ func (d *notSupportedDriver) PowerOnVMByName(vmName string) error {
 // IsUsingSSH returns true if the command will be run using ssh
 func (d *notSupportedDriver) IsUsingSSH() bool {
 	return false
+}
+
+// IsNodeRebootedInGivenTimeRange return true if node rebooted in given time range
+func (d *notSupportedDriver) IsNodeRebootedInGivenTimeRange(Node, time.Duration) (bool, error) {
+	return false, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "PowerOnVmByName()",
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Earlier code was expecting PX service to be down after invoking reboot command. This works well when reboot command prompt return immediately and then waits for PX to be down.

But this doesn't work well in case of EKS jobs when reboot command prompt got hang and by the time it returns EC2 instances already rebooted and up.  Later code was expecting PX to be down which was already up.

With this fix, code will check if node is already rebooted after invoking the `reboot command` and will not wait for PX to be down in a node  if it is already rebooted.

**Which issue(s) this PR fixes** (optional)
Closes # PTX-5127

**Special notes for your reviewer**:

Tested the code here: http://jenkins.pwx.dev.purestorage.com/job/Torpedo/view/Torpedo-Detailed/job/tp-nextpx-eks/319/consoleFull (It failed in cleanup, that is not because of this changes)

Snip of console out put
--------------------------
15:46:53  STEP: reboot node: ip-192-168-69-224.us-west-2.compute.internal
15:46:53  INFO[2022-04-20 22:46:53] Rebooting node ip-192-168-69-224.us-west-2.compute.internal 
15:46:53  DEBU[2022-04-20 22:46:53] Finding the debug pod to run command on node ip-192-168-69-224.us-west-2.compute.internal 
15:46:53  DEBU[2022-04-20 22:46:53] Running command on pod debug-74d45 [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c sudo reboot -f]] 
15:48:01  STEP: wait for node: ip-192-168-69-224.us-west-2.compute.internal to be back up
15:48:01  DEBU[2022-04-20 22:47:52] Finding the debug pod to run command on node ip-192-168-69-224.us-west-2.compute.internal 
15:48:01  DEBU[2022-04-20 22:47:53] Running command on pod debug-74d45 [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c date]] 
15:48:01  STEP: Check if node: ip-192-168-69-224.us-west-2.compute.internal rebooted in last 3 minutes
15:48:01  INFO[2022-04-20 22:47:53] Checking the uptime for a node ip-192-168-69-224.us-west-2.compute.internal 
15:48:01  DEBU[2022-04-20 22:47:53] Finding the debug pod to run command on node ip-192-168-69-224.us-west-2.compute.internal 
15:48:01  DEBU[2022-04-20 22:47:53] Running command on pod debug-74d45 [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c sudo uptime -s]] 
15:48:01  STEP: wait to scheduler: k8s and volume driver: pxd to start
15:48:01  DEBU[2022-04-20 22:47:53] waiting for PX node to be up: ip-192-168-69-224.us-west-2.compute.internal 
15:48:01  DEBU[2022-04-20 22:47:53] Getting node info for node: [ip-192-168-69-224.us-west-2.compute.internal] 
15:48:01  DEBU[2022-04-20 22:47:53] checking PX status on node: ip-192-168-69-224.us-west-2.compute.internal 
15:48:01  INFO[2022-04-20 22:47:53] Updating node: id:"51379683-ae79-4977-bc99-61b306ef8c44"  cpu:4.974489795918367  mem_total:16787288064  mem_used:2000478208  mem_free:14786809856  status:STATUS_OK  mgmt_ip:"192.168.69.224"  data_ip:"192.168.69.224"  hostname:"ip-192-168-69-224.us-west-2.compute.internal"  node_labels:{key:"City"  value:"Portland"}  node_labels:{key:"Country"  value:"United States"}  node_labels:{key:"Data IP"  value:"192.168.69.224"}  node_labels:{key:"ISP"  value:"Amazon.com, Inc."}  node_labels:{key:"ISP IP"  value:"34.219.113.133"}  node_labels:{key:"Kernel Version"  value:"5.4.181-99.354.amzn2.x86_64"}  node_labels:{key:"LAT"  value:"4.55235E+01"}  node_labels:{key:"LNG"  value:"-1.22676E+02"}  node_labels:{key:"Management IP"  value:"192.168.69.224"}  node_labels:{key:"OS"  value:"Amazon Linux 2"}  node_labels:{key:"PX Version"  value:"2.11.0-3a15746"}  node_labels:{key:"Region"  value:"OR"}  node_labels:{key:"Timezone"  value:"America/Los_Angeles"}  node_labels:{key:"Zip"  value:"97207"}  scheduler_node_name:"ip-192-168-69-224.us-west-2.compute.internal"  HWType:VirtualMachine  security_status:UNSECURED 
15:48:01  INFO[2022-04-20 22:47:53] PX is enabled on node ip-192-168-69-224.us-west-2.compute.internal. 
15:48:01  INFO[2022-04-20 22:47:53] Checking PX node id:"977f506a-320b-4eed-8cb6-cf19e8dba07b"  cpu:1.6518424396442186  mem_total:16787288064  mem_used:2001829888  mem_free:14785458176  status:STATUS_OK  mgmt_ip:"192.168.45.130"  data_ip:"192.168.45.130"  hostname:"ip-192-168-45-130.us-west-2.compute.internal"  node_labels:{key:"City"  value:"Portland"}  node_labels:{key:"Country"  value:"United States"}  node_labels:{key:"Data IP"  value:"192.168.45.130"}  node_labels:{key:"ISP"  value:"Amazon.com, Inc."}  node_labels:{key:"ISP IP"  value:"18.237.115.30"}  node_labels:{key:"Kernel Version"  value:"5.4.181-99.354.amzn2.x86_64"}  node_labels:{key:"LAT"  value:"4.55235E+01"}  node_labels:{key:"LNG"  value:"-1.22676E+02"}  node_labels:{key:"Management IP"  value:"192.168.45.130"}  node_labels:{key:"OS"  value:"Amazon Linux 2"}  node_labels:{key:"PX Version"  value:"2.11.0-3a15746"}  node_labels:{key:"Region"  value:"OR"}  node_labels:{key:"Timezone"  value:"America/Los_Angeles"}  node_labels:{key:"Zip"  value:"97207"}  scheduler_node_name:"ip-192-168-45-130.us-west-2.compute.internal"  HWType:VirtualMachine  security_status:UNSECURED for address 192.168.69.224 
15:48:01  INFO[2022-04-20 22:47:53] Checking PX node id:"a4ad4ea1-c410-4e01-a4ba-763719ffd7aa"  cpu:1.5286624203821657  mem_total:16787288064  mem_used:1448894464  mem_free:15338393600  status:STATUS_OK  mgmt_ip:"192.168.42.192"  data_ip:"192.168.42.192"  hostname:"ip-192-168-42-192.us-west-2.compute.internal"  node_labels:{key:"City"  value:"Portland"}  node_labels:{key:"Country"  value:"United States"}  node_labels:{key:"Data IP"  value:"192.168.42.192"}  node_labels:{key:"ISP"  value:"Amazon.com, Inc."}  node_labels:{key:"ISP IP"  value:"54.149.121.51"}  node_labels:{key:"Kernel Version"  value:"5.4.181-99.354.amzn2.x86_64"}  node_labels:{key:"LAT"  value:"4.55235E+01"}  node_labels:{key:"LNG"  value:"-1.22676E+02"}  node_labels:{key:"Management IP"  value:"192.168.42.192"}  node_labels:{key:"OS"  value:"Amazon Linux 2"}  node_labels:{key:"PX Version"  value:"2.11.0-3a15746"}  node_labels:{key:"Region"  value:"OR"}  node_labels:{key:"Timezone"  value:"America/Los_Angeles"}  node_labels:{key:"Zip"  value:"97207"}  scheduler_node_name:"ip-192-168-42-192.us-west-2.compute.internal"  HWType:VirtualMachine  security_status:UNSECURED for address 192.168.69.224 

