### PR TITLE
PTX-7746: wait until resync is done before starting the test

### DIFF
--- a/tests/reboot/reboot_test.go
+++ b/tests/reboot/reboot_test.go
@@ -154,9 +154,30 @@ var _ = Describe("{ReallocateSharedMount}", func() {
 				Expect(err).NotTo(HaveOccurred())
 				for _, vol := range vols {
 					if vol.Shared {
+
 						n, err := Inst().V.GetNodeForVolume(vol, defaultCommandTimeout, defaultCommandRetry)
 						Expect(err).NotTo(HaveOccurred())
 						logrus.Infof("volume %s is attached on node %s [%s]", vol.ID, n.SchedulerNodeName, n.Addresses[0])
+
+						// Workaround to avoid PWX-24277 for now.
+						Step(fmt.Sprintf("wait until volume %v status is Up", vol.ID), func() {
+							Eventually(func() (string, error) {
+								connOpts := node.ConnectionOpts{
+									Timeout:         defaultCommandTimeout,
+									TimeBeforeRetry: defaultCommandRetry,
+									Sudo:            true,
+								}
+								cmd := fmt.Sprintf("pxctl volume inspect %s | grep \"Replication Status\"", vol.ID)
+								output, err := Inst().N.RunCommandWithNoRetry(*n, cmd, connOpts)
+								if err != nil {
+									logrus.Warnf("failed to get replication state of volume %v: %v", vol.ID, err)
+									return "", err
+								}
+								return output, nil
+							}, 20*time.Minute, 10*time.Second).Should(ContainSubstring("Up"),
+								"volume %v status is not Up for app %v", vol.ID, ctx.App.Key)
+						})
+
 						err = Inst().S.DisableSchedulingOnNode(*n)
 						Expect(err).NotTo(HaveOccurred())
 						err = Inst().V.StopDriver([]node.Node{*n}, false, nil)


### PR DESCRIPTION
**What this PR does / why we need it**:
Volume could be resync'ing due to the preceding node reboot. Wait
until the volume is Up before starting the new iteration of
ReallocateSharedMount test.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**Which issue(s) this PR fixes** (optional)
PTX-7746

**Special notes for your reviewer**:

