### PR TITLE
Fix for log initialisation for OCP 

### DIFF
--- a/drivers/volume/portworx/schedops/ocp-schedops.go
+++ b/drivers/volume/portworx/schedops/ocp-schedops.go
@@ -1,6 +1,8 @@
 package schedops
 
-import "github.com/sirupsen/logrus"
+import (
+	"github.com/sirupsen/logrus"
+)
 
 // This is a subclass of k8sSchedOps
 // This is needed to differentiate k8s and OCP scheduler
@@ -16,4 +18,5 @@ func init() {
 
 func (o *ocpSchedOps) Init(logger *logrus.Logger) {
 	o.log = logger
+	o.k8sSchedOps.log = logger
 }

--- a/tests/common.go
+++ b/tests/common.go
@@ -318,14 +318,6 @@ var dash *aetosutil.Dashboard
 func InitInstance() {
 	var err error
 	var token string
-	if Inst().ConfigMap != "" {
-		log.Infof("Using Config Map: %s ", Inst().ConfigMap)
-		token, err = Inst().S.GetTokenFromConfigMap(Inst().ConfigMap)
-		expect(err).NotTo(haveOccurred())
-		log.Infof("Token used for initializing: %s ", token)
-	} else {
-		token = ""
-	}
 
 	err = Inst().S.Init(scheduler.InitOptions{
 		SpecDir:                          Inst().SpecDir,
@@ -348,6 +340,15 @@ func InitInstance() {
 		log.Errorf("Error occured while Scheduler Driver Initialization, Err: %v", err)
 	}
 	expect(err).NotTo(haveOccurred())
+
+	if Inst().ConfigMap != "" {
+		log.Infof("Using Config Map: %s ", Inst().ConfigMap)
+		token, err = Inst().S.GetTokenFromConfigMap(Inst().ConfigMap)
+		expect(err).NotTo(haveOccurred())
+		log.Infof("Token used for initializing: %s ", token)
+	} else {
+		token = ""
+	}
 
 	err = Inst().N.Init(node.InitOptions{
 		SpecDir: Inst().SpecDir,


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
log object is not assigned for schedops when schedular is OCP  This PR fixes it 
Also when config map is passed, k8s object is accessed befor log object is assigned. this PR fixes it

**Which issue(s) this PR fixes** (optional)
Closes #PTX-13455

**Special notes for your reviewer**:

