### PR TITLE
Shrunk Pure Elastic data file size down to 2 GiB

### DIFF
--- a/tests/common.go
+++ b/tests/common.go
@@ -748,7 +748,7 @@ func getPureAppDataDir(namespace string) (string, int) {
 		return "/var/www/html", units.GiB / 2
 	}
 	if strings.HasPrefix(namespace, "elasticsearch") {
-		return "/usr/share/elasticsearch/data", units.GiB * 5
+		return "/usr/share/elasticsearch/data", units.GiB * 2
 	}
 	return "", 0
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Looks like my last PR of writing 5 GiB was a bit too much, depending on how big elastics data volume was. Let's try 2 GiB instead.

