### PR TITLE
PTX-10669 Added support for k8s 1.24

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -389,6 +389,9 @@ spec:
   - key: node-role.kubernetes.io/controlplane
     operator: Equal
     value: "true"
+  - key: node-role.kubernetes.io/control-plane
+    operator: Equal
+    value: "true"
   - key: node-role.kubernetes.io/etcd
     operator: Equal
     value: "true"


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
On k8s 1.24 there is no label _master_ where we schedule torpedo pod, but _control-plane_ label

**Which issue(s) this PR fixes** (optional)
Closes https://portworx.atlassian.net/browse/PTX-10669

**Special notes for your reviewer**:

