### PR TITLE
Metrics Provider for Torpedo (PTX-5085:Check alerts for each event in Longevity cluster)

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -176,6 +176,14 @@ if [ -z "$AWS_REGION" ]; then
     echo "Using default AWS_REGION of ${AWS_REGION}"
 fi
 
+if [ -z "$TORPEDO_JOB_TYPE"]; then
+    TORPEDO_JOB_TYPE="functional"
+fi
+
+if [ -z "$TORPEDO_JOB_NAME"]; then
+    TORPEDO_JOB_NAME="torpedo-daily-job"
+fi
+
 for i in $@
 do
 case $i in
@@ -454,6 +462,8 @@ spec:
             "--testset-id=$TESTSET_ID",
             "--branch=$BRANCH",
             "--product=$PRODUCT",
+            "--torpedo-job-name=$TORPEDO_JOB_NAME",
+            "--torpedo-job-type=$TORPEDO_JOB_TYPE",
             "$APP_DESTROY_TIMEOUT_ARG",
     ]
     tty: true

--- a/drivers/monitor/monitor.go
+++ b/drivers/monitor/monitor.go
@@ -1,0 +1,62 @@
+package monitor
+
+import (
+	"fmt"
+
+	"github.com/portworx/torpedo/pkg/errors"
+	prometheus "github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+)
+
+type Driver interface {
+
+	// Init initializes the monitor driver
+	Init(string, string) error
+
+	// String returns the string name of this driver.
+	String() string
+
+	// IncrementGaugeMetrics increment Gauge metrics
+	IncrementGaugeMetric(metric *prometheus.GaugeVec, testName string)
+
+	// DecrementGaugeMetrics decrement Gauge metrics
+	DecrementGaugeMetric(metric *prometheus.GaugeVec, testName string)
+
+	// IncrementCounterMetrics increment counter metrics
+	IncrementCounterMetric(metric *prometheus.CounterVec, testName string)
+
+	// IncrementGaugeMetricsUsingAdditionalLabel increment gauage metrics with additional labels
+	IncrementGaugeMetricsUsingAdditionalLabel(metric *prometheus.GaugeVec, testName string, additionalLabels ...string)
+
+	// SetGaugeMetrics set with value provided
+	SetGaugeMetric(metric *prometheus.GaugeVec, value float64, testName string)
+
+	// SetGaugeMetricWithNonDefaultLabels set value for guage metric
+	SetGaugeMetricWithNonDefaultLabels(metric *prometheus.GaugeVec, value float64, testName string, additionalLabels ...string)
+}
+
+var (
+	monitor = make(map[string]Driver)
+)
+
+// Get returns a registered scheduler test provider.
+func Get(name string) (Driver, error) {
+	if m, ok := monitor[name]; ok {
+		return m, nil
+	}
+	return nil, &errors.ErrNotFound{
+		ID:   name,
+		Type: "Monitor",
+	}
+}
+
+// Register registers the given scheduler driver
+func Register(name string, m Driver) error {
+	if _, ok := monitor[name]; !ok {
+		logrus.Infof("Registering driver name: %s", name)
+		monitor[name] = m
+	} else {
+		return fmt.Errorf("monitor driver: %s is already registered", name)
+	}
+	return nil
+}

--- a/drivers/monitor/prometheus/prometheus.go
+++ b/drivers/monitor/prometheus/prometheus.go
@@ -1,0 +1,143 @@
+package prometheus
+
+import (
+	"net/http"
+
+	"github.com/portworx/torpedo/drivers/monitor"
+	prometheus "github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/sirupsen/logrus"
+)
+
+type Prom struct {
+	port           string
+	jobName        string
+	jobType        string
+	vCenterName    string
+	vCenerCluster  string
+	vCenterNetwork string
+}
+
+const (
+	// DriverName is the name of the Prometheus monitor driver implementation
+	DriverName = "prometheus"
+
+	// DefaultMetricsPort is port used for exposing metrics
+	DefaultMetricsPort = ":8181"
+)
+
+var (
+	//metricsLabel
+	metricsLabel = []string{
+		// Test Name
+		"test_name",
+
+		// Torpedo Job Name
+		"job_name",
+
+		// Torpedo Job Type
+		"job_type",
+	}
+)
+
+// Define Torpedo metrics
+var (
+	// torpedoAlertTestFailed will be set when test failed
+	TorpedoAlertTestFailed = AddGaugeMetric("torpedo_alert_test_failed", "Alert for torpedo test failed", "error_string")
+
+	// torpedoTestRunning tells about test execution state
+	TorpedoTestRunning = AddGaugeMetric("torpedo_test_running", "Torpedo test executing state ")
+
+	// torpedoTestTriggerCount counter tells number of time test triggered
+	TorpedoTestTotalTriggerCount = AddCounterMetric("torpedo_test_total_trigger_count", "Torpedo test total trigger count")
+
+	// torpedoTestPassCount counter counts number of time test passed
+	TorpedoTestPassCount = AddCounterMetric("torpedo_test_pass_count", "Torpedo test pass count")
+
+	// torpedoTestFailCount counter counts number of time test fail
+	TorpedoTestFailCount = AddCounterMetric("torpedo_test_fail_count", "Torpedo test fail count")
+)
+
+// AddGaugeMetrics adds GaugeVec metrics
+func AddGaugeMetric(name string, helpMessage string, additionalLabels ...string) *prometheus.GaugeVec {
+	additionalLabels = append(metricsLabel, additionalLabels...)
+
+	gauageMetrics := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: name,
+			Help: helpMessage,
+		},
+		additionalLabels,
+	)
+	prometheus.MustRegister(gauageMetrics)
+	return gauageMetrics
+}
+
+// AddCounterMetric adds CounterVec metrics
+func AddCounterMetric(name string, helpMessage string, additionalLabels ...string) *prometheus.CounterVec {
+	additionalLabels = append(metricsLabel, additionalLabels...)
+
+	counterMetrics := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: name,
+			Help: helpMessage,
+		}, additionalLabels,
+	)
+	prometheus.MustRegister(counterMetrics)
+	return counterMetrics
+}
+
+// IncrementGaugeMetric increment Gauage Metrics
+func (p *Prom) IncrementGaugeMetric(metric *prometheus.GaugeVec, testName string) {
+	metric.WithLabelValues(testName, p.jobName, p.jobType).Inc()
+}
+
+// IncrementGaugeMetricsUsingAdditionalLabel increment Gauage Metrics
+func (p *Prom) IncrementGaugeMetricsUsingAdditionalLabel(metric *prometheus.GaugeVec, testName string, additionalLabels ...string) {
+	lvs := []string{testName, p.jobName, p.jobType}
+	lvs = append(lvs, additionalLabels...)
+	metric.WithLabelValues(lvs...).Inc()
+}
+
+// DecrementGaugeMetric decrement Gauage Metrics
+func (p *Prom) DecrementGaugeMetric(metric *prometheus.GaugeVec, testName string) {
+	metric.WithLabelValues(testName, p.jobName, p.jobType).Dec()
+}
+
+// IncrementCounterMetric increment Gauage Metrics
+func (p *Prom) IncrementCounterMetric(metric *prometheus.CounterVec, testName string) {
+	metric.WithLabelValues(testName, p.jobName, p.jobType).Inc()
+}
+
+// SetGaugeMetric set GaugeMetricVec value to given value
+func (p *Prom) SetGaugeMetric(metric *prometheus.GaugeVec, value float64, testName string) {
+	metric.WithLabelValues(testName, p.jobName, p.jobType).Set(value)
+}
+
+// SetGaugeMetric set GaugeMetricVec value to given value
+func (p *Prom) SetGaugeMetricWithNonDefaultLabels(metric *prometheus.GaugeVec, value float64, testName string, additionalLabels ...string) {
+	lvs := []string{testName, p.jobName, p.jobType}
+	lvs = append(lvs, additionalLabels...)
+	metric.WithLabelValues(lvs...).Set(value)
+}
+
+// String returns the string name of this driver.
+func (p *Prom) String() string {
+	return DriverName
+}
+
+// Init method init Prom object and start metrics handler
+func (p *Prom) Init(jobName string, jobType string) error {
+	p.port = DefaultMetricsPort
+	p.jobName = jobName
+	p.jobType = jobType
+	http.Handle("/metrics", promhttp.Handler())
+	logrus.Infof("Starting http service on port: %s", p.port)
+	go http.ListenAndServe(p.port, nil)
+	return nil
+}
+
+func init() {
+	p := &Prom{}
+	monitor.Register(DriverName, p)
+}

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -87,6 +87,8 @@ type InitOptions struct {
 	VolDriverName string
 	// NodeDriverName node driver name
 	NodeDriverName string
+	// MonitorDriverName monitor driver name
+	MonitorDriverName string
 	// ConfigMap  identifies what config map should be used to
 	SecretConfigMapName string
 	// HelmValuesConfigMapName custom values for helm charts

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.21.4
 	k8s.io/apimachinery v0.24.3
 	k8s.io/client-go v12.0.0+incompatible
+	github.com/prometheus/client_golang v1.11.0
 )
 
 replace (


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding Monitor Driver to expose metrics from Torpedo .

These metrics can be exposed and integrated with Prometheus Server.

This code will be useful in following cases:

1. `Monitoring` and `Alerting` when test failed for long running jobs like longevity
2. Tracking number of times test triggered in longevity 
3. Adding any new metrics into Torpedo tests

**Which issue(s) this PR fixes** (optional)
Closes # PTX-5085

**Special notes for your reviewer**:
Tested the alert with simulating longevity test failed

![image](https://user-images.githubusercontent.com/26619624/195670779-8357fc3a-354a-4dd3-8d54-8a2ad586fb53.png)

