### PR TITLE
PTX-13295 Added support for custom Portworx namespace

### DIFF
--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -107,10 +107,6 @@ const (
 	PureBlock = "pure_block"
 	// PortworxStrict provisioner for using same provisioner as provided in the spec
 	PortworxStrict = "strict"
-	// PXDaemonSet DaemonSet Name
-	PXDaemonSet = "portworx"
-	// PXNamespace default namespace
-	PXNamespace = "kube-system"
 	// CsiProvisioner is csi provisioner
 	CsiProvisioner = "pxd.portworx.com"
 )
@@ -131,8 +127,8 @@ const (
 	SnapshotReadyTimeout             = 5 * time.Minute
 	numOfRestoredPVCForCloneManyTest = 500
 
-	autopilotServiceName          = "autopilot"
 	autopilotDefaultNamespace     = "kube-system"
+	portworxServiceName           = "portworx-service"
 	resizeSupportedAnnotationKey  = "torpedo.io/resize-supported"
 	autopilotEnabledAnnotationKey = "torpedo.io/autopilot-enabled"
 	pvcLabelsAnnotationKey        = "torpedo.io/pvclabels-enabled"
@@ -4987,7 +4983,7 @@ func (k *K8s) GetAutopilotNamespace() (string, error) {
 		return "", err
 	}
 	for _, svc := range allServices.Items {
-		if svc.Name == autopilotServiceName {
+		if svc.Name == portworxServiceName {
 			return svc.Namespace, nil
 		}
 	}

--- a/drivers/volume/common.go
+++ b/drivers/volume/common.go
@@ -83,6 +83,14 @@ func (d *DefaultDriver) String() string {
 	return ""
 }
 
+func (d *DefaultDriver) GetVolumeDriverNamespace() (string, error) {
+	return "", &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "GetVolumeDriverNamespace()",
+	}
+
+}
+
 // Init initializes the volume driver under the given scheduler
 func (d *DefaultDriver) Init(sched, nodeDriver, token, storageProvisioner, csiGenericDriverConfigMap string) error {
 	StorageProvisioner = DefaultStorageProvisioner

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -192,6 +192,7 @@ type portworx struct {
 	portworxServiceClient pxapi.PortworxServiceClient
 	schedOps              schedops.Driver
 	nodeDriver            node.Driver
+	namespace             string
 	refreshEndpoint       bool
 	token                 string
 	skipPXSvcEndpoint     bool
@@ -286,6 +287,10 @@ func (d *portworx) String() string {
 	return DriverName
 }
 
+func (d *portworx) GetVolumeDriverNamespace() (string, error) {
+	return d.schedOps.GetPortworxNamespace()
+}
+
 // init is all the functionality of Init, but allowing you to set a custom driver name
 func (d *portworx) init(sched, nodeDriver, token, storageProvisioner, csiGenericDriverConfigMap, driverName string, logger *logrus.Logger) error {
 	d.log = logger
@@ -306,6 +311,12 @@ func (d *portworx) init(sched, nodeDriver, token, storageProvisioner, csiGeneric
 		return fmt.Errorf("failed to get scheduler operator for portworx. Err: %v", err)
 	}
 	d.schedOps.Init(d.log)
+
+	namespace, err := d.GetVolumeDriverNamespace()
+	if err != nil {
+		return err
+	}
+	d.namespace = namespace
 
 	if err = d.setDriver(); err != nil {
 		return err
@@ -2004,7 +2015,7 @@ func (d *portworx) getExpectedPoolSizes(listApRules *apapi.AutopilotRuleList) (m
 //GetAutoFsTrimStatus get status of autofstrim
 func (d *portworx) GetAutoFsTrimStatus(endpoint string) (map[string]api.FilesystemTrim_FilesystemTrimStatus, error) {
 
-	sdkport, _ := getSDKPort()
+	sdkport, _ := d.getSDKPort()
 	pxEndpoint := net.JoinHostPort(endpoint, strconv.Itoa(int(sdkport)))
 	newConn, err := grpc.Dial(pxEndpoint, grpc.WithInsecure())
 	if err != nil {
@@ -2402,12 +2413,12 @@ func (d *portworx) setDriver() error {
 }
 
 func (d *portworx) testAndSetEndpointUsingService(endpoint string) error {
-	sdkPort, err := getSDKPort()
+	sdkPort, err := d.getSDKPort()
 	if err != nil {
 		return err
 	}
 
-	restPort, err := getRestPort()
+	restPort, err := d.getRestPort()
 	if err != nil {
 		return err
 	}
@@ -2416,12 +2427,12 @@ func (d *portworx) testAndSetEndpointUsingService(endpoint string) error {
 }
 
 func (d *portworx) testAndSetEndpointUsingNodeIP(ip string) error {
-	sdkPort, err := getSDKContainerPort()
+	sdkPort, err := d.getSDKContainerPort()
 	if err != nil {
 		return err
 	}
 
-	restPort, err := getRestContainerPort()
+	restPort, err := d.getRestContainerPort()
 	if err != nil {
 		return err
 	}
@@ -2671,7 +2682,7 @@ func (d *portworx) GetClusterPairingInfo(kubeConfigPath, token string) (map[stri
 	// file up cluster pair info
 	pairInfo[clusterIP] = pxNodes[0].Addresses[0]
 	pairInfo[tokenKey] = resp.Result.Token
-	pwxServicePort, err := getRestContainerPort()
+	pwxServicePort, err := d.getRestContainerPort()
 	if err != nil {
 		return nil, err
 	}
@@ -2918,7 +2929,7 @@ func (d *portworx) getClusterPairManager() api.OpenStorageClusterPairClient {
 }
 
 func (d *portworx) getClusterPairManagerByAddress(addr, token string) (api.OpenStorageClusterPairClient, error) {
-	pxPort, err := getSDKContainerPort()
+	pxPort, err := d.getSDKContainerPort()
 	if err != nil {
 		return nil, err
 	}
@@ -2949,7 +2960,7 @@ func (d *portworx) getAlertsManager() api.OpenStorageAlertsClient {
 }
 
 func (d *portworx) getNodeManagerByAddress(addr string) (api.OpenStorageNodeClient, error) {
-	pxPort, err := getSDKContainerPort()
+	pxPort, err := d.getSDKContainerPort()
 	if err != nil {
 		return nil, err
 	}
@@ -2980,7 +2991,7 @@ func (d *portworx) maintenanceOp(n node.Node, op string) error {
 	// we are removing using service endpoint because services would
 	// return a random node endpoint the service chooses and puts it in maintenance.
 	// this would fail the status check in `EnterMaintenanc` and `ExitMaintenance`
-	pxdRestPort, err := getRestContainerPort()
+	pxdRestPort, err := d.getRestContainerPort()
 	if err != nil {
 		return err
 	}
@@ -3148,7 +3159,7 @@ func hasIgnorePrefix(str string) bool {
 func (d *portworx) GetKvdbMembers(n node.Node) (map[string]*torpedovolume.MetadataNode, error) {
 	var err error
 	kvdbMembers := make(map[string]*torpedovolume.MetadataNode)
-	pxdRestPort, err := getRestPort()
+	pxdRestPort, err := d.getRestPort()
 
 	if err != nil {
 		return kvdbMembers, err
@@ -3160,7 +3171,7 @@ func (d *portworx) GetKvdbMembers(n node.Node) (map[string]*torpedovolume.Metada
 
 	if err != nil || endpoint == "" {
 		d.log.Warnf("unable to get service endpoint falling back to node addr: err=%v, skipPXSvcEndpoint=%v", err, d.skipPXSvcEndpoint)
-		pxdRestPort, err = getRestContainerPort()
+		pxdRestPort, err = d.getRestContainerPort()
 		if err != nil {
 			return kvdbMembers, err
 		}
@@ -3817,7 +3828,7 @@ func (d *portworx) RunSecretsLogin(n node.Node, secretType string) error {
 }
 
 func (d *portworx) GetStorageCluster() (*v1.StorageCluster, error) {
-	pxOps, err := pxOperator.ListStorageClusters(schedops.PXNamespace)
+	pxOps, err := pxOperator.ListStorageClusters(d.namespace)
 	if err != nil {
 		er := fmt.Errorf("Error getting Storage Clusters list, Err: %v", err.Error())
 		d.log.Error(er.Error())
@@ -3854,7 +3865,7 @@ func (d *portworx) UpdateStorageClusterImage(imageName string) error {
 }
 
 func (d *portworx) GetPXStorageCluster() (*v1.StorageCluster, error) {
-	pxOps, err := pxOperator.ListStorageClusters(schedops.PXNamespace)
+	pxOps, err := pxOperator.ListStorageClusters(d.namespace)
 	if err != nil {
 		err = fmt.Errorf("Error getting Storage Clusters list, Err: %v", err.Error())
 		d.log.Error(err.Error())
@@ -3882,7 +3893,7 @@ func (d *portworx) ValidateStorageCluster(endpointURL, endpointVersion string) e
 	} else if k8serrors.IsNotFound(err) {
 		return nil
 	}
-	pxOps, err := pxOperator.ListStorageClusters(schedops.PXNamespace)
+	pxOps, err := pxOperator.ListStorageClusters(d.namespace)
 	if err != nil {
 		return err
 	}
@@ -4037,8 +4048,8 @@ func parseMaxSize(maxSize string) (uint64, error, error) {
 }
 
 // getRestPort gets the service port for rest api, required when using service endpoint
-func getRestPort() (int32, error) {
-	svc, err := k8sCore.GetService(schedops.PXServiceName, schedops.PXNamespace)
+func (d *portworx) getRestPort() (int32, error) {
+	svc, err := k8sCore.GetService(schedops.PXServiceName, d.namespace)
 	if err != nil {
 		return 0, err
 	}
@@ -4051,8 +4062,8 @@ func getRestPort() (int32, error) {
 }
 
 // getRestContainerPort gets the rest api container port exposed in the node, required when using node ip
-func getRestContainerPort() (int32, error) {
-	svc, err := k8sCore.GetService(schedops.PXServiceName, schedops.PXNamespace)
+func (d *portworx) getRestContainerPort() (int32, error) {
+	svc, err := k8sCore.GetService(schedops.PXServiceName, d.namespace)
 	if err != nil {
 		return 0, err
 	}
@@ -4065,8 +4076,8 @@ func getRestContainerPort() (int32, error) {
 }
 
 // getSDKPort gets sdk service port, required when using service endpoint
-func getSDKPort() (int32, error) {
-	svc, err := k8sCore.GetService(schedops.PXServiceName, schedops.PXNamespace)
+func (d *portworx) getSDKPort() (int32, error) {
+	svc, err := k8sCore.GetService(schedops.PXServiceName, d.namespace)
 	if err != nil {
 		return 0, err
 	}
@@ -4079,8 +4090,8 @@ func getSDKPort() (int32, error) {
 }
 
 // getSDKContainerPort gets the sdk container port in the node, required when using node ip
-func getSDKContainerPort() (int32, error) {
-	svc, err := k8sCore.GetService(schedops.PXServiceName, schedops.PXNamespace)
+func (d *portworx) getSDKContainerPort() (int32, error) {
+	svc, err := k8sCore.GetService(schedops.PXServiceName, d.namespace)
 	if err != nil {
 		return 0, err
 	}

--- a/drivers/volume/portworx/schedops/dcos-schedops.go
+++ b/drivers/volume/portworx/schedops/dcos-schedops.go
@@ -69,6 +69,11 @@ func (d *dcosSchedOps) ValidateSnapshot(volParams map[string]string, parent *api
 	return nil
 }
 
+func (d *dcosSchedOps) GetPortworxNamespace() (string, error) {
+	// TODO: Implement this
+	return "", nil
+}
+
 func (d *dcosSchedOps) GetServiceEndpoint() (string, error) {
 	// PX driver is accessed directly on agent nodes. There is no DC/OS level
 	// service endpoint which can be used to redirect the calls to PX driver

--- a/drivers/volume/portworx/schedops/schedops.go
+++ b/drivers/volume/portworx/schedops/schedops.go
@@ -38,6 +38,8 @@ type Driver interface {
 	ValidateSnapshot(volumeParams map[string]string, parent *api.Volume) error
 	// GetVolumeName returns the volume name based on the volume object received
 	GetVolumeName(v *volume.Volume) string
+	// GetPortworxNamespace returns the Portworx namespace
+	GetPortworxNamespace() (string, error)
 	// GetServiceEndpoint returns the hostname of portworx service if it is present
 	GetServiceEndpoint() (string, error)
 	// UpgradePortworx upgrades portworx to the given docker image and tag

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -49,13 +49,16 @@ type Options struct {
 // Driver defines an external volume driver interface that must be implemented
 // by any external storage provider that wants to qualify their product with
 // Torpedo.  The functions defined here are meant to be destructive and illustrative
-// of failure scenarious that can happen with an external storage provider.
+// of failure scenarios that can happen with an external storage provider.
 type Driver interface {
 	// Init initializes the volume driver under the given scheduler
 	Init(sched string, nodeDriver string, token string, storageProvisioner string, csiGenericConfigMap string, logger *logrus.Logger) error
 
 	// String returns the string name of this driver.
 	String() string
+
+	// GetVolumeDriverNamespace returns the namespace of this driver.
+	GetVolumeDriverNamespace() (string, error)
 
 	// CreateVolume creates a volume with the default setting
 	// returns volume_id of the new volume
@@ -69,10 +72,10 @@ type Driver interface {
 	// returns the device path
 	AttachVolume(volumeID string) (string, error)
 
-	// DetachVolume detaches the volume given the volumeID
+	// DetachVolume detaches the volume for given volumeID
 	DetachVolume(volumeID string) error
 
-	// Delete the volume of the Volume ID provided
+	// DeleteVolume deletes the volume for given volumeID
 	DeleteVolume(volumeID string) error
 
 	// InspectVolume inspects the volume with the given name

--- a/tests/basic/longevity_test.go
+++ b/tests/basic/longevity_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/portworx/torpedo/drivers/node"
 	"github.com/portworx/torpedo/drivers/scheduler"
 	k8s "github.com/portworx/torpedo/drivers/scheduler/k8s"
-	"github.com/portworx/torpedo/drivers/volume/portworx/schedops"
 	. "github.com/portworx/torpedo/tests"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -448,8 +447,12 @@ func SetTopologyLabelsOnNodes() ([]map[string]string, error) {
 
 	logrus.Info("Add Topology Labels on node")
 	var secret PureSecret
+	volumeDriverNamespace, err := Inst().V.GetVolumeDriverNamespace()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get volume driver namespace. Error [%v]", err)
+	}
 	pureSecretString, err := Inst().S.GetSecretData(
-		schedops.PXNamespace, PureSecretName, PureSecretDataField,
+		volumeDriverNamespace, PureSecretName, PureSecretDataField,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to read pure secret [%s]. Error [%v]",
@@ -493,7 +496,8 @@ func SetTopologyLabelsOnNodes() ([]map[string]string, error) {
 
 	// Bouncing Back the PX pods on all nodes to restart Csi Registrar Container
 	logrus.Info("Bouncing back the PX pods after setting the Topology Labels on Nodes")
-	if err := deletePXPods(""); err != nil {
+
+	if err := deletePXPods(volumeDriverNamespace); err != nil {
 		return nil, fmt.Errorf("Failed to delete PX pods. Error:[%v]", err)
 	}
 
@@ -514,9 +518,6 @@ func SetTopologyLabelsOnNodes() ([]map[string]string, error) {
 // deletePXPods delete px pods
 func deletePXPods(nameSpace string) error {
 	pxLabel := make(map[string]string)
-	if nameSpace == "" {
-		nameSpace = k8s.PXNamespace
-	}
 	pxLabel["name"] = "portworx"
 	if err := core.Instance().DeletePodsByLabels(nameSpace, pxLabel, podDestroyTimeout); err != nil {
 		return err


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Added support for custom Portworx namespace

**Which issue(s) this PR fixes** (optional)
Closes https://portworx.atlassian.net/browse/PTX-13295

**Special notes for your reviewer**:
I created a portworx/torpedo:PTX-13295 image to test
@Rohit-PX please run couple tests as I touched stork code
@lsrinivas-pure please run Longevity test as I touched longevity test code

Successful Torpedo run here: https://jenkins.pwx.dev.purestorage.com/job/Torpedo/view/Torpedo%20NextPX/job/tp-nextpx-op-custom-ns/366/
Successful Torpedo run on basic volume driver here: https://jenkins.pwx.dev.purestorage.com/job/Torpedo/view/Torpedo%20NextPX/job/tp-nextpx-basic-vol-driver/673/