### PR TITLE
Detect portworx pod restart

### DIFF
--- a/drivers/node/node.go
+++ b/drivers/node/node.go
@@ -55,6 +55,7 @@ type Node struct {
 	IsStorageDriverInstalled bool
 	IsMetadataNode           bool
 	StoragePools             []StoragePool
+	PxPodRestartCount        int32
 }
 
 // ConnectionOpts provide basic options for all operations and can be embedded by other options

--- a/drivers/scheduler/dcos/dcos.go
+++ b/drivers/scheduler/dcos/dcos.go
@@ -957,6 +957,14 @@ func (d *dcos) DeleteCsiSnapshot(ctx *scheduler.Context, snapshotName string, sn
 	}
 
 }
+
+func (d *dcos) GetPodsRestartCount(namespace string, label map[string]string) (map[*corev1.Pod]int32, error) {
+	// GetPodsRestartCount is not supported
+	return nil, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "GetPodsRestartCoun()",
+	}
+}
 func init() {
 	d := &dcos{}
 	scheduler.Register(SchedName, d)

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -384,6 +384,9 @@ type Driver interface {
 
 	// DeleteCsiSnapshot delete a snapshots from namespace
 	DeleteCsiSnapshot(ctx *Context, snapshotName string, snapshotNameSpace string) error
+
+	// GetPodsRestartCount gets restart count maps for pods in given namespace
+	GetPodsRestartCount(namespace string, label map[string]string) (map[*corev1.Pod]int32, error)
 }
 
 var (

--- a/tests/common.go
+++ b/tests/common.go
@@ -191,14 +191,16 @@ const (
 
 //Dashboard params
 const (
-	enableDashBoardFlag = "enable-dash"
-	userFlag            = "user"
-	testTypeFlag        = "test-type"
-	testDescriptionFlag = "test-desc"
-	testTagsFlag        = "test-tags"
-	testSetIDFlag       = "testset-id"
-	testBranchFlag      = "branch"
-	testProductFlag     = "product"
+	enableDashBoardFlag     = "enable-dash"
+	userFlag                = "user"
+	testTypeFlag            = "test-type"
+	testDescriptionFlag     = "test-desc"
+	testTagsFlag            = "test-tags"
+	testSetIDFlag           = "testset-id"
+	testBranchFlag          = "branch"
+	testProductFlag         = "product"
+	failOnPxPodRestartCount = "fail-on-px-pod-restartcount"
+	portworxOperatorName    = "portworx-operator"
 )
 
 // Backup constants
@@ -237,6 +239,7 @@ const (
 	authTokenParam                        = "auth-token"
 	defaultTorpedoJob                     = "torpedo-job"
 	defaultTorpedoJobType                 = "functional"
+	labelNameKey                          = "name"
 )
 
 const (
@@ -559,6 +562,10 @@ func ValidateContext(ctx *scheduler.Context, errChan ...*chan error) {
 					}
 				})
 			}
+		})
+
+		Step("Validate Px pod restart count", func() {
+			ValidatePxPodRestartCount(ctx, errChan...)
 		})
 	})
 }
@@ -1620,6 +1627,45 @@ func ValidateStoragePools(contexts []*scheduler.Context) {
 	err = Inst().V.ValidateStoragePools()
 	expect(err).NotTo(haveOccurred())
 
+}
+
+// ValidatePxPodRestartCount validates portworx restart count
+func ValidatePxPodRestartCount(ctx *scheduler.Context, errChan ...*chan error) {
+	context("Validating portworx pods restart count ...", func() {
+		Step("Getting current restart counts for portworx pods and matching", func() {
+			pxLabel := make(map[string]string)
+			pxLabel[labelNameKey] = defaultStorageProvisioner
+			pxPodRestartCountMap, err := Inst().S.GetPodsRestartCount(pxNamespace, pxLabel)
+			dash.VerifyFatal(err, nil, "Getting portworx pod restart count")
+
+			// Validate portworx pod restart count after test
+			for pod, value := range pxPodRestartCountMap {
+				n, err := node.GetNodeByIP(pod.Status.HostIP)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Validate get node object using IP: %s", pod.Status.HostIP))
+				if n.PxPodRestartCount != value {
+					log.Errorf("Portworx pods restart many times in a node: [%s]", n.Name)
+					if Inst().PortworxPodRestartCheck {
+						dash.VerifyFatal(fmt.Errorf("portworx pods restart [%d] times", value), nil, "Validate portworx restart count")
+					}
+				}
+				log.Infof("Portworx pods restart count: [%d] matching with expected count: [%d]", value, n.PxPodRestartCount)
+			}
+
+			// Validate portworx operator pod check
+			pxLabel[labelNameKey] = portworxOperatorName
+			pxPodRestartCountMap, err = Inst().S.GetPodsRestartCount(pxNamespace, pxLabel)
+			dash.VerifyFatal(err, nil, "Getting portworx operator pod restart count")
+			for _, v := range pxPodRestartCountMap {
+				if v > 0 {
+					log.Errorf("Portworx operator pods restarted many times: [%d]", v)
+					if Inst().PortworxPodRestartCheck {
+						dash.VerifyFatal(fmt.Errorf("portworx operator pods restart [%d] times", v), nil, "Checking portworx pod restart count")
+					}
+				}
+			}
+			log.Info("Portworx operator pod not restarted during this test")
+		})
+	})
 }
 
 // DescribeNamespace takes in the scheduler contexts and describes each object within the test context.
@@ -3827,6 +3873,7 @@ type Torpedo struct {
 	Dash                                *aetosutil.Dashboard
 	JobName                             string
 	JobType                             string
+	PortworxPodRestartCheck             bool
 }
 
 // ParseFlags parses command line flags
@@ -3853,6 +3900,7 @@ func ParseFlags() {
 	var customConfigPath string
 	var hyperConverged bool
 	var enableDash bool
+	var pxPodRestartCheck bool
 
 	// TODO: We rely on the customAppConfig map to be passed into k8s.go and stored there.
 	// We modify this map from the tests and expect that the next RescanSpecs will pick up the new custom configs.
@@ -3934,6 +3982,7 @@ func ParseFlags() {
 	flag.StringVar(&testBranch, testBranchFlag, "master", "branch of the product")
 	flag.StringVar(&testProduct, testProductFlag, "PxEnp", "Portworx product under test")
 	flag.StringVar(&pxRuntimeOpts, "px-runtime-opts", "", "comma separated list of run time options for cluster update")
+	flag.BoolVar(&pxPodRestartCheck, failOnPxPodRestartCount, false, "Set it true for px pods restart check during test")
 	flag.Parse()
 
 	log = logInstance.GetLogInstance()
@@ -4061,6 +4110,7 @@ func ParseFlags() {
 				Dash:                                dash,
 				JobName:                             torpedoJobName,
 				JobType:                             torpedoJobType,
+				PortworxPodRestartCheck:             pxPodRestartCheck,
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to detect and report when portworx pods got restarted because of any issue.

By default, this code don't fail any torpedo test when it find portworx pods restarted.  

Flag `fail-on-px-pod-restartcount` is added to fail the test when this code detect portworx pod restart during test.

Codes take care of any tests injection operations (Node reboot/Kill portworx service) which makes portworx pod restart 

**Which issue(s) this PR fixes** (optional)
Closes # PTX-12246

**Special notes for your reviewer**:
https://jenkins.pwx.dev.purestorage.com/job/Dev/job/torpedo-dev03/48/

