### PR TITLE
PWX-24550: Enables 'deep' inspection to validate Device Path

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -980,7 +980,13 @@ func (d *portworx) ValidateCreateVolume(volumeName string, params map[string]str
 	}
 	volDriver := d.getVolDriver()
 	t := func() (interface{}, bool, error) {
-		volumeInspectResponse, err := volDriver.Inspect(d.getContextWithToken(context.Background(), token), &api.SdkVolumeInspectRequest{VolumeId: volumeName})
+		volumeInspectResponse, err := volDriver.Inspect(d.getContextWithToken(context.Background(), token),
+			&api.SdkVolumeInspectRequest{
+				VolumeId: volumeName,
+				Options: &api.VolumeInspectOptions{
+					Deep: true,
+				},
+			})
 		if err != nil {
 			return nil, true, err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
It seems without this flag we use some sort of cached value. `pxctl v i` worked fine, but the SDK was not.

