### PR TITLE
[PA-229] Upgrade data service image patch versions

### DIFF
--- a/tests/pds/dataservice_test.go
+++ b/tests/pds/dataservice_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"net/http"
-	"os"
 	"strconv"
 	"testing"
 
@@ -61,8 +60,6 @@ var (
 	DeployAllImages                         bool
 	dsVersion                               string
 	dsBuild                                 string
-	oldDSImage                              string
-	oldDSVersion                            string
 	deployments                             map[string][]*pds.ModelsDeployment
 	dataServiceVersionBuildMap              map[string][]string
 	dataServiceImageMap                     map[string][]string
@@ -136,6 +133,147 @@ var _ = BeforeSuite(func() {
 	})
 })
 
+func UpgradeDataService(oldVersion string, oldImage string, dsVersion string, dsBuild string) {
+
+	Step("Deploy Data Services", func() {
+		logrus.Infof("Version/Build: %v %v", oldVersion, oldImage)
+		deployments, dataServiceImageMap, dataServiceVersionBuildMap, err = pdslib.DeployDataServices(dataServiceNameIDMap, projectID,
+			deploymentTargetID,
+			dnsZone,
+			deploymentName,
+			namespaceID,
+			dataServiceNameDefaultAppConfigMap,
+			replicas,
+			serviceType,
+			dataServiceDefaultResourceTemplateIDMap,
+			storageTemplateID,
+			DeployAllVersions,
+			DeployAllImages,
+			oldVersion,
+			oldImage,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deployments).NotTo(BeEmpty())
+		Step("Validate Storage Configurations", func() {
+			for ds, deployment := range deployments {
+				for index := range deployment {
+					logrus.Infof("data service deployed %v ", ds)
+					resourceTemp, storageOp, config, err := pdslib.ValidateDataServiceVolumes(deployment[index], ds, dataServiceDefaultResourceTemplateIDMap, storageTemplateID)
+					Expect(err).NotTo(HaveOccurred())
+					logrus.Infof("filesystem used %v ", config.Spec.StorageOptions.Filesystem)
+					logrus.Infof("storage replicas used %v ", config.Spec.StorageOptions.Replicas)
+					logrus.Infof("cpu requests used %v ", config.Spec.Resources.Requests.CPU)
+					logrus.Infof("memory requests used %v ", config.Spec.Resources.Requests.Memory)
+					logrus.Infof("storage requests used %v ", config.Spec.Resources.Requests.Storage)
+					logrus.Infof("No of nodes requested %v ", config.Spec.Nodes)
+					logrus.Infof("volume group %v ", storageOp.VolumeGroup)
+
+					Expect(resourceTemp.Resources.Requests.CPU).Should(Equal(config.Spec.Resources.Requests.CPU))
+					Expect(resourceTemp.Resources.Requests.Memory).Should(Equal(config.Spec.Resources.Requests.Memory))
+					Expect(resourceTemp.Resources.Requests.Storage).Should(Equal(config.Spec.Resources.Requests.Storage))
+					Expect(resourceTemp.Resources.Limits.CPU).Should(Equal(config.Spec.Resources.Limits.CPU))
+					Expect(resourceTemp.Resources.Limits.Memory).Should(Equal(config.Spec.Resources.Limits.Memory))
+					repl, err := strconv.Atoi(config.Spec.StorageOptions.Replicas)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(storageOp.Replicas).Should(Equal(int32(repl)))
+					Expect(storageOp.Filesystem).Should(Equal(config.Spec.StorageOptions.Filesystem))
+					Expect(config.Spec.Nodes).Should(Equal(replicas))
+					for version, build := range dataServiceVersionBuildMap {
+						Expect(config.Spec.Version).Should(Equal(version + "-" + build[index]))
+					}
+
+				}
+			}
+		})
+	})
+
+	Step("Running Workloads before scaling up of dataservices ", func() {
+		for ds, deployment := range deployments {
+			for index := range deployment {
+				if ds == postgresql {
+					deploymentName := "pgload"
+					pod, dep, err = pdslib.CreateDataServiceWorkloads(ds, deployment[index].GetId(), "100", "1", deploymentName, namespace)
+					Expect(err).NotTo(HaveOccurred())
+				}
+				if ds == rabbitmq {
+					deploymentName := "rmq"
+					pod, dep, err = pdslib.CreateDataServiceWorkloads(ds, deployment[index].GetId(), "", "", deploymentName, namespace)
+					Expect(err).NotTo(HaveOccurred())
+				}
+				if ds == redis {
+					deploymentName := "redisbench"
+					pod, dep, err = pdslib.CreateDataServiceWorkloads(ds, deployment[index].GetId(), "", "", deploymentName, namespace)
+					Expect(err).NotTo(HaveOccurred())
+				}
+				if ds == cassandra {
+					deploymentName := "cassandra-stress"
+					pod, dep, err = pdslib.CreateDataServiceWorkloads(ds, deployment[index].GetId(), "", "", deploymentName, namespace)
+					Expect(err).NotTo(HaveOccurred())
+				}
+			}
+		}
+	})
+
+	Step("Update the data service patch versions", func() {
+		for ds, deployment := range deployments {
+			for index := range deployment {
+				logrus.Infof("Version/Build: %v %v", dsVersion, dsBuild)
+				updatedDeployment, err := pdslib.UpdateDataServiceVerison(deployment[index].GetDataServiceId(), deployment[index].GetId(),
+					dataServiceNameDefaultAppConfigMap[ds],
+					replicas, dataServiceDefaultResourceTemplateIDMap[ds], dsBuild, dsVersion)
+
+				Expect(err).NotTo(HaveOccurred())
+				logrus.Infof("data service deployed %v ", ds)
+				resourceTemp, storageOp, config, err := pdslib.ValidateDataServiceVolumes(updatedDeployment, ds, dataServiceDefaultResourceTemplateIDMap, storageTemplateID)
+				Expect(err).NotTo(HaveOccurred())
+
+				logrus.Infof("filesystem used %v ", config.Spec.StorageOptions.Filesystem)
+				logrus.Infof("storage replicas used %v ", config.Spec.StorageOptions.Replicas)
+				logrus.Infof("cpu requests used %v ", config.Spec.Resources.Requests.CPU)
+				logrus.Infof("memory requests used %v ", config.Spec.Resources.Requests.Memory)
+				logrus.Infof("storage requests used %v ", config.Spec.Resources.Requests.Storage)
+				logrus.Infof("No of nodes requested %v ", config.Spec.Nodes)
+				logrus.Infof("volume group %v ", storageOp.VolumeGroup)
+				logrus.Infof("version/images used %v ", config.Spec.Version)
+
+				Expect(resourceTemp.Resources.Requests.CPU).Should(Equal(config.Spec.Resources.Requests.CPU))
+				Expect(resourceTemp.Resources.Requests.Memory).Should(Equal(config.Spec.Resources.Requests.Memory))
+				Expect(resourceTemp.Resources.Requests.Storage).Should(Equal(config.Spec.Resources.Requests.Storage))
+				Expect(resourceTemp.Resources.Limits.CPU).Should(Equal(config.Spec.Resources.Limits.CPU))
+				Expect(resourceTemp.Resources.Limits.Memory).Should(Equal(config.Spec.Resources.Limits.Memory))
+				repl, err := strconv.Atoi(config.Spec.StorageOptions.Replicas)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(storageOp.Replicas).Should(Equal(int32(repl)))
+				Expect(storageOp.Filesystem).Should(Equal(config.Spec.StorageOptions.Filesystem))
+				Expect(config.Spec.Nodes).Should(Equal(replicas))
+				for version, build := range dataServiceVersionBuildMap {
+					Expect(config.Spec.Version).Should(Equal(version + "-" + build[index]))
+				}
+			}
+		}
+	})
+
+	defer func() {
+		Step("Delete the worload generating deployments", func() {
+			if DataService == "Cassandra" || DataService == "PostgreSQL" {
+				err = pdslib.DeleteK8sDeployments(dep.Name, namespace)
+			} else {
+				err = pdslib.DeleteK8sPods(pod.Name, namespace)
+			}
+			Expect(err).NotTo(HaveOccurred())
+
+		})
+		Step("Delete created deployments")
+		for _, dep := range deployments {
+			for index := range dep {
+				resp, err := pdslib.DeleteDeployment(dep[index].GetId())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).Should(BeEquivalentTo(http.StatusAccepted))
+			}
+		}
+	}()
+}
+
 var _ = Describe("{UpgradeDataServiceVersion}", func() {
 
 	JustBeforeEach(func() {
@@ -152,149 +290,45 @@ var _ = Describe("{UpgradeDataServiceVersion}", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dataServiceNameDefaultAppConfigMap).NotTo(BeEmpty())
 			})
-			oldDSImage = pdslib.GetAndExpectStringEnvVar(ImageToBeUpdated)
-			oldDSVersion = pdslib.GetAndExpectStringEnvVar(VersionToBeUpdated)
+
 		} else {
 			Expect(DeployAllDataService).To(Equal(true))
 		}
 	})
 
-	It("upgrade dataservice version", func() {
-		Step("Deploy Data Services", func() {
-			deployments, dataServiceImageMap, dataServiceVersionBuildMap, err = pdslib.DeployDataServices(dataServiceNameIDMap, projectID,
-				deploymentTargetID,
-				dnsZone,
-				deploymentName,
-				namespaceID,
-				dataServiceNameDefaultAppConfigMap,
-				replicas,
-				serviceType,
-				dataServiceDefaultResourceTemplateIDMap,
-				storageTemplateID,
-				DeployAllVersions,
-				DeployAllImages,
-				oldDSVersion,
-				oldDSImage,
-			)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(deployments).NotTo(BeEmpty())
-			Step("Validate Storage Configurations", func() {
-				for ds, deployment := range deployments {
-					for index := range deployment {
-						logrus.Infof("data service deployed %v ", ds)
-						resourceTemp, storageOp, config, err := pdslib.ValidateDataServiceVolumes(deployment[index], ds, dataServiceDefaultResourceTemplateIDMap, storageTemplateID)
-						Expect(err).NotTo(HaveOccurred())
-						logrus.Infof("filesystem used %v ", config.Spec.StorageOptions.Filesystem)
-						logrus.Infof("storage replicas used %v ", config.Spec.StorageOptions.Replicas)
-						logrus.Infof("cpu requests used %v ", config.Spec.Resources.Requests.CPU)
-						logrus.Infof("memory requests used %v ", config.Spec.Resources.Requests.Memory)
-						logrus.Infof("storage requests used %v ", config.Spec.Resources.Requests.Storage)
-						logrus.Infof("No of nodes requested %v ", config.Spec.Nodes)
-						logrus.Infof("volume group %v ", storageOp.VolumeGroup)
+	It("runs the dataservice version upgrade test", func() {
+		oldImage := pdslib.GetAndExpectStringEnvVar(ImageToBeUpdated)
+		oldVersion := pdslib.GetAndExpectStringEnvVar(VersionToBeUpdated)
+		UpgradeDataService(oldVersion, oldImage, dsVersion, dsBuild)
+	})
 
-						Expect(resourceTemp.Resources.Requests.CPU).Should(Equal(config.Spec.Resources.Requests.CPU))
-						Expect(resourceTemp.Resources.Requests.Memory).Should(Equal(config.Spec.Resources.Requests.Memory))
-						Expect(resourceTemp.Resources.Requests.Storage).Should(Equal(config.Spec.Resources.Requests.Storage))
-						Expect(resourceTemp.Resources.Limits.CPU).Should(Equal(config.Spec.Resources.Limits.CPU))
-						Expect(resourceTemp.Resources.Limits.Memory).Should(Equal(config.Spec.Resources.Limits.Memory))
-						repl, err := strconv.Atoi(config.Spec.StorageOptions.Replicas)
-						Expect(err).NotTo(HaveOccurred())
-						Expect(storageOp.Replicas).Should(Equal(int32(repl)))
-						Expect(storageOp.Filesystem).Should(Equal(config.Spec.StorageOptions.Filesystem))
-						Expect(config.Spec.Nodes).Should(Equal(replicas))
-						for version, build := range dataServiceVersionBuildMap {
-							Expect(config.Spec.Version).Should(Equal(version + "-" + build[index]))
-						}
+})
 
-					}
-				}
-			})
-		})
+var _ = Describe("{UpgradeDataServiceImage}", func() {
 
-		Step("Running Workloads before scaling up of dataservices ", func() {
-			for ds, deployment := range deployments {
-				for index := range deployment {
-					if ds == postgresql {
-						deploymentName := "pgload"
-						pod, dep, err = pdslib.CreateDataServiceWorkloads(ds, deployment[index].GetId(), "100", "1", deploymentName, namespace)
-						Expect(err).NotTo(HaveOccurred())
-					}
-					if ds == rabbitmq {
-						deploymentName := "rmq"
-						pod, dep, err = pdslib.CreateDataServiceWorkloads(ds, deployment[index].GetId(), "", "", deploymentName, namespace)
-						Expect(err).NotTo(HaveOccurred())
-					}
-					if ds == redis {
-						deploymentName := "redisbench"
-						pod, dep, err = pdslib.CreateDataServiceWorkloads(ds, deployment[index].GetId(), "", "", deploymentName, namespace)
-						Expect(err).NotTo(HaveOccurred())
-					}
-					if ds == cassandra {
-						deploymentName := "cassandra-stress"
-						pod, dep, err = pdslib.CreateDataServiceWorkloads(ds, deployment[index].GetId(), "", "", deploymentName, namespace)
-						Expect(err).NotTo(HaveOccurred())
-					}
-				}
+	JustBeforeEach(func() {
+		if !DeployAllDataService {
+			supportedDataServices = append(supportedDataServices, DataService)
+			for _, ds := range supportedDataServices {
+				logrus.Infof("supported dataservices %v", ds)
 			}
-		})
-
-		Step("Update the data service patch versions", func() {
-			for ds, deployment := range deployments {
-				for index := range deployment {
-					updatedDeployment, err := pdslib.UpdateDataServiceVerison(deployment[index].GetDataServiceId(), deployment[index].GetId(),
-						dataServiceNameDefaultAppConfigMap[ds],
-						replicas, dataServiceDefaultResourceTemplateIDMap[ds], dsBuild, dsVersion)
-
-					Expect(err).NotTo(HaveOccurred())
-					logrus.Infof("data service deployed %v ", ds)
-					resourceTemp, storageOp, config, err := pdslib.ValidateDataServiceVolumes(updatedDeployment, ds, dataServiceDefaultResourceTemplateIDMap, storageTemplateID)
-					Expect(err).NotTo(HaveOccurred())
-
-					logrus.Infof("filesystem used %v ", config.Spec.StorageOptions.Filesystem)
-					logrus.Infof("storage replicas used %v ", config.Spec.StorageOptions.Replicas)
-					logrus.Infof("cpu requests used %v ", config.Spec.Resources.Requests.CPU)
-					logrus.Infof("memory requests used %v ", config.Spec.Resources.Requests.Memory)
-					logrus.Infof("storage requests used %v ", config.Spec.Resources.Requests.Storage)
-					logrus.Infof("No of nodes requested %v ", config.Spec.Nodes)
-					logrus.Infof("volume group %v ", storageOp.VolumeGroup)
-					logrus.Infof("version/images used %v ", config.Spec.Version)
-
-					Expect(resourceTemp.Resources.Requests.CPU).Should(Equal(config.Spec.Resources.Requests.CPU))
-					Expect(resourceTemp.Resources.Requests.Memory).Should(Equal(config.Spec.Resources.Requests.Memory))
-					Expect(resourceTemp.Resources.Requests.Storage).Should(Equal(config.Spec.Resources.Requests.Storage))
-					Expect(resourceTemp.Resources.Limits.CPU).Should(Equal(config.Spec.Resources.Limits.CPU))
-					Expect(resourceTemp.Resources.Limits.Memory).Should(Equal(config.Spec.Resources.Limits.Memory))
-					repl, err := strconv.Atoi(config.Spec.StorageOptions.Replicas)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(storageOp.Replicas).Should(Equal(int32(repl)))
-					Expect(storageOp.Filesystem).Should(Equal(config.Spec.StorageOptions.Filesystem))
-					Expect(config.Spec.Nodes).Should(Equal(replicas))
-					for version, build := range dataServiceVersionBuildMap {
-						Expect(config.Spec.Version).Should(Equal(version + "-" + build[index]))
-					}
-				}
-			}
-		})
-
-		defer func() {
-			Step("Delete the worload generating deployments", func() {
-				if DataService == "Cassandra" || DataService == "PostgreSQL" {
-					err = pdslib.DeleteK8sDeployments(dep.Name, namespace)
-				} else {
-					err = pdslib.DeleteK8sPods(pod.Name, namespace)
-				}
+			Step("Get the resource and app config template for supported dataservice", func() {
+				dataServiceDefaultResourceTemplateIDMap, dataServiceNameIDMap, err = pdslib.GetResourceTemplate(tenantID, supportedDataServices)
 				Expect(err).NotTo(HaveOccurred())
 
+				dataServiceNameDefaultAppConfigMap, err = pdslib.GetAppConfTemplate(tenantID, dataServiceNameIDMap)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dataServiceNameDefaultAppConfigMap).NotTo(BeEmpty())
 			})
-			Step("Delete created deployments")
-			for _, dep := range deployments {
-				for index := range dep {
-					resp, err := pdslib.DeleteDeployment(dep[index].GetId())
-					Expect(err).NotTo(HaveOccurred())
-					Expect(resp.StatusCode).Should(BeEquivalentTo(http.StatusAccepted))
-				}
-			}
-		}()
+
+		} else {
+			Expect(DeployAllDataService).To(Equal(true))
+		}
+	})
+
+	It("runs the dataservice build image upgrade test", func() {
+		oldImage := pdslib.GetAndExpectStringEnvVar(ImageToBeUpdated)
+		UpgradeDataService(dsVersion, oldImage, dsVersion, dsBuild)
 	})
 
 })
@@ -470,8 +504,8 @@ var _ = Describe("{DeployAllDataServices}", func() {
 	})
 })
 
-func TestMain(m *testing.M) {
-	// call flag.Parse() here if TestMain uses flags
-	ParseFlags()
-	os.Exit(m.Run())
-}
+// func TestMain(m *testing.M) {
+// 	// call flag.Parse() here if TestMain uses flags
+// 	ParseFlags()
+// 	os.Exit(m.Run())
+// }

--- a/tests/pds/dataservice_test.go
+++ b/tests/pds/dataservice_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"net/http"
+	"os"
 	"strconv"
 	"testing"
 
@@ -500,8 +501,8 @@ var _ = Describe("{DeployAllDataServices}", func() {
 	})
 })
 
-// func TestMain(m *testing.M) {
-// 	// call flag.Parse() here if TestMain uses flags
-// 	ParseFlags()
-// 	os.Exit(m.Run())
-// }
+func TestMain(m *testing.M) {
+	// call flag.Parse() here if TestMain uses flags
+	ParseFlags()
+	os.Exit(m.Run())
+}

--- a/tests/pds/dataservice_test.go
+++ b/tests/pds/dataservice_test.go
@@ -291,8 +291,6 @@ var _ = Describe("{UpgradeDataServiceVersion}", func() {
 				Expect(dataServiceNameDefaultAppConfigMap).NotTo(BeEmpty())
 			})
 
-		} else {
-			Expect(DeployAllDataService).To(Equal(true))
 		}
 	})
 
@@ -321,8 +319,6 @@ var _ = Describe("{UpgradeDataServiceImage}", func() {
 				Expect(dataServiceNameDefaultAppConfigMap).NotTo(BeEmpty())
 			})
 
-		} else {
-			Expect(DeployAllDataService).To(Equal(true))
 		}
 	})
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [x] Signed off your work as per the DCO.
  [x] Add unit-tests
-->

**What this PR does / why we need it**:
This is a PR for upgrading only the image version, keeping the DS_VERSION constant. The env variables DS_VERSION, IMAGE_TO_UPDATE, DS_BUILD will be used for this test. The test first creates a deployment with DS_VERSION/IMAGE_TO_UPDATE and then runs some load against it. Next, it upgrades ONLY the image, from IMAGE_TO_UPGRADE (old image) to the image mentioned in DS_BUILD (new image). 

How to run:
```
export DS_VERSION=14.4
export IMAGE_TO_UPDATE=4416feb
export DS_BUILD=b64d741
ginkgo --focus UpgradeDataServiceImage -v /path/to/torpedo/bin/pds.test -log-location `pwd`
```

**Which issue(s) this PR fixes** (optional)
Closes #PA-229

**Special notes for your reviewer**:
This change creates one new spec UpgradeDataServiceImage and modifies the existing spec UpgradeDataServiceVersion and ensures that both of these related testcases use a common runner function. The environment variables needed for the new testcase have been mentioned above.

Test Execution Logs: https://gist.github.com/bhsrinivasan-px/69b83bb6127ee098ae9cb6380613e029
