### PR TITLE
PWX-27277: a single test binary per torpedo container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,16 @@ script:
 after_success:
   - if [ "${TRAVIS_BRANCH}" == "master" ] && [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
       echo "${DOCKER_PASS}" | docker login -u="${DOCKER_USER}" --password-stdin;
+      # build basic.test container
       make container;
-      sudo docker tag "${DOCKER_HUB_REPO}/${DOCKER_HUB_TORPEDO_IMAGE}:${DOCKER_HUB_TAG}" "${DOCKER_HUB_REPO}/${DOCKER_HUB_TORPEDO_IMAGE}:${TRAVIS_BRANCH}";
-      sudo docker push "${DOCKER_HUB_REPO}/${DOCKER_HUB_TORPEDO_IMAGE}:${DOCKER_HUB_TAG}";
-      sudo docker push "${DOCKER_HUB_REPO}/${DOCKER_HUB_TORPEDO_IMAGE}:${TRAVIS_BRANCH}";
+      sudo docker tag "${DOCKER_HUB_REPO}/torpedo:${DOCKER_HUB_TAG}" "${DOCKER_HUB_REPO}/torpedo:${TRAVIS_BRANCH}";
+      sudo docker push "${DOCKER_HUB_REPO}/torpedo:${DOCKER_HUB_TAG}";
+      sudo docker push "${DOCKER_HUB_REPO}/torpedo:${TRAVIS_BRANCH}";
+      # build pds.test container
+      make container-pds;
+      sudo docker tag "${DOCKER_HUB_REPO}/torpedo-pds:${DOCKER_HUB_TAG}" "${DOCKER_HUB_REPO}/torpedo-pds:${TRAVIS_BRANCH}";
+      sudo docker push "${DOCKER_HUB_REPO}/torpedo-pds:${DOCKER_HUB_TAG}";
+      sudo docker push "${DOCKER_HUB_REPO}/torpedo-pds:${TRAVIS_BRANCH}";
     fi
 notifications:
   email:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.16.7-alpine AS build
 LABEL maintainer="harsh@portworx.com"
-ARG ginkgo_build_one
+ARG MAKE_TARGET
 
 WORKDIR /go/src/github.com/portworx/torpedo
 
@@ -34,7 +34,7 @@ COPY .git .git
 COPY tests tests
 
 # Compile
-RUN --mount=type=cache,target=/root/.cache/go-build GINKGO_BUILD_ONE=$ginkgo_build_one make build
+RUN --mount=type=cache,target=/root/.cache/go-build make $MAKE_TARGET
 
 # Build a fresh container with just the binaries
 FROM alpine

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,19 @@
-TORPEDO_IMG=$(DOCKER_HUB_REPO)/$(DOCKER_HUB_TORPEDO_IMAGE):$(DOCKER_HUB_TAG)
+# Rule of thumb (to prevent huge containers):
+#	A single torpedo container should contain only one test binary.
+#
+# make {build|container}:
+#	create basic.test binary/container (<repo>/torpedo:<tag>)
+#
+# make {build-pds|container-pds}:
+#	 create pds.test binary/container (<repo>/torpedo-pds:<tag>)
+#
+# make all:
+#	 verify that all test binaries build successfully
+#
+# Note that DOCKER_HUB_TORPEDO_IMAGE environment variable is not used since
+# it is set automatically depending on which binary is being built.
+#
+
 .PHONY: vendor
 
 export GO111MODULE=on
@@ -16,12 +31,6 @@ endif
 ifndef PKGS
 # shell does not honor export command above, so we need to explicitly pass GOFLAGS here
 PKGS := $(shell GOFLAGS=-mod=vendor go list ./... 2>&1 | grep -v 'github.com/portworx/torpedo/tests')
-endif
-
-# To build just one test binary, use GINKGO_BUILD_ONE=<name> e.g. GINKGO_BUILD_ONE=basic make build
-GINKGO_BUILD_DIR=./tests/
-ifdef GINKGO_BUILD_ONE
-	GINKGO_BUILD_DIR=./tests/$(GINKGO_BUILD_ONE)
 endif
 
 ifeq ($(BUILD_TYPE),debug)
@@ -42,7 +51,7 @@ PGBENCH_IMG=$(DOCKER_HUB_REPO)/torpedo-pgbench:latest
 ESLOAD_IMG=$(DOCKER_HUB_REPO)/torpedo-esload:latest
 
 
-all: vet build fmt
+all: vet build build-pds fmt
 
 deps:
 	go get -d -v $(PKGS)
@@ -64,12 +73,23 @@ fmt:
 $(GOPATH)/bin/ginkgo:
 	GOFLAGS= GO111MODULE=on go install github.com/onsi/ginkgo/ginkgo@v1.16.5
 
+# this target builds the basic.test binary only. Use build-pds for pds.test binary.
+build: GINKGO_BUILD_DIR=./tests/basic
 build: $(GOPATH)/bin/ginkgo
 	mkdir -p $(BIN)
 	go build -tags "$(TAGS)" $(BUILDFLAGS) $(PKGS)
 
 	ginkgo build -r $(GINKGO_BUILD_DIR)
+	find $(GINKGO_BUILD_DIR) -name '*.test' | awk '{cmd="cp  "$$1"  $(BIN)"; system(cmd)}'
+	chmod -R 755 bin/*
 
+# this target builds the pds.test binary only.
+build-pds: GINKGO_BUILD_DIR=./tests/pds
+build-pds: $(GOPATH)/bin/ginkgo
+	mkdir -p $(BIN)
+	go build -tags "$(TAGS)" $(BUILDFLAGS) $(PKGS)
+
+	ginkgo build -r $(GINKGO_BUILD_DIR)
 	find $(GINKGO_BUILD_DIR) -name '*.test' | awk '{cmd="cp  "$$1"  $(BIN)"; system(cmd)}'
 	chmod -R 755 bin/*
 
@@ -106,18 +126,33 @@ pretest: vet errcheck
 test:
 	go test -tags "$(TAGS)" $(TESTFLAGS) $(PKGS)
 
+# this target builds a container with test.basic binary only. Repo is hardcoded to ".../torpedo".
+container: TORPEDO_IMG=$(DOCKER_HUB_REPO)/torpedo:$(DOCKER_HUB_TAG)
 container:
-	@echo "Building container: docker build --tag $(TORPEDO_IMG) --build-arg ginkgo_build_one=$(GINKGO_BUILD_ONE) -f Dockerfile ."
-	sudo DOCKER_BUILDKIT=1 docker build --tag $(TORPEDO_IMG) --build-arg ginkgo_build_one=$(GINKGO_BUILD_ONE) -f Dockerfile .
+	@echo "Building basic.test container "$(TORPEDO_IMG)
+	sudo DOCKER_BUILDKIT=1 docker build --tag $(TORPEDO_IMG) --build-arg MAKE_TARGET=build -f Dockerfile .
 
+# this target builds a container with test.pds binary only. Repo is hardcoded to ".../torpedo-pds".
+container-pds: TORPEDO_IMG=$(DOCKER_HUB_REPO)/torpedo-pds:$(DOCKER_HUB_TAG)
+container-pds:
+	@echo "Building pds.test container "$(TORPEDO_IMG)
+	sudo DOCKER_BUILDKIT=1 docker build --tag $(TORPEDO_IMG) --build-arg MAKE_TARGET=build-pds -f Dockerfile .
+
+deploy: TORPEDO_IMG=$(DOCKER_HUB_REPO)/torpedo:$(DOCKER_HUB_TAG)
 deploy: container
+	sudo docker push $(TORPEDO_IMG)
+
+deploy-pds: TORPEDO_IMG=$(DOCKER_HUB_REPO)/torpedo-pds:$(DOCKER_HUB_TAG)
+deploy-pds: container-pds
 	sudo docker push $(TORPEDO_IMG)
 
 clean:
 	-sudo rm -rf bin
 	-sudo find . -type f -name "*.test" -delete
-	@echo "Deleting image "$(TORPEDO_IMG)
-	-docker rmi -f $(TORPEDO_IMG)
+	@echo "Deleting basic image"
+	-docker rmi -f $(DOCKER_HUB_REPO)/torpedo:$(DOCKER_HUB_TAG)
+	@echo "Deleting pds image"
+	-docker rmi -f $(DOCKER_HUB_REPO)/torpedo-pds:$(DOCKER_HUB_TAG)
 	go clean -i $(PKGS)
 
 sidecar: sidecar-wp-cli


### PR DESCRIPTION
**What this PR does / why we need it**:

We have combined all related tests into tests/basic directory. There is still a separate directory for pds tests since those tests are substantially different.

This commit enforces a rule that one torpedo container will include only one test binary. For example,

- portworx/torpedo:master will contain only basic.test
- portworx/torpedo-pds:master will contain only pds.test

This will ensure that the container size will not balloon up again as people add more test directories such as pxbackup, mpxe etc.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->


**Which issue(s) this PR fixes** (optional)
PWX-27277

**Special notes for your reviewer**:

