### PR TITLE
Adding autopilot rebalance test for longevity

### DIFF
--- a/drivers/volume/common.go
+++ b/drivers/volume/common.go
@@ -873,3 +873,19 @@ func (d *DefaultDriver) AddBlockDrives(n *node.Node, drivePath []string) error {
 		Operation: "AddBlockDrives()",
 	}
 }
+
+// GetRebalanceJobs returns the list of rebalance jobs
+func (d *DefaultDriver) GetRebalanceJobs() ([]*api.StorageRebalanceJob, error) {
+	return nil, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "GetRebalanceJobs()",
+	}
+}
+
+// GetRebalanceJobStatus returns the rebalance jobs response
+func (d *DefaultDriver) GetRebalanceJobStatus(jobID string) (*api.SdkGetRebalanceJobStatusResponse, error) {
+	return nil, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "GetRebalanceJobStatus()",
+	}
+}

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -4462,6 +4462,20 @@ func waitForAddDriveToComplete(n node.Node, drivePath string, d *portworx) error
 
 }
 
+// GetRebalanceJobs returns the list of rebalance jobs
+func (d *portworx) GetRebalanceJobs() ([]*api.StorageRebalanceJob, error) {
+	jobsResp, err := d.storagePoolManager.EnumerateRebalanceJobs(d.getContext(), &api.SdkEnumerateRebalanceJobsRequest{})
+	if err != nil {
+		return nil, err
+	}
+	return jobsResp.GetJobs(), nil
+}
+
+// GetRebalanceJobStatus returns the rebalance jobs response
+func (d *portworx) GetRebalanceJobStatus(jobID string) (*api.SdkGetRebalanceJobStatusResponse, error) {
+	return d.storagePoolManager.GetRebalanceJobStatus(d.getContext(), &api.SdkGetRebalanceJobStatusRequest{Id: jobID})
+}
+
 func init() {
 	torpedovolume.Register(DriverName, provisioners, &portworx{})
 	torpedovolume.Register(PureDriverName, csiProvisionerOnly, &pure{portworx: portworx{}})

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -354,6 +354,12 @@ type Driver interface {
 
 	// AddBlockDrives add drives to the node using PXCTL
 	AddBlockDrives(n *node.Node, drivePath []string) error
+
+	// GetRebalanceJobs returns the list of rebalance jobs
+	GetRebalanceJobs() ([]*api.StorageRebalanceJob, error)
+
+	// GetRebalanceJobStatus returns the rebalance jobs response
+	GetRebalanceJobStatus(jobID string) (*api.SdkGetRebalanceJobStatusResponse, error)
 }
 
 // StorageProvisionerType provisioner to be used for torpedo volumes

--- a/pkg/aututils/aututils.go
+++ b/pkg/aututils/aututils.go
@@ -417,7 +417,7 @@ func WaitForActionApprovalsObjects(namespace, name string) error {
 func PoolRuleRebalanceAbsolute(provisionedValLimit, usedValLimit int, approvalRequired bool) apapi.AutopilotRule {
 	apRuleObject := apapi.AutopilotRule{
 		ObjectMeta: meta_v1.ObjectMeta{
-			Name: fmt.Sprintf("pool-rebalance-absolute-prov-%d-used=%d", provisionedValLimit, usedValLimit),
+			Name: fmt.Sprintf("pool-rebalance-absolute-prov-%d-used-%d", provisionedValLimit, usedValLimit),
 		},
 		Spec: apapi.AutopilotRuleSpec{
 			Conditions: apapi.RuleConditions{

--- a/pkg/aututils/aututils.go
+++ b/pkg/aututils/aututils.go
@@ -32,6 +32,10 @@ const (
 	PxVolumeUsagePercentMetric = "100 * (px_volume_usage_bytes / px_volume_capacity_bytes)"
 	// PxVolumeTotalCapacityMetric is metric for total volume capacity
 	PxVolumeTotalCapacityMetric = "px_volume_capacity_bytes / 1000000000"
+	//PXPoolProvisionedSpaceMetric is metric for pool provisioned space
+	PXPoolProvisionedSpaceMetric = "100 * (px_pool_stats_provisioned_bytes/ on (pool) px_pool_stats_total_bytes)"
+	//PXPoolUsedSpaceMetric is metric for pool used space
+	PXPoolUsedSpaceMetric = "100 * (px_pool_stats_used_bytes/ on (pool) px_pool_stats_total_bytes)"
 	// RuleActionsScalePercentage is name for scale percentage rule action
 	RuleActionsScalePercentage = "scalepercentage"
 	// RuleActionsScaleSize is name for scale size rule action
@@ -406,4 +410,39 @@ func WaitForActionApprovalsObjects(namespace, name string) error {
 		return err
 	}
 	return nil
+}
+
+// PoolRuleRebalanceAbsolute returns an autopilot pool rebalance rule that
+// uses provisioned and used stats deviation percentage alias key
+func PoolRuleRebalanceAbsolute(provisionedValLimit, usedValLimit int, approvalRequired bool) apapi.AutopilotRule {
+	apRuleObject := apapi.AutopilotRule{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: fmt.Sprintf("pool-rebalance-absolute-prov-%d-used=%d", provisionedValLimit, usedValLimit),
+		},
+		Spec: apapi.AutopilotRuleSpec{
+			Conditions: apapi.RuleConditions{
+				Expressions: []*apapi.LabelSelectorRequirement{
+					{
+						Key:      PXPoolProvisionedSpaceMetric,
+						Operator: apapi.LabelSelectorOpGt,
+						Values:   []string{fmt.Sprintf("%d", provisionedValLimit)},
+					},
+					{
+						Key:      PXPoolUsedSpaceMetric,
+						Operator: apapi.LabelSelectorOpGt,
+						Values:   []string{fmt.Sprintf("%d", usedValLimit)},
+					},
+				},
+			},
+			Actions: []*apapi.RuleAction{
+				{
+					Name: RebalanceSpecAction,
+				},
+			},
+		},
+	}
+	if approvalRequired {
+		apRuleObject.Spec.Enforcement = apapi.ApprovalRequired
+	}
+	return apRuleObject
 }

--- a/pkg/restutil/restutil.go
+++ b/pkg/restutil/restutil.go
@@ -139,10 +139,10 @@ func setBasicAuthAndHeaders(req *http.Request, auth *Auth, headers map[string]st
 }
 
 func getBody(rBody io.ReadCloser) ([]byte, error) {
-	log.Debugf("Response: %v", rBody)
 	respBody, err := ioutil.ReadAll(rBody)
 	if err != nil {
 		return nil, err
 	}
+	log.Debugf("Response: %s", string(respBody))
 	return respBody, nil
 }

--- a/tests/basic/basic_test.go
+++ b/tests/basic/basic_test.go
@@ -59,9 +59,9 @@ var _ = BeforeSuite(func() {
 
 var _ = AfterSuite(func() {
 	f = CreateLogFile("SystemCheck.log")
-	defer dash.TestCaseEnd()
-	defer CloseLogFile(f)
 	defer dash.TestSetEnd()
+	defer CloseLogFile(f)
+	defer dash.TestCaseEnd()
 	if f != nil {
 		SetTorpedoFileOutput(log, f)
 	}

--- a/tests/basic/longevity_test.go
+++ b/tests/basic/longevity_test.go
@@ -93,6 +93,7 @@ var _ = Describe("{Longevity}", func() {
 		HAIncreaseAndReboot:  TriggerHAIncreaseAndReboot,
 		AddDiskAndReboot:     TriggerPoolAddDiskAndReboot,
 		ResizeDiskAndReboot:  TriggerPoolResizeDiskAndReboot,
+		AutopilotRebalance:   TriggerAutopilotPoolRebalance,
 	}
 	//Creating a distinct trigger to make sure email triggers at regular intervals
 	emailTriggerFunction = map[string]func(){
@@ -578,6 +579,7 @@ func populateIntervals() {
 	triggerInterval[AddDrive] = make(map[int]time.Duration)
 	triggerInterval[AddDiskAndReboot] = make(map[int]time.Duration)
 	triggerInterval[ResizeDiskAndReboot] = make(map[int]time.Duration)
+	triggerInterval[AutopilotRebalance] = make(map[int]time.Duration)
 
 	baseInterval := 10 * time.Minute
 	triggerInterval[BackupScaleMongo][10] = 1 * baseInterval
@@ -1038,6 +1040,17 @@ func populateIntervals() {
 	triggerInterval[ResizeDiskAndReboot][2] = 24 * baseInterval
 	triggerInterval[ResizeDiskAndReboot][1] = 30 * baseInterval
 
+	triggerInterval[AutopilotRebalance][10] = 1 * baseInterval
+	triggerInterval[AutopilotRebalance][9] = 3 * baseInterval
+	triggerInterval[AutopilotRebalance][8] = 6 * baseInterval
+	triggerInterval[AutopilotRebalance][7] = 9 * baseInterval
+	triggerInterval[AutopilotRebalance][6] = 12 * baseInterval
+	triggerInterval[AutopilotRebalance][5] = 15 * baseInterval
+	triggerInterval[AutopilotRebalance][4] = 18 * baseInterval
+	triggerInterval[AutopilotRebalance][3] = 21 * baseInterval
+	triggerInterval[AutopilotRebalance][2] = 24 * baseInterval
+	triggerInterval[AutopilotRebalance][1] = 27 * baseInterval
+
 	baseInterval = 300 * time.Minute
 
 	triggerInterval[UpgradeStork][10] = 1 * baseInterval
@@ -1171,6 +1184,7 @@ func populateIntervals() {
 	triggerInterval[AddDrive][0] = 0
 	triggerInterval[AddDiskAndReboot][0] = 0
 	triggerInterval[ResizeDiskAndReboot][0] = 0
+	triggerInterval[AutopilotRebalance][0] = 0
 }
 
 func isTriggerEnabled(triggerType string) (time.Duration, bool) {

--- a/tests/basic/sharedv4_test.go
+++ b/tests/basic/sharedv4_test.go
@@ -1,232 +1,232 @@
 package tests
 
-import (
-	"fmt"
-	"regexp"
-	"strings"
-	"time"
-
-	"github.com/libopenstorage/openstorage/pkg/mount"
-	"github.com/portworx/sched-ops/k8s/apps"
-	"github.com/portworx/torpedo/drivers/node"
-	"github.com/portworx/torpedo/drivers/scheduler"
-	"github.com/portworx/torpedo/pkg/testrailuttils"
-	"github.com/sirupsen/logrus"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/portworx/torpedo/tests"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-)
-
-const (
-	devicePathPrefix = "/dev/pxd/pxd"
-)
-
-var _ = Describe("{Sharedv4Functional}", func() {
-	var testrailID, runID int
-	var contexts, testSharedV4Contexts []*scheduler.Context
-	var workers []node.Node
-	var numPods int
-	var namespacePrefix string
-	var volumeMountRW = regexp.MustCompile(`,rw,|,rw|rw,|rw`)
-	var volumeMountRO = regexp.MustCompile(`,ro,|,ro|ro,|ro`)
-
-	JustBeforeEach(func() {
-		runID = testrailuttils.AddRunsToMilestone(testrailID)
-
-		// Set up all apps
-		contexts = nil
-		for i := 0; i < Inst().GlobalScaleFactor; i++ {
-			contexts = append(contexts, ScheduleApplications(fmt.Sprintf("%s-%d", namespacePrefix, i))...)
-		}
-
-		// Skip the test if there are no test-sharedv4 apps
-		testSharedV4Contexts = getTestSharedV4Contexts(contexts)
-		if len(testSharedV4Contexts) == 0 {
-			Skip("No test-sharedv4 apps were found")
-		}
-		workers = node.GetWorkerNodes()
-		numPods = len(workers)
-
-		Step("scale the test-sharedv4 apps so that one pod runs on each worker node", func() {
-			scaleApps(testSharedV4Contexts, numPods)
-		})
-		ValidateApplications(contexts)
-	})
-
-	Context("{SharedV4MountRecovery}", func() {
-		BeforeEach(func() {
-			namespacePrefix = "sharedv4mountrecovery"
-		})
-
-		JustBeforeEach(func() {
-			for _, ctx := range testSharedV4Contexts {
-				k8sApps := apps.Instance()
-				// we are removing the anti-affinity rule to force the race condition in testing.
-				// without anti-affinity rule, pods creating and terminating can happen at the same time, causing
-				// pods can mount on vols that are about to be detached/unmounted. Anti-affinity rule
-				// forced creating pods to wait for terminating pods due to one pod per node IP restriction.
-				Step(
-					fmt.Sprintf("setup app %s to remove anti-affinity rules", ctx.App.Key),
-					func() {
-
-						Step(fmt.Sprintf("update %s deployment without anti-affinity", ctx.App.Key), func() {
-							deployments, err := k8sApps.ListDeployments(ctx.GetID(), metav1.ListOptions{})
-							Expect(err).NotTo(HaveOccurred())
-							deployment := deployments.Items[0]
-							deployment.Spec.Template.Spec.Affinity = nil
-
-							_, err = k8sApps.UpdateDeployment(&deployment)
-							Expect(err).NotTo(HaveOccurred())
-						})
-
-						Step(fmt.Sprintf("scale down app: %s to 0 ", ctx.App.Key), func() {
-							scaleApp(ctx, 0)
-						})
-
-						// wait until all pods are gone
-						Step(fmt.Sprintf("wait for app %s to have 0 pods", ctx.App.Key), func() {
-							waitForNumPodsToEqual(ctx, 0)
-						})
-
-						Step(fmt.Sprintf("scale the app back to numPods for %s", ctx.App.Key), func() {
-							scaleApp(ctx, numPods)
-
-							ValidateContext(ctx)
-						})
-
-					})
-			}
-
-		})
-
-		It("should set device path to RO and validate recovery", func() {
-			for _, ctx := range testSharedV4Contexts {
-				var err error
-				vol, apiVol, attachedNode := getSv4TestAppVol(ctx)
-				counterCollectionInterval := 3 * time.Duration(numPods) * time.Second
-				devicePath := fmt.Sprintf("%s%s", devicePathPrefix, apiVol.Id)
-
-				// In porx, we check the export path is read-only when it is previously RO and
-				// changed to RW by fs due to occuring error. Specifically, when mnt.Opts (default)
-				// is RW and mnt.VfsOpts (fs state) is RO.
-				// By setting device path to RO, we mock the same behavior. Check state in
-				// `/proc/self/mountinfo`
-				Step(fmt.Sprintf("mark device path as RO %s", ctx.App.Key), func() {
-					setPathToROMode(devicePath, attachedNode)
-
-					// check only mnt.VfsOpts (fs state) is RO
-					mntList, err := mount.GetMounts()
-					Expect(err).NotTo(HaveOccurred())
-					for _, mnt := range mntList {
-						if mnt.Mountpoint != devicePath {
-							continue
-						}
-						Expect(volumeMountRW.MatchString(mnt.Opts)).To(BeTrue())
-						Expect(volumeMountRO.MatchString(mnt.VfsOpts)).To(BeTrue())
-					}
-				})
-
-				Step(fmt.Sprintf("validate the counters are inactive %s", ctx.App.Key), func() {
-					counters := getAppCounters(apiVol, attachedNode, counterCollectionInterval)
-					activePods := getActivePods(counters)
-					Expect(len(activePods)).To(Equal(0))
-				})
-
-				Step(fmt.Sprintf("restart vol driver %s", ctx.App.Key), func() {
-					restartVolumeDriverOnNode(attachedNode)
-					ValidateContext(ctx)
-					// updates the attachedNode; sometimes the volume is moved when restart to fix the readonly volume
-					attachedNode, err = Inst().V.GetNodeForVolume(vol, cmdTimeout, cmdRetry)
-					Expect(err).NotTo(HaveOccurred())
-				})
-
-				Step(fmt.Sprintf("validate counter are active for %s", ctx.App.Key), func() {
-					var counters map[string]appCounter
-					// we are seeing a case where the application is validated and running but sharedv4 volume is
-					// not mounted/exported yet. adding the eventually here to retry to make sure we capture the
-					// counters correctly. Setting timeout of 5 minutes for now as mounting and exporting
-					// shouldn't take that long.
-					Eventually(func() bool {
-						counters = getAppCounters(apiVol, attachedNode, counterCollectionInterval)
-						activePods := getActivePods(counters)
-						return (len(activePods) == numPods)
-					}, 5*time.Minute, 20*time.Second).Should(BeTrue(),
-						"number of active keys did not match for volume %v (%v) for app %v. counters map: %v",
-						vol.ID, apiVol.Id, ctx.App.Key, counters)
-				})
-
-				Step(fmt.Sprintf("validate device path is set as RW for %s", ctx.App.Key), func() {
-					mntList, err := mount.GetMounts()
-					Expect(err).NotTo(HaveOccurred())
-
-					for _, mnt := range mntList {
-						if mnt.Mountpoint != devicePath {
-							continue
-						}
-						Expect(volumeMountRW.MatchString(mnt.Opts)).To(BeTrue())
-						Expect(volumeMountRW.MatchString(mnt.VfsOpts)).To(BeTrue())
-					}
-				})
-			}
-		})
-	})
-
-	// Template for additional tests
-	// Context("{}", func() {
-	// 	BeforeEach(func() {
-	// 		testrailID = 0
-	//      namespacePrefix = ""
-	// 	})
-	//
-	// 	JustBeforeEach(func() {
-	//		// since the apps are deployed by JustBeforeEach in the outer block,
-	// 		// any test-specific changes to the deployed apps should go here.
-	// 	})
-	//
-	// 	It("", func() {
-	// 		for _, ctx := range testSharedV4Contexts {
-	// 		}
-	// 	})
-
-	// 	AfterEach(func() {
-	// 	})
-	// })
-
-	AfterEach(func() {
-		Step("destroy apps", func() {
-			if CurrentGinkgoTestDescription().Failed {
-				logrus.Info("not destroying apps because the test failed\n")
-				return
-			}
-			for _, ctx := range contexts {
-				TearDownContext(ctx, map[string]bool{scheduler.OptionsWaitForResourceLeakCleanup: true})
-			}
-		})
-	})
-
-	JustAfterEach(func() {
-		AfterEachTest(contexts, testrailID, runID)
-	})
-})
-
-// returns the contexts that are running test-sharedv4* apps
-func getTestSharedV4Contexts(contexts []*scheduler.Context) []*scheduler.Context {
-	var testSharedV4Contexts []*scheduler.Context
-	for _, ctx := range contexts {
-		if !strings.HasPrefix(ctx.App.Key, "test-sharedv4") {
-			continue
-		}
-		testSharedV4Contexts = append(testSharedV4Contexts, ctx)
-	}
-	return testSharedV4Contexts
-}
-
-// set the given path to ro
-func setPathToROMode(path string, node *node.Node) {
-	cmd := fmt.Sprintf("mount -oremount,ro %s", path)
-	_, err := runCmd(cmd, *node)
-
-	Expect(err).NotTo(HaveOccurred())
-}
+//import (
+//	"fmt"
+//	"regexp"
+//	"strings"
+//	"time"
+//
+//	"github.com/libopenstorage/openstorage/pkg/mount"
+//	"github.com/portworx/sched-ops/k8s/apps"
+//	"github.com/portworx/torpedo/drivers/node"
+//	"github.com/portworx/torpedo/drivers/scheduler"
+//	"github.com/portworx/torpedo/pkg/testrailuttils"
+//	"github.com/sirupsen/logrus"
+//
+//	. "github.com/onsi/ginkgo"
+//	. "github.com/onsi/gomega"
+//	. "github.com/portworx/torpedo/tests"
+//	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+//)
+//
+//const (
+//	devicePathPrefix = "/dev/pxd/pxd"
+//)
+//
+//var _ = Describe("{Sharedv4Functional}", func() {
+//	var testrailID, runID int
+//	var contexts, testSharedV4Contexts []*scheduler.Context
+//	var workers []node.Node
+//	var numPods int
+//	var namespacePrefix string
+//	var volumeMountRW = regexp.MustCompile(`,rw,|,rw|rw,|rw`)
+//	var volumeMountRO = regexp.MustCompile(`,ro,|,ro|ro,|ro`)
+//
+//	JustBeforeEach(func() {
+//		runID = testrailuttils.AddRunsToMilestone(testrailID)
+//
+//		// Set up all apps
+//		contexts = nil
+//		for i := 0; i < Inst().GlobalScaleFactor; i++ {
+//			contexts = append(contexts, ScheduleApplications(fmt.Sprintf("%s-%d", namespacePrefix, i))...)
+//		}
+//
+//		// Skip the test if there are no test-sharedv4 apps
+//		testSharedV4Contexts = getTestSharedV4Contexts(contexts)
+//		if len(testSharedV4Contexts) == 0 {
+//			Skip("No test-sharedv4 apps were found")
+//		}
+//		workers = node.GetWorkerNodes()
+//		numPods = len(workers)
+//
+//		Step("scale the test-sharedv4 apps so that one pod runs on each worker node", func() {
+//			scaleApps(testSharedV4Contexts, numPods)
+//		})
+//		ValidateApplications(contexts)
+//	})
+//
+//	Context("{SharedV4MountRecovery}", func() {
+//		BeforeEach(func() {
+//			namespacePrefix = "sharedv4mountrecovery"
+//		})
+//
+//		JustBeforeEach(func() {
+//			for _, ctx := range testSharedV4Contexts {
+//				k8sApps := apps.Instance()
+//				// we are removing the anti-affinity rule to force the race condition in testing.
+//				// without anti-affinity rule, pods creating and terminating can happen at the same time, causing
+//				// pods can mount on vols that are about to be detached/unmounted. Anti-affinity rule
+//				// forced creating pods to wait for terminating pods due to one pod per node IP restriction.
+//				Step(
+//					fmt.Sprintf("setup app %s to remove anti-affinity rules", ctx.App.Key),
+//					func() {
+//
+//						Step(fmt.Sprintf("update %s deployment without anti-affinity", ctx.App.Key), func() {
+//							deployments, err := k8sApps.ListDeployments(ctx.GetID(), metav1.ListOptions{})
+//							Expect(err).NotTo(HaveOccurred())
+//							deployment := deployments.Items[0]
+//							deployment.Spec.Template.Spec.Affinity = nil
+//
+//							_, err = k8sApps.UpdateDeployment(&deployment)
+//							Expect(err).NotTo(HaveOccurred())
+//						})
+//
+//						Step(fmt.Sprintf("scale down app: %s to 0 ", ctx.App.Key), func() {
+//							scaleApp(ctx, 0)
+//						})
+//
+//						// wait until all pods are gone
+//						Step(fmt.Sprintf("wait for app %s to have 0 pods", ctx.App.Key), func() {
+//							waitForNumPodsToEqual(ctx, 0)
+//						})
+//
+//						Step(fmt.Sprintf("scale the app back to numPods for %s", ctx.App.Key), func() {
+//							scaleApp(ctx, numPods)
+//
+//							ValidateContext(ctx)
+//						})
+//
+//					})
+//			}
+//
+//		})
+//
+//		It("should set device path to RO and validate recovery", func() {
+//			for _, ctx := range testSharedV4Contexts {
+//				var err error
+//				vol, apiVol, attachedNode := getSv4TestAppVol(ctx)
+//				counterCollectionInterval := 3 * time.Duration(numPods) * time.Second
+//				devicePath := fmt.Sprintf("%s%s", devicePathPrefix, apiVol.Id)
+//
+//				// In porx, we check the export path is read-only when it is previously RO and
+//				// changed to RW by fs due to occuring error. Specifically, when mnt.Opts (default)
+//				// is RW and mnt.VfsOpts (fs state) is RO.
+//				// By setting device path to RO, we mock the same behavior. Check state in
+//				// `/proc/self/mountinfo`
+//				Step(fmt.Sprintf("mark device path as RO %s", ctx.App.Key), func() {
+//					setPathToROMode(devicePath, attachedNode)
+//
+//					// check only mnt.VfsOpts (fs state) is RO
+//					mntList, err := mount.GetMounts()
+//					Expect(err).NotTo(HaveOccurred())
+//					for _, mnt := range mntList {
+//						if mnt.Mountpoint != devicePath {
+//							continue
+//						}
+//						Expect(volumeMountRW.MatchString(mnt.Opts)).To(BeTrue())
+//						Expect(volumeMountRO.MatchString(mnt.VfsOpts)).To(BeTrue())
+//					}
+//				})
+//
+//				Step(fmt.Sprintf("validate the counters are inactive %s", ctx.App.Key), func() {
+//					counters := getAppCounters(apiVol, attachedNode, counterCollectionInterval)
+//					activePods := getActivePods(counters)
+//					Expect(len(activePods)).To(Equal(0))
+//				})
+//
+//				Step(fmt.Sprintf("restart vol driver %s", ctx.App.Key), func() {
+//					restartVolumeDriverOnNode(attachedNode)
+//					ValidateContext(ctx)
+//					// updates the attachedNode; sometimes the volume is moved when restart to fix the readonly volume
+//					attachedNode, err = Inst().V.GetNodeForVolume(vol, cmdTimeout, cmdRetry)
+//					Expect(err).NotTo(HaveOccurred())
+//				})
+//
+//				Step(fmt.Sprintf("validate counter are active for %s", ctx.App.Key), func() {
+//					var counters map[string]appCounter
+//					// we are seeing a case where the application is validated and running but sharedv4 volume is
+//					// not mounted/exported yet. adding the eventually here to retry to make sure we capture the
+//					// counters correctly. Setting timeout of 5 minutes for now as mounting and exporting
+//					// shouldn't take that long.
+//					Eventually(func() bool {
+//						counters = getAppCounters(apiVol, attachedNode, counterCollectionInterval)
+//						activePods := getActivePods(counters)
+//						return (len(activePods) == numPods)
+//					}, 5*time.Minute, 20*time.Second).Should(BeTrue(),
+//						"number of active keys did not match for volume %v (%v) for app %v. counters map: %v",
+//						vol.ID, apiVol.Id, ctx.App.Key, counters)
+//				})
+//
+//				Step(fmt.Sprintf("validate device path is set as RW for %s", ctx.App.Key), func() {
+//					mntList, err := mount.GetMounts()
+//					Expect(err).NotTo(HaveOccurred())
+//
+//					for _, mnt := range mntList {
+//						if mnt.Mountpoint != devicePath {
+//							continue
+//						}
+//						Expect(volumeMountRW.MatchString(mnt.Opts)).To(BeTrue())
+//						Expect(volumeMountRW.MatchString(mnt.VfsOpts)).To(BeTrue())
+//					}
+//				})
+//			}
+//		})
+//	})
+//
+//	// Template for additional tests
+//	// Context("{}", func() {
+//	// 	BeforeEach(func() {
+//	// 		testrailID = 0
+//	//      namespacePrefix = ""
+//	// 	})
+//	//
+//	// 	JustBeforeEach(func() {
+//	//		// since the apps are deployed by JustBeforeEach in the outer block,
+//	// 		// any test-specific changes to the deployed apps should go here.
+//	// 	})
+//	//
+//	// 	It("", func() {
+//	// 		for _, ctx := range testSharedV4Contexts {
+//	// 		}
+//	// 	})
+//
+//	// 	AfterEach(func() {
+//	// 	})
+//	// })
+//
+//	AfterEach(func() {
+//		Step("destroy apps", func() {
+//			if CurrentGinkgoTestDescription().Failed {
+//				logrus.Info("not destroying apps because the test failed\n")
+//				return
+//			}
+//			for _, ctx := range contexts {
+//				TearDownContext(ctx, map[string]bool{scheduler.OptionsWaitForResourceLeakCleanup: true})
+//			}
+//		})
+//	})
+//
+//	JustAfterEach(func() {
+//		AfterEachTest(contexts, testrailID, runID)
+//	})
+//})
+//
+//// returns the contexts that are running test-sharedv4* apps
+//func getTestSharedV4Contexts(contexts []*scheduler.Context) []*scheduler.Context {
+//	var testSharedV4Contexts []*scheduler.Context
+//	for _, ctx := range contexts {
+//		if !strings.HasPrefix(ctx.App.Key, "test-sharedv4") {
+//			continue
+//		}
+//		testSharedV4Contexts = append(testSharedV4Contexts, ctx)
+//	}
+//	return testSharedV4Contexts
+//}
+//
+//// set the given path to ro
+//func setPathToROMode(path string, node *node.Node) {
+//	cmd := fmt.Sprintf("mount -oremount,ro %s", path)
+//	_, err := runCmd(cmd, *node)
+//
+//	Expect(err).NotTo(HaveOccurred())
+//}

--- a/tests/basic/sharedv4_test.go
+++ b/tests/basic/sharedv4_test.go
@@ -1,232 +1,232 @@
 package tests
 
-//import (
-//	"fmt"
-//	"regexp"
-//	"strings"
-//	"time"
-//
-//	"github.com/libopenstorage/openstorage/pkg/mount"
-//	"github.com/portworx/sched-ops/k8s/apps"
-//	"github.com/portworx/torpedo/drivers/node"
-//	"github.com/portworx/torpedo/drivers/scheduler"
-//	"github.com/portworx/torpedo/pkg/testrailuttils"
-//	"github.com/sirupsen/logrus"
-//
-//	. "github.com/onsi/ginkgo"
-//	. "github.com/onsi/gomega"
-//	. "github.com/portworx/torpedo/tests"
-//	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-//)
-//
-//const (
-//	devicePathPrefix = "/dev/pxd/pxd"
-//)
-//
-//var _ = Describe("{Sharedv4Functional}", func() {
-//	var testrailID, runID int
-//	var contexts, testSharedV4Contexts []*scheduler.Context
-//	var workers []node.Node
-//	var numPods int
-//	var namespacePrefix string
-//	var volumeMountRW = regexp.MustCompile(`,rw,|,rw|rw,|rw`)
-//	var volumeMountRO = regexp.MustCompile(`,ro,|,ro|ro,|ro`)
-//
-//	JustBeforeEach(func() {
-//		runID = testrailuttils.AddRunsToMilestone(testrailID)
-//
-//		// Set up all apps
-//		contexts = nil
-//		for i := 0; i < Inst().GlobalScaleFactor; i++ {
-//			contexts = append(contexts, ScheduleApplications(fmt.Sprintf("%s-%d", namespacePrefix, i))...)
-//		}
-//
-//		// Skip the test if there are no test-sharedv4 apps
-//		testSharedV4Contexts = getTestSharedV4Contexts(contexts)
-//		if len(testSharedV4Contexts) == 0 {
-//			Skip("No test-sharedv4 apps were found")
-//		}
-//		workers = node.GetWorkerNodes()
-//		numPods = len(workers)
-//
-//		Step("scale the test-sharedv4 apps so that one pod runs on each worker node", func() {
-//			scaleApps(testSharedV4Contexts, numPods)
-//		})
-//		ValidateApplications(contexts)
-//	})
-//
-//	Context("{SharedV4MountRecovery}", func() {
-//		BeforeEach(func() {
-//			namespacePrefix = "sharedv4mountrecovery"
-//		})
-//
-//		JustBeforeEach(func() {
-//			for _, ctx := range testSharedV4Contexts {
-//				k8sApps := apps.Instance()
-//				// we are removing the anti-affinity rule to force the race condition in testing.
-//				// without anti-affinity rule, pods creating and terminating can happen at the same time, causing
-//				// pods can mount on vols that are about to be detached/unmounted. Anti-affinity rule
-//				// forced creating pods to wait for terminating pods due to one pod per node IP restriction.
-//				Step(
-//					fmt.Sprintf("setup app %s to remove anti-affinity rules", ctx.App.Key),
-//					func() {
-//
-//						Step(fmt.Sprintf("update %s deployment without anti-affinity", ctx.App.Key), func() {
-//							deployments, err := k8sApps.ListDeployments(ctx.GetID(), metav1.ListOptions{})
-//							Expect(err).NotTo(HaveOccurred())
-//							deployment := deployments.Items[0]
-//							deployment.Spec.Template.Spec.Affinity = nil
-//
-//							_, err = k8sApps.UpdateDeployment(&deployment)
-//							Expect(err).NotTo(HaveOccurred())
-//						})
-//
-//						Step(fmt.Sprintf("scale down app: %s to 0 ", ctx.App.Key), func() {
-//							scaleApp(ctx, 0)
-//						})
-//
-//						// wait until all pods are gone
-//						Step(fmt.Sprintf("wait for app %s to have 0 pods", ctx.App.Key), func() {
-//							waitForNumPodsToEqual(ctx, 0)
-//						})
-//
-//						Step(fmt.Sprintf("scale the app back to numPods for %s", ctx.App.Key), func() {
-//							scaleApp(ctx, numPods)
-//
-//							ValidateContext(ctx)
-//						})
-//
-//					})
-//			}
-//
-//		})
-//
-//		It("should set device path to RO and validate recovery", func() {
-//			for _, ctx := range testSharedV4Contexts {
-//				var err error
-//				vol, apiVol, attachedNode := getSv4TestAppVol(ctx)
-//				counterCollectionInterval := 3 * time.Duration(numPods) * time.Second
-//				devicePath := fmt.Sprintf("%s%s", devicePathPrefix, apiVol.Id)
-//
-//				// In porx, we check the export path is read-only when it is previously RO and
-//				// changed to RW by fs due to occuring error. Specifically, when mnt.Opts (default)
-//				// is RW and mnt.VfsOpts (fs state) is RO.
-//				// By setting device path to RO, we mock the same behavior. Check state in
-//				// `/proc/self/mountinfo`
-//				Step(fmt.Sprintf("mark device path as RO %s", ctx.App.Key), func() {
-//					setPathToROMode(devicePath, attachedNode)
-//
-//					// check only mnt.VfsOpts (fs state) is RO
-//					mntList, err := mount.GetMounts()
-//					Expect(err).NotTo(HaveOccurred())
-//					for _, mnt := range mntList {
-//						if mnt.Mountpoint != devicePath {
-//							continue
-//						}
-//						Expect(volumeMountRW.MatchString(mnt.Opts)).To(BeTrue())
-//						Expect(volumeMountRO.MatchString(mnt.VfsOpts)).To(BeTrue())
-//					}
-//				})
-//
-//				Step(fmt.Sprintf("validate the counters are inactive %s", ctx.App.Key), func() {
-//					counters := getAppCounters(apiVol, attachedNode, counterCollectionInterval)
-//					activePods := getActivePods(counters)
-//					Expect(len(activePods)).To(Equal(0))
-//				})
-//
-//				Step(fmt.Sprintf("restart vol driver %s", ctx.App.Key), func() {
-//					restartVolumeDriverOnNode(attachedNode)
-//					ValidateContext(ctx)
-//					// updates the attachedNode; sometimes the volume is moved when restart to fix the readonly volume
-//					attachedNode, err = Inst().V.GetNodeForVolume(vol, cmdTimeout, cmdRetry)
-//					Expect(err).NotTo(HaveOccurred())
-//				})
-//
-//				Step(fmt.Sprintf("validate counter are active for %s", ctx.App.Key), func() {
-//					var counters map[string]appCounter
-//					// we are seeing a case where the application is validated and running but sharedv4 volume is
-//					// not mounted/exported yet. adding the eventually here to retry to make sure we capture the
-//					// counters correctly. Setting timeout of 5 minutes for now as mounting and exporting
-//					// shouldn't take that long.
-//					Eventually(func() bool {
-//						counters = getAppCounters(apiVol, attachedNode, counterCollectionInterval)
-//						activePods := getActivePods(counters)
-//						return (len(activePods) == numPods)
-//					}, 5*time.Minute, 20*time.Second).Should(BeTrue(),
-//						"number of active keys did not match for volume %v (%v) for app %v. counters map: %v",
-//						vol.ID, apiVol.Id, ctx.App.Key, counters)
-//				})
-//
-//				Step(fmt.Sprintf("validate device path is set as RW for %s", ctx.App.Key), func() {
-//					mntList, err := mount.GetMounts()
-//					Expect(err).NotTo(HaveOccurred())
-//
-//					for _, mnt := range mntList {
-//						if mnt.Mountpoint != devicePath {
-//							continue
-//						}
-//						Expect(volumeMountRW.MatchString(mnt.Opts)).To(BeTrue())
-//						Expect(volumeMountRW.MatchString(mnt.VfsOpts)).To(BeTrue())
-//					}
-//				})
-//			}
-//		})
-//	})
-//
-//	// Template for additional tests
-//	// Context("{}", func() {
-//	// 	BeforeEach(func() {
-//	// 		testrailID = 0
-//	//      namespacePrefix = ""
-//	// 	})
-//	//
-//	// 	JustBeforeEach(func() {
-//	//		// since the apps are deployed by JustBeforeEach in the outer block,
-//	// 		// any test-specific changes to the deployed apps should go here.
-//	// 	})
-//	//
-//	// 	It("", func() {
-//	// 		for _, ctx := range testSharedV4Contexts {
-//	// 		}
-//	// 	})
-//
-//	// 	AfterEach(func() {
-//	// 	})
-//	// })
-//
-//	AfterEach(func() {
-//		Step("destroy apps", func() {
-//			if CurrentGinkgoTestDescription().Failed {
-//				logrus.Info("not destroying apps because the test failed\n")
-//				return
-//			}
-//			for _, ctx := range contexts {
-//				TearDownContext(ctx, map[string]bool{scheduler.OptionsWaitForResourceLeakCleanup: true})
-//			}
-//		})
-//	})
-//
-//	JustAfterEach(func() {
-//		AfterEachTest(contexts, testrailID, runID)
-//	})
-//})
-//
-//// returns the contexts that are running test-sharedv4* apps
-//func getTestSharedV4Contexts(contexts []*scheduler.Context) []*scheduler.Context {
-//	var testSharedV4Contexts []*scheduler.Context
-//	for _, ctx := range contexts {
-//		if !strings.HasPrefix(ctx.App.Key, "test-sharedv4") {
-//			continue
-//		}
-//		testSharedV4Contexts = append(testSharedV4Contexts, ctx)
-//	}
-//	return testSharedV4Contexts
-//}
-//
-//// set the given path to ro
-//func setPathToROMode(path string, node *node.Node) {
-//	cmd := fmt.Sprintf("mount -oremount,ro %s", path)
-//	_, err := runCmd(cmd, *node)
-//
-//	Expect(err).NotTo(HaveOccurred())
-//}
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/libopenstorage/openstorage/pkg/mount"
+	"github.com/portworx/sched-ops/k8s/apps"
+	"github.com/portworx/torpedo/drivers/node"
+	"github.com/portworx/torpedo/drivers/scheduler"
+	"github.com/portworx/torpedo/pkg/testrailuttils"
+	"github.com/sirupsen/logrus"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/portworx/torpedo/tests"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	devicePathPrefix = "/dev/pxd/pxd"
+)
+
+var _ = Describe("{Sharedv4Functional}", func() {
+	var testrailID, runID int
+	var contexts, testSharedV4Contexts []*scheduler.Context
+	var workers []node.Node
+	var numPods int
+	var namespacePrefix string
+	var volumeMountRW = regexp.MustCompile(`,rw,|,rw|rw,|rw`)
+	var volumeMountRO = regexp.MustCompile(`,ro,|,ro|ro,|ro`)
+
+	JustBeforeEach(func() {
+		runID = testrailuttils.AddRunsToMilestone(testrailID)
+
+		// Set up all apps
+		contexts = nil
+		for i := 0; i < Inst().GlobalScaleFactor; i++ {
+			contexts = append(contexts, ScheduleApplications(fmt.Sprintf("%s-%d", namespacePrefix, i))...)
+		}
+
+		// Skip the test if there are no test-sharedv4 apps
+		testSharedV4Contexts = getTestSharedV4Contexts(contexts)
+		if len(testSharedV4Contexts) == 0 {
+			Skip("No test-sharedv4 apps were found")
+		}
+		workers = node.GetWorkerNodes()
+		numPods = len(workers)
+
+		Step("scale the test-sharedv4 apps so that one pod runs on each worker node", func() {
+			scaleApps(testSharedV4Contexts, numPods)
+		})
+		ValidateApplications(contexts)
+	})
+
+	Context("{SharedV4MountRecovery}", func() {
+		BeforeEach(func() {
+			namespacePrefix = "sharedv4mountrecovery"
+		})
+
+		JustBeforeEach(func() {
+			for _, ctx := range testSharedV4Contexts {
+				k8sApps := apps.Instance()
+				// we are removing the anti-affinity rule to force the race condition in testing.
+				// without anti-affinity rule, pods creating and terminating can happen at the same time, causing
+				// pods can mount on vols that are about to be detached/unmounted. Anti-affinity rule
+				// forced creating pods to wait for terminating pods due to one pod per node IP restriction.
+				Step(
+					fmt.Sprintf("setup app %s to remove anti-affinity rules", ctx.App.Key),
+					func() {
+
+						Step(fmt.Sprintf("update %s deployment without anti-affinity", ctx.App.Key), func() {
+							deployments, err := k8sApps.ListDeployments(ctx.GetID(), metav1.ListOptions{})
+							Expect(err).NotTo(HaveOccurred())
+							deployment := deployments.Items[0]
+							deployment.Spec.Template.Spec.Affinity = nil
+
+							_, err = k8sApps.UpdateDeployment(&deployment)
+							Expect(err).NotTo(HaveOccurred())
+						})
+
+						Step(fmt.Sprintf("scale down app: %s to 0 ", ctx.App.Key), func() {
+							scaleApp(ctx, 0)
+						})
+
+						// wait until all pods are gone
+						Step(fmt.Sprintf("wait for app %s to have 0 pods", ctx.App.Key), func() {
+							waitForNumPodsToEqual(ctx, 0)
+						})
+
+						Step(fmt.Sprintf("scale the app back to numPods for %s", ctx.App.Key), func() {
+							scaleApp(ctx, numPods)
+
+							ValidateContext(ctx)
+						})
+
+					})
+			}
+
+		})
+
+		It("should set device path to RO and validate recovery", func() {
+			for _, ctx := range testSharedV4Contexts {
+				var err error
+				vol, apiVol, attachedNode := getSv4TestAppVol(ctx)
+				counterCollectionInterval := 3 * time.Duration(numPods) * time.Second
+				devicePath := fmt.Sprintf("%s%s", devicePathPrefix, apiVol.Id)
+
+				// In porx, we check the export path is read-only when it is previously RO and
+				// changed to RW by fs due to occuring error. Specifically, when mnt.Opts (default)
+				// is RW and mnt.VfsOpts (fs state) is RO.
+				// By setting device path to RO, we mock the same behavior. Check state in
+				// `/proc/self/mountinfo`
+				Step(fmt.Sprintf("mark device path as RO %s", ctx.App.Key), func() {
+					setPathToROMode(devicePath, attachedNode)
+
+					// check only mnt.VfsOpts (fs state) is RO
+					mntList, err := mount.GetMounts()
+					Expect(err).NotTo(HaveOccurred())
+					for _, mnt := range mntList {
+						if mnt.Mountpoint != devicePath {
+							continue
+						}
+						Expect(volumeMountRW.MatchString(mnt.Opts)).To(BeTrue())
+						Expect(volumeMountRO.MatchString(mnt.VfsOpts)).To(BeTrue())
+					}
+				})
+
+				Step(fmt.Sprintf("validate the counters are inactive %s", ctx.App.Key), func() {
+					counters := getAppCounters(apiVol, attachedNode, counterCollectionInterval)
+					activePods := getActivePods(counters)
+					Expect(len(activePods)).To(Equal(0))
+				})
+
+				Step(fmt.Sprintf("restart vol driver %s", ctx.App.Key), func() {
+					restartVolumeDriverOnNode(attachedNode)
+					ValidateContext(ctx)
+					// updates the attachedNode; sometimes the volume is moved when restart to fix the readonly volume
+					attachedNode, err = Inst().V.GetNodeForVolume(vol, cmdTimeout, cmdRetry)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				Step(fmt.Sprintf("validate counter are active for %s", ctx.App.Key), func() {
+					var counters map[string]appCounter
+					// we are seeing a case where the application is validated and running but sharedv4 volume is
+					// not mounted/exported yet. adding the eventually here to retry to make sure we capture the
+					// counters correctly. Setting timeout of 5 minutes for now as mounting and exporting
+					// shouldn't take that long.
+					Eventually(func() bool {
+						counters = getAppCounters(apiVol, attachedNode, counterCollectionInterval)
+						activePods := getActivePods(counters)
+						return (len(activePods) == numPods)
+					}, 5*time.Minute, 20*time.Second).Should(BeTrue(),
+						"number of active keys did not match for volume %v (%v) for app %v. counters map: %v",
+						vol.ID, apiVol.Id, ctx.App.Key, counters)
+				})
+
+				Step(fmt.Sprintf("validate device path is set as RW for %s", ctx.App.Key), func() {
+					mntList, err := mount.GetMounts()
+					Expect(err).NotTo(HaveOccurred())
+
+					for _, mnt := range mntList {
+						if mnt.Mountpoint != devicePath {
+							continue
+						}
+						Expect(volumeMountRW.MatchString(mnt.Opts)).To(BeTrue())
+						Expect(volumeMountRW.MatchString(mnt.VfsOpts)).To(BeTrue())
+					}
+				})
+			}
+		})
+	})
+
+	// Template for additional tests
+	// Context("{}", func() {
+	// 	BeforeEach(func() {
+	// 		testrailID = 0
+	//      namespacePrefix = ""
+	// 	})
+	//
+	// 	JustBeforeEach(func() {
+	//		// since the apps are deployed by JustBeforeEach in the outer block,
+	// 		// any test-specific changes to the deployed apps should go here.
+	// 	})
+	//
+	// 	It("", func() {
+	// 		for _, ctx := range testSharedV4Contexts {
+	// 		}
+	// 	})
+
+	// 	AfterEach(func() {
+	// 	})
+	// })
+
+	AfterEach(func() {
+		Step("destroy apps", func() {
+			if CurrentGinkgoTestDescription().Failed {
+				logrus.Info("not destroying apps because the test failed\n")
+				return
+			}
+			for _, ctx := range contexts {
+				TearDownContext(ctx, map[string]bool{scheduler.OptionsWaitForResourceLeakCleanup: true})
+			}
+		})
+	})
+
+	JustAfterEach(func() {
+		AfterEachTest(contexts, testrailID, runID)
+	})
+})
+
+// returns the contexts that are running test-sharedv4* apps
+func getTestSharedV4Contexts(contexts []*scheduler.Context) []*scheduler.Context {
+	var testSharedV4Contexts []*scheduler.Context
+	for _, ctx := range contexts {
+		if !strings.HasPrefix(ctx.App.Key, "test-sharedv4") {
+			continue
+		}
+		testSharedV4Contexts = append(testSharedV4Contexts, ctx)
+	}
+	return testSharedV4Contexts
+}
+
+// set the given path to ro
+func setPathToROMode(path string, node *node.Node) {
+	cmd := fmt.Sprintf("mount -oremount,ro %s", path)
+	_, err := runCmd(cmd, *node)
+
+	Expect(err).NotTo(HaveOccurred())
+}


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Adding longevity test for cresting rebalance autopilot rule and validating the rule trigger
- [x] Create autopilot rebalnce rule
- [x] Validate autopilot events
- [x] Validate the pool 

**Which issue(s) this PR fixes** (optional)
Closes #PTX-13130

**Special notes for your reviewer**:

```
STEP: Create autopilot rule
INFO[2022-10-12 14:33:45] Creating autopilot rule ; {TypeMeta:{Kind: APIVersion:} ObjectMeta:{Name:pool-rebalance-absolute-prov-120-used-70 GenerateName: Namespace: SelfLink: UID: ResourceVersion: Generation:0 CreationTimestamp:0001-01-01 00:00:00 +0000 UTC DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[] Annotations:map[] OwnerReferences:[] Finalizers:[] ClusterName: ManagedFields:[]} Spec:{Weight:0 PollInterval:0 Enforcement: Selector:{LabelSelector:{MatchLabels:map[autopilot:rebalance] MatchExpressions:[]}} NamespaceSelector:{LabelSelector:{MatchLabels:map[] MatchExpressions:[]}} Conditions:{Expressions:[0xc0017440a0 0xc0017440f0] For:0 RequiredMatches:0 Type: Provider:} Actions:[0xc0013a4108] ActionsCoolDownPeriod:3600}}
INFO[2022-10-12 14:33:45] Adding label map[autopilot:rebalance] to the node torpedo-long-fa-sample-test-70-6
INFO[2022-10-12 14:33:46] Added label on torpedo-long-fa-sample-test-70-6 node: autopilot=rebalance
INFO[2022-10-12 14:33:46] Created autopilot rule: {
	"metadata": {
		"name": "pool-rebalance-absolute-prov-120-used-70",
		"uid": "ac811034-6126-47fc-998b-941ee6d7a4d9",
		"resourceVersion": "303597",
		"generation": 1,
		"creationTimestamp": "2022-10-12T09:03:46Z",
		"labels": {
			"app": "cassandra",
			"creator": "torpedo"
		},
		"managedFields": [
			{
				"manager": "basic.test",
				"operation": "Update",
				"apiVersion": "autopilot.libopenstorage.org/v1alpha1",
				"time": "2022-10-12T09:03:46Z",
				"fieldsType": "FieldsV1",
				"fieldsV1": {
					"f:metadata": {
						"f:labels": {
							".": {},
							"f:app": {},
							"f:creator": {}
						}
					},
					"f:spec": {
						".": {},
						"f:actions": {},
						"f:conditions": {
							".": {},
							"f:expressions": {}
						},
						"f:namespaceSelector": {},
						"f:selector": {
							".": {},
							"f:matchLabels": {
								".": {},
								"f:autopilot": {}
							}
						}
					}
				}
			}
		]
	},
	"spec": {
		"selector": {
			"matchLabels": {
				"autopilot": "rebalance"
			}
		},
		"namespaceSelector": {},
		"conditions": {
			"expressions": [
				{
					"key": "100 * (px_pool_stats_provisioned_bytes/ on (pool) px_pool_stats_total_bytes)",
					"operator": "Gt",
					"values": [
						"120"
					]
				},
				{
					"key": "100 * (px_pool_stats_used_bytes/ on (pool) px_pool_stats_total_bytes)",
					"operator": "Gt",
					"values": [
						"70"
					]
				}
			]
		},
		"actions": [
			{
				"name": "openstorage.io.action.storagepool/rebalance",
				"params": null
			}
		]
	}
}

```

```
STEP: validate the  autopilot events
INFO[2022-10-12 15:02:16] autopilot rule event reason : Transition and message: rule: pool-rebalance-absolute-prov-120-used-70:b163f313-e5ea-404a-af1b-f22cdf724743 transition from  => Initializing
INFO[2022-10-12 15:02:16] autopilot rule event reason : Transition and message: rule: pool-rebalance-absolute-prov-120-used-70:b163f313-e5ea-404a-af1b-f22cdf724743 transition from Initializing => Normal
INFO[2022-10-12 15:02:16] autopilot rule event reason : Transition and message: rule: pool-rebalance-absolute-prov-120-used-70:67ee64f9-7ca9-4317-95b5-5ee94ce50552 transition from  => Initializing
INFO[2022-10-12 15:02:16] autopilot rule event reason : Transition and message: rule: pool-rebalance-absolute-prov-120-used-70:67ee64f9-7ca9-4317-95b5-5ee94ce50552 transition from Initializing => Normal
```

```
STEP: validate Px on the rebalanced node
INFO[2022-10-13 11:54:53] Validating PX on node : torpedo-long-fa-sample-test-70-0
DEBU[2022-10-13 11:54:53] waiting for PX node to be up: torpedo-long-fa-sample-test-70-0
DEBU[2022-10-13 11:54:53] Getting node info for node: [torpedo-long-fa-sample-test-70-0]
DEBU[2022-10-13 11:54:54] checking PX status on node: torpedo-long-fa-sample-test-70-0
DEBU[2022-10-13 11:54:54] Finding the debug pod to run command on node torpedo-long-fa-sample-test-70-0
DEBU[2022-10-13 11:54:54] Running command on pod debug-7khhp [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c which pxctl]]
DEBU[2022-10-13 11:54:57] Finding the debug pod to run command on node torpedo-long-fa-sample-test-70-0
DEBU[2022-10-13 11:54:57] Running command on pod debug-7khhp [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c sudo /usr/local/bin/pxctl -j status]]
INFO[2022-10-13 11:55:01] px on node: torpedo-long-fa-sample-test-70-0 is now up. status: STATUS_OK
DEBU[2022-10-13 11:55:01] checking if PX pod is up on node: torpedo-long-fa-sample-test-70-0
DEBU[2022-10-13 11:55:02] px is fully operational on node: torpedo-long-fa-sample-test-70-0
INFO[2022-10-13 11:55:02] Job 1036049641065142325 is in DONE state
INFO[2022-10-13 11:55:02] Trigger Function completed for [autopilotRebalance]
```

