### PR TITLE
PWX-27035: sharedv4-svc as the default for sharedv4 volumes

### DIFF
--- a/drivers/scheduler/k8s/specs/bonnie-sharedv4/px-bonnie-storage.yml
+++ b/drivers/scheduler/k8s/specs/bonnie-sharedv4/px-bonnie-storage.yml
@@ -10,6 +10,7 @@ parameters:
   sharedv4: "true"
   nodiscard: "true"
   mount_options: "nodiscard=true"
+  sharedv4_svc_type: ""
 allowVolumeExpansion: true
 ---
 kind: PersistentVolumeClaim

--- a/drivers/scheduler/k8s/specs/bonnie-sv4-svc/px-bonnie-storage.yml
+++ b/drivers/scheduler/k8s/specs/bonnie-sv4-svc/px-bonnie-storage.yml
@@ -10,7 +10,6 @@ parameters:
   nodiscard: "true"
   mount_options: "nodiscard=true"
   sharedv4: "true"
-  sharedv4_svc_type: "ClusterIP"
 allowVolumeExpansion: true
 ---
 kind: PersistentVolumeClaim

--- a/drivers/scheduler/k8s/specs/fio-sharedv4/px-fio-storage.yaml
+++ b/drivers/scheduler/k8s/specs/fio-sharedv4/px-fio-storage.yaml
@@ -9,6 +9,7 @@ parameters:
   io_profile: "db_remote"
   repl: "3"
   sharedv4: "true"
+  sharedv4_svc_type: ""
 allowVolumeExpansion: true
 ---
 kind: PersistentVolumeClaim

--- a/drivers/scheduler/k8s/specs/fio-sv4-svc/px-fio-storage.yaml
+++ b/drivers/scheduler/k8s/specs/fio-sv4-svc/px-fio-storage.yaml
@@ -9,7 +9,6 @@ parameters:
   io_profile: "db_remote"
   repl: "3"
   sharedv4: "true"
-  sharedv4_svc_type: "ClusterIP"
 allowVolumeExpansion: true
 ---
 kind: PersistentVolumeClaim

--- a/drivers/scheduler/k8s/specs/nginx-sharedv4/px-nginx-storage.yaml
+++ b/drivers/scheduler/k8s/specs/nginx-sharedv4/px-nginx-storage.yaml
@@ -15,6 +15,7 @@ provisioner: kubernetes.io/portworx-volume
 parameters:
   repl: "3"
   sharedv4: "true"
+  sharedv4_svc_type: ""
 allowVolumeExpansion: true
 ---
 ##### Portworx persistent volume claim

--- a/drivers/scheduler/k8s/specs/nginx-sv4-svc-1pv/px-nginx-storage.yaml
+++ b/drivers/scheduler/k8s/specs/nginx-sv4-svc-1pv/px-nginx-storage.yaml
@@ -15,7 +15,6 @@ provisioner: kubernetes.io/portworx-volume
 parameters:
   repl: "2"
   sharedv4: "true"
-  sharedv4_svc_type: "ClusterIP"
 allowVolumeExpansion: true
 ---
 ##### Portworx persistent volume claim

--- a/drivers/scheduler/k8s/specs/nginx-sv4-svc/px-nginx-storage.yaml
+++ b/drivers/scheduler/k8s/specs/nginx-sv4-svc/px-nginx-storage.yaml
@@ -15,7 +15,6 @@ provisioner: kubernetes.io/portworx-volume
 parameters:
   repl: "3"
   sharedv4: "true"
-  sharedv4_svc_type: "ClusterIP"
 allowVolumeExpansion: true
 ---
 ##### Portworx persistent volume claim

--- a/drivers/scheduler/k8s/specs/test-sharedv4/pvc.yaml
+++ b/drivers/scheduler/k8s/specs/test-sharedv4/pvc.yaml
@@ -7,6 +7,7 @@ provisioner: kubernetes.io/portworx-volume
 parameters:
   repl: "3"
   sharedv4: "true"
+  sharedv4_svc_type: ""
 allowVolumeExpansion: true
 ---
 ##### Portworx persistent volume claim

--- a/drivers/scheduler/k8s/specs/test-sv4-svc-2/pvc.yaml
+++ b/drivers/scheduler/k8s/specs/test-sv4-svc-2/pvc.yaml
@@ -9,7 +9,6 @@ parameters:
   aggregation_level: "2"
   io_profile: "db"
   sharedv4: "true"
-  sharedv4_svc_type: "ClusterIP"
 allowVolumeExpansion: true
 ---
 ##### Portworx persistent volume claim

--- a/drivers/scheduler/k8s/specs/test-sv4-svc/pvc.yaml
+++ b/drivers/scheduler/k8s/specs/test-sv4-svc/pvc.yaml
@@ -10,7 +10,6 @@ parameters:
   sharedv4: {{ .StorageClassSharedv4 }}
   {{ else }}
   sharedv4: "true"{{ end }}
-  sharedv4_svc_type: "ClusterIP"
 allowVolumeExpansion: true
 ---
 ##### Portworx persistent volume claim

--- a/drivers/scheduler/k8s/specs/vdbench-fastpath/px-vdbench-storage.yml
+++ b/drivers/scheduler/k8s/specs/vdbench-fastpath/px-vdbench-storage.yml
@@ -8,6 +8,7 @@ parameters:
   placement_strategy: "fastpath-repl1-vdbench-vps"
   repl: "1"
   sharedv4: "true"
+  sharedv4_svc_type: ""
   fastpath: "true"
   allow_others: "true"
   fs: "ext4"

--- a/drivers/scheduler/k8s/specs/vdbench-sharedv4/px-vdbench-storage.yml
+++ b/drivers/scheduler/k8s/specs/vdbench-sharedv4/px-vdbench-storage.yml
@@ -16,6 +16,7 @@ parameters:
   sharedv4: "true"
   nodiscard: "true"
   mount_options: "nodiscard=true"
+  sharedv4_svc_type: ""
 allowVolumeExpansion: true
 ---
 kind: PersistentVolumeClaim

--- a/drivers/scheduler/k8s/specs/vdbench-sv4-multivol/px-vdbench-storage.yml
+++ b/drivers/scheduler/k8s/specs/vdbench-sv4-multivol/px-vdbench-storage.yml
@@ -7,6 +7,7 @@ provisioner: kubernetes.io/portworx-volume
 parameters:
   repl: "3"
   sharedv4: "true"
+  sharedv4_svc_type: ""
   nodiscard: "true"
   mount_options: "nodiscard=true"
 allowVolumeExpansion: true

--- a/drivers/scheduler/k8s/specs/vdbench-sv4-r2-mvol/px-vdbench-storage.yml
+++ b/drivers/scheduler/k8s/specs/vdbench-sv4-r2-mvol/px-vdbench-storage.yml
@@ -7,6 +7,7 @@ provisioner: kubernetes.io/portworx-volume
 parameters:
   repl: "2"
   sharedv4: "true"
+  sharedv4_svc_type: ""
   nodiscard: "true"
   mount_options: "nodiscard=true"
 allowVolumeExpansion: true

--- a/drivers/scheduler/k8s/specs/vdbench-sv4-svc-multivol/px-vdbench-storage.yml
+++ b/drivers/scheduler/k8s/specs/vdbench-sv4-svc-multivol/px-vdbench-storage.yml
@@ -9,5 +9,4 @@ parameters:
   sharedv4: "true"
   nodiscard: "true"
   mount_options: "nodiscard=true"
-  sharedv4_svc_type: "ClusterIP"
 allowVolumeExpansion: true

--- a/drivers/scheduler/k8s/specs/vdbench-sv4-svc/px-vdbench-storage.yml
+++ b/drivers/scheduler/k8s/specs/vdbench-sv4-svc/px-vdbench-storage.yml
@@ -16,7 +16,6 @@ parameters:
   sharedv4: "true"
   mount_options: "nodiscard=true"
   nodiscard: "true"
-  sharedv4_svc_type: "ClusterIP"
 allowVolumeExpansion: true
 ---
 kind: PersistentVolumeClaim

--- a/drivers/scheduler/k8s/specs/vdbench-v4-fstrim/vd-sharedv4-st.yaml
+++ b/drivers/scheduler/k8s/specs/vdbench-v4-fstrim/vd-sharedv4-st.yaml
@@ -9,7 +9,6 @@ parameters:
   sharedv4: "true"
   nodiscard: "true"
   mount_options: "nodiscard=true"
-  sharedv4_svc_type: "ClusterIP"
 allowVolumeExpansion: true
 ---
 kind: PersistentVolumeClaim

--- a/drivers/scheduler/k8s/specs/wordpress-sharedv4/storage.yaml
+++ b/drivers/scheduler/k8s/specs/wordpress-sharedv4/storage.yaml
@@ -8,6 +8,7 @@ parameters:
   priority_io: "high"
   sharedv4: "true"
   io_profile: "cms"
+  sharedv4_svc_type: ""
 allowVolumeExpansion: true
 ---
 apiVersion: storage.k8s.io/v1

--- a/drivers/scheduler/k8s/specs/wordpress-sv4-svc/storage.yaml
+++ b/drivers/scheduler/k8s/specs/wordpress-sv4-svc/storage.yaml
@@ -7,7 +7,6 @@ parameters:
   repl: "3"
   priority_io: "high"
   sharedv4: "true"
-  sharedv4_svc_type: "ClusterIP"
   io_profile: "cms"
 allowVolumeExpansion: true
 ---


### PR DESCRIPTION
**What this PR does / why we need it**:
StorageClass needs to specify sharedv4_svc_type: "" when sharedv4 volume is desired otherwise sharedv4 service volume gets created.

Changed sharedv4 specs to specify that parameter.

Changed sharedv4-svc specs to omit that parameter (except for one to test "ClusterIP" value).

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**Which issue(s) this PR fixes** (optional)
PWX-25794

**Special notes for your reviewer**:

