### PR TITLE
PWX-24203 add retry for counter

### DIFF
--- a/tests/basic/sharedv4_test.go
+++ b/tests/basic/sharedv4_test.go
@@ -131,11 +131,15 @@ var _ = Describe("{Sharedv4Functional}", func() {
 
 				Step(fmt.Sprintf("validate counter are active for %s", ctx.App.Key), func() {
 					var counters map[string]appCounter
+					// we are seeing a case where the application is validated and running but sharedv4 volume is
+					// not mounted/exported yet. adding the eventually here to retry to make sure we capture the
+					// counters correctly. Setting timeout of 5 minutes for now as mounting and exporting
+					// shouldn't take that long.
 					Eventually(func() bool {
 						counters = getAppCounters(apiVol, attachedNode, counterCollectionInterval)
 						activePods := getActivePods(counters)
 						return (len(activePods) == numPods)
-					}, 3*time.Minute, 10*time.Second).Should(BeTrue(),
+					}, 5*time.Minute, 20*time.Second).Should(BeTrue(),
 						"number of active keys did not match for volume %v (%v) for app %v. counters map: %v",
 						vol.ID, apiVol.Id, ctx.App.Key, counters)
 				})

--- a/tests/basic/sharedv4_test.go
+++ b/tests/basic/sharedv4_test.go
@@ -130,9 +130,14 @@ var _ = Describe("{Sharedv4Functional}", func() {
 				})
 
 				Step(fmt.Sprintf("validate counter are active for %s", ctx.App.Key), func() {
-					counters := getAppCounters(apiVol, attachedNode, counterCollectionInterval)
-					activePods := getActivePods(counters)
-					Expect(len(activePods)).To(Equal(numPods))
+					var counters map[string]appCounter
+					Eventually(func() bool {
+						counters = getAppCounters(apiVol, attachedNode, counterCollectionInterval)
+						activePods := getActivePods(counters)
+						return (len(activePods) == numPods)
+					}, 3*time.Minute, 10*time.Second).Should(BeTrue(),
+						"number of active keys did not match for volume %v (%v) for app %v. counters map: %v",
+						vol.ID, apiVol.Id, ctx.App.Key, counters)
 				})
 
 				Step(fmt.Sprintf("validate device path is set as RW for %s", ctx.App.Key), func() {


### PR DESCRIPTION
Signed-off-by: dahuang <dahuang@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
SharedV4 test is failing sometimes because counters were shown as inactive when sharedv4 volumes are still being mounted. To fix this, we are adding `Eventually` to retry on validating counters after restarting px. 

**Which issue(s) this PR fixes** (optional)
PWX24203

**Special notes for your reviewer**:
Tested with ginkgo locally and passed

