### PR TITLE
NEWSTACK-573: restore a single snapshot to multiple PVCs

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -69,6 +69,10 @@ if [ -z "${IS_PURE_VOLUMES}" ]; then
     IS_PURE_VOLUMES=false
 fi
 
+if [ -z "${PURE_FA_CLONE_MANY_TEST}" ]; then
+    PURE_FA_CLONE_MANY_TEST=false
+fi
+
 if [ -z "${PURE_SAN_TYPE}" ]; then
     PURE_SAN_TYPE=ISCSI
 fi
@@ -428,6 +432,7 @@ spec:
             "--enable-stork-upgrade=$ENABLE_STORK_UPGRADE",
             "--secret-type=$SECRET_TYPE",
             "--pure-volumes=$IS_PURE_VOLUMES",
+            "--pure-fa-snapshot-restore-to-many-test=$PURE_FA_CLONE_MANY_TEST",
             "--pure-san-type=$PURE_SAN_TYPE",
             "--vault-addr=$VAULT_ADDR",
             "--vault-token=$VAULT_TOKEN",

--- a/drivers/scheduler/dcos/dcos.go
+++ b/drivers/scheduler/dcos/dcos.go
@@ -867,11 +867,11 @@ func (d *dcos) ValidateTopologyLabel(ctx *scheduler.Context) error {
 	}
 }
 
-func (d *dcos) CreateCsiSanpshotClass(snapClassName string, deleionPolicy string) (*v1beta1.VolumeSnapshotClass, error) {
-	//CreateCsiSanpshotClass is not supported
+func (d *dcos) CreateCsiSnapshotClass(snapClassName string, deleionPolicy string) (*v1beta1.VolumeSnapshotClass, error) {
+	//CreateCsiSnapshotClass is not supported
 	return nil, &errors.ErrNotSupported{
 		Type:      "Function",
-		Operation: "CreateCsiSanpshotClasss()",
+		Operation: "CreateCsiSnapshotClass()",
 	}
 }
 
@@ -904,6 +904,14 @@ func (d *dcos) CSISnapshotTest(ctx *scheduler.Context, request scheduler.CSISnap
 	return &errors.ErrNotSupported{
 		Type:      "Function",
 		Operation: "CSISnapshotTest()",
+	}
+}
+
+func (d *dcos) CSISnapshotAndRestoreMany(ctx *scheduler.Context, request scheduler.CSISnapshotRequest) error {
+	//CSISnapshotAndRestoreMany is not supported for DCOS
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "CSISnapshotAndRestoreMany()",
 	}
 }
 

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -104,6 +104,8 @@ type InitOptions struct {
 	PureVolumes bool
 	// PureSANType identifies which SAN type is being used for Pure volumes
 	PureSANType string
+	// RunCSISnapshotAndRestoreManyTest identifies if Pure clone many test is enabled
+	RunCSISnapshotAndRestoreManyTest bool
 }
 
 // ScheduleOptions are options that callers to pass to influence the apps that get schduled
@@ -338,8 +340,8 @@ type Driver interface {
 	// RecyleNode deletes nodes with given node
 	RecycleNode(n node.Node) error
 
-	// CreateCsiSanpshotClass create csi snapshot class
-	CreateCsiSanpshotClass(snapClassName string, deleionPolicy string) (*v1beta1.VolumeSnapshotClass, error)
+	// CreateCsiSnapshotClass create csi snapshot class
+	CreateCsiSnapshotClass(snapClassName string, deleionPolicy string) (*v1beta1.VolumeSnapshotClass, error)
 
 	// CreateCsiSnapshot create csi snapshot for given pvc
 	// TODO: there's probably better place to place this test, it creates the snapshot and also does the validation.
@@ -352,6 +354,9 @@ type Driver interface {
 	// At the same time, there's also other validation functions in this interface as well. So we should look into ways
 	// to make the interface consistent
 	CSISnapshotTest(*Context, CSISnapshotRequest) error
+
+	// CSISnapshotAndRestoreMany create a single snapshot and try to restore many volumes
+	CSISnapshotAndRestoreMany(*Context, CSISnapshotRequest) error
 
 	// CSICloneTest clones a volume and validate the content
 	CSICloneTest(*Context, CSICloneRequest) error

--- a/tests/common.go
+++ b/tests/common.go
@@ -284,17 +284,18 @@ func InitInstance() {
 
 	err = Inst().S.Init(scheduler.InitOptions{
 		SpecDir:                 Inst().SpecDir,
-		VolDriverName:           Inst().V.String(),
-		NodeDriverName:          Inst().N.String(),
-		SecretConfigMapName:     Inst().ConfigMap,
-		CustomAppConfig:         Inst().CustomAppConfig,
-		StorageProvisioner:      Inst().Provisioner,
-		SecretType:              Inst().SecretType,
-		VaultAddress:            Inst().VaultAddress,
-		VaultToken:              Inst().VaultToken,
-		PureVolumes:             Inst().PureVolumes,
-		PureSANType:             Inst().PureSANType,
-		HelmValuesConfigMapName: Inst().HelmValuesConfigMap,
+		VolDriverName:                    Inst().V.String(),
+		NodeDriverName:                   Inst().N.String(),
+		SecretConfigMapName:              Inst().ConfigMap,
+		CustomAppConfig:                  Inst().CustomAppConfig,
+		StorageProvisioner:               Inst().Provisioner,
+		SecretType:                       Inst().SecretType,
+		VaultAddress:                     Inst().VaultAddress,
+		VaultToken:                       Inst().VaultToken,
+		PureVolumes:                      Inst().PureVolumes,
+		PureSANType:                      Inst().PureSANType,
+		RunCSISnapshotAndRestoreManyTest: Inst().RunCSISnapshotAndRestoreManyTest,
+		HelmValuesConfigMapName:          Inst().HelmValuesConfigMap,
 	})
 	expect(err).NotTo(haveOccurred())
 
@@ -489,6 +490,12 @@ func ValidateContextForPureVolumesSDK(ctx *scheduler.Context, errChan ...*chan e
 			}
 		})
 
+		Step(fmt.Sprintf("validate %s app's pure volume snapshot and restoring to many volumes", ctx.App.Key), func() {
+			if !ctx.SkipVolumeValidation {
+				ValidatePureVolumeLargeNumOfClones(ctx, errChan...)
+			}
+		})
+
 		Step(fmt.Sprintf("validate if %s app's volumes are setup", ctx.App.Key), func() {
 			if ctx.SkipVolumeValidation {
 				return
@@ -567,6 +574,12 @@ func ValidateContextForPureVolumesPXCTL(ctx *scheduler.Context, errChan ...*chan
 		Step(fmt.Sprintf("validate %s app's pure volumes snapshot and restore", ctx.App.Key), func() {
 			if !ctx.SkipVolumeValidation {
 				ValidateCSISnapshotAndRestore(ctx, errChan...)
+			}
+		})
+
+		Step(fmt.Sprintf("validate %s app's pure volume snapshot and restoring to many volumes", ctx.App.Key), func() {
+			if !ctx.SkipVolumeValidation {
+				ValidatePureVolumeLargeNumOfClones(ctx, errChan...)
 			}
 		})
 
@@ -830,7 +843,7 @@ func ValidateCSISnapshotAndRestore(ctx *scheduler.Context, errChan ...*chan erro
 		var err error
 		timestamp := strconv.Itoa(int(time.Now().Unix()))
 		snapShotClassName := PureSnapShotClass + "-" + timestamp
-		if _, err := Inst().S.CreateCsiSanpshotClass(snapShotClassName, "Delete"); err != nil {
+		if _, err := Inst().S.CreateCsiSnapshotClass(snapShotClassName, "Delete"); err != nil {
 			logrus.Errorf("Create volume snapshot class failed with error: [%v]", err)
 			expect(err).NotTo(haveOccurred(), "failed to create snapshot class")
 		}
@@ -884,6 +897,41 @@ func ValidateCSIVolumeClone(ctx *scheduler.Context, errChan ...*chan error) {
 		}
 	})
 }
+
+// ValidatePureVolumeLargeNumOfClones is the ginkgo spec for restoring a snapshot to many volumes
+func ValidatePureVolumeLargeNumOfClones(ctx *scheduler.Context, errChan ...*chan error) {
+	context("For validation of an restoring large number of volumes from a snapshot", func() {
+		var err error
+		timestamp := strconv.Itoa(int(time.Now().Unix()))
+		snapShotClassName := PureSnapShotClass + "." + timestamp
+		if _, err := Inst().S.CreateCsiSnapshotClass(snapShotClassName, "Delete"); err != nil {
+			logrus.Errorf("Create volume snapshot class failed with error: [%v]", err)
+			expect(err).NotTo(haveOccurred(), "failed to create snapshot class")
+		}
+
+		var vols []*volume.Volume
+		Step(fmt.Sprintf("get %s app's pure volumes", ctx.App.Key), func() {
+			vols, err = Inst().S.GetPureVolumes(ctx, "pure_block")
+			processError(err, errChan...)
+		})
+		if len(vols) == 0 {
+			logrus.Warnf("No FlashArray DirectAccess volumes, skipping")
+			processError(err, errChan...)
+		} else {
+			request := scheduler.CSISnapshotRequest {
+				Namespace: vols[0].Namespace,
+				Timestamp: timestamp,
+				OriginalPVCName: vols[0].Name,
+				SnapName: "basic-csi-snapshot-many" + timestamp,
+				RestoredPVCName: "csi-restored-many" + timestamp,
+				SnapshotclassName: snapShotClassName,
+			}
+			err = Inst().S.CSISnapshotAndRestoreMany(ctx, request)
+			processError(err, errChan...)
+		}
+	})
+}
+
 
 func checkPureVolumeExpectedSizeChange(sizeChangeInBytes uint64) error {
 	if sizeChangeInBytes < (512-30)*oneMegabytes || sizeChangeInBytes > (512+30)*oneMegabytes {
@@ -3486,8 +3534,9 @@ type Torpedo struct {
 	Backup                              backup.Driver
 	SecretType                          string
 	PureVolumes                         bool
-	PureSANType                         string
-	VaultAddress                        string
+	PureSANType                      string
+	RunCSISnapshotAndRestoreManyTest bool
+	VaultAddress                     string
 	VaultToken                          string
 	SchedUpgradeHops                    string
 	AutopilotUpgradeImage               string
@@ -3528,6 +3577,7 @@ func ParseFlags() {
 	var secretType string
 	var pureVolumes bool
 	var pureSANType string
+	var runCSISnapshotAndRestoreManyTest bool
 	var vaultAddress string
 	var vaultToken string
 	var schedUpgradeHops string
@@ -3564,6 +3614,7 @@ func ParseFlags() {
 	flag.StringVar(&secretType, "secret-type", scheduler.SecretK8S, "Path to custom configuration files")
 	flag.BoolVar(&pureVolumes, "pure-volumes", false, "To enable using Pure backend for shared volumes")
 	flag.StringVar(&pureSANType, "pure-san-type", "ISCSI", "If using Pure volumes, which SAN type is being used. ISCSI, FC, and NVMEOF-RDMA are all valid values.")
+	flag.BoolVar(&runCSISnapshotAndRestoreManyTest, "pure-fa-snapshot-restore-to-many-test", false, "If using Pure volumes, to enable Pure clone many tests")
 	flag.StringVar(&vaultAddress, "vault-addr", "", "Path to custom configuration files")
 	flag.StringVar(&vaultToken, "vault-token", "", "Path to custom configuration files")
 	flag.StringVar(&schedUpgradeHops, "sched-upgrade-hops", "", "Comma separated list of versions scheduler upgrade to take hops")
@@ -3639,24 +3690,25 @@ func ParseFlags() {
 				AppList:                             appList,
 				Provisioner:                         provisionerName,
 				MaxStorageNodesPerAZ:                storageNodesPerAZ,
-				DestroyAppTimeout:                   destroyAppTimeout,
-				DriverStartTimeout:                  driverStartTimeout,
-				AutoStorageNodeRecoveryTimeout:      autoStorageNodeRecoveryTimeout,
-				ConfigMap:                           configMapName,
-				BundleLocation:                      bundleLocation,
-				CustomAppConfig:                     customAppConfig,
-				Backup:                              backupDriver,
-				SecretType:                          secretType,
-				PureVolumes:                         pureVolumes,
-				PureSANType:                         pureSANType,
-				VaultAddress:                        vaultAddress,
-				VaultToken:                          vaultToken,
-				SchedUpgradeHops:                    schedUpgradeHops,
-				AutopilotUpgradeImage:               autopilotUpgradeImage,
-				CsiGenericDriverConfigMap:           csiGenericDriverConfigMapName,
-				LicenseExpiryTimeoutHours:           licenseExpiryTimeoutHours,
-				MeteringIntervalMins:                meteringIntervalMins,
-				IsHyperConverged:                    hyperConverged,
+				DestroyAppTimeout:                destroyAppTimeout,
+				DriverStartTimeout:               driverStartTimeout,
+				AutoStorageNodeRecoveryTimeout:   autoStorageNodeRecoveryTimeout,
+				ConfigMap:                        configMapName,
+				BundleLocation:                   bundleLocation,
+				CustomAppConfig:                  customAppConfig,
+				Backup:                           backupDriver,
+				SecretType:                       secretType,
+				PureVolumes:                      pureVolumes,
+				PureSANType:                      pureSANType,
+				RunCSISnapshotAndRestoreManyTest: runCSISnapshotAndRestoreManyTest,
+				VaultAddress:                     vaultAddress,
+				VaultToken:                       vaultToken,
+				SchedUpgradeHops:                 schedUpgradeHops,
+				AutopilotUpgradeImage:            autopilotUpgradeImage,
+				CsiGenericDriverConfigMap:        csiGenericDriverConfigMapName,
+				LicenseExpiryTimeoutHours:        licenseExpiryTimeoutHours,
+				MeteringIntervalMins:             meteringIntervalMins,
+				IsHyperConverged:                 hyperConverged,
 			}
 		})
 	}

--- a/tests/testTriggers.go
+++ b/tests/testTriggers.go
@@ -4370,7 +4370,7 @@ func TriggerCsiSnapShot(contexts *[]*scheduler.Context, recordChan *chan *EventR
 		if !isCsiVolumeSnapshotClassExist {
 			logrus.Info("Creating csi volume snapshot class")
 			snapShotClassName := PureSnapShotClass + time.Now().Format("01-02-15h04m05s")
-			if volSnapshotClass, err = Inst().S.CreateCsiSanpshotClass(snapShotClassName, "Delete"); err != nil {
+			if volSnapshotClass, err = Inst().S.CreateCsiSnapshotClass(snapShotClassName, "Delete"); err != nil {
 				logrus.Errorf("Create volume snapshot class failed with error: [%v]", err)
 				UpdateOutcome(event, err)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
this test specifically covers Apple's use case, create a single snapshot, and restore the snapshot to multiple volumes. The test will be disabled by default as it is time consuming, can be enabled with flag `PURE_FA_CLONE_MANY_TEST` set to true.


**Which issue(s) this PR fixes** (optional)
NEWSTACK-573

**Special notes for your reviewer**:

