### PR TITLE
Reduce logs in torpedo runs

### DIFF
--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -344,12 +344,12 @@ func (k *K8s) RefreshNodeRegistry() error {
 
 // ParseSpecs parses the application spec file
 func (k *K8s) ParseSpecs(specDir, storageProvisioner string) ([]interface{}, error) {
-	logrus.Infof("ParseSpecs k.CustomConfig = %v", k.customConfig)
+	logrus.Tracef("ParseSpecs k.CustomConfig = %v", k.customConfig)
 	fileList := make([]string, 0)
 	if err := filepath.Walk(specDir, func(path string, f os.FileInfo, err error) error {
 		if f != nil && !f.IsDir() {
 			if isValidProvider(path, storageProvisioner) {
-				logrus.Infof("	add filepath: %s", path)
+				logrus.Tracef("	add filepath: %s", path)
 				fileList = append(fileList, path)
 			}
 		}
@@ -359,7 +359,7 @@ func (k *K8s) ParseSpecs(specDir, storageProvisioner string) ([]interface{}, err
 		return nil, err
 	}
 
-	logrus.Infof("fileList: %v", fileList)
+	logrus.Tracef("fileList: %v", fileList)
 	var specs []interface{}
 
 	splitPath := strings.Split(specDir, "/")
@@ -456,7 +456,7 @@ func (k *K8s) IsAppHelmChartType(fileName string) (bool, error) {
 
 	// Parse the files and check for certain keys for helmRepo info
 
-	logrus.Infof("Reading file: %s", fileName)
+	logrus.Tracef("Reading file: %s", fileName)
 	file, err := ioutil.ReadFile(fileName)
 	if err != nil {
 		return false, err

--- a/drivers/scheduler/spec/factory.go
+++ b/drivers/scheduler/spec/factory.go
@@ -20,9 +20,9 @@ var appSpecFactory = make(map[string]*AppSpec)
 // register registers a new spec with the factory
 func (f *Factory) register(id string, app *AppSpec) {
 	if _, ok := appSpecFactory[id]; !ok {
-		logrus.Infof("Registering new app: %v", id)
+		logrus.Tracef("Registering new app: %v", id)
 	} else {
-		logrus.Infof("Substitute with new app: %v", id)
+		logrus.Tracef("Substitute with new app: %v", id)
 	}
 	// NOTE: In case of spec rescan we need to substitute old app with another one
 	appSpecFactory[id] = app
@@ -76,8 +76,8 @@ func NewFactory(specDir, storageProvisioner string, parser Parser) (*Factory, er
 			specID := file.Name()
 
 			specToParse := path.Join(f.specDir, specID)
-			logrus.Infof("Parsing: %v...", path.Join(f.specDir, specID))
-			logrus.Infof("Storage provisioner %s", storageProvisioner)
+			logrus.Tracef("Parsing: %v...", path.Join(f.specDir, specID))
+			logrus.Tracef("Storage provisioner %s", storageProvisioner)
 			specs, err := f.specParser.ParseSpecs(specToParse, storageProvisioner)
 			if err != nil {
 				return nil, err

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -585,7 +585,7 @@ func (d *portworx) updateNode(n *node.Node, pxNodes []*api.StorageNode) error {
 
 	for _, address := range n.Addresses {
 		for _, pxNode := range pxNodes {
-			logrus.Infof("Checking PX node %+v for address %s", pxNode, address)
+			logrus.Tracef("Checking PX node %+v for address %s", pxNode, address)
 			if address == pxNode.DataIp || address == pxNode.MgmtIp || n.Name == pxNode.SchedulerNodeName {
 				if len(pxNode.Id) > 0 {
 					n.StorageNode = pxNode


### PR DESCRIPTION
Signed-off-by: Rohit-PX <rkulkarni@purestorage.com>

**What this PR does / why we need it**:
Reduce unnecessary logs in torpedo debug mode. Logs include the following:
* List of spec files parsed, this gets printed for every test and for every app
* Printing of the entire PX object at the beginning of the test
* Logs every time an app is registered

All these statements are being moved to the `Tracef` mode so that even if required we can run the job in trace mode if some debugging is required.

Results are as follows when running with just `mysql` app and `SetupTeardown` test:
* Before log file size: 1.3M
* After log file size: 60K 
Attaching both files in the PR

Advantages:
* This will make debugging torpedo easier
* It will reduce the size of the files on the jenkins server


**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

