### PR TITLE
PWX-27143: Determine the diags_server connection port using the confi…

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -3285,7 +3285,27 @@ func collectDiags(n node.Node, config *torpedovolume.DiagRequestConfig, diagOps 
 			return fmt.Errorf("failed to collect diags on node %v, Err: %v %v", hostname, err, out)
 		}
 	} else {
-		url := netutil.MakeURL("http://", n.Addresses[0], 9014)
+		diagsPort := 9014
+		// Need to get the diags server port based on the px mgmnt port for OCP its not the standard 9001
+		out, err := d.nodeDriver.RunCommand(n, "cat /etc/pwx/px_env", opts)
+		if err == nil {
+			envVars := map[string]string{}
+			for _, line := range strings.Split(out, "\n") {
+				splits := strings.Split(line, "=")
+				if len(splits) > 1 {
+					envVars[splits[0]] = splits[1]
+				}
+			}
+			pxMgmntPort, err := strconv.Atoi(envVars["PWX_MGMT_PORT"])
+			if err == nil {
+				if pxMgmntPort != 9001 {
+					diagsPort = pxMgmntPort + 10
+				}
+			}
+		}
+
+		url := netutil.MakeURL("http://", n.Addresses[0], diagsPort)
+		logrus.Infof("Diags server url: %s", url)
 
 		c, err := client.NewClient(url, "", "")
 		if err != nil {


### PR DESCRIPTION
…gured mgmnt port.

Signed-off-by: Jose Rivera <jose@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
On OCP the default diags server port is shifted based on the PX mgmnt port of 17001.   So change code to determine the diags server port using the mgmnt port instead of hard coding to 9014. 
**Which issue(s) this PR fixes** (optional)
Closes #
PWX-27143

**Special notes for your reviewer**:

