### PR TITLE
Adding code to run openshift test suite

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -186,6 +186,7 @@ if [[ -z "$TEST_SUITE" || "$TEST_SUITE" == "" ]]; then
             "bin/upgrade_cluster.test",
             "bin/pxcentral.test",
             "bin/storage_pool.test",
+            "bin/openshift.test",
 '
 else
   TEST_SUITE=$(echo \"$TEST_SUITE\" | sed "s/,/\",\n\"/g")","

--- a/tests/openshift/ocp_node_recycle_test.go
+++ b/tests/openshift/ocp_node_recycle_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 	"github.com/portworx/torpedo/drivers/node"
+	"github.com/portworx/torpedo/drivers/scheduler/openshift"
 	. "github.com/portworx/torpedo/tests"
 	"github.com/sirupsen/logrus"
 )
@@ -29,9 +30,9 @@ var _ = BeforeSuite(func() {
 // Sanity test for OCP Recycle method
 var _ = Describe("{RecycleOCPNode}", func() {
 
-	if Inst().S.String() != "openshift" {
-		fmt.Printf("Failed: This test is not supported for scheduler: [%s]", Inst().S.String())
-		Expect(Inst().S.String()).To(Equal("openshift"))
+	if Inst().S.String() != openshift.SchedName {
+		logrus.Warnf("Failed: This test is not supported for scheduler: [%s]", Inst().S.String())
+		return
 	}
 
 	It("Validing the drives and pools after recyling a node", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
These changes needed to add openshift test suite in Torpedo. This will allow to run openshift test cases from Torpedo jobs.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
Tested the code and now it don't fails the test. It throws the waring and skip the openshift test for not applicable scheduler: 
https://jenkins.pwx.dev.purestorage.com/job/Users/job/Smit/job/tp-k8s-matrix-op-test/5/consoleFull
`
10:33:26 INFO[2022-05-02 17:33:25] Backup driver name                           
10:33:26 WARN[2022-05-02 17:33:25] Failed: This test is not supported for scheduler: [k8s] 
10:33:26 Running Suite: Torpedo : Recycle
10:33:26 ================================
10:33:26 Random Seed: 1651512256
10:33:26 Will run 0 of 0 specs`

