### PR TITLE
PWX-27167: Execute remote pxctl commands using API which handles when…

### DIFF
--- a/drivers/volume/common.go
+++ b/drivers/volume/common.go
@@ -786,6 +786,14 @@ func (d *DefaultDriver) GetPxVersionOnNode(n node.Node) (string, error) {
 	}
 }
 
+// GetPxctlCmdOutputConnectionOpts returns the command output run on the given node with ConnectionOpts and any error
+func (d *DefaultDriver) GetPxctlCmdOutputConnectionOpts(n node.Node, command string, opts node.ConnectionOpts, retry bool) (string, error) {
+	return "", &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "GetPxctlCmdOutputConnectionOpts()",
+	}
+}
+
 // GetPxctlCmdOutput returns the command output run on the given node and any error
 func (d *DefaultDriver) GetPxctlCmdOutput(n node.Node, command string) (string, error) {
 	return "", &errors.ErrNotSupported{

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -330,6 +330,9 @@ type Driver interface {
 	//GetAutoFsTrimStatus get status of autofstrim
 	GetAutoFsTrimStatus(pxEndpoint string) (map[string]api.FilesystemTrim_FilesystemTrimStatus, error)
 
+	// GetPxctlCmdOutputConnectionOpts returns the command output run on the given node with ConnectionOpts and any error
+	GetPxctlCmdOutputConnectionOpts(n node.Node, command string, opts node.ConnectionOpts, retry bool) (string, error)
+
 	// GetPxctlCmdOutput returns the command output run on the given node and any error
 	GetPxctlCmdOutput(n node.Node, command string) (string, error)
 

--- a/tests/telemetry/telemetry_test.go
+++ b/tests/telemetry/telemetry_test.go
@@ -23,24 +23,35 @@ import (
 )
 
 const (
-	cmdRetry   = 5 * time.Second
-	cmdTimeout = 15 * time.Second
+	cmdRetry               = 5 * time.Second
+	cmdTimeout             = 15 * time.Second
+	TelemetryEnabledStatus = "100"
 )
 
-const (
-	TelemetryEnabledStatus = "100"
+var (
+	telemetryCmdConnectionOpts = node.ConnectionOpts{
+		Timeout:         cmdTimeout,
+		TimeBeforeRetry: cmdRetry,
+		Sudo:            false,
+	}
+	isTelemetryOperatorEnabled = false
 )
 
 // Taken from SharedV4 tests...
 func runCmd(cmd string, n node.Node, cmdConnectionOpts *node.ConnectionOpts) (string, error) {
 	if cmdConnectionOpts == nil {
-		cmdConnectionOpts = &node.ConnectionOpts{
-			Timeout:         cmdTimeout,
-			TimeBeforeRetry: cmdRetry,
-			Sudo:            false,
-		}
+		cmdConnectionOpts = &telemetryCmdConnectionOpts
 	}
 	output, err := Inst().N.RunCommandWithNoRetry(n, cmd, *cmdConnectionOpts)
+	return output, err
+}
+
+func runPxctlCommand(pxctlCmd string, n node.Node, cmdConnectionOpts *node.ConnectionOpts) (string, error) {
+	if cmdConnectionOpts == nil {
+		cmdConnectionOpts = &telemetryCmdConnectionOpts
+	}
+
+	output, err := Inst().V.GetPxctlCmdOutputConnectionOpts(n, pxctlCmd, *cmdConnectionOpts, false)
 	return output, err
 }
 
@@ -55,13 +66,26 @@ func TestTelemetryBasic(t *testing.T) {
 
 func TelemetryEnabled(currNode node.Node) bool {
 	// This returns true if telemetry is enabled
-	out, err := runCmd("/opt/pwx/bin/pxctl status -j | jq .telemetrystatus.connection_status.error_code", currNode, nil)
+	out, err := runPxctlCommand("status -j | jq .telemetrystatus.connection_status.error_code", currNode, nil)
 	Expect(err).NotTo(HaveOccurred(), "Error getting telemetry status for %s", currNode.Name)
 	return strings.TrimSpace(out) == TelemetryEnabledStatus
 }
 
 var _ = BeforeSuite(func() {
 	InitInstance()
+	logrus.Infof("Checking telemetry status...")
+	isOpBased, _ := Inst().V.IsOperatorBasedInstall()
+	if isOpBased {
+		spec, err := Inst().V.GetStorageCluster()
+		Expect(err).ToNot(HaveOccurred())
+		if spec.Spec.Monitoring != nil && spec.Spec.Monitoring.Telemetry != nil && spec.Spec.Monitoring.Telemetry.Enabled {
+			logrus.Infof("Telemetry is operator enabled.")
+			isTelemetryOperatorEnabled = true
+		}
+	}
+	if !isTelemetryOperatorEnabled {
+		logrus.Infof("Telemetry is not enabled.")
+	}
 })
 
 // This test telemetry health via pxctl
@@ -72,6 +96,9 @@ var _ = Describe("{DiagsTelemetryPxctlHealthyStatus}", func() {
 	testrailID := 54907
 	JustBeforeEach(func() {
 		runID = testrailuttils.AddRunsToMilestone(testrailID)
+		if !isTelemetryOperatorEnabled {
+			Skip("Skip test because telemetry is not enabled...")
+		}
 	})
 
 	It("Validate, pxctl displays telemetry status", func() {
@@ -80,7 +107,7 @@ var _ = Describe("{DiagsTelemetryPxctlHealthyStatus}", func() {
 
 		for _, currNode := range node.GetWorkerNodes() {
 			Step(fmt.Sprintf("run pxctl status to check telemetry status on node %v", currNode.Name), func() {
-				output, err := runCmd("/opt/pwx/bin/pxctl status | egrep ^Telemetry:", currNode, nil)
+				output, err := runPxctlCommand("status | egrep ^Telemetry:", currNode, nil)
 				Expect(err).NotTo(HaveOccurred(), "Failed to get status for nodee %v", currNode.Name)
 				logrus.Infof("node %s: %s", currNode.Name, output)
 				telemetryNodeStatus[currNode.Name], _ = regexp.MatchString(`Telemetry:.*Healthy`, output)
@@ -99,6 +126,7 @@ var _ = Describe("{DiagsTelemetryPxctlHealthyStatus}", func() {
 // This test performs basic test of starting an application and destroying it (along with storage)
 var _ = Describe("{DiagsBasic}", func() {
 	var contexts []*scheduler.Context
+
 	It("has to setup, validate, try to get diags on nodes and teardown apps", func() {
 		contexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -136,6 +164,9 @@ var _ = Describe("{DiagsCCMOnS3}", func() {
 	JustBeforeEach(func() {
 		for _, testRailID := range testrailIDs {
 			runIDs = append(runIDs, testrailuttils.AddRunsToMilestone(testRailID))
+		}
+		if !isTelemetryOperatorEnabled {
+			Skip("Skip test because telemetry is not enabled...")
 		}
 	})
 	var contexts []*scheduler.Context
@@ -181,8 +212,12 @@ var _ = Describe("{ProfileOnlyDiags}", func() {
 	var testrailID = 54911
 	// testrailID corresponds to: https://portworx.testrail.net/index.php?/cases/view/54917
 	var runID int
+
 	JustBeforeEach(func() {
 		runID = testrailuttils.AddRunsToMilestone(testrailID)
+		if !isTelemetryOperatorEnabled {
+			Skip("Skip test because telemetry is not enabled...")
+		}
 	})
 	var contexts []*scheduler.Context
 	var diagsFiles []string
@@ -239,8 +274,12 @@ var _ = Describe("{DiagsClusterWide}", func() {
 	var testrailID = 54916
 	// testrailID corresponds to: https://portworx.testrail.net/index.php?/cases/view/54916
 	var runID int
+
 	JustBeforeEach(func() {
 		runID = testrailuttils.AddRunsToMilestone(testrailID)
+		if !isTelemetryOperatorEnabled {
+			Skip("Skip test because telemetry is not enabled...")
+		}
 	})
 	var contexts []*scheduler.Context
 	var diagFile string
@@ -250,7 +289,7 @@ var _ = Describe("{DiagsClusterWide}", func() {
 		// One node at a time, collect diags and verify in S3
 		for _, currNode := range node.GetWorkerNodes() {
 			Step(fmt.Sprintf("run pxctl sv diags to collect cluster wide diags  %v", currNode.Name), func() {
-				_, err := runCmd("/opt/pwx/bin/pxctl sv diags -a -c", currNode, nil)
+				_, err := runPxctlCommand("sv diags -a -c", currNode, nil)
 				Expect(err).NotTo(HaveOccurred(), "Error running diags on Node: %s", currNode.Name)
 			})
 			Step(fmt.Sprintf("Get the svc diags collected above %s", currNode.Name), func() {
@@ -284,6 +323,7 @@ var _ = Describe("{DiagsClusterWide}", func() {
 // This test performs basic test of starting an application and destroying it (along with storage)
 var _ = Describe("{DiagsAsyncBasic}", func() {
 	var contexts []*scheduler.Context
+
 	It("has to setup, validate, try to get a-sync diags on nodes and teardown apps", func() {
 		contexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -336,6 +376,9 @@ var _ = Describe("{DiagsAutoStorage}", func() {
 		for _, testRailID := range testProcNmsTestRailIDs {
 			runIDs[testRailID] = testrailuttils.AddRunsToMilestone(testRailID)
 		}
+		if !isTelemetryOperatorEnabled {
+			Skip("Skip test because telemetry is not enabled...")
+		}
 	})
 
 	It("has to setup, validate, try to collect auto diags on nodes after px-storage/px crash", func() {
@@ -377,7 +420,7 @@ var _ = Describe("{DiagsAutoStorage}", func() {
 				Step(fmt.Sprintf("'%s': run pxctl status to check when the server has gone down on %v",
 					pxProcessNm, currNode.Name), func() {
 					Eventually(func() (string, error) {
-						output, err := runCmd("/opt/pwx/bin/pxctl status | egrep ^PX", currNode, nil)
+						output, err := runPxctlCommand("status | egrep ^PX", currNode, nil)
 						return output, err
 					}, 45*time.Second, 1*time.Second).Should(ContainSubstring("PX is not running on this host"),
 						"'%s': failed to forcefully stop driver on node %s", pxProcessNm, currNode.Name)
@@ -438,6 +481,9 @@ var _ = Describe("{DiagsOnStoppedPXnode}", func() {
 	testrailID := 54918
 	JustBeforeEach(func() {
 		runID = testrailuttils.AddRunsToMilestone(testrailID)
+		if !isTelemetryOperatorEnabled {
+			Skip("Skip test because telemetry is not enabled...")
+		}
 	})
 
 	It("Validate, pxctl displays telemetry status", func() {
@@ -499,8 +545,12 @@ var _ = Describe("{DiagsSpecificNode}", func() {
 	var testrailID = 54915
 	// testrailID corresponds to: https://portworx.testrail.net/index.php?/cases/view/54916
 	var runID int
+
 	JustBeforeEach(func() {
 		runID = testrailuttils.AddRunsToMilestone(testrailID)
+		if !isTelemetryOperatorEnabled {
+			Skip("Skip test because telemetry is not enabled...")
+		}
 	})
 	var contexts []*scheduler.Context
 	var diagFile string
@@ -524,7 +574,7 @@ var _ = Describe("{DiagsSpecificNode}", func() {
 		})
 
 		Step(fmt.Sprintf("run pxctl sv diags on node %s to collect diags on specific node %v", currNode.Name, diagNode.Name), func() {
-			_, err := runCmd(fmt.Sprintf("/opt/pwx/bin/pxctl sv diags -a -n %s", diagNode.VolDriverNodeID), currNode, nil)
+			_, err := runPxctlCommand(fmt.Sprintf("sv diags -a -n %s", diagNode.VolDriverNodeID), currNode, nil)
 			Expect(err).NotTo(HaveOccurred(), "Error running diags on Node %s to %s", currNode.Name, diagNode.Name)
 		})
 


### PR DESCRIPTION
… PX-Security is enabled.  Only execute telemetry tests when telemetry is enabled by operator.

Signed-off-by: Jose Rivera <jose@portworx.com>


**What this PR does / why we need it**:
telemetry tests will collect diags use remote 'pxctl service diags...' call.   Unfortunately we executing that call we were not taking into consideration if PX-Security was enabled which requires an auth token.  So change the code so that the remote calls can use an API which executes the calls but also handles the security.    Also only execute some telemetry tests when  telemetry is enabled via the operator.

 
**Which issue(s) this PR fixes** (optional)
Closes #
PWX-27167
**Special notes for your reviewer**:

