### PR TITLE
Added testcase for backup pods verification

### DIFF
--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -29,6 +29,9 @@ import (
 
 const (
 	enumerateBatchSize = 100
+	post_install_hook_pod = "pxcentral-post-install-hook"
+	quick_maintenance_pod = "quick-maintenance-repo"
+	full_maintenance_pod  = "full-maintenance-repo"
 )
 
 var (
@@ -1983,10 +1986,11 @@ func validateBackupCluster() bool {
 	}
 	bkp_pods, err := core.Instance().GetPods(ns, nil)
 	for _, pod := range bkp_pods.Items {
-		matched, _ := regexp.MatchString("^pxcentral-post-install-hook", pod.GetName())
+		matched, _ := regexp.MatchString(post_install_hook_pod, pod.GetName())
 		if !matched {
-			equal, _ := regexp.MatchString("^full-maintenance-repo || ^quick-maintenance-repo", pod.GetName())
-			if !equal {
+			equal, _ := regexp.MatchString(quick_maintenance_pod, pod.GetName())
+			equal1, _ := regexp.MatchString(full_maintenance_pod, pod.GetName())
+			if !(equal || equal1){
 				logrus.Info("Checking if all the containers are up or not")
 				res := core.Instance().IsPodRunning(pod)
 				if !res {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
To verify if pxcentral-post-install-hook pod is in completed state, all backup pod are in Ready state
**Which issue(s) this PR fixes** (optional)
Closes # PA-198, PA-199

**Special notes for your reviewer**:

Step:
Get the pxcentral-post-install-hook pod in backup namespace
 Get the details of pxcentral-post-install-hook pod
Verify if the reason for Terminated state of pod is " Completed"


Get the list of all pods in backup namespace[except full-maintenance-repo  or quick-maintenance-repo ]
 Verify if all the pods are in Ready State 

