### PR TITLE
Adding fix in OCP recyle test when executing tests for Storageless nodes

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -93,6 +93,7 @@ const (
 const (
 	defaultTimeout                    = 2 * time.Minute
 	defaultRetryInterval              = 10 * time.Second
+	podUpRetryInterval                = 30 * time.Second
 	maintenanceOpTimeout              = 1 * time.Minute
 	maintenanceWaitTimeout            = 2 * time.Minute
 	inspectVolumeTimeout              = 1 * time.Minute
@@ -101,6 +102,7 @@ const (
 	validateReplicationUpdateTimeout  = 60 * time.Minute
 	validateClusterStartTimeout       = 2 * time.Minute
 	validatePXStartTimeout            = 5 * time.Minute
+	validatePxPodsUpTimeout           = 30 * time.Minute
 	validateNodeStopTimeout           = 5 * time.Minute
 	validateStoragePoolSizeTimeout    = 3 * time.Hour
 	validateStoragePoolSizeInterval   = 30 * time.Second
@@ -437,7 +439,7 @@ func (d *portworx) WaitForPxPodsToBeUp(n node.Node) error {
 		return "", false, nil
 	}
 
-	if _, err := task.DoRetryWithTimeout(t, validatePXStartTimeout, defaultRetryInterval); err != nil {
+	if _, err := task.DoRetryWithTimeout(t, validatePxPodsUpTimeout, podUpRetryInterval); err != nil {
 		return fmt.Errorf("PX pod failed to come up on node : [%s]. Error: [%v]", n.Name, err)
 	}
 	return nil

--- a/tests/openshift/ocp_node_recycle_test.go
+++ b/tests/openshift/ocp_node_recycle_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 	"github.com/portworx/torpedo/drivers/node"
+	"github.com/portworx/torpedo/drivers/scheduler"
 	"github.com/portworx/torpedo/drivers/scheduler/openshift"
 	. "github.com/portworx/torpedo/tests"
 	"github.com/sirupsen/logrus"
@@ -35,53 +36,66 @@ var _ = Describe("{RecycleOCPNode}", func() {
 		return
 	}
 
+	var contexts []*scheduler.Context
+
 	It("Validing the drives and pools after recyling a node", func() {
 		Step("Get the storage and storageless nodes and delete them", func() {
+			contexts = make([]*scheduler.Context, 0)
+
+			for i := 0; i < Inst().GlobalScaleFactor; i++ {
+				contexts = append(contexts, ScheduleApplications(fmt.Sprintf("crashonenode-%d", i))...)
+			}
+
+			ValidateApplications(contexts)
 			storagelessNodes, err := Inst().V.GetStoragelessNodes()
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to get storageless nodes. Error: [%v]", err))
-			delNode, err := node.GetNodeByName(storagelessNodes[0].Hostname)
-			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to get node object using Name. Error: [%v]", err))
-			Step(
-				fmt.Sprintf("Listing all nodes before recycling a storageless node %s", delNode.Name),
-				func() {
-					workerNodes := node.GetWorkerNodes()
-					for x, wNode := range workerNodes {
-						logrus.Infof("WorkerNode[%d] is: [%s] and volDriverID is [%s]", x, wNode.Name, wNode.VolDriverNodeID)
-					}
-				})
-			Step(
-				fmt.Sprintf("Recycle a storageless node and validating the drives: %s", delNode.Name),
-				func() {
-					err := Inst().S.RecycleNode(delNode)
-					Expect(err).NotTo(HaveOccurred(),
-						fmt.Sprintf("Failed to recycle a node [%s]. Error: [%v]", delNode.Name, err))
+			if storagelessNodes != nil {
+				delNode, err := node.GetNodeByName(storagelessNodes[0].Hostname)
+				Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to get node object using Name. Error: [%v]", err))
+				Step(
+					fmt.Sprintf("Listing all nodes before recycling a storageless node %s", delNode.Name),
+					func() {
+						workerNodes := node.GetWorkerNodes()
+						for x, wNode := range workerNodes {
+							logrus.Infof("WorkerNode[%d] is: [%s] and volDriverID is [%s]", x, wNode.Name, wNode.VolDriverNodeID)
+						}
+					})
+				Step(
+					fmt.Sprintf("Recycle a storageless node and validating the drives: %s", delNode.Name),
+					func() {
+						err := Inst().S.RecycleNode(delNode)
+						Expect(err).NotTo(HaveOccurred(),
+							fmt.Sprintf("Failed to recycle a node [%s]. Error: [%v]", delNode.Name, err))
 
-				})
+					})
+				Step(
+					fmt.Sprintf("Listing all nodes after recycle a storageless node %s", delNode.Name),
+					func() {
+						workerNodes := node.GetWorkerNodes()
+						for x, wNode := range workerNodes {
+							logrus.Infof("WorkerNode[%d] is: [%s] and volDriverID is [%s]", x, wNode.Name, wNode.VolDriverNodeID)
+						}
+					})
+			}
+			// Validating the apps after recycling the StorageLess node
+			ValidateApplications(contexts)
+			workerNodes := node.GetStorageDriverNodes()
+			delNode := workerNodes[0]
 			Step(
-				fmt.Sprintf("Listing all nodes after recycle a storageless node %s", delNode.Name),
+				fmt.Sprintf("Recycle a storage node: [%s] and validating the drives", delNode.Name),
 				func() {
-					workerNodes := node.GetWorkerNodes()
-					for x, wNode := range workerNodes {
-						logrus.Infof("WorkerNode[%d] is: [%s] and volDriverID is [%s]", x, wNode.Name, wNode.VolDriverNodeID)
-					}
-				})
-			Step(
-				fmt.Sprintf("Recycle a storage node and validating the drives: %s", delNode.Name),
-				func() {
-					workerNodes := node.GetStorageDriverNodes()
-					delNode = workerNodes[0]
 					err := Inst().S.RecycleNode(delNode)
 					Expect(err).NotTo(HaveOccurred(),
 						fmt.Sprintf("Failed to recycle a node [%s]. Error: [%v]", delNode.Name, err))
 				})
-			Step(
-				fmt.Sprintf("Listing all nodes after recycling a storage node %s", delNode.Name),
-				func() {
-					workerNodes := node.GetWorkerNodes()
-					for x, wNode := range workerNodes {
-						logrus.Infof("WorkerNode[%d] is: [%s] and volDriverID is [%s]", x, wNode.Name, wNode.VolDriverNodeID)
-					}
-				})
+			Step(fmt.Sprintf("Listing all nodes after recycling a storage node %s", delNode.Name), func() {
+				workerNodes := node.GetWorkerNodes()
+				for x, wNode := range workerNodes {
+					logrus.Infof("WorkerNode[%d] is: [%s] and volDriverID is [%s]", x, wNode.Name, wNode.VolDriverNodeID)
+				}
+			})
+			// Validating the apps after recycling the Storage node
+			ValidateApplications(contexts)
 		})
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixing the issue with OCP recycle node test when cluster doesn't have storage-less node present.

Increasing the timeout when new node got created and waiting for PX pods to come up in a new node.  

**Which issue(s) this PR fixes** (optional)
Closes # PTX-7667

**Special notes for your reviewer**:
https://jenkins.pwx.dev.purestorage.com/job/Dev/job/torpedo-dev03/42/console
https://jenkins.pwx.dev.purestorage.com/job/Torpedo/view/Torpedo-Detailed/job/tp-ocp-stable-csi/21/console

