### PR TITLE
Adds a data directory for Pure mysql app

### DIFF
--- a/tests/common.go
+++ b/tests/common.go
@@ -753,6 +753,9 @@ func getPureAppDataDir(namespace string) (string, int) {
 	if strings.HasPrefix(namespace, "elasticsearch") {
 		return "/usr/share/elasticsearch/data", units.GiB * 2
 	}
+	if strings.HasPrefix(namespace, "mysql-without-enc") {
+		return "/var/lib/mysql", units.GiB
+	}
 	return "", 0
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
BytesUsed wasn't changing for mysql because it didn't have a data directory, so we were just writing to the container root. We will now write to the correct directory, so that check should work now.
