### PR TITLE
If no pods are found for the specs in current context, bail out during pod terminating check.

### DIFF
--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -2085,10 +2085,8 @@ func (k *K8s) WaitForRunning(ctx *scheduler.Context, timeout, retryInterval time
 		var terminatingPods []string
 		pods, err := k.getPodsForApp(ctx)
 		// sadly, getPodsForApp returns an error if there are no pods
-		if err != schederrors.ErrPodsNotFound {
+		if err != nil {
 			return nil, false, nil
-		} else if err != nil {
-			return nil, true, fmt.Errorf("failed to get pods for app %v: %w", ctx.App.Key, err)
 		}
 		for _, pod := range pods {
 			if !pod.DeletionTimestamp.IsZero() {


### PR DESCRIPTION
Signed-off-by: Diptiranjan

**What this PR does / why we need it**:
After doing the restore, for checking if the related resources are properly restored, we call WaitForRunning()
Now because pod terminating check got added, it is not finding the pods with owner reference as the specs in current context(which are basically the resources that torpedo created in backup cluster).


**Which issue(s) this PR fixes** (optional)
Closes # PB-2327

**Special notes for your reviewer**:
*Test*
https://jenkins.portworx.dev/job/PX-Backup/view/PX-Master/job/px-backup-integration/874/

