### PR TITLE
[PTX-6425] Get complete list of nodes while checking for core files

### DIFF
--- a/tests/common.go
+++ b/tests/common.go
@@ -1278,7 +1278,7 @@ func runCmdWithNoSudo(cmd string, n node.Node) error {
 func PerformSystemCheck() {
 	context("checking for core files...", func() {
 		Step("verifying if core files are present on each node", func() {
-			nodes := node.GetWorkerNodes()
+			nodes := node.GetNodes()
 			expect(nodes).NotTo(beEmpty())
 			for _, n := range nodes {
 				if !n.IsStorageDriverInstalled {


### PR DESCRIPTION
Get complete list of nodes while checking for core files 
not just worker nodes.(On IBM OpenShift setup, nodes are marked
as both worker as well as master.)

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

