### PR TITLE
Adding changes for FADA longetivity test automation

### DIFF
--- a/drivers/node/node.go
+++ b/drivers/node/node.go
@@ -49,6 +49,8 @@ type Node struct {
 	Type                     Type
 	Zone                     string
 	Region                   string
+	TopologyZone             string
+	TopologyRegion           string
 	IsStorageDriverInstalled bool
 	IsMetadataNode           bool
 	StoragePools             []StoragePool

--- a/drivers/node/node_registry.go
+++ b/drivers/node/node_registry.go
@@ -105,6 +105,28 @@ func GetStorageNodes() []Node {
 	return nodeList
 }
 
+// GetNodesByTopologyZoneLabel gets all the nodes with Topology Zone Value matching
+func GetNodesByTopologyZoneLabel(zone string) []Node {
+	var nodeList []Node
+	for _, n := range nodeRegistry {
+		if n.TopologyZone == zone {
+			nodeList = append(nodeList, n)
+		}
+	}
+	return nodeList
+}
+
+// GetNodesByTopologyRegionLabel gets all the nodes with Topology Region Value matching
+func GetNodesByTopologyRegionLabel(region string) []Node {
+	var nodeList []Node
+	for _, n := range nodeRegistry {
+		if n.TopologyRegion == region {
+			nodeList = append(nodeList, n)
+		}
+	}
+	return nodeList
+}
+
 // GetMetadataNodes gets all the nodes which serves as internal kvdb metadata node
 func GetMetadataNodes() []Node {
 	var nodeList []Node
@@ -152,6 +174,18 @@ func GetNodeByName(nodeName string) (Node, error) {
 		}
 	}
 	return Node{}, fmt.Errorf("FAILED: Node [%s] not found in node registry", nodeName)
+}
+
+// GetNodeByIP return a node which matches with given IP
+func GetNodeByIP(nodeIP string) (Node, error) {
+	for _, n := range nodeRegistry {
+		for _, addr := range n.Addresses {
+			if addr == nodeIP {
+				return n, nil
+			}
+		}
+	}
+	return Node{}, fmt.Errorf("FAILED: Node with [%s] not found in node registry", nodeIP)
 }
 
 // CleanupRegistry removes entry of all nodes from registry

--- a/drivers/scheduler/dcos/dcos.go
+++ b/drivers/scheduler/dcos/dcos.go
@@ -10,6 +10,7 @@ import (
 
 	docker "github.com/docker/docker/client"
 	marathon "github.com/gambol99/go-marathon"
+	v1beta1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1beta1"
 	snapv1 "github.com/kubernetes-incubator/external-storage/snapshot/pkg/apis/crd/v1"
 	apapi "github.com/libopenstorage/autopilot-api/pkg/apis/autopilot/v1alpha1"
 	"github.com/portworx/sched-ops/task"
@@ -115,8 +116,8 @@ func (d *dcos) DeleteSnapShot(ctx *scheduler.Context, snapshotName, snapshotName
 	}
 }
 
-//GetShapShotsInNameSpace get the snapshots list for the namespace
-func (d *dcos) GetShapShotsInNameSpace(ctx *scheduler.Context, snapshotNameSpace string) (*snapv1.VolumeSnapshotList, error) {
+// GetSnapshotsInNameSpace get the snapshots list for the namespace
+func (d *dcos) GetSnapshotsInNameSpace(ctx *scheduler.Context, snapshotNameSpace string) (*snapv1.VolumeSnapshotList, error) {
 
 	return nil, &errors.ErrNotSupported{
 		Type:      "Function",
@@ -847,6 +848,63 @@ func (d *dcos) RecycleNode(n node.Node) error {
 		Type:      "Function",
 		Operation: "RecycleNode()",
 	}
+}
+
+func (d *dcos) ValidateTopologyLabel(ctx *scheduler.Context) error {
+	//ValidateTopologyLabel is not supported
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "ValidateTopologyLabel()",
+	}
+}
+
+func (d *dcos) CreateCsiSanpshotClass(snapClassName string, deleionPolicy string) (*v1beta1.VolumeSnapshotClass, error) {
+	//CreateCsiSanpshotClass is not supported
+	return nil, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "CreateCsiSanpshotClasss()",
+	}
+}
+
+func (d *dcos) CreateCsiSnapshot(name string, class string, pvc string) (*v1beta1.VolumeSnapshot, error) {
+	//CreateCsiSanpshot is not supported
+	return nil, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "CreateCsiSanpshot()",
+	}
+}
+
+func (d *dcos) CreateCsiSnapsForVolumes(ctx *scheduler.Context, snapClass string) (map[string]*v1beta1.VolumeSnapshot, error) {
+	//CreateCsiSnapsForVolumes is not supported
+	return nil, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "CreateCsiSanpshot()",
+	}
+}
+
+func (d *dcos) GetCsiSnapshots(namespace string, pvcName string) ([]v1beta1.VolumeSnapshot, error) {
+	// GetCsiSnapshots is not supported
+	return nil, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "GetCsiSnapshots()",
+	}
+}
+
+func (d *dcos) ValidateCsiSnapshots(ctx *scheduler.Context, volSnapMa map[string]*v1beta1.VolumeSnapshot) error {
+	// ValidateCsiSnapshots is not supported
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "ValidateCsiSnapshots()",
+	}
+}
+
+func (d *dcos) RestoreCsiSnapAndValidate(ctx *scheduler.Context) (map[string]corev1.PersistentVolumeClaim, error) {
+	// RestoreCsiSnapAndValidate is not supported
+	return nil, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "RestoreCsiSnapAndValidate()",
+	}
+
 }
 
 func init() {

--- a/drivers/scheduler/errors.go
+++ b/drivers/scheduler/errors.go
@@ -480,3 +480,135 @@ type ErrFailedToBringUpNode struct {
 func (e *ErrFailedToBringUpNode) Error() string {
 	return fmt.Sprintf("Failed to bring up a Node : [%v] due to err: %v", e.Node, e.Cause)
 }
+
+// ErrFailedToValidateTopologyLabel error when failed to validate topology label in namespace
+type ErrFailedToValidateTopologyLabel struct {
+	// Pod is the pod that failed to schedule
+	NameSpace string
+	// Cause is the underlying cause of the error
+	Cause error
+}
+
+func (e *ErrFailedToValidateTopologyLabel) Error() string {
+	return fmt.Sprintf("Failed to validate topology label in namespace: %v due to err: %v", e.NameSpace, e.Cause)
+}
+
+// ErrTopologyLabelMismatch  error when pod schedule on a node where label not matched
+type ErrTopologyLabelMismatch struct {
+	// Pod is the pod that failed to schedule
+	PodName string
+	// Cause is the underlying cause of the error
+	Cause string
+}
+
+func (e *ErrTopologyLabelMismatch) Error() string {
+	return fmt.Sprintf("Failed to match topology label for pod: %v due to err: %v", e.PodName, e.Cause)
+}
+
+// ErrFailedToCreateSnapshot error when snapshot create is failed
+type ErrFailedToCreateSnapshot struct {
+	// PvcName is name of the pvc for which snapshot create failed
+	PvcName string
+	// Cause is the underlying cause of the error
+	Cause error
+}
+
+func (e *ErrFailedToCreateSnapshot) Error() string {
+	return fmt.Sprintf("Failed to create snapshot for volume: %v due to err: %v", e.PvcName, e.Cause)
+}
+
+// ErrFailedToCreateCsiSnapshots error when snapshot create is failed
+type ErrFailedToCreateCsiSnapshots struct {
+	// App specs
+	App *spec.AppSpec
+	// Cause is the underlying cause of the error
+	Cause string
+}
+
+func (e *ErrFailedToCreateCsiSnapshots) Error() string {
+	return fmt.Sprintf("Failed to create snapshot for App: %v due to err: %v", e.App, e.Cause)
+}
+
+// ErrFailedToCreateSnapshotClass error when snapshot create is failed
+type ErrFailedToCreateSnapshotClass struct {
+	// Name is name of the snapshot class which failed to create
+	Name string
+	// Cause is the underlying cause of the error
+	Cause error
+}
+
+func (e *ErrFailedToCreateSnapshotClass) Error() string {
+	return fmt.Sprintf("Failed to create snapshot for volume: %v due to err: %v", e.Name, e.Cause)
+}
+
+// ErrFailedToGetSnapshotList error when snapshot create is failed
+type ErrFailedToGetSnapshotList struct {
+	// Name is name of the namespace
+	Name string
+	// Cause is the underlying cause of the error
+	Cause error
+}
+
+func (e *ErrFailedToGetSnapshotList) Error() string {
+	return fmt.Sprintf("Failed to list snapshot in namespace: %v due to err: %v", e.Name, e.Cause)
+}
+
+// ErrFailedToValidateSnapshot error is failed to validate the snapshot for a volume
+type ErrFailedToValidateSnapshot struct {
+	// Name is name of the PVC
+	Name string
+	// Cause is the underlying cause of the error
+	Cause error
+}
+
+func (e *ErrFailedToValidateSnapshot) Error() string {
+	return fmt.Sprintf("Failed to validate snapshot for volume: %v due to err: %v", e.Name, e.Cause)
+}
+
+// ErrFailedToValidateCsiSnapshots error is failed to validate the snapshot for a volume
+type ErrFailedToValidateCsiSnapshots struct {
+	// AppSpec
+	App *spec.AppSpec
+	// Cause is the underlying cause of the error
+	Cause string
+}
+
+func (e *ErrFailedToValidateCsiSnapshots) Error() string {
+	return fmt.Sprintf("Failed to validate Csi snapshot for App: %v due to err: %v", e.App.Key, e.Cause)
+}
+
+// ErrFailedToValidatePvc error is failed to validate PVC
+type ErrFailedToValidatePvc struct {
+	// Name is the name of the PVC
+	Name string
+	// Cause is the underlying cause of the error
+	Cause error
+}
+
+func (e *ErrFailedToValidatePvc) Error() string {
+	return fmt.Sprintf("Failed to validate PVC: %v due to err: %v", e.Name, e.Cause)
+}
+
+// ErrFailedToValidatePvcAfterRestore error is failed to validate PVC
+type ErrFailedToValidatePvcAfterRestore struct {
+	// Name is the name of the PVC
+	App *spec.AppSpec
+	// Cause is the underlying cause of the error
+	Cause string
+}
+
+func (e *ErrFailedToValidatePvcAfterRestore) Error() string {
+	return fmt.Sprintf("Failed to validate PVC for App: %v due to err: %v", e.App, e.Cause)
+}
+
+// ErrFailedToRestore error is failed to restore from snapshot
+type ErrFailedToRestore struct {
+	// Name is the name of the PVC
+	App *spec.AppSpec
+	// Cause is the underlying cause of the error
+	Cause string
+}
+
+func (e *ErrFailedToRestore) Error() string {
+	return fmt.Sprintf("Failed to validate PVC for App: %v due to err: %v", e.App, e.Cause)
+}

--- a/drivers/scheduler/k8s/specs/cassandra/pure/pure-storage-class.yaml
+++ b/drivers/scheduler/k8s/specs/cassandra/pure/pure-storage-class.yaml
@@ -1,0 +1,12 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: portworx-sc
+provisioner: pxd.portworx.com
+parameters:
+  backend: "pure_block"
+  max_iops: "1000"
+  max_bandwidth: "1G"
+  fs: "ext4"
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true

--- a/drivers/scheduler/k8s/specs/fio-fa-cloud-drives/fio-config-map.yaml
+++ b/drivers/scheduler/k8s/specs/fio-fa-cloud-drives/fio-config-map.yaml
@@ -1,0 +1,86 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fio-job-config
+data:
+    fio.job: |
+        [global]
+        name=fio-rand-RW
+        directory=/scratch/
+        rw=randwrite
+        rwmixread=75
+        randrepeat=1
+        blocksize_range=4k-512k
+        direct=1
+        end_fsync=1
+        do_verify=1
+        verify=crc32c
+        verify_pattern=0xdeadbeef
+        disable_lat=0
+        time_based=1
+        runtime=99999999
+        [file1]
+        filesize=1M-10M
+        nrfiles=1000
+        ioengine=libaio
+        iodepth=128
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grok-exporter
+data:
+  config.yml: |-
+    global:
+      config_version: 3
+    input:
+      type: file
+      path: /logs/fio.log
+      readall: false
+      fail_on_missing_logfile: true
+    imports:
+    - type: grok_patterns
+      dir: ./patterns
+    grok_patterns:
+    - 'FIO_IOPS [0-9]*[.][0-9]k$|[0-9]*'
+    metrics:
+        - type: gauge
+          name: iops
+          help: FIO IOPS Write Gauge Metrics
+          match: '  write: %{GREEDYDATA}, iops=%{NUMBER:val1}%{GREEDYDATA:thsd}, %{GREEDYDATA}'
+          value: '{{`{{if eq .thsd "k"}}{{multiply .val1 1000}}{{else}}{{.val1}}{{end}}`}}'
+          labels:
+              iops_suffix: '{{`{{.thsd}}`}}'
+          cumulative: false
+          retention: 1s
+        - type: gauge
+          name: bandwidth
+          help: FIO Bandwidth Write Gauge Metrics
+          match: '  write: io=%{GREEDYDATA}, bw=%{NUMBER:val2}%{GREEDYDATA:kbs}, %{GREEDYDATA}, %{GREEDYDATA}'
+          value: '{{`{{if eq .kbs "KB/s"}}{{divide .val2 1024}}{{else}}{{.val2}}{{end}}`}}'
+          labels:
+              bw_unit: '{{`{{.kbs}}`}}'
+          cumulative: false
+          retention: 1s
+        - type: gauge
+          name: avg_latency
+          help: FIO AVG Latency Write Gauge Metrics
+          match: '     lat (%{GREEDYDATA:nsec}): min=%{GREEDYDATA}, max=%{GREEDYDATA}, avg=%{NUMBER:val3}, stdev=%{GREEDYDATA}'
+          value: '{{`{{if eq .nsec "(usec)"}}{{divide .val3 1000}}{{else}}{{.val3}}{{end}}`}}'
+          labels:
+              lat_unit: '{{`{{.nsec}}`}}'
+          cumulative: false
+          retention: 1s
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fio-ready-probe
+data:
+  ready-probe.sh: |
+    #!/bin/bash
+    if [ `cat /root/fio.log | grep 'error\|bad magic header' | wc -l` -ge 1 ]; then 
+      exit 1; 
+    else 
+      exit 0; 
+    fi

--- a/drivers/scheduler/k8s/specs/fio-fa-cloud-drives/fio.yaml
+++ b/drivers/scheduler/k8s/specs/fio-fa-cloud-drives/fio.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: fio
+spec:
+  serviceName: fio
+  replicas: 3
+  selector:
+    matchLabels:
+      app: fio
+  template:
+    metadata:
+      labels:
+        app: fio
+    spec:
+      schedulerName: stork
+      containers:
+      - name: fio
+        image: portworx/fio_drv
+        command: ["fio"]
+        resources:
+          limits:
+            cpu: "2"
+            memory: 4Gi
+          requests:
+            cpu: "1"
+            memory: 4Gi
+        args: ["/configs/fio.job", "--status-interval=1", "--eta=never", "--output=/logs/fio.log"]
+        volumeMounts:
+        - name: fio-config-vol
+          mountPath: /configs
+        - name: fio-data
+          mountPath: /scratch
+        - name: fio-log
+          mountPath: /logs
+      - name: grok
+        image: pwxvin/grok-exporter:v1.0.0-RC4
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: grok-port
+          containerPort: 9144
+          protocol: TCP
+        volumeMounts:
+        - name: grok-config-volume
+          mountPath: /etc/grok_exporter
+        - name: fio-log
+          mountPath: /logs
+      volumes:
+      - name: fio-config-vol
+        configMap:
+          name: fio-job-config
+      - name: grok-config-volume
+        configMap:
+          name: grok-exporter
+  volumeClaimTemplates:
+  - metadata:
+      name: fio-data
+    spec:
+      storageClassName: fio-cloudsnap-sc
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 200Gi
+  - metadata:
+      name: fio-log
+    spec:
+      storageClassName: fio-cloudsnap-sc
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 50Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grok-exporter-svc
+  labels:
+      app: fio
+spec:
+  clusterIP: None
+  selector: 
+    app: fio
+  ports:
+  - name: grok-port
+    port: 9144
+    targetPort: 9144

--- a/drivers/scheduler/k8s/specs/fio-fa-cloud-drives/px-storage-class.yaml
+++ b/drivers/scheduler/k8s/specs/fio-fa-cloud-drives/px-storage-class.yaml
@@ -1,0 +1,15 @@
+##### Portworx storage class
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: fio-cloudsnap-sc
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  repl: "2"
+  priority_io: "high"
+  io_profile: "db_remote"
+  snapshotschedule.stork.libopenstorage.org/interval-schedule: |
+    schedulePolicyName: intervalpolicy
+    annotations:
+      portworx/snapshot-type: cloud
+allowVolumeExpansion: true

--- a/drivers/scheduler/k8s/specs/fio-fa-davol/fio-config-map.yaml
+++ b/drivers/scheduler/k8s/specs/fio-fa-davol/fio-config-map.yaml
@@ -1,0 +1,86 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fio-job-config
+data:
+    fio.job: |
+        [global]
+        name=fio-rand-RW
+        directory=/scratch/
+        rw=randwrite
+        rwmixread=75
+        randrepeat=1
+        blocksize_range=4k-512k
+        direct=1
+        end_fsync=1
+        do_verify=1
+        verify=crc32c
+        verify_pattern=0xdeadbeef
+        disable_lat=0
+        time_based=1
+        runtime=99999999
+        [file1]
+        filesize=1M-10M
+        nrfiles=10000
+        ioengine=libaio
+        iodepth=128
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grok-exporter
+data:
+  config.yml: |-
+    global:
+      config_version: 3
+    input:
+      type: file
+      path: /logs/fio.log
+      readall: false
+      fail_on_missing_logfile: true
+    imports:
+    - type: grok_patterns
+      dir: ./patterns
+    grok_patterns:
+    - 'FIO_IOPS [0-9]*[.][0-9]k$|[0-9]*'
+    metrics:
+        - type: gauge
+          name: iops
+          help: FIO IOPS Write Gauge Metrics
+          match: '  write: %{GREEDYDATA}, iops=%{NUMBER:val1}%{GREEDYDATA:thsd}, %{GREEDYDATA}'
+          value: '{{`{{if eq .thsd "k"}}{{multiply .val1 1000}}{{else}}{{.val1}}{{end}}`}}'
+          labels:
+              iops_suffix: '{{`{{.thsd}}`}}'
+          cumulative: false
+          retention: 1s
+        - type: gauge
+          name: bandwidth
+          help: FIO Bandwidth Write Gauge Metrics
+          match: '  write: io=%{GREEDYDATA}, bw=%{NUMBER:val2}%{GREEDYDATA:kbs}, %{GREEDYDATA}, %{GREEDYDATA}'
+          value: '{{`{{if eq .kbs "KB/s"}}{{divide .val2 1024}}{{else}}{{.val2}}{{end}}`}}'
+          labels:
+              bw_unit: '{{`{{.kbs}}`}}'
+          cumulative: false
+          retention: 1s
+        - type: gauge
+          name: avg_latency
+          help: FIO AVG Latency Write Gauge Metrics
+          match: '     lat (%{GREEDYDATA:nsec}): min=%{GREEDYDATA}, max=%{GREEDYDATA}, avg=%{NUMBER:val3}, stdev=%{GREEDYDATA}'
+          value: '{{`{{if eq .nsec "(usec)"}}{{divide .val3 1000}}{{else}}{{.val3}}{{end}}`}}'
+          labels:
+              lat_unit: '{{`{{.nsec}}`}}'
+          cumulative: false
+          retention: 1s
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fio-ready-probe
+data:
+  ready-probe.sh: |
+    #!/bin/bash
+    if [ `cat /root/fio.log | grep 'error\|bad magic header' | wc -l` -ge 1 ]; then 
+      exit 1; 
+    else 
+      exit 0; 
+    fi

--- a/drivers/scheduler/k8s/specs/fio-fa-davol/fio.yaml
+++ b/drivers/scheduler/k8s/specs/fio-fa-davol/fio.yaml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: fio
+spec:
+  serviceName: fio
+  {{ if .Replicas }}
+  replicas: {{ .Replicas }}
+  {{ else }}
+  replicas: 6{{ end }}
+  selector:
+    matchLabels:
+      app: fio
+  template:
+    metadata:
+      labels:
+        app: fio
+    spec:
+      schedulerName: stork
+      containers:
+      - name: fio
+        image: portworx/fio_drv
+        command: ["fio"]
+        resources:
+          limits:
+            cpu: "2"
+            memory: 4Gi
+          requests:
+            cpu: "1"
+            memory: 4Gi
+        args: ["/configs/fio.job", "--status-interval=1", "--eta=never", "--output=/logs/fio.log"]
+        volumeMounts:
+        - name: fio-config-vol
+          mountPath: /configs
+        - name: fio-data
+          mountPath: /scratch
+        - name: fio-log
+          mountPath: /logs
+      - name: grok
+        image: pwxvin/grok-exporter:v1.0.0-RC4
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: grok-port
+          containerPort: 9144
+          protocol: TCP
+        volumeMounts:
+        - name: grok-config-volume
+          mountPath: /etc/grok_exporter
+        - name: fio-log
+          mountPath: /logs
+      volumes:
+      - name: fio-config-vol
+        configMap:
+          name: fio-job-config
+      - name: grok-config-volume
+        configMap:
+          name: grok-exporter
+  volumeClaimTemplates:
+  - metadata:
+      name: fio-data
+    spec:
+      storageClassName: fio-fa-da-sc
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+        {{ if .VolumeSize }}
+          storage: {{ .VolumeSize }}
+        {{ else }}
+          storage: 200Gi{{ end }}
+  - metadata:
+      name: fio-log
+    spec:
+      storageClassName: fio-log-fa-da-sc
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 50Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grok-exporter-svc
+  labels:
+      app: fio
+spec:
+  clusterIP: None
+  selector: 
+    app: fio
+  ports:
+  - name: grok-port
+    port: 9144
+    targetPort: 9144

--- a/drivers/scheduler/k8s/specs/fio-fa-davol/px-storage-class.yaml
+++ b/drivers/scheduler/k8s/specs/fio-fa-davol/px-storage-class.yaml
@@ -1,0 +1,28 @@
+##### FA direct access storage class
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: fio-fa-da-sc
+provisioner: pxd.portworx.com
+parameters:
+  backend: "pure_block"
+  max_iops: "1000"
+  max_bandwidth: "1G"
+  fs: "ext4"
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+---
+##### FA direct access storage class
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: fio-log-fa-da-sc
+provisioner: pxd.portworx.com
+parameters:
+  backend: "pure_block"
+  max_iops: "1000"
+  max_bandwidth: "1G"
+  fs: "ext4"
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+

--- a/drivers/scheduler/k8s/specs/fio-fb-davol/fio-config-map.yaml
+++ b/drivers/scheduler/k8s/specs/fio-fb-davol/fio-config-map.yaml
@@ -1,0 +1,86 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fio-job-config
+data:
+    fio.job: |
+        [global]
+        name=fio-rand-RW
+        directory=/scratch/
+        rw=randwrite
+        rwmixread=75
+        randrepeat=1
+        blocksize_range=4k-512k
+        direct=1
+        end_fsync=1
+        do_verify=1
+        verify=crc32c
+        verify_pattern=0xdeadbeef
+        disable_lat=0
+        time_based=1
+        runtime=99999999
+        [file1]
+        filesize=1M-10M
+        nrfiles=10000
+        ioengine=libaio
+        iodepth=128
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grok-exporter
+data:
+  config.yml: |-
+    global:
+      config_version: 3
+    input:
+      type: file
+      path: /logs/fio.log
+      readall: false
+      fail_on_missing_logfile: true
+    imports:
+    - type: grok_patterns
+      dir: ./patterns
+    grok_patterns:
+    - 'FIO_IOPS [0-9]*[.][0-9]k$|[0-9]*'
+    metrics:
+        - type: gauge
+          name: iops
+          help: FIO IOPS Write Gauge Metrics
+          match: '  write: %{GREEDYDATA}, iops=%{NUMBER:val1}%{GREEDYDATA:thsd}, %{GREEDYDATA}'
+          value: '{{`{{if eq .thsd "k"}}{{multiply .val1 1000}}{{else}}{{.val1}}{{end}}`}}'
+          labels:
+              iops_suffix: '{{`{{.thsd}}`}}'
+          cumulative: false
+          retention: 1s
+        - type: gauge
+          name: bandwidth
+          help: FIO Bandwidth Write Gauge Metrics
+          match: '  write: io=%{GREEDYDATA}, bw=%{NUMBER:val2}%{GREEDYDATA:kbs}, %{GREEDYDATA}, %{GREEDYDATA}'
+          value: '{{`{{if eq .kbs "KB/s"}}{{divide .val2 1024}}{{else}}{{.val2}}{{end}}`}}'
+          labels:
+              bw_unit: '{{`{{.kbs}}`}}'
+          cumulative: false
+          retention: 1s
+        - type: gauge
+          name: avg_latency
+          help: FIO AVG Latency Write Gauge Metrics
+          match: '     lat (%{GREEDYDATA:nsec}): min=%{GREEDYDATA}, max=%{GREEDYDATA}, avg=%{NUMBER:val3}, stdev=%{GREEDYDATA}'
+          value: '{{`{{if eq .nsec "(usec)"}}{{divide .val3 1000}}{{else}}{{.val3}}{{end}}`}}'
+          labels:
+              lat_unit: '{{`{{.nsec}}`}}'
+          cumulative: false
+          retention: 1s
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fio-ready-probe
+data:
+  ready-probe.sh: |
+    #!/bin/bash
+    if [ `cat /root/fio.log | grep 'error\|bad magic header' | wc -l` -ge 1 ]; then 
+      exit 1; 
+    else 
+      exit 0; 
+    fi

--- a/drivers/scheduler/k8s/specs/fio-fb-davol/fio.yaml
+++ b/drivers/scheduler/k8s/specs/fio-fb-davol/fio.yaml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: fio
+spec:
+  serviceName: fio
+  {{ if .Replicas }}
+  replicas: {{ .Replicas }}
+  {{ else }}
+  replicas: 6{{ end }}
+  selector:
+    matchLabels:
+      app: fio
+  template:
+    metadata:
+      labels:
+        app: fio
+    spec:
+      schedulerName: stork
+      containers:
+      - name: fio
+        image: portworx/fio_drv
+        command: ["fio"]
+        resources:
+          limits:
+            cpu: "2"
+            memory: 4Gi
+          requests:
+            cpu: "1"
+            memory: 4Gi
+        args: ["/configs/fio.job", "--status-interval=1", "--eta=never", "--output=/logs/fio.log"]
+        volumeMounts:
+        - name: fio-config-vol
+          mountPath: /configs
+        - name: fio-data
+          mountPath: /scratch
+        - name: fio-log
+          mountPath: /logs
+      - name: grok
+        image: pwxvin/grok-exporter:v1.0.0-RC4
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: grok-port
+          containerPort: 9144
+          protocol: TCP
+        volumeMounts:
+        - name: grok-config-volume
+          mountPath: /etc/grok_exporter
+        - name: fio-log
+          mountPath: /logs
+      volumes:
+      - name: fio-config-vol
+        configMap:
+          name: fio-job-config
+      - name: grok-config-volume
+        configMap:
+          name: grok-exporter
+  volumeClaimTemplates:
+  - metadata:
+      name: fio-data
+    spec:
+      storageClassName: fio-fb-sc
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+        {{ if .VolumeSize }}
+          storage: {{ .VolumeSize }}
+        {{ else }}
+          storage: 200Gi{{ end }}
+  - metadata:
+      name: fio-log
+    spec:
+      storageClassName: fio-log-fb-sc
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 50Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grok-exporter-svc
+  labels:
+      app: fio
+spec:
+  clusterIP: None
+  selector: 
+    app: fio
+  ports:
+  - name: grok-port
+    port: 9144
+    targetPort: 9144

--- a/drivers/scheduler/k8s/specs/fio-fb-davol/px-storage-class.yaml
+++ b/drivers/scheduler/k8s/specs/fio-fb-davol/px-storage-class.yaml
@@ -1,0 +1,29 @@
+##### FA direct access storage class
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: fio-fb-sc
+provisioner: pxd.portworx.com
+parameters:
+  backend: "pure_file"
+  pure_export_rules: "*(rw)"
+mountOptions:
+  - nfsvers=4.1
+  - tcp
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+---
+##### FA direct access storage class
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: fio-log-fb-sc
+provisioner: pxd.portworx.com
+parameters:
+  backend: "pure_file"
+  pure_export_rules: "*(rw)"
+mountOptions:
+  - nfsvers=4.1
+  - tcp
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true

--- a/drivers/scheduler/k8s/specs/kafka-stack/pure-storage-class.yaml
+++ b/drivers/scheduler/k8s/specs/kafka-stack/pure-storage-class.yaml
@@ -1,0 +1,21 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+    name: elasticsearch-sc
+provisioner: pxd.portworx.com
+parameters:
+    backend: "pure_block"
+    csi.storage.k8s.io/fstype: ext4
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+    name: zk-sc
+provisioner: pxd.portworx.com
+parameters:
+    backend: "pure_block"
+    csi.storage.k8s.io/fstype: ext4
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true

--- a/drivers/scheduler/k8s/specs/mongodb/pure/pure-storage-class.yaml
+++ b/drivers/scheduler/k8s/specs/mongodb/pure/pure-storage-class.yaml
@@ -1,0 +1,9 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: px-ha-sc
+provisioner: pxd.portworx.com
+parameters:
+  backend: "pure_block"
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true

--- a/drivers/scheduler/k8s/specs/pgbench/pure/pgbench-pure-storage.yaml
+++ b/drivers/scheduler/k8s/specs/pgbench/pure/pgbench-pure-storage.yaml
@@ -1,17 +1,12 @@
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-    name: elasticsearch-sc
+  name: pgbench-sc
 provisioner: pxd.portworx.com
 parameters:
-  # Tests:
-  # * FlashArray Direct Access w/ filesystem
-  # * Specifying filesystem type, creation options, and mount options
-  # * Specifying QoS
   backend: "pure_block"
-  max_iops: "30000"
-  max_bandwidth: "10G"
+  max_iops: "1000"
+  max_bandwidth: "1G"
   csi.storage.k8s.io/fstype: ext4
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
-

--- a/drivers/scheduler/k8s/specs/postgres/pure/pure-storage-class.yaml
+++ b/drivers/scheduler/k8s/specs/postgres/pure/pure-storage-class.yaml
@@ -1,17 +1,11 @@
+##### FA Direct access storage class
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-    name: elasticsearch-sc
+  name: postgres-sc
 provisioner: pxd.portworx.com
 parameters:
-  # Tests:
-  # * FlashArray Direct Access w/ filesystem
-  # * Specifying filesystem type, creation options, and mount options
-  # * Specifying QoS
   backend: "pure_block"
-  max_iops: "30000"
-  max_bandwidth: "10G"
   csi.storage.k8s.io/fstype: ext4
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
-

--- a/drivers/scheduler/k8s/specs/sysbench/pure/pure-storage-class.yaml
+++ b/drivers/scheduler/k8s/specs/sysbench/pure/pure-storage-class.yaml
@@ -1,7 +1,7 @@
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-    name: elasticsearch-sc
+  name: sysbench-sc
 provisioner: pxd.portworx.com
 parameters:
   # Tests:
@@ -9,8 +9,7 @@ parameters:
   # * Specifying filesystem type, creation options, and mount options
   # * Specifying QoS
   backend: "pure_block"
-  max_iops: "30000"
-  max_bandwidth: "10G"
+  max_bandwidth: "1G"
   csi.storage.k8s.io/fstype: ext4
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true

--- a/drivers/scheduler/k8s/specs/vdbench-fb-vols/pure-fb-storage-class.yaml
+++ b/drivers/scheduler/k8s/specs/vdbench-fb-vols/pure-fb-storage-class.yaml
@@ -1,0 +1,14 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: vdbench-fb-sc-nfsv4
+provisioner: pxd.portworx.com
+parameters:
+  backend: "pure_file"
+  pure_export_rules: "*(rw)"
+mountOptions:
+  - nfsvers=4.1
+  - tcp
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+

--- a/drivers/scheduler/k8s/specs/vdbench-fb-vols/pure-vdbench-storage.yaml
+++ b/drivers/scheduler/k8s/specs/vdbench-fb-vols/pure-vdbench-storage.yaml
@@ -1,0 +1,24 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: vdbench-pvc-fb
+spec:
+  storageClassName: vdbench-fb-sc-nfsv4
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 75Gi
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: vdbench-pvc-output-fb
+spec:
+  storageClassName: vdbench-fb-sc-nfsv4
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+

--- a/drivers/scheduler/k8s/specs/vdbench-fb-vols/px-vdbench-app.yaml
+++ b/drivers/scheduler/k8s/specs/vdbench-fb-vols/px-vdbench-app.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vdbench-fb-volumes
+spec:
+  replicas: 5
+  selector:
+    matchLabels:
+      app: vdbench-fb-volumes
+  template:
+    metadata:
+      labels:
+        app: vdbench-fb-volumes
+    spec:
+      schedulerName: stork
+      securityContext: 
+        fsGroupChangePolicy: "OnRootMismatch"
+      containers:
+        - name: vdbench
+          image: portworx/vdbench:torpedo
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 500Mi
+            requests:
+              memory: 256Mi
+              cpu: 100m
+          command: ["./bench_runner.sh"]
+          args: ["Basic", "5400", "$(POD_NAME)", "output/$(POD_NAME)"]
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          volumeMounts:
+            - name: vdbench-persistent-storage
+              mountPath: /tmp
+            - name: vdbench-output-persistent-storage
+              mountPath: /output
+      volumes:
+        - name: vdbench-persistent-storage
+          persistentVolumeClaim:
+            claimName: vdbench-pvc-fb
+        - name: vdbench-output-persistent-storage
+          persistentVolumeClaim:
+            claimName: vdbench-pvc-output-fb
+

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -7,6 +7,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	v1beta1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1beta1"
 	snapv1 "github.com/kubernetes-incubator/external-storage/snapshot/pkg/apis/crd/v1"
 	apapi "github.com/libopenstorage/autopilot-api/pkg/apis/autopilot/v1alpha1"
 	"github.com/portworx/torpedo/drivers/api"
@@ -124,6 +125,8 @@ type ScheduleOptions struct {
 	Upgrade bool
 	// Namespace to schedule app installation if not empty
 	Namespace string
+	// TopoLogy Labels
+	TopologyLabels []map[string]string
 }
 
 // Driver must be implemented to provide test support to various schedulers.
@@ -182,14 +185,17 @@ type Driver interface {
 	// ValidateVolumes validates storage volumes in the provided context
 	ValidateVolumes(cc *Context, timeout, retryInterval time.Duration, options *VolumeOptions) error
 
+	// ValidateTopologyLabel validate topology Labels for App
+	ValidateTopologyLabel(cc *Context) error
+
 	// GetSnapShotData retruns volumesnapshotdata
 	GetSnapShotData(ctx *Context, snapshotName, snapshotNameSpace string) (*snapv1.VolumeSnapshotData, error)
 
-	//DeleteSnapshots  delete the snapshots
+	// DeleteSnapshots  delete the snapshots
 	DeleteSnapShot(ctx *Context, snapshotName, snapshotNameSpace string) error
 
-	//GetShapShotsInNameSpace get the snapshots list for the namespace
-	GetShapShotsInNameSpace(ctx *Context, snapshotNameSpace string) (*snapv1.VolumeSnapshotList, error)
+	// GetSnapshotsInNameSpace get the snapshots list for the namespace
+	GetSnapshotsInNameSpace(ctx *Context, snapshotNameSpace string) (*snapv1.VolumeSnapshotList, error)
 
 	// DeleteVolumes will delete all storage volumes for the given context
 	DeleteVolumes(*Context, *VolumeOptions) ([]*volume.Volume, error)
@@ -321,8 +327,26 @@ type Driver interface {
 	// DeleteSecret deletes secret with given name in given namespace
 	DeleteSecret(namespace, name string) error
 
-	//RecyleNode deletes nodes with given node
+	// RecyleNode deletes nodes with given node
 	RecycleNode(n node.Node) error
+
+	// CreateCsiSanpshotClass create csi snapshot class
+	CreateCsiSanpshotClass(snapClassName string, deleionPolicy string) (*v1beta1.VolumeSnapshotClass, error)
+
+	// CreateCsiSnapshot create csi snapshot for given pvc
+	CreateCsiSnapshot(name string, class string, pvc string) (*v1beta1.VolumeSnapshot, error)
+
+	// CreateCsiSnapsForVolumes create csi snapshots for all volumes in a context
+	CreateCsiSnapsForVolumes(*Context, string) (map[string]*v1beta1.VolumeSnapshot, error)
+
+	// GetCsiSnapshots return snapshot lists for a volume
+	GetCsiSnapshots(string, string) ([]v1beta1.VolumeSnapshot, error)
+
+	// ValidateCsiSnapshots validate csi snapshots in the context
+	ValidateCsiSnapshots(*Context, map[string]*v1beta1.VolumeSnapshot) error
+
+	// RestoreCsiSnapAndValidate restore csi snapshot and validate the restore.
+	RestoreCsiSnapAndValidate(*Context) (map[string]corev1.PersistentVolumeClaim, error)
 }
 
 var (

--- a/drivers/volume/common.go
+++ b/drivers/volume/common.go
@@ -708,3 +708,11 @@ func (d *DefaultDriver) GetPxctlCmdOutput(n node.Node, command string) (string, 
 		Operation: "GetPxctlCmdOutput()",
 	}
 }
+
+// IsPureVolume returns true if volume is FA/FB DA volumes else false
+func (d *DefaultDriver) IsPureVolume(volume *Volume) (bool, error) {
+	return false, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "IsPureVolume()",
+	}
+}

--- a/drivers/volume/portworx/errors.go
+++ b/drivers/volume/portworx/errors.go
@@ -157,3 +157,27 @@ type ErrFailedToRejoinNode struct {
 func (e *ErrFailedToRejoinNode) Error() string {
 	return fmt.Sprintf("Failed to rejoin node: %v due to err: %v", e.Node, e.Cause)
 }
+
+// ErrFailedToGetVolumeProxySpec error type for failing to get volume Spec
+type ErrFailedToGetVolumeProxySpec struct {
+	// ID is the ID/name of the volume for which we could not get the Volume Proxy Spec
+	ID string
+	// Cause is the underlying cause of the error
+	Cause string
+}
+
+func (e *ErrFailedToGetVolumeProxySpec) Error() string {
+	return fmt.Sprintf("Failed to get proxy spec for a volume: %v due to err: %v", e.ID, e.Cause)
+}
+
+// ErrCsiTopologyMismatch error type for CSI Topology mismatch
+type ErrCsiTopologyMismatch struct {
+	// Name of the volume where topology not matching
+	VolName string
+	// Cause is the underlying cause of the error
+	Cause error
+}
+
+func (e *ErrCsiTopologyMismatch) Error() string {
+	return fmt.Sprintf("CSI Topology not matching for volume: %v. Err: %v", e.VolName, e.Cause)
+}

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -230,6 +230,9 @@ type Driver interface {
 	// IsStorageExpansionEnabled returns true if storage expansion enabled
 	IsStorageExpansionEnabled() (bool, error)
 
+	// IsPureVolume(volume *torpedovolume.Volume) return true if given volume is FA/FB DA volumes
+	IsPureVolume(volume *Volume) (bool, error)
+
 	// EstimatePoolExpandSize calculates expected pool size based on autopilot rule
 	EstimatePoolExpandSize(apRule apapi.AutopilotRule, pool node.StoragePool, node node.Node) (uint64, error)
 

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/hashicorp/go-version v1.2.1
 	github.com/hashicorp/vault/api v1.0.5-0.20200902155336-f9d5ce5a171a
 	github.com/heptio/velero v0.0.0-00010101000000-000000000000 // indirect
+	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.0.0 // indirect
 	github.com/kubernetes-incubator/external-storage v0.20.4-openstorage-rc7
 	github.com/libopenstorage/autopilot-api v1.3.0
 	github.com/libopenstorage/cloudops v0.0.0-20220420143942-8bdd341e5b41


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding code for FA Direct Access Volume automation
1. Adding a code to support both CSI and Portworx volume plugin
2. Adding a code to check if volume is pure volume or not
3. Not performing operation on pure volumes which are not supported
4. Adding a code to set the Topology in k8s node
5. Adding a code to set Topology info in PX nodes
6. Adding a code to validate Topology
7. Adding a code for csi snapshots and validation
8. Adding a code for csi snap restore and validation

**Which issue(s) this PR fixes** (optional)
Closes # PTX-6731

**Special notes for your reviewer**:

1. Completed the dev run successfully for portworx provisioner:
https://jenkins.pwx.dev.purestorage.com/job/Dev/job/torpedo-dev03/31/

2.Ran the CSI job successfully using my torpedo image
https://jenkins.pwx.dev.purestorage.com/job/Torpedo/view/Torpedo-Detailed/job/tp-k8s-matrix-op-csi/250/parameters/

3. Tested the code with Daemonset base installation
http://jen-endurance.pwx.dev.purestorage.com/job/Torpedo/job/tp-fada-longevity/39/console