### PR TITLE
Attempted fix for pxctl being missing after successful startup

### DIFF
--- a/drivers/node/ssh/ssh.go
+++ b/drivers/node/ssh/ssh.go
@@ -579,7 +579,7 @@ func (s *SSH) doCmdSSH(n node.Node, options node.ConnectionOpts, cmd string, ign
 		return "", fmt.Errorf("fail to setup stdout")
 	}
 	if options.Sudo {
-		cmd = fmt.Sprintf("sudo su -c '%s'", cmd)
+		cmd = fmt.Sprintf("sudo su -c '%s' -", cmd) // Hyphen necessary to preserve PATH for commands like "which pxctl"
 	}
 	session.Start(cmd)
 	err = session.Wait()


### PR DESCRIPTION
**What this PR does / why we need it**:
We've seen a few test runs where PX supposedly installed successfully, and pxctl did eventually become available, but there seems to be some period in the middle where pxctl isn't available in the PATH. This PR tries replacing the short `pxctl` with the full path.
