### PR TITLE
PWX-26600: Removes Pure QoS parameters if protocol is NVMe

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -69,6 +69,10 @@ if [ -z "${IS_PURE_VOLUMES}" ]; then
     IS_PURE_VOLUMES=false
 fi
 
+if [ -z "${PURE_SAN_TYPE}" ]; then
+    PURE_SAN_TYPE=ISCSI
+fi
+
 if [ -n "${PROVISIONER}" ]; then
     PROVISIONER="$PROVISIONER"
 fi
@@ -424,6 +428,7 @@ spec:
             "--enable-stork-upgrade=$ENABLE_STORK_UPGRADE",
             "--secret-type=$SECRET_TYPE",
             "--pure-volumes=$IS_PURE_VOLUMES",
+            "--pure-san-type=$PURE_SAN_TYPE",
             "--vault-addr=$VAULT_ADDR",
             "--vault-token=$VAULT_TOKEN",
             "--autopilot-upgrade-version=$AUTOPILOT_UPGRADE_VERSION",

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -102,6 +102,8 @@ type InitOptions struct {
 	VaultToken string
 	// PureVolumes identifies if this setup is using Pure backend
 	PureVolumes bool
+	// PureSANType identifies which SAN type is being used for Pure volumes
+	PureSANType string
 }
 
 // ScheduleOptions are options that callers to pass to influence the apps that get schduled

--- a/tests/common.go
+++ b/tests/common.go
@@ -287,6 +287,7 @@ func InitInstance() {
 		VaultAddress:            Inst().VaultAddress,
 		VaultToken:              Inst().VaultToken,
 		PureVolumes:             Inst().PureVolumes,
+		PureSANType:             Inst().PureSANType,
 		HelmValuesConfigMapName: Inst().HelmValuesConfigMap,
 	})
 	expect(err).NotTo(haveOccurred())
@@ -3145,6 +3146,7 @@ type Torpedo struct {
 	Backup                              backup.Driver
 	SecretType                          string
 	PureVolumes                         bool
+	PureSANType                         string
 	VaultAddress                        string
 	VaultToken                          string
 	SchedUpgradeHops                    string
@@ -3185,6 +3187,7 @@ func ParseFlags() {
 	var enableStorkUpgrade bool
 	var secretType string
 	var pureVolumes bool
+	var pureSANType string
 	var vaultAddress string
 	var vaultToken string
 	var schedUpgradeHops string
@@ -3220,6 +3223,7 @@ func ParseFlags() {
 	flag.StringVar(&customConfigPath, "custom-config", "", "Path to custom configuration files")
 	flag.StringVar(&secretType, "secret-type", scheduler.SecretK8S, "Path to custom configuration files")
 	flag.BoolVar(&pureVolumes, "pure-volumes", false, "To enable using Pure backend for shared volumes")
+	flag.StringVar(&pureSANType, "pure-san-type", "ISCSI", "If using Pure volumes, which SAN type is being used. ISCSI, FC, and NVMEOF-RDMA are all valid values.")
 	flag.StringVar(&vaultAddress, "vault-addr", "", "Path to custom configuration files")
 	flag.StringVar(&vaultToken, "vault-token", "", "Path to custom configuration files")
 	flag.StringVar(&schedUpgradeHops, "sched-upgrade-hops", "", "Comma separated list of versions scheduler upgrade to take hops")
@@ -3304,6 +3308,7 @@ func ParseFlags() {
 				Backup:                              backupDriver,
 				SecretType:                          secretType,
 				PureVolumes:                         pureVolumes,
+				PureSANType:                         pureSANType,
 				VaultAddress:                        vaultAddress,
 				VaultToken:                          vaultToken,
 				SchedUpgradeHops:                    schedUpgradeHops,


### PR DESCRIPTION
**What this PR does / why we need it**:
The Pure provider currently does not support QoS parameters with NVMe. We need to remove the parameters for the app to start successfully, but only for NVMe, other protocols should still have it.

