### PR TITLE
PTX-10669 Fix toleration key operator

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -338,7 +338,7 @@ if [ -n "${K8S_VENDOR}" ]; then
             ;;
     esac
 else
-    K8S_VENDOR_KEY=node-role.kubernetes.io/master
+    K8S_VENDOR_KEY=node-role.kubernetes.io/control-plane
 fi
 
 cat > torpedo.yaml <<EOF
@@ -387,9 +387,6 @@ spec:
     operator: Equal
     effect: NoSchedule
   - key: node-role.kubernetes.io/controlplane
-    operator: Equal
-    value: "true"
-  - key: node-role.kubernetes.io/control-plane
     operator: Equal
     value: "true"
   - key: node-role.kubernetes.io/etcd


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
It fixes an issue where torpedo pod can't be scheduled on any nodes because of not matching affinity rules on 1.24 k8s version 

**Which issue(s) this PR fixes** (optional)
Closes https://portworx.atlassian.net/browse/PTX-10669

**Special notes for your reviewer**:
I changed default K8S_VENDOR_KEY to node-role.kubernetes.io/control-plane to support 1.24 k8s version, for all <1.24 versions we have to pass K8S_VENDOR=kubernetes which will set K8S_VENDOR_KEY=node-role.kubernetes.io/master
