### PR TITLE
Fix for nil pointer in updateoutcome when err is nil

### DIFF
--- a/tests/testTriggers.go
+++ b/tests/testTriggers.go
@@ -255,10 +255,9 @@ func GenerateUUID() string {
 // UpdateOutcome updates outcome based on error
 func UpdateOutcome(event *EventRecord, err error) {
 
-	logrus.Infof("Hit Error: %s in event %v", err.Error(), event)
 	if err != nil && event != nil {
 		Inst().M.IncrementCounterMetric(TestFailedCount, event.Event.Type)
-		logrus.Infof("updating event outcome for [%v]", event.Event.Type)
+		logrus.Infof("Hit Error: %s in event %s", err.Error(), event.Event.Type)
 		er := fmt.Errorf(err.Error() + "<br>")
 		Inst().M.IncrementGaugeMetricsUsingAdditionalLabel(FailedTestAlert, event.Event.Type, err.Error())
 		event.Outcome = append(event.Outcome, er)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
UpdateOutcome is givinng nil pointer when there is no error- This PR fixes it

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

