### PR TITLE
:sparkles: decomm and comm longevity test

### DIFF
--- a/drivers/scheduler/k8s/specs/pgbench-io-portion/px-pgbench-storage.yaml
+++ b/drivers/scheduler/k8s/specs/pgbench-io-portion/px-pgbench-storage.yaml
@@ -4,7 +4,7 @@ metadata:
   name: postgres-pgbench-sc
 provisioner: kubernetes.io/portworx-volume
 parameters:
-  repl: "1"
+  repl: "2"
   priority_io: "low"
 allowVolumeExpansion: true
 ---

--- a/drivers/volume/common.go
+++ b/drivers/volume/common.go
@@ -351,6 +351,15 @@ func (d *DefaultDriver) WaitDriverUpOnNode(n node.Node, timeout time.Duration) e
 	}
 }
 
+// GetPxNodes returns current PX nodes in the cluster
+func (d *DefaultDriver) GetPxNodes() ([]*api.StorageNode, error) {
+	return nil, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "GetPxNodes()",
+	}
+
+}
+
 // WaitDriverDownOnNode must wait till the volume driver becomes unusable on a given node
 func (d *DefaultDriver) WaitDriverDownOnNode(n node.Node) error {
 	return &errors.ErrNotSupported{

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -1584,6 +1584,12 @@ func (d *portworx) getPxNodeByID(nodeID string) (*api.StorageNode, error) {
 	return nodeResponse.Node, nil
 }
 
+func (d *portworx) GetPxNodes() ([]*api.StorageNode, error) {
+
+	return d.getPxNodes()
+
+}
+
 func (d *portworx) getPxNodes(nManagers ...api.OpenStorageNodeClient) ([]*api.StorageNode, error) {
 	var nodeManager api.OpenStorageNodeClient
 	if nManagers == nil {
@@ -2461,12 +2467,14 @@ func (d *portworx) DecommissionNode(n *node.Node) error {
 		}
 	}
 
-	if err := d.StopDriver([]node.Node{*n}, false, nil); err != nil {
+	if err := d.EnterMaintenance(*n); err != nil {
 		return &ErrFailedToDecommissionNode{
 			Node:  n.Name,
 			Cause: fmt.Sprintf("Failed to stop driver on node: %v. Err: %v", n.Name, err),
 		}
 	}
+
+	time.Sleep(10 * time.Second)
 
 	nodeResp, err := d.getNodeManager().Inspect(d.getContext(), &api.SdkNodeInspectRequest{NodeId: n.VolDriverNodeID})
 	if err != nil {
@@ -2475,14 +2483,20 @@ func (d *portworx) DecommissionNode(n *node.Node) error {
 			Cause: fmt.Sprintf("Failed to inspect node: %v. Err: %v", nodeResp.Node, err),
 		}
 	}
+	logrus.Infof("removing node %v", nodeResp.Node.Id)
 
 	// TODO replace when sdk supports node removal
-	if err = d.legacyClusterManager.Remove([]api.Node{{Id: nodeResp.Node.Id}}, false); err != nil {
-		return &ErrFailedToDecommissionNode{
-			Node:  n.Name,
-			Cause: err.Error(),
+	if err = d.legacyClusterManager.Remove([]api.Node{{Id: nodeResp.Node.Id}}, true); err != nil {
+		if !strings.Contains(err.Error(), "Node remove is pending") {
+			return &ErrFailedToDecommissionNode{
+				Node:  n.Name,
+				Cause: err.Error(),
+			}
 		}
 	}
+
+	logrus.Infof(" %v: Node remove is pending. Waiting for it to complete", nodeResp.Node.Id)
+	time.Sleep(30 * time.Second)
 
 	// update node in registry
 	n.IsStorageDriverInstalled = false
@@ -2492,6 +2506,33 @@ func (d *portworx) DecommissionNode(n *node.Node) error {
 
 	// force refresh endpoint
 	d.refreshEndpoint = true
+
+	latestNodes, err := d.getPxNodes()
+
+	if err != nil {
+		return &ErrFailedToDecommissionNode{
+			Node:  n.Name,
+			Cause: err.Error(),
+		}
+
+	}
+
+	isNodeExist := false
+	for _, latestNode := range latestNodes {
+		if latestNode.Hostname == n.Hostname {
+			isNodeExist = true
+			break
+		}
+	}
+
+	if isNodeExist {
+		return &ErrFailedToDecommissionNode{
+			Node:  n.Name,
+			Cause: fmt.Errorf("node %s still exist in the PX cluster", n.Name).Error(),
+		}
+	}
+
+	logrus.Infof("Successfully removed node %v", nodeResp.Node.Id)
 
 	return nil
 }
@@ -2503,30 +2544,44 @@ func (d *portworx) RejoinNode(n *node.Node) error {
 		TimeBeforeRetry: defaultRetryInterval,
 		Timeout:         defaultTimeout,
 	}
+
 	if _, err := d.nodeDriver.RunCommand(*n, fmt.Sprintf("%s sv node-wipe --all", d.getPxctlPath(*n)), opts); err != nil {
 		return &ErrFailedToRejoinNode{
 			Node:  n.Name,
-			Cause: err.Error(),
+			Cause: fmt.Sprintf("Error while running node wipe: %v. Err: %v", n.Name, err),
 		}
 	}
+	logrus.Info("Node wipe is successfull")
+
 	if err := k8sCore.RemoveLabelOnNode(n.Name, schedops.PXServiceLabelKey); err != nil {
 		return &ErrFailedToRejoinNode{
 			Node:  n.Name,
 			Cause: fmt.Sprintf("Failed to set label on node: %v. Err: %v", n.Name, err),
 		}
 	}
+
 	if err := k8sCore.RemoveLabelOnNode(n.Name, schedops.PXEnabledLabelKey); err != nil {
 		return &ErrFailedToRejoinNode{
 			Node:  n.Name,
 			Cause: fmt.Sprintf("Failed to set label on node: %v. Err: %v", n.Name, err),
 		}
 	}
+
+	if err := d.RestartDriver(*n, nil); err != nil {
+		return &ErrFailedToRejoinNode{
+			Node:  n.Name,
+			Cause: err.Error(),
+		}
+
+	}
+
 	if err := k8sCore.UnCordonNode(n.Name, defaultTimeout, defaultRetryInterval); err != nil {
 		return &ErrFailedToRejoinNode{
 			Node:  n.Name,
 			Cause: fmt.Sprintf("Failed to uncordon node: %v. Err: %v", n.Name, err),
 		}
 	}
+
 	return nil
 }
 

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -155,6 +155,9 @@ type Driver interface {
 	// RandomizeVolumeName randomizes the volume name from the given name
 	RandomizeVolumeName(name string) string
 
+	// GetPxNodes returns current PX nodes in the cluster
+	GetPxNodes() ([]*api.StorageNode, error)
+
 	// RecoverDriver will recover a volume driver from a failure/storage down state.
 	// This could be used by a volume driver to recover itself from any underlying storage
 	// failure.

--- a/tests/basic/sharedv4_test.go
+++ b/tests/basic/sharedv4_test.go
@@ -2,9 +2,11 @@ package tests
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
+	"github.com/libopenstorage/openstorage/pkg/mount"
 	"github.com/portworx/sched-ops/k8s/apps"
 	"github.com/portworx/torpedo/drivers/node"
 	"github.com/portworx/torpedo/drivers/scheduler"
@@ -129,19 +131,19 @@ var _ = Describe("{Sharedv4Functional}", func() {
 					Expect(len(activePods)).To(Equal(numPods))
 				})
 
-				// Step(fmt.Sprintf("validate device path is set as RW for %s", ctx.App.Key), func() {
-				// 	mntList, err := mount.GetMounts()
-				// 	Expect(err).NotTo(HaveOccurred())
-				// 	var volumeMountRW = regexp.MustCompile(`,rw,|,rw|rw,|rw`)
+				Step(fmt.Sprintf("validate device path is set as RW for %s", ctx.App.Key), func() {
+					mntList, err := mount.GetMounts()
+					Expect(err).NotTo(HaveOccurred())
+					var volumeMountRW = regexp.MustCompile(`,rw,|,rw|rw,|rw`)
 
-				// 	for _, mnt := range mntList {
-				// 		if mnt.Mountpoint != devicePath {
-				// 			continue
-				// 		}
-				// 		Expect(volumeMountRW.MatchString(mnt.Opts)).To(BeTrue())
-				// 		Expect(volumeMountRW.MatchString(mnt.VfsOpts)).To(BeTrue())
-				// 	}
-				// })
+					for _, mnt := range mntList {
+						if mnt.Mountpoint != devicePath {
+							continue
+						}
+						Expect(volumeMountRW.MatchString(mnt.Opts)).To(BeTrue())
+						Expect(volumeMountRW.MatchString(mnt.VfsOpts)).To(BeTrue())
+					}
+				})
 			}
 		})
 	})

--- a/tests/basic/sharedv4_test.go
+++ b/tests/basic/sharedv4_test.go
@@ -2,11 +2,9 @@ package tests
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 	"time"
 
-	"github.com/libopenstorage/openstorage/pkg/mount"
 	"github.com/portworx/sched-ops/k8s/apps"
 	"github.com/portworx/torpedo/drivers/node"
 	"github.com/portworx/torpedo/drivers/scheduler"
@@ -131,19 +129,19 @@ var _ = Describe("{Sharedv4Functional}", func() {
 					Expect(len(activePods)).To(Equal(numPods))
 				})
 
-				Step(fmt.Sprintf("validate device path is set as RW for %s", ctx.App.Key), func() {
-					mntList, err := mount.GetMounts()
-					Expect(err).NotTo(HaveOccurred())
-					var volumeMountRW = regexp.MustCompile(`,rw,|,rw|rw,|rw`)
+				// Step(fmt.Sprintf("validate device path is set as RW for %s", ctx.App.Key), func() {
+				// 	mntList, err := mount.GetMounts()
+				// 	Expect(err).NotTo(HaveOccurred())
+				// 	var volumeMountRW = regexp.MustCompile(`,rw,|,rw|rw,|rw`)
 
-					for _, mnt := range mntList {
-						if mnt.Mountpoint != devicePath {
-							continue
-						}
-						Expect(volumeMountRW.MatchString(mnt.Opts)).To(BeTrue())
-						Expect(volumeMountRW.MatchString(mnt.VfsOpts)).To(BeTrue())
-					}
-				})
+				// 	for _, mnt := range mntList {
+				// 		if mnt.Mountpoint != devicePath {
+				// 			continue
+				// 		}
+				// 		Expect(volumeMountRW.MatchString(mnt.Opts)).To(BeTrue())
+				// 		Expect(volumeMountRW.MatchString(mnt.VfsOpts)).To(BeTrue())
+				// 	}
+				// })
 			}
 		})
 	})

--- a/tests/longevity/longevity_test.go
+++ b/tests/longevity/longevity_test.go
@@ -80,6 +80,8 @@ var _ = Describe("{Longevity}", func() {
 		AutoFsTrim:           TriggerAutoFsTrim,
 		RestartManyVolDriver: TriggerRestartManyVolDriver,
 		RebootManyNodes:      TriggerRebootManyNodes,
+		NodeDecommission:     TriggerNodeDecommission,
+		NodeRejoin:           TriggerNodeRejoin,
 	}
 	It("has to schedule app and introduce test triggers", func() {
 		Step(fmt.Sprintf("Start watch on K8S configMap [%s/%s]",

--- a/tests/longevity/longevity_test.go
+++ b/tests/longevity/longevity_test.go
@@ -234,6 +234,7 @@ func populateDisruptiveTriggers() {
 		RestartManyVolDriver:            true,
 		RebootManyNodes:                 true,
 		RestartKvdbVolDriver:            true,
+		NodeDecommission:                true,
 	}
 }
 
@@ -346,6 +347,8 @@ func populateIntervals() {
 	triggerInterval[AutoFsTrim] = make(map[int]time.Duration)
 	triggerInterval[RestartManyVolDriver] = make(map[int]time.Duration)
 	triggerInterval[RebootManyNodes] = make(map[int]time.Duration)
+	triggerInterval[NodeDecommission] = make(map[int]time.Duration)
+	triggerInterval[NodeRejoin] = make(map[int]time.Duration)
 
 	baseInterval := 10 * time.Minute
 	triggerInterval[BackupScaleMongo][10] = 1 * baseInterval
@@ -717,6 +720,28 @@ func populateIntervals() {
 	triggerInterval[AutoFsTrim][3] = 21 * baseInterval
 	triggerInterval[AutoFsTrim][2] = 24 * baseInterval
 	triggerInterval[AutoFsTrim][1] = 27 * baseInterval
+
+	triggerInterval[NodeDecommission][10] = 1 * baseInterval
+	triggerInterval[NodeDecommission][9] = 3 * baseInterval
+	triggerInterval[NodeDecommission][8] = 6 * baseInterval
+	triggerInterval[NodeDecommission][7] = 9 * baseInterval
+	triggerInterval[NodeDecommission][6] = 12 * baseInterval
+	triggerInterval[NodeDecommission][5] = 15 * baseInterval
+	triggerInterval[NodeDecommission][4] = 18 * baseInterval
+	triggerInterval[NodeDecommission][3] = 21 * baseInterval
+	triggerInterval[NodeDecommission][2] = 24 * baseInterval
+	triggerInterval[NodeDecommission][1] = 27 * baseInterval
+
+	triggerInterval[NodeRejoin][10] = 1 * baseInterval
+	triggerInterval[NodeRejoin][9] = 3 * baseInterval
+	triggerInterval[NodeRejoin][8] = 6 * baseInterval
+	triggerInterval[NodeRejoin][7] = 9 * baseInterval
+	triggerInterval[NodeRejoin][6] = 12 * baseInterval
+	triggerInterval[NodeRejoin][5] = 15 * baseInterval
+	triggerInterval[NodeRejoin][4] = 18 * baseInterval
+	triggerInterval[NodeRejoin][3] = 21 * baseInterval
+	triggerInterval[NodeRejoin][2] = 24 * baseInterval
+	triggerInterval[NodeRejoin][1] = 27 * baseInterval
 
 	baseInterval = 300 * time.Minute
 

--- a/tests/testTriggers.go
+++ b/tests/testTriggers.go
@@ -240,6 +240,10 @@ const (
 	AppTasksDown = "appScaleUpAndDown"
 	// AutoFsTrim enables Auto Fstrim in PX cluster
 	AutoFsTrim = "autoFsTrim"
+	// NodeDecommission decommission random node in the PX cluster
+	NodeDecommission = "ndoeDecomm"
+	//NodeRejoin rejoins the decommissioned node into the PX cluster
+	NodeRejoin = "nodeRejoin"
 )
 
 // TriggerCoreChecker checks if any cores got generated

--- a/tests/testTriggers.go
+++ b/tests/testTriggers.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/onsi/ginkgo"
 
+	opsapi "github.com/libopenstorage/openstorage/api"
 	"github.com/pborman/uuid"
 	api "github.com/portworx/px-backup-api/pkg/apis/v1"
 	"github.com/portworx/sched-ops/k8s/core"
@@ -110,6 +111,9 @@ type EventRecord struct {
 // eventRing is circular buffer to store
 // events for sending email notifications
 var eventRing *ring.Ring
+
+//decommissionedNode for rejoin test
+var decommissionedNode = node.Node{}
 
 // emailRecords stores events for rendering
 // email template
@@ -241,7 +245,7 @@ const (
 	// AutoFsTrim enables Auto Fstrim in PX cluster
 	AutoFsTrim = "autoFsTrim"
 	// NodeDecommission decommission random node in the PX cluster
-	NodeDecommission = "ndoeDecomm"
+	NodeDecommission = "nodeDecomm"
 	//NodeRejoin rejoins the decommissioned node into the PX cluster
 	NodeRejoin = "nodeRejoin"
 )
@@ -3299,7 +3303,7 @@ func TriggerUpgradeVolumeDriver(contexts *[]*scheduler.Context, recordChan *chan
 	event := &EventRecord{
 		Event: Event{
 			ID:   GenerateUUID(),
-			Type: CoreChecker,
+			Type: UpgradeVolumeDriver,
 		},
 		Start:   time.Now().Format(time.RFC1123),
 		Outcome: []error{},
@@ -3418,7 +3422,7 @@ func TriggerUpgradeStork(contexts *[]*scheduler.Context, recordChan *chan *Event
 	event := &EventRecord{
 		Event: Event{
 			ID:   GenerateUUID(),
-			Type: PoolResizeDisk,
+			Type: UpgradeStork,
 		},
 		Start:   time.Now().Format(time.RFC1123),
 		Outcome: []error{},
@@ -3620,6 +3624,168 @@ func waitForFsTrimStatus(event *EventRecord, attachedNode, volumeID string) stri
 	}
 
 	return ""
+
+}
+
+// TriggerNodeDecommission decommission the node for the PX cluster
+func TriggerNodeDecommission(contexts *[]*scheduler.Context, recordChan *chan *EventRecord) {
+	defer ginkgo.GinkgoRecover()
+	event := &EventRecord{
+		Event: Event{
+			ID:   GenerateUUID(),
+			Type: NodeDecommission,
+		},
+		Start:   time.Now().Format(time.RFC1123),
+		Outcome: []error{},
+	}
+
+	defer func() {
+		event.End = time.Now().Format(time.RFC1123)
+		*recordChan <- event
+	}()
+
+	var workerNodes []node.Node
+	var nodeToDecomm node.Node
+
+	Step("Decommission a random node", func() {
+
+		workerNodes = node.GetWorkerNodes()
+		index := rand.Intn(len(workerNodes))
+		nodeToDecomm = workerNodes[index]
+		Step(fmt.Sprintf("decommission node %s", nodeToDecomm.Name), func() {
+			err := Inst().S.PrepareNodeToDecommission(nodeToDecomm, Inst().Provisioner)
+			if err != nil {
+				UpdateOutcome(event, err)
+			} else {
+				err = Inst().V.DecommissionNode(&nodeToDecomm)
+				if err != nil {
+					logrus.Infof("Error while decommissioning the node: %v, Error:%v", nodeToDecomm.Name, err)
+					UpdateOutcome(event, err)
+				}
+
+			}
+
+			t := func() (interface{}, bool, error) {
+				status, err := Inst().V.GetNodeStatus(nodeToDecomm)
+				if err != nil {
+					return false, true, fmt.Errorf("error getting node %v status", nodeToDecomm.Name)
+				}
+				if *status == opsapi.Status_STATUS_NONE {
+					return true, false, nil
+				}
+				return false, true, fmt.Errorf("node %s not decomissioned yet", nodeToDecomm.Name)
+			}
+			_, err = task.DoRetryWithTimeout(t, defaultTimeout, defaultRetryInterval)
+
+			if err != nil {
+				UpdateOutcome(event, err)
+			} else {
+
+				decommissionedNode = nodeToDecomm
+
+			}
+
+		})
+
+	})
+
+	for _, ctx := range *contexts {
+
+		Step(fmt.Sprintf("validating context after node: [%s] decommission",
+			nodeToDecomm.Name), func() {
+			errorChan := make(chan error, errorChannelSize)
+			ctx.SkipVolumeValidation = true
+			ValidateContext(ctx, &errorChan)
+			for err := range errorChan {
+				UpdateOutcome(event, err)
+			}
+		})
+	}
+}
+
+// TriggerNodeRejoin rejoins the decommissioned node
+func TriggerNodeRejoin(contexts *[]*scheduler.Context, recordChan *chan *EventRecord) {
+	defer ginkgo.GinkgoRecover()
+	event := &EventRecord{
+		Event: Event{
+			ID:   GenerateUUID(),
+			Type: NodeRejoin,
+		},
+		Start:   time.Now().Format(time.RFC1123),
+		Outcome: []error{},
+	}
+
+	defer func() {
+		event.End = time.Now().Format(time.RFC1123)
+		*recordChan <- event
+	}()
+
+	var decommissionedNodeName string
+
+	Step("Rejoin the node", func() {
+
+		if decommissionedNode.Name != "" {
+			decommissionedNodeName = decommissionedNode.Name
+
+			Step(fmt.Sprintf("Rejoin node %s", decommissionedNode.Name), func() {
+				err := Inst().V.RejoinNode(&decommissionedNode)
+
+				if err != nil {
+					logrus.Infof("Error while rejoining the node. error: %v", err)
+					UpdateOutcome(event, err)
+				} else {
+					logrus.Info("Waiting for node to rejoin and refresh inventory")
+					time.Sleep(90 * time.Second)
+					err = Inst().S.RefreshNodeRegistry()
+					if err != nil {
+						UpdateOutcome(event, err)
+					}
+
+					latestNodes, err := Inst().V.GetPxNodes()
+					if err != nil {
+						UpdateOutcome(event, err)
+					}
+
+					isNodeExist := false
+					for _, latestNode := range latestNodes {
+
+						logrus.Infof("Inspecting Node: %v", latestNode.Hostname)
+
+						if latestNode.Hostname == decommissionedNode.Hostname {
+							isNodeExist = true
+							break
+						}
+
+					}
+					if !isNodeExist {
+						err = fmt.Errorf("node %v rejoin failed", decommissionedNode.Hostname)
+						UpdateOutcome(event, err)
+					} else {
+						logrus.Infof("node %v rejoin is successful ", decommissionedNode.Hostname)
+					}
+
+				}
+
+			})
+
+			decommissionedNode = node.Node{}
+
+		}
+
+	})
+
+	for _, ctx := range *contexts {
+
+		Step(fmt.Sprintf("validating context after node: [%s] rejoin",
+			decommissionedNodeName), func() {
+			errorChan := make(chan error, errorChannelSize)
+			ctx.SkipVolumeValidation = true
+			ValidateContext(ctx, &errorChan)
+			for err := range errorChan {
+				UpdateOutcome(event, err)
+			}
+		})
+	}
 
 }
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Addint node decommssion and rejoin as part of longevity

**Which issue(s) this PR fixes** (optional)
Closes # PT-4703
**Special notes for your reviewer**:

Decomm node:

STEP: Decommission a random node
STEP: decommission node torpedo-long-fa-sample-test-36-4
INFO[2022-05-17 17:43:27] testAndSetEndpoint failed for 10.233.17.201: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 10.233.17.201:9020: i/o timeout"
INFO[2022-05-17 17:43:27] Getting new driver.
INFO[2022-05-17 17:43:29] Using 10.13.10.193:9020 as endpoint for portworx volume driver
DEBU[2022-05-17 17:43:29] Inspecting node [torpedo-long-fa-sample-test-36-4] with volume driver node id [557773e0-bcb0-4c43-b9ca-8f0488a0371a]
INFO[2022-05-17 17:44:00] testAndSetEndpoint failed for 10.233.17.201: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 10.233.17.201:9020: i/o timeout"
INFO[2022-05-17 17:44:00] Getting new driver.
INFO[2022-05-17 17:44:02] Using 10.13.10.193:9020 as endpoint for portworx volume driver
INFO[2022-05-17 17:44:02] removing node 557773e0-bcb0-4c43-b9ca-8f0488a0371a
INFO[2022-05-17 17:44:11]  557773e0-bcb0-4c43-b9ca-8f0488a0371a: Node remove is pending
INFO[2022-05-17 17:45:02] testAndSetEndpoint failed for 10.233.17.201: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 10.233.17.201:9020: i/o timeout"
INFO[2022-05-17 17:45:02] Getting new driver.
INFO[2022-05-17 17:45:03] Waiting for lock for trigger [nodeRejoin]
INFO[2022-05-17 17:45:04] Using 10.13.8.182:9020 as endpoint for portworx volume driver
INFO[2022-05-17 17:45:06] Successfully removed node 557773e0-bcb0-4c43-b9ca-8f0488a0371a


Rejoin node:

STEP: Rejoin the node
STEP: Rejoin node torpedo-long-fa-sample-test-36-4
DEBU[2022-05-17 17:45:43] Finding the debug pod to run command on node torpedo-long-fa-sample-test-36-4
DEBU[2022-05-17 17:45:44] Running command on pod debug-265tc [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c which pxctl]]
DEBU[2022-05-17 17:45:46] Finding the debug pod to run command on node torpedo-long-fa-sample-test-36-4
DEBU[2022-05-17 17:45:47] Running command on pod debug-265tc [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c sudo /usr/local/bin/pxctl sv node-wipe --all]]
INFO[2022-05-17 17:45:56] Node wipe is successfull
INFO[2022-05-17 17:45:57] Remove service label is successfull
INFO[2022-05-17 17:45:57] Remove enable label is successfull
INFO[2022-05-17 17:45:58] Restart Driver is successfull
INFO[2022-05-17 17:45:58] Uncordon is successfull
INFO[2022-05-17 17:46:43] Waiting for lock for trigger [nodeDecomm]
INFO[2022-05-17 17:47:30] Parsed node [torpedo-long-fa-sample-test-36-0] as Type: Worker, Zone: , Region
INFO[2022-05-17 17:47:30] Parsed node [torpedo-long-fa-sample-test-36-1] as Type: Worker, Zone: , Region
INFO[2022-05-17 17:47:31] Parsed node [torpedo-long-fa-sample-test-36-2] as Type: Worker, Zone: , Region
INFO[2022-05-17 17:47:31] Parsed node [torpedo-long-fa-sample-test-36-3] as Type: Master, Zone: , Region
INFO[2022-05-17 17:47:32] Parsed node [torpedo-long-fa-sample-test-36-4] as Type: Worker, Zone: , Region
INFO[2022-05-17 17:47:32] Parsed node [torpedo-long-fa-sample-test-36-5] as Type: Worker, Zone: , Region
INFO[2022-05-17 17:47:53] testAndSetEndpoint failed for 10.233.17.201: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 10.233.17.201:9020: i/o timeout"
INFO[2022-05-17 17:47:53] Getting new driver.
INFO[2022-05-17 17:47:55] Using 10.13.8.190:9020 as endpoint for portworx volume driver
INFO[2022-05-17 17:47:57] Latest Node: torpedo-long-fa-sample-test-36-1
INFO[2022-05-17 17:47:57] Latest Node: torpedo-long-fa-sample-test-36-5
INFO[2022-05-17 17:47:57] Latest Node: torpedo-long-fa-sample-test-36-0
INFO[2022-05-17 17:47:57] Latest Node: torpedo-long-fa-sample-test-36-2
INFO[2022-05-17 17:47:57] Latest Node: torpedo-long-fa-sample-test-36-4
INFO[2022-05-17 17:47:57] node torpedo-long-fa-sample-test-36-4 rejoin is successful

