### PR TITLE
Adding code to validate deviceMapper device cleanup from nodes

### DIFF
--- a/drivers/node/node.go
+++ b/drivers/node/node.go
@@ -194,6 +194,9 @@ type Driver interface {
 
 	// IsNodeRebootedInGivenTimeRange check if node is rebooted within given time range
 	IsNodeRebootedInGivenTimeRange(Node, time.Duration) (bool, error)
+
+	// GetDeviceMapperCount return devicemapper count
+	GetDeviceMapperCount(Node, time.Duration) (int, error)
 }
 
 // Register registers the given node driver
@@ -406,6 +409,14 @@ func (d *notSupportedDriver) IsUsingSSH() bool {
 func (d *notSupportedDriver) IsNodeRebootedInGivenTimeRange(Node, time.Duration) (bool, error) {
 	return false, &errors.ErrNotSupported{
 		Type:      "Function",
-		Operation: "PowerOnVmByName()",
+		Operation: "IsNodeRebootedInGivenTimeRange()",
+	}
+}
+
+// GetDeviceMapperCount return device mapper count in a node
+func (d *notSupportedDriver) GetDeviceMapperCount(Node, time.Duration) (int, error) {
+	return -1, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "GetDeviceMapperCount()",
 	}
 }

--- a/drivers/volume/common.go
+++ b/drivers/volume/common.go
@@ -816,6 +816,14 @@ func (d *DefaultDriver) GetKvdbMembers(n node.Node) (map[string]*MetadataNode, e
 	}
 }
 
+// GetNodePureVolumeAttachedCountMap return Map of nodeName and number of pure volume attached on that node
+func (d *DefaultDriver) GetNodePureVolumeAttachedCountMap() (map[string]int, error) {
+	return nil, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "GetNodePureVolumeAttachedCountMap()",
+	}
+}
+
 // RejoinNode rejoins a given node back to the cluster
 func (d *DefaultDriver) RejoinNode(n *node.Node) error {
 	return &errors.ErrNotSupported{

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -335,6 +335,9 @@ type Driver interface {
 
 	//GetKvdbMembers returns KVDB memebers of the PX cluster
 	GetKvdbMembers(n node.Node) (map[string]*MetadataNode, error)
+
+	// GetNodePureVolumeAttachedCountMap returns map of node name and count of pure volume attached on that node
+	GetNodePureVolumeAttachedCountMap() (map[string]int, error)
 }
 
 // StorageProvisionerType provisioner to be used for torpedo volumes

--- a/tests/longevity/longevity_test.go
+++ b/tests/longevity/longevity_test.go
@@ -103,6 +103,7 @@ var _ = Describe("{Longevity}", func() {
 		RelaxedReclaim:       TriggerRelaxedReclaim,
 		Trashcan:             TriggerTrashcan,
 		KVDBFailover:         TriggerKVDBFailover,
+		ValidateDeviceMapper: TriggerValidateDeviceMapperCleanup,
 	}
 	//Creating a distinct trigger to make sure email triggers at regular intervals
 	emailTriggerFunction = map[string]func(){
@@ -565,6 +566,7 @@ func populateIntervals() {
 	triggerInterval[RelaxedReclaim] = make(map[int]time.Duration)
 	triggerInterval[Trashcan] = make(map[int]time.Duration)
 	triggerInterval[KVDBFailover] = make(map[int]time.Duration)
+	triggerInterval[ValidateDeviceMapper] = make(map[int]time.Duration)
 
 	baseInterval := 10 * time.Minute
 	triggerInterval[BackupScaleMongo][10] = 1 * baseInterval
@@ -1048,6 +1050,17 @@ func populateIntervals() {
 	triggerInterval[CsiSnapRestore][2] = 24 * baseInterval
 	triggerInterval[CsiSnapRestore][1] = 27 * baseInterval
 
+	triggerInterval[ValidateDeviceMapper][10] = 1 * baseInterval
+	triggerInterval[ValidateDeviceMapper][9] = 3 * baseInterval
+	triggerInterval[ValidateDeviceMapper][8] = 6 * baseInterval
+	triggerInterval[ValidateDeviceMapper][7] = 9 * baseInterval
+	triggerInterval[ValidateDeviceMapper][6] = 12 * baseInterval
+	triggerInterval[ValidateDeviceMapper][5] = 15 * baseInterval
+	triggerInterval[ValidateDeviceMapper][4] = 18 * baseInterval
+	triggerInterval[ValidateDeviceMapper][3] = 21 * baseInterval
+	triggerInterval[ValidateDeviceMapper][2] = 24 * baseInterval
+	triggerInterval[ValidateDeviceMapper][1] = 27 * baseInterval
+
 	// Chaos Level of 0 means disable test trigger
 	triggerInterval[DeployApps][0] = 0
 	triggerInterval[RebootNode][0] = 0
@@ -1090,6 +1103,7 @@ func populateIntervals() {
 	triggerInterval[CsiSnapRestore][0] = 0
 	triggerInterval[RelaxedReclaim][0] = 0
 	triggerInterval[KVDBFailover][0] = 0
+	triggerInterval[ValidateDeviceMapper][0] = 0
 }
 
 func isTriggerEnabled(triggerType string) (time.Duration, bool) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR add a code to validate deviceMapper device cleans up check after FADA pods failover to another nodes.

**Which issue(s) this PR fixes** (optional)
Closes # PTX-7680

**Special notes for your reviewer**:
Completed the dev run successfully: https://jenkins.pwx.dev.purestorage.com/job/Dev/job/torpedo-dev03/40/
**Snip of job console logs**
=======================
`01:36:56 INFO[2022-07-29 08:36:56] Waiting for lock for trigger [validateDeviceMapper]

01:36:56  
01:36:56 INFO[2022-07-29 08:36:56] Successfully taken lock for trigger [validateDeviceMapper]
01:36:56  
01:36:56 INFO[2022-07-29 08:36:56] Validating the deviceMapper devices cleaned up or not 
01:36:56 STEP: Match the devicemapper devices in each node if it matches the expected count or not 
01:37:00 INFO[2022-07-29 08:37:01] Validating the node: torpedo-tp-fada-longevity-85-3 
01:37:00 DEBU[2022-07-29 08:37:01] Inspecting node [torpedo-tp-fada-longevity-85-3] with volume driver node id [404c02a4-8084-49e9-8a52-0a6b3bc48117] 

01:37:00 INFO[2022-07-29 08:37:01] Getting the current devicemapper devices counts in a node torpedo-tp-fada-longevity-85-3 
01:37:01 INFO[2022-07-29 08:37:02] Currently [%!s(int=13)] device mapped to a node: [torpedo-tp-fada-longevity-85-3] 
01:37:01 INFO[2022-07-29 08:37:02] Successfully validated the deviceMapper device cleaned up in a node: torpedo-tp-fada-longevity-85-3 
01:37:01 INFO[2022-07-29 08:37:02] Validating the node: torpedo-tp-fada-longevity-85-4 
01:37:01 DEBU[2022-07-29 08:37:02] Inspecting node [torpedo-tp-fada-longevity-85-4] with volume driver node id [2775b3a7-bbf8-41b4-847c-d4cfb5e11a7f] 
01:37:01 INFO[2022-07-29 08:37:02] Getting the current devicemapper devices counts in a node torpedo-tp-fada-longevity-85-4 
01:37:01 INFO[2022-07-29 08:37:02] Currently [%!s(int=3)] device mapped to a node: [torpedo-tp-fada-longevity-85-4] 
01:37:01 INFO[2022-07-29 08:37:02] Successfully validated the deviceMapper device cleaned up in a node: torpedo-tp-fada-longevity-85-4 
01:37:01 INFO[2022-07-29 08:37:02] Validating the node: torpedo-tp-fada-longevity-85-6 
01:37:01 DEBU[2022-07-29 08:37:02] Inspecting node [torpedo-tp-fada-longevity-85-6] with volume driver node id [9bc34425-45ca-4772-9587-70644309c42c] 
01:37:02 INFO[2022-07-29 08:37:02] Getting the current devicemapper devices counts in a node torpedo-tp-fada-longevity-85-6 
01:37:02 INFO[2022-07-29 08:37:02] Currently [%!s(int=8)] device mapped to a node: [torpedo-tp-fada-longevity-85-6] 
01:37:02 INFO[2022-07-29 08:37:02] Successfully validated the deviceMapper device cleaned up in a node: torpedo-tp-fada-longevity-85-6 
01:37:02 INFO[2022-07-29 08:37:02] Validating the node: torpedo-tp-fada-longevity-85-7 
01:37:02 DEBU[2022-07-29 08:37:02] Inspecting node [torpedo-tp-fada-longevity-85-7] with volume driver node id [71cd1f8c-9e7f-4f9a-9815-dd4864278166] 
01:37:02 INFO[2022-07-29 08:37:02] Getting the current devicemapper devices counts in a node torpedo-tp-fada-longevity-85-7 
01:37:02 INFO[2022-07-29 08:37:03] Currently [%!s(int=3)] device mapped to a node: [torpedo-tp-fada-longevity-85-7] 
01:37:02 INFO[2022-07-29 08:37:03] Successfully validated the deviceMapper device cleaned up in a node: torpedo-tp-fada-longevity-85-7 
01:37:02 INFO[2022-07-29 08:37:03] Validating the node: torpedo-tp-fada-longevity-85-0 
01:37:02 DEBU[2022-07-29 08:37:03] Inspecting node [torpedo-tp-fada-longevity-85-0] with volume driver node id [b38f786f-8a23-46bf-8da3-e4fd6873479a] 
01:37:02 INFO[2022-07-29 08:37:03] Getting the current devicemapper devices counts in a node torpedo-tp-fada-longevity-85-0 
01:37:03 INFO[2022-07-29 08:37:03] Currently [%!s(int=2)] device mapped to a node: [torpedo-tp-fada-longevity-85-0] 
01:37:03 INFO[2022-07-29 08:37:03] Successfully validated the deviceMapper device cleaned up in a node: torpedo-tp-fada-longevity-85-0 `
