### PR TITLE
Elasticsearch spec for systemtesting

### DIFF
--- a/drivers/scheduler/k8s/systemtestSpec/elasticsearch/es-exporter.yaml
+++ b/drivers/scheduler/k8s/systemtestSpec/elasticsearch/es-exporter.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: es-exporter
+  labels:
+    component: elasticsearch
+    role: exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      component: elasticsearch
+      role: exporter
+  template:
+    metadata:
+      labels:
+        component: elasticsearch
+        role: exporter
+    spec:
+      containers:
+        - name: es-exporter
+          image: quay.io/prometheuscommunity/elasticsearch-exporter:latest
+          args:
+            - '--es.uri=http://esnode-0.elasticsearch-api.elasticsearch.svc.cluster.local:9200'
+            - --es.all
+            - --es.indices
+          ports:
+            - containerPort: 9114
+              name: metrics
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: es-exporter-nodeport
+  labels:
+    component: elasticsearch
+    role: exporter
+spec:
+  type: NodePort
+  ports:
+  - port: 9114
+    name: metrics
+  selector:
+    component: elasticsearch
+    role: exporter

--- a/drivers/scheduler/k8s/systemtestSpec/elasticsearch/px-elasticdata-app-read-update.yaml
+++ b/drivers/scheduler/k8s/systemtestSpec/elasticsearch/px-elasticdata-app-read-update.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: es-load-readupdate
+  labels:
+    app: es-load
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: es-load
+  template:
+    metadata:
+      labels:
+        app: es-load
+    spec:
+      containers:
+      - name: es-load-readupdate
+        image: docker.pwx.dev.purestorage.com/portworx/elasticsearch_read_update
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        command:
+          - /bin/bash
+          - -c
+          - "./esreadupdate.sh --es_address esnode-0.elasticsearch-api.$POD_NAMESPACE.svc.cluster.local:9200"
+      restartPolicy: Always

--- a/drivers/scheduler/k8s/systemtestSpec/elasticsearch/px-elasticdata-app.yaml
+++ b/drivers/scheduler/k8s/systemtestSpec/elasticsearch/px-elasticdata-app.yaml
@@ -1,0 +1,157 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch-cluster
+spec:
+  clusterIP: None
+  selector:
+    app: es-cluster
+  ports:
+  - name: transport
+    port: 9300
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch-api
+spec:
+  selector:
+    app: es-cluster
+  ports:
+  - name: http
+    port: 9200
+    targetPort: 9200
+  type: NodePort
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: es-config
+data:
+  elasticsearch.yml: |
+    cluster.name: my-elastic-cluster-repl1
+    network.host: "0.0.0.0"
+    bootstrap.memory_lock: false
+    discovery.zen.ping.unicast.hosts: elasticsearch-cluster
+    discovery.zen.minimum_master_nodes: 1
+    xpack.security.enabled: false
+    xpack.monitoring.enabled: false
+    indices.memory.index_buffer_size: 30%
+  ES_JAVA_OPTS: -Xms8196m -Xmx8196m
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: esnode
+spec:
+  serviceName: elasticsearch-api
+  replicas: 3
+  selector:
+    matchLabels:
+      app: es-cluster
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: es-cluster
+    spec:
+      schedulerName: stork
+      securityContext:
+        fsGroup: 1000
+      initContainers:
+      - name: init-sysctl
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        command: ["sysctl", "-w", "vm.max_map_count=262144"]
+      containers:
+      - name: elasticsearch
+        resources:
+          requests:
+            memory: 8Gi
+            cpu: "1"
+          limits:
+            cpu: "2"
+        securityContext:
+          privileged: true
+          runAsUser: 1000
+          capabilities:
+            add:
+              - IPC_LOCK
+              - SYS_RESOURCE
+        image: docker.elastic.co/elasticsearch/elasticsearch:6.5.0
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: ES_JAVA_OPTS
+          valueFrom:
+            configMapKeyRef:
+              name: es-config
+              key: ES_JAVA_OPTS
+        readinessProbe:
+          httpGet:
+            scheme: HTTP
+            path: /_cluster/health?local=true
+            port: 9200
+          initialDelaySeconds: 5
+        ports:
+        - containerPort: 9200
+          name: es-http
+        - containerPort: 9300
+          name: es-transport
+        volumeMounts:
+        - name: es-data
+          mountPath: /usr/share/elasticsearch/data
+        - name: elasticsearch-config
+          mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
+          subPath: elasticsearch.yml
+      volumes:
+      - name: elasticsearch-config
+        configMap:
+          name: es-config
+          items:
+          - key: elasticsearch.yml
+            path: elasticsearch.yml
+  volumeClaimTemplates:
+  - metadata:
+      name: es-data
+    spec:
+      storageClassName: elasticsearch-sc-read-write
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 250Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: es-load
+  labels:
+    app: es-load
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: es-load
+  template:
+    metadata:
+      labels:
+        app: es-load
+    spec:
+      containers:
+      - name: es-load
+        image: portworx/torpedo-esload:1.1
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        command:
+          - /bin/bash
+          - -c
+          - "./esload.sh --es_address esnode-0.elasticsearch-api.$POD_NAMESPACE.svc.cluster.local:9200 --indices 10 --documents 750 --seconds 172800 --not-green --clients 3 --max-fields-per-document 200 --no-cleanup"
+      restartPolicy: Always
+

--- a/drivers/scheduler/k8s/systemtestSpec/elasticsearch/px-storage-class.yaml
+++ b/drivers/scheduler/k8s/systemtestSpec/elasticsearch/px-storage-class.yaml
@@ -1,0 +1,9 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+    name: elasticsearch-sc-read-write
+provisioner: kubernetes.io/portworx-volume
+parameters:
+   repl: "2"
+   nodiscard: "true"
+allowVolumeExpansion: true

--- a/drivers/scheduler/k8s/systemtestSpec/elasticsearch/servicemonitor.yaml
+++ b/drivers/scheduler/k8s/systemtestSpec/elasticsearch/servicemonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: es-exporter-metrics-sm
+  namespace: kube-system
+  labels:
+    name: portworx-prometheus-sm
+spec:
+  selector:
+    matchLabels:
+      component: elasticsearch
+      role: exporter
+  namespaceSelector:
+    any: true
+  endpoints:
+  - port: metrics
+    targetPort: 9114

--- a/drivers/scheduler/sidecars/elasticsearch_read_update.dockerfile
+++ b/drivers/scheduler/sidecars/elasticsearch_read_update.dockerfile
@@ -1,0 +1,12 @@
+FROM alpine/git AS downloader
+USER root
+RUN cd /tmp && git clone https://github.com/logzio/elasticsearch-stress-test.git
+FROM python:2
+WORKDIR /usr/src/elasticsearch-stress-test
+COPY --from=downloader /tmp/elasticsearch-stress-test/elasticsearch-stress-test.py ./
+COPY --from=downloader /tmp/elasticsearch-stress-test/requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY scripts/elasticsearch/elasticsearch_readupdate.py ./
+COPY scripts/elasticsearch/esreadupdate.sh ./
+RUN chmod 777 ./esreadupdate.sh
+ENTRYPOINT ["sh", "/esreadupdate.sh"]

--- a/drivers/scheduler/sidecars/scripts/elasticsearch/elasticsearch_readupdate.py
+++ b/drivers/scheduler/sidecars/scripts/elasticsearch/elasticsearch_readupdate.py
@@ -1,0 +1,91 @@
+from elasticsearch import Elasticsearch
+import argparse
+import time
+import random
+import sys
+import pdb
+import string
+import copy
+query = {
+  "query": {"match_all": {}}
+ }
+source_to_update = {}
+elasticsearch_user_name ='es_username'
+elasticsearch_user_password ='es_password'
+
+# Just to control the minimum value globally (though its not configurable)
+def generate_random_int(max_size):
+    try:
+        return random.randint(1, max_size)
+    except:
+        print("Not supporting {0} as valid sizes!".format(max_size))
+        sys.exit(1)
+
+def modified_source(source_doc):
+    source_doc_cp = dict()
+    for key in source_doc.keys():
+        source_doc_cp[key] = ''.join(generate_random_string(255))
+    return source_doc_cp
+    
+def generate_random_string(max_size):
+    return ''.join(random.choice(string.ascii_lowercase) for _ in range(generate_random_int(max_size)))
+
+def main():
+    # Set a parser object
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--es_address", nargs='+', help="The address of your cluster (no protocol or port)", required=True)
+    args = parser.parse_args()
+    #args.es_address
+    #es= Elasticsearch("esnode-0.elasticsearch-api.elasticsearchrepl1.svc.cluster.local:9200", http_auth=None, verify_certs=True,  ssl_context= None,  timeout=1200)
+    es= Elasticsearch(args.es_address, http_auth=None, verify_certs=True,  ssl_context= None,  timeout=1200)
+    #For read evey index and later update 1/5 document  inside each data.
+    for es_index in es.indices.get('*'):
+        print("es index "+es_index)
+        #using scroll API to search docs for given indice
+        result = es.search(index=es_index, body={"query":{"match_all":{}}}, size=100 , scroll="5m")
+        for doc in result['hits']['hits']:
+            print ("DOC ID"+doc['_id'])#, doc['_source']
+        old_scroll_id = result['_scroll_id']
+        results = result['hits']['hits']
+        print("Lenght of hits "+str(len(results)))
+        try:
+            counter = 0
+            while len(results)>0:
+                for i, r in enumerate(results):
+                    counter+=1
+                    print(i)
+                    print r['_id']
+                    if counter == 5:
+                        #print(r)
+                        #add_fields()
+                        source_doc_cp = modified_source(r['_source'])
+                        try:
+                            response = es.update(index=es_index,doc_type="stresstest", id=r['_id'], body={"doc":source_doc_cp},refresh=True)
+                            print('Update doc response :', response)
+                        except Exception as ex:
+                            print("Exception while updating %s : %s", es_index, ex)
+                        counter = 0
+                        #response = es.update(index=es_index, doc_type="stresstest", id=r['_id'], body=add_fields())
+                result = es.scroll(scroll_id=old_scroll_id,
+                    scroll='5m'  # length of time to keep search context
+                    )
+                # check if there's a new scroll ID
+                if old_scroll_id != result['_scroll_id']:
+                    print("NEW SCROLL ID:", result['_scroll_id'])
+                # keep track of pass scroll _id
+                old_scroll_id = result['_scroll_id']
+                results = result['hits']['hits']
+                print("Scroll id "+old_scroll_id)
+                print("Lenght of hits " +str(len(results)))
+        except Exception as ex:
+            print("Exception thrown while querying %s : %s",es_index, ex)
+        print("Picking next indes after 1 minute")
+        time.sleep(60)    
+try:
+    main()
+except Exception as e:
+    print("Got unexpected exception. probably a bug, please report it.")
+    print("")
+    print(e.message)
+    print("")
+    sys.exit(1)

--- a/drivers/scheduler/sidecars/scripts/elasticsearch/esreadupdate.sh
+++ b/drivers/scheduler/sidecars/scripts/elasticsearch/esreadupdate.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -x
+pid=0
+esload() {
+	while true; do
+		python elasticsearch_readupdate.py "$@"
+		sleep 5
+	done
+}
+
+# SIGTERM-handler
+term_handler() {
+	if [ $pid -ne 0 ]; then
+		kill -SIGTERM "$pid"
+		wait "$pid"
+	fi
+	exit 143; # 128 + 15 -- SIGTERM
+}
+
+# setup handlers
+# on callback, kill the last background process, which is "tail -f"
+trap 'kill ${!}; term_handler' SIGTERM
+
+# run app
+esload "$@" &
+pid="$!"
+
+# wait forever
+while true
+do
+	tail -f /dev/null & wait "${!}"
+done


### PR DESCRIPTION
1. This spec writes lots of  data and data retains throughout the test

as passed parameters are "--indices 10 --documents 750 --seconds 172800 --not-green --clients 3 --max-fields-per-document 200 --no-cleanup""
2. Node exporter is available incase if you want to export the metrics to Prometheues
3. New deployment spec created to read data from indices/document and update documents.
4. Nodiscard is enabled on storage spec to support Autofstrim
