### PR TITLE
Re-establish session for VM Reset operation

### DIFF
--- a/drivers/node/vsphere/vsphere.go
+++ b/drivers/node/vsphere/vsphere.go
@@ -96,9 +96,9 @@ func (v *vsphere) TestConnection(n node.Node, options node.ConnectionOpts) error
 	}
 	vm := vmMap[n.Name]
 	cmd := "hostname"
-
 	t := func() (interface{}, bool, error) {
 		powerState, err := vm.PowerState(v.ctx)
+		logrus.Infof("Power state of VM : %s state %v ", vm.Name(), powerState)
 		if err != nil || powerState != types.VirtualMachinePowerStatePoweredOn {
 			return nil, true, &node.ErrFailedToTestConnection{
 				Node:  n,
@@ -122,8 +122,7 @@ func (v *vsphere) TestConnection(n node.Node, options node.ConnectionOpts) error
 // getVMFinder return find.Finder instance
 func (v *vsphere) getVMFinder() (*find.Finder, error) {
 	login := fmt.Sprintf("%s%s:%s@%s/sdk", Protocol, v.vsphereUsername, v.vspherePassword, v.vsphereHostIP)
-	logrus.Infof("Logging in to ESXi using: %s", login)
-
+	logrus.Infof("Logging in to Virtual Center using: %s", login)
 	u, err := url.Parse(login)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing url %s", login)
@@ -161,7 +160,8 @@ func (v *vsphere) connect() error {
 	if err != nil {
 		return err
 	}
-
+	// vmMap Reset to get the new valid VMs info.
+	vmMap = make(map[string]*object.VirtualMachine)
 	// Find virtual machines in datacenter
 	vms, err := f.VirtualMachineList(v.ctx, "*")
 	if err != nil {
@@ -206,9 +206,10 @@ func (v *vsphere) RebootNode(n node.Node, options node.RebootNodeOpts) error {
 	if _, ok := vmMap[n.Name]; !ok {
 		return fmt.Errorf("could not fetch VM for node: %s", n.Name)
 	}
-
 	vm := vmMap[n.Name]
-
+	//Reestblish connection to avoid session timeout.
+	v.connect()
+	vm = vmMap[n.Name]
 	logrus.Infof("Rebooting VM: %s  ", vm.Name())
 	err := vm.RebootGuest(v.ctx)
 	if err != nil {

--- a/drivers/node/vsphere/vsphere.go
+++ b/drivers/node/vsphere/vsphere.go
@@ -206,10 +206,9 @@ func (v *vsphere) RebootNode(n node.Node, options node.RebootNodeOpts) error {
 	if _, ok := vmMap[n.Name]; !ok {
 		return fmt.Errorf("could not fetch VM for node: %s", n.Name)
 	}
-	vm := vmMap[n.Name]
 	//Reestblish connection to avoid session timeout.
 	v.connect()
-	vm = vmMap[n.Name]
+	vm := vmMap[n.Name]
 	logrus.Infof("Rebooting VM: %s  ", vm.Name())
 	err := vm.RebootGuest(v.ctx)
 	if err != nil {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
VMReset can be called 1 hour or beyond that time to Reset VM from VC, but observed that VC connection was expired by the time Longivity test calls RebootNode. Hence re-establishing session before performing VMReset.
**Which issue(s) this PR fixes** (optional)
Closes #
https://portworx.atlassian.net/browse/PTX-11122
**Special notes for your reviewer**:

