### PR TITLE
:wrench: Increasing timeouts for destroy app validation

### DIFF
--- a/tests/common.go
+++ b/tests/common.go
@@ -1294,7 +1294,7 @@ func PerformSystemCheck() {
 					TimeBeforeRetry: 10 * time.Second,
 				})
 				if len(file) != 0 || err != nil {
-					logrus.Info("an error occurred, collecting bundle")
+					logrus.Infof("an error occurred on node [%v], collecting bundle", n.Name)
 					CollectSupport()
 				}
 				expect(err).NotTo(haveOccurred())

--- a/tests/reboot/reboot_test.go
+++ b/tests/reboot/reboot_test.go
@@ -174,6 +174,7 @@ var _ = Describe("{ReallocateSharedMount}", func() {
 						logrus.Info("wait for 1 minute for node reboot")
 						time.Sleep(defaultCommandTimeout)
 						ctx.RefreshStorageEndpoint = true
+						ctx.ReadinessTimeout = 15 * time.Minute
 						ValidateContext(ctx)
 						n2, err := Inst().V.GetNodeForVolume(vol, defaultCommandTimeout, defaultCommandRetry)
 						Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Increase the time out for app deletion and also force deleting terminating stuck pods when there is node restart happening

**Which issue(s) this PR fixes** (optional)
Closes # [PTX-6889](https://portworx.atlassian.net/browse/PTX-6889)

**Special notes for your reviewer**:
https://jenkins.pwx.dev.purestorage.com/job/Torpedo/view/Torpedo-Detailed/job/tp-bonnie-sharedv4/224/console
https://jenkins.pwx.dev.purestorage.com/job/Torpedo/view/Torpedo-Detailed/job/tp-bonnie-sharedv4-svc/47/console [this run failed due to bug PWX-24170]

