### PR TITLE
Removes a spammy info line from VerifyFatal

### DIFF
--- a/pkg/aetosutil/dashboardutil.go
+++ b/pkg/aetosutil/dashboardutil.go
@@ -396,7 +396,6 @@ func (d *Dashboard) VerifySafely(actual, expected interface{}, description strin
 //VerifyFatal verify test and abort operation upon failure
 func (d *Dashboard) VerifyFatal(actual, expected interface{}, description string) {
 
-	d.Log.Info("Verify Fatal")
 	d.VerifySafely(actual, expected, description)
 	var err error
 	if actual != expected {


### PR DESCRIPTION

**What this PR does / why we need it**:
Makes the torpedo logs a little easier on the eyes by removing a generally extra log line

