### PR TITLE
Added more descriptive error messages to Pure test asserts

### DIFF
--- a/tests/pure_directaccess/pure_test.go
+++ b/tests/pure_directaccess/pure_test.go
@@ -2,12 +2,13 @@ package puredirectaccess
 
 import (
 	"fmt"
+	"os"
+	"testing"
+
 	"github.com/onsi/ginkgo/reporters"
 	"github.com/portworx/torpedo/drivers/node"
 	"github.com/portworx/torpedo/drivers/scheduler"
 	"github.com/portworx/torpedo/drivers/scheduler/k8s"
-	"os"
-	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -61,7 +62,7 @@ func createCloudsnapCredential() {
 		TimeBeforeRetry: k8s.DefaultRetryInterval,
 		Sudo:            true,
 	})
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred(), "unexpected error creating cloudsnap credential")
 }
 
 func deleteCloudsnapCredential() {
@@ -71,7 +72,7 @@ func deleteCloudsnapCredential() {
 		TimeBeforeRetry: k8s.DefaultRetryInterval,
 		Sudo:            true,
 	})
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred(), "unexpected error deleting cloudsnap credential")
 }
 
 // This test performs basic tests making sure Pure direct access are running as expected


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds some more descriptive error messages so that the Torpedo error description makes a bit more sense. Currently we see some failures like "expected (false) to be (true)" which is super opaque. This will make it at least a bit more obvious what went wrong, reducing triage time and allowing some automated triage.


