### PR TITLE
Fixes torpedo spec for kubeadm clusters

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -367,6 +367,8 @@ spec:
   - key: node-role.kubernetes.io/controlplane
     operator: Equal
     value: "true"
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
   - key: node-role.kubernetes.io/etcd
     operator: Equal
     value: "true"


### PR DESCRIPTION
**What this PR does / why we need it**:
`kubeadm` seems to use different control plane labels than other k8s providers. Stumbled on the fix last week, figured I'd make it permanent.

