### PR TITLE
Fix for autopilot tests

### DIFF
--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -2765,7 +2765,7 @@ func (k *K8s) ValidateVolumes(ctx *scheduler.Context, timeout, retryInterval tim
 				for _, rule := range listApRules.Items {
 					for _, a := range rule.Spec.Actions {
 						if a.Name == aututils.VolumeSpecAction && isAutopilotMatchPvcLabels(rule, obj) {
-							err := k.validatePVCSize(ctx, obj, rule, timeout, retryInterval)
+							err := k.validatePVCSize(ctx, obj, rule, 5*timeout, retryInterval)
 							if err != nil {
 								return err
 							}


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
It increases the timeout for waiting expected volume size.

Tested here:
https://jenkins.pwx.dev.purestorage.com/job/Autopilot/job/tp-aut-nextpx-resize-pvc-csi/122/