### PR TITLE
PTX-6742: drop caches before collecting counters in sharedv4 svc test

### DIFF
--- a/tests/basic/sharedv4_svc_test.go
+++ b/tests/basic/sharedv4_svc_test.go
@@ -1167,6 +1167,7 @@ func getAppCounters(vol *api.Volume, attachedNode *node.Node, sleepInterval time
 }
 
 func getAppCountersSnapshot(vol *api.Volume, attachedNode *node.Node) map[string]int {
+	dropCaches(attachedNode)
 	counterByPodName := map[string]int{}
 	// We find all the files in the root dir where the pods are writing their counters.
 	// Example:
@@ -1198,6 +1199,11 @@ func getAppCountersSnapshot(vol *api.Volume, attachedNode *node.Node) map[string
 		counterByPodName[podName] = val
 	}
 	return counterByPodName
+}
+
+func dropCaches(attachedNode *node.Node) {
+	output, err := runCmd("sync; echo 1 > /proc/sys/vm/drop_caches", *attachedNode)
+	Expect(err).NotTo(HaveOccurred(), "failed to drop caches: %v", output)
 }
 
 // Validate the app counters after the failover.


### PR DESCRIPTION
**What this PR does / why we need it**:

Sometimes the test fails probably because it reads stale counters and
mistakenly thinks that the pod is not active.

This patch drops the file system caches so that the test does not
read stale values.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->


**Which issue(s) this PR fixes** (optional)
PTX-6742

**Special notes for your reviewer**:

