### PR TITLE
NEWSTACK-372: Add verification for FADA snapshot and restore

### DIFF
--- a/drivers/scheduler/dcos/dcos.go
+++ b/drivers/scheduler/dcos/dcos.go
@@ -883,6 +883,14 @@ func (d *dcos) CreateCsiSnapsForVolumes(ctx *scheduler.Context, snapClass string
 	}
 }
 
+func (d *dcos) CreateCsiSnapsAndValidate(ctx *scheduler.Context, snapClass string) error {
+	//CreateCsiSnapsAndValidate is not supported
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "CreateCsiSnapsAndValidate()",
+	}
+}
+
 func (d *dcos) GetCsiSnapshots(namespace string, pvcName string) ([]*v1beta1.VolumeSnapshot, error) {
 	// GetCsiSnapshots is not supported
 	return nil, &errors.ErrNotSupported{

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -339,6 +339,8 @@ type Driver interface {
 	// CreateCsiSnapshot create csi snapshot for given pvc
 	CreateCsiSnapshot(name string, namespace string, class string, pvc string) (*v1beta1.VolumeSnapshot, error)
 
+	// CreateCsiSnapsAndValidate create csi snapshot and return a pvc using that snapshot
+	CreateCsiSnapsAndValidate(*Context, string) error
 	// CreateCsiSnapsForVolumes create csi snapshots for all volumes in a context
 	CreateCsiSnapsForVolumes(*Context, string) (map[string]*v1beta1.VolumeSnapshot, error)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently we do have snapshot test for FADA, but it only verifies that the creation succeed, this PR adds test to verify the content of the restored volume from snapshot. 
**Which issue(s) this PR fixes** (optional)
NEWSTACK-372, NEWSTACK-376
**Special notes for your reviewer**:

