### PR TITLE
NEWSTACK-384: Added test for volume in pxctl v l

### DIFF
--- a/drivers/volume/common.go
+++ b/drivers/volume/common.go
@@ -245,6 +245,14 @@ func (d *DefaultDriver) ValidateCreateGroupSnapshotUsingPxctl() error {
 	}
 }
 
+// ValidateVolumeInPxctlList validates whether the given volume appears in the output of "pxctl v l"
+func (d *DefaultDriver) ValidateVolumeInPxctlList(volumeName string) error {
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "ValidateVolumeInPxctlList()",
+	}
+}
+
 // ValidateGetByteUsedForVolume validates and returns byteUsed for given volume.
 func (d *DefaultDriver) ValidateGetByteUsedForVolume(volumeName string, params map[string]string) (uint64, error) {
 	return 0, &errors.ErrNotSupported{

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -76,6 +76,7 @@ const (
 	pxMinVersionForStorkUpgrade               = "2.1"
 	formattingCommandPxctlLocalSnapshotCreate = "pxctl volume snapshot create %s --name %s"
 	formattingCommandPxctlCloudSnapCreate     = "pxctl cloudsnap backup %s"
+	pxctlVolumeList                           = "pxctl volume list "
 	pxctlVolumeUpdate                         = "pxctl volume update "
 	pxctlGroupSnapshotCreate                  = "pxctl volume snapshot group"
 	refreshEndpointParam                      = "refresh-endpoint"
@@ -1263,6 +1264,25 @@ func (d *portworx) ValidateCreateGroupSnapshotUsingPxctl() error {
 	if err != nil {
 		logrus.WithError(err).Error("error when creating groupsnapshot using PXCTL")
 		return err
+	}
+
+	return nil
+}
+
+func (d *portworx) ValidateVolumeInPxctlList(volumeName string) error {
+	nodes := node.GetStorageDriverNodes()
+	out, err := d.nodeDriver.RunCommandWithNoRetry(nodes[0], pxctlVolumeList, node.ConnectionOpts{
+		Timeout:         crashDriverTimeout,
+		TimeBeforeRetry: defaultRetryInterval,
+	})
+	if err != nil {
+		logrus.WithError(err).Error("error when listing volumes using PXCTL")
+		return err
+	}
+
+	if !strings.Contains(out, volumeName) {
+		logrus.Errorf("volume name %s is not present in PXCTL volume list", volumeName)
+		return fmt.Errorf("volume name %s is not present in PXCTL volume list", volumeName)
 	}
 
 	return nil

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -107,6 +107,9 @@ type Driver interface {
 	// ValidatePureVolumesNoReplicaSets validates pure volumes has no replicaset
 	ValidatePureVolumesNoReplicaSets(volumeName string, params map[string]string) error
 
+	// ValidateVolumeInPxctlList validates that the given volume appears in the output of `pxctl v l`
+	ValidateVolumeInPxctlList(name string) error
+
 	// ValidateUpdateVolume validates if volume changes has been applied
 	ValidateUpdateVolume(vol *Volume, params map[string]string) error
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a test to make sure that Pure volumes show up in the output of `pxctl v l`.