### PR TITLE
Set throttle to re-sync with new knobs

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -441,6 +441,7 @@ spec:
             "--pure-san-type=$PURE_SAN_TYPE",
             "--vault-addr=$VAULT_ADDR",
             "--vault-token=$VAULT_TOKEN",
+            "--px-runtime-opts=$PX_RUNTIME_OPTS",
             "--autopilot-upgrade-version=$AUTOPILOT_UPGRADE_VERSION",
             "--csi-generic-driver-config-map=$CSI_GENERIC_CONFIGMAP",
             "--sched-upgrade-hops=$SCHEDULER_UPGRADE_HOPS",

--- a/pkg/aetosutil/dashboardutil.go
+++ b/pkg/aetosutil/dashboardutil.go
@@ -194,6 +194,15 @@ func (d *Dashboard) TestSetEnd() {
 
 // TestCaseEnd update testcase  to dashboard DB
 func (d *Dashboard) TestCaseEnd() {
+	result := "PASS"
+
+	for _, v := range verifications {
+
+		if !v.ResultStatus {
+			result = "FAIL"
+			break
+		}
+	}
 	if d.IsEnabled {
 
 		if d.testcaseID == 0 {
@@ -212,25 +221,16 @@ func (d *Dashboard) TestCaseEnd() {
 			d.Log.Infof("TestCase %d ended successfully", d.testcaseID)
 		}
 
-		result := "PASS"
-
-		for _, v := range verifications {
-
-			if !v.ResultStatus {
-				result = "FAIL"
-				break
-			}
-		}
-
-		d.Log.Info("--------Test End------")
-		d.Log.Infof("#Test: %s ", testCase.ShortName)
-		d.Log.Infof("#Description: %s ", testCase.Description)
-		d.Log.Infof("#Resuly: %s ", result)
-		d.Log.Info("------------------------")
 		verifications = nil
 		removeTestCaseFromStack(d.testcaseID)
 
 	}
+
+	d.Log.Info("--------Test End------")
+	d.Log.Infof("#Test: %s ", testCase.ShortName)
+	d.Log.Infof("#Description: %s ", testCase.Description)
+	d.Log.Infof("#Result: %s ", result)
+	d.Log.Info("------------------------")
 }
 
 func removeTestCaseFromStack(testcaseID int) {
@@ -275,6 +275,11 @@ func (d *Dashboard) TestSetUpdate(testSet *TestSet) {
 
 // TestCaseBegin start the test case and push data to dashboard DB
 func (d *Dashboard) TestCaseBegin(testName, description, testRepoID string, tags []string) {
+
+	d.Log.Info("--------Test Start------")
+	d.Log.Infof("#Test: %s ", testName)
+	d.Log.Infof("#Description: %s ", description)
+	d.Log.Info("------------------------")
 	if d.IsEnabled {
 		if d.TestSetID == 0 {
 			d.Log.Errorf("TestSetID is empty, skipping begin testcase")
@@ -329,10 +334,6 @@ func (d *Dashboard) TestCaseBegin(testName, description, testRepoID string, tags
 				d.Log.Errorf("TestCase creation failed. Cause : %v", err)
 			}
 		}
-		d.Log.Info("--------Test Start------")
-		d.Log.Infof("#Test: %s ", testCase.ShortName)
-		d.Log.Infof("#Description: %s ", description)
-		d.Log.Info("------------------------")
 
 		testCasesStack = append(testCasesStack, d.testcaseID)
 

--- a/tests/basic/longevity_test.go
+++ b/tests/basic/longevity_test.go
@@ -716,17 +716,6 @@ func populateIntervals() {
 	triggerInterval[BackupRestartNode][6] = 5 * baseInterval
 	triggerInterval[BackupRestartNode][5] = 6 * baseInterval
 
-	triggerInterval[AppTasksDown][10] = 1 * baseInterval
-	triggerInterval[AppTasksDown][9] = 2 * baseInterval
-	triggerInterval[AppTasksDown][8] = 3 * baseInterval
-	triggerInterval[AppTasksDown][7] = 4 * baseInterval
-	triggerInterval[AppTasksDown][6] = 5 * baseInterval
-	triggerInterval[AppTasksDown][5] = 6 * baseInterval
-	triggerInterval[AppTasksDown][4] = 7 * baseInterval
-	triggerInterval[AppTasksDown][3] = 8 * baseInterval
-	triggerInterval[AppTasksDown][2] = 9 * baseInterval
-	triggerInterval[AppTasksDown][1] = 10 * baseInterval
-
 	triggerInterval[AsyncDR][10] = 1 * baseInterval
 	triggerInterval[AsyncDR][9] = 3 * baseInterval
 	triggerInterval[AsyncDR][8] = 6 * baseInterval
@@ -739,6 +728,17 @@ func populateIntervals() {
 	triggerInterval[AsyncDR][1] = 27 * baseInterval
 
 	baseInterval = 60 * time.Minute
+
+	triggerInterval[AppTasksDown][10] = 1 * baseInterval
+	triggerInterval[AppTasksDown][9] = 2 * baseInterval
+	triggerInterval[AppTasksDown][8] = 3 * baseInterval
+	triggerInterval[AppTasksDown][7] = 4 * baseInterval
+	triggerInterval[AppTasksDown][6] = 5 * baseInterval
+	triggerInterval[AppTasksDown][5] = 6 * baseInterval
+	triggerInterval[AppTasksDown][4] = 7 * baseInterval
+	triggerInterval[AppTasksDown][3] = 8 * baseInterval
+	triggerInterval[AppTasksDown][2] = 9 * baseInterval
+	triggerInterval[AppTasksDown][1] = 10 * baseInterval
 
 	triggerInterval[RebootNode][10] = 1 * baseInterval
 	triggerInterval[RebootNode][9] = 3 * baseInterval

--- a/tests/basic/node_decommission_test.go
+++ b/tests/basic/node_decommission_test.go
@@ -13,8 +13,11 @@ import (
 )
 
 var _ = Describe("{DecommissionNode}", func() {
+
+	JustBeforeEach(func() {
+		StartTorpedoTest("DecommissionNode", "Validate node decommission", nil)
+	})
 	var contexts []*scheduler.Context
-	StartTorpedoTest("DecommissionNode", "Validate node decommission", nil)
 
 	testName := "decommissionnode"
 	stepLog := "has to decommission a node and check if node was decommissioned successfully"

--- a/tests/basic/sharedv4_multivol_test.go
+++ b/tests/basic/sharedv4_multivol_test.go
@@ -128,7 +128,10 @@ var _ = Describe("{MultiVolumeMountsForSharedV4}", func() {
 
 // This test performs sharedv4 nfs server pod termination failover use case
 var _ = Describe("{NFSServerNodeDelete}", func() {
-	StartTorpedoTest("NFSServerNodeDelete", "Vslidate NFS server delete", nil)
+	JustBeforeEach(func() {
+		StartTorpedoTest("NFSServerNodeDelete", "Vslidate NFS server delete", nil)
+	})
+
 	var contexts []*scheduler.Context
 	stepLog := "has to validate that the new pods started successfully after nfs server node is terminated"
 	It(stepLog, func() {

--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -19,7 +19,10 @@ const poolResizeTimeout = time.Minute * 90
 const retryTimeout = time.Minute
 
 var _ = Describe("{StoragePoolExpandDiskResize}", func() {
-	StartTorpedoTest("StoragePoolExpandDiskResize", "Validate storage pool expansion expansion using resize-disk option", nil)
+	JustBeforeEach(func() {
+		StartTorpedoTest("StoragePoolExpandDiskResize", "Validate storage pool expansion expansion using resize-disk option", nil)
+	})
+
 	var contexts []*scheduler.Context
 	stepLog := "has to schedule apps, and expand it by resizing a disk"
 	It(stepLog, func() {
@@ -103,7 +106,9 @@ var _ = Describe("{StoragePoolExpandDiskResize}", func() {
 })
 
 var _ = Describe("{StoragePoolExpandDiskAdd}", func() {
-	StartTorpedoTest("StoragePoolExpandDiskAdd", "Validate storage pool expansion expansion using add-disk option", nil)
+	JustBeforeEach(func() {
+		StartTorpedoTest("StoragePoolExpandDiskAdd", "Validate storage pool expansion expansion using add-disk option", nil)
+	})
 	var contexts []*scheduler.Context
 
 	stepLog := "should get the existing pool and expand it by adding a disk"
@@ -188,7 +193,10 @@ var _ = Describe("{StoragePoolExpandDiskAdd}", func() {
 })
 
 var _ = Describe("{PoolResizeDiskReboot}", func() {
-	StartTorpedoTest("PoolResizeDiskReboot", "Initiate pool expansion using resize-disk and reboot node", nil)
+	JustBeforeEach(func() {
+		StartTorpedoTest("PoolResizeDiskReboot", "Initiate pool expansion using resize-disk and reboot node", nil)
+	})
+
 	var contexts []*scheduler.Context
 
 	stepLog := "has to schedule apps, and expand it by resizing a disk"
@@ -281,7 +289,9 @@ var _ = Describe("{PoolResizeDiskReboot}", func() {
 })
 
 var _ = Describe("{PoolAddDiskReboot}", func() {
-	StartTorpedoTest("PoolAddDiskReboot", "Initiate pool expansion using add-disk and reboot node", nil)
+	JustBeforeEach(func() {
+		StartTorpedoTest("PoolAddDiskReboot", "Initiate pool expansion using add-disk and reboot node", nil)
+	})
 	var contexts []*scheduler.Context
 
 	stepLog := "should get the existing pool and expand it by adding a disk"

--- a/tests/common.go
+++ b/tests/common.go
@@ -3921,7 +3921,7 @@ func ParseFlags() {
 	flag.IntVar(&testsetID, testSetIDFlag, 0, "testset id to post the results")
 	flag.StringVar(&testBranch, testBranchFlag, "master", "branch of the product")
 	flag.StringVar(&testProduct, testProductFlag, "PxEnp", "Portworx product under test")
-	flag.StringVar(&pxRuntimeOpts, "px-runtime-opts", "", "run time options for cluster update")
+	flag.StringVar(&pxRuntimeOpts, "px-runtime-opts", "", "comma separated list of run time options for cluster update")
 	flag.Parse()
 
 	log = logInstance.GetLogInstance()
@@ -4734,8 +4734,7 @@ func updatePxRuntimeOpts() error {
 			optionsMap[optArr[0]] = optArr[1]
 		}
 		currNode := node.GetWorkerNodes()[0]
-		err = Inst().V.SetClusterRunTimeOpts(currNode, optionsMap)
-		return err
+		return Inst().V.SetClusterRunTimeOpts(currNode, optionsMap)
 	} else {
 		log.Info("No run time options provided to update")
 	}

--- a/tests/testTriggers.go
+++ b/tests/testTriggers.go
@@ -471,6 +471,11 @@ func TriggerDeployNewApps(contexts *[]*scheduler.Context, recordChan *chan *Even
 	Inst().M.IncrementCounterMetric(TotalTriggerCount, event.Event.Type)
 	Inst().M.SetGaugeMetricWithNonDefaultLabels(FailedTestAlert, 0, event.Event.Type, "")
 
+	Step(fmt.Sprintf("Set throttle to re-sync"), func() {
+		err := updatePxRuntimeOpts()
+		UpdateOutcome(event, err)
+	})
+
 	errorChan := make(chan error, errorChannelSize)
 	labels := Inst().TopologyLabels
 	Step("Deploy applications", func() {

--- a/tests/testTriggers.go
+++ b/tests/testTriggers.go
@@ -472,8 +472,7 @@ func TriggerDeployNewApps(contexts *[]*scheduler.Context, recordChan *chan *Even
 	Inst().M.SetGaugeMetricWithNonDefaultLabels(FailedTestAlert, 0, event.Event.Type, "")
 
 	Step(fmt.Sprintf("Set throttle to re-sync"), func() {
-		err := updatePxRuntimeOpts()
-		UpdateOutcome(event, err)
+		UpdateOutcome(event, updatePxRuntimeOpts())
 	})
 
 	errorChan := make(chan error, errorChannelSize)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
- Adding options to update run rime options using parameters

- Minor fixes for logging

**Which issue(s) this PR fixes** (optional)
Closes #PTX-13132

**Special notes for your reviewer**:
```
STEP: Set throttle to re-sync
2022-11-02 19:27:16 +0530:[INFO dashboardutil.go::(*Dashboard).Infof:422]  Setting run time options: max_pending_resync_writes=2,blocks_per_resync_range=16
2022-11-02 19:27:16 +0530:[DEBUG restutil.go::getBody:158]  Response: {"status":"OK"}
2022-11-02 19:27:17 +0530:[DEBUG ssh.go::(*SSH).doCmdUsingPod.func1:611]  Running command on pod debug-9prjf [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c which pxctl]]
2022-11-02 19:27:21 +0530:[DEBUG ssh.go::(*SSH).doCmdUsingPod.func1:611]  Running command on pod debug-9prjf [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c sudo /usr/local/bin/pxctl cluster options update --runtime-options max_pending_resync_writes=2,blocks_per_resync_range=16]]
2022-11-02 19:27:23 +0530:[DEBUG portworx.go::(*portworx).SetClusterRunTimeOpts:3712]  Successfully set rt_opts
```

```
[root@torpedo-long-fa-sample-test-71-6 ~]# pxctl cluster options list
Default RPC timeout (minutes)                           : 5
Auto decommission timeout (minutes)                     : 20
Replica move timeout (minutes)                          : 1440
Replica move timestamp records threshold                : 134217728
Internal Snapshot Interval (minutes)                    : 30
Re-add timeout (minutes)                                : 1440
Resync repl-add                                         : off
Domain policy                                           : eventual
Cloudsnap optimized Restores                            : off
Cloudsnap Catalog                                       : off
Cloudsnap Abort Timeout (minutes)                       : 10
Cloudsnap Error Retry Limit                             : 3
Cloudsnap minimum Periodic schedule Interval (minutes)  : 15
Cloudsnap maximum threads                               : 16
Cloudsnap network interface                             :
Cloudsnap Using Metadata Enabled                        : on
Cloudsnap Metadata Upload Bytes limit                   : 10240 MiB
Cloudsnap Metadata Upload Percent limit                 : 15 %
Cloudsnaps Cleanup Failed Delay                         : 0
Cloudsnap full backup frequency                         : 7
Disable Provisioning Labels                             :
License expiry check (days)                             : 7
License expiry check interval                           : 6h0m5s
PxHttpProxy                                             :
Temporary Kvdb loss support                             : on
Unique Blocks size of volumes check interval            : 12h0m0s
Maximum concurrent API invocations                      : 20
Number of sharedv4 threads                              : 128
Sharedv4 (NFS) mount timeout in seconds                 : 130
Runtime options                                         : selector: -, options: blocks_per_resync_range=16,max_pending_resync_writes=2
ScheduleSnapshots Detached Volume Action                : optimized
Cache flush                                             : disabled
Cache flush interval in seconds                         : 30
Lttng last command executed                             :
Lttng disk usage setting (GB)                           : 0
Lttng loglevel setting                                  :
SkinnySnap                                              : off
SkinnySnap replication factor                           : 1
Cloudsnap cluster network usage limit                   : Not configured
RelaxedReclaim                                          : off
RelaxedReclaim maximum pending                          : 256
Volume expiration minutes                               : 0s
Auto Fstrim                                             : off
Max Fstrim IO rate                                      : 32 MiB
Min Fstrim IO rate                                      : 1 MiB
Max replicas per Node                                   : 4294967295
Pool Cache Configuration                                : off
```


