### PR TITLE
Added Longevity test for stork application backup

### DIFF
--- a/pkg/applicationbackup/applicationbackup.go
+++ b/pkg/applicationbackup/applicationbackup.go
@@ -1,0 +1,107 @@
+package applicationbackup
+
+import (
+	"fmt"
+	"time"
+
+	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	"github.com/portworx/sched-ops/k8s/core"
+	storkops "github.com/portworx/sched-ops/k8s/stork"
+	"github.com/portworx/sched-ops/task"
+	"github.com/sirupsen/logrus"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	configMapName                          = "secret-configmap"
+	backupLocationType                     = storkv1.BackupLocationS3
+	backupLocationPath                     = "testpath"
+	s3SecretName                           = "s3secret"
+	applicationBackupScheduleRetryInterval = 10 * time.Second
+	applicationBackupScheduleRetryTimeout  = 5 * time.Minute
+)
+
+func CreateBackupLocation(
+	name string,
+	namespace string,
+	secretName string,
+) (*storkv1.BackupLocation, error) {
+	logrus.Infof("Using backup location type as %v", backupLocationType)
+	secretObj, err := core.Instance().GetSecret(secretName, "default")
+	if err != nil {
+		return nil, fmt.Errorf("secret %v is not present in default namespace", secretName)
+	}
+	// copy secret to the app namespace
+	newSecretObj := secretObj.DeepCopy()
+	newSecretObj.Namespace = namespace
+	newSecretObj.ResourceVersion = ""
+	_, err = core.Instance().CreateSecret(newSecretObj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to copy secret %v in required namespace %v", secretName, namespace)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("secret %v is not getting created  in default namespace", secretName)
+	}
+	backupLocation := &storkv1.BackupLocation{
+		ObjectMeta: meta.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: map[string]string{"stork.libopenstorage.ord/skipresource": "true"},
+		},
+		Location: storkv1.BackupLocationItem{
+			Type:         backupLocationType,
+			Path:         backupLocationPath,
+			SecretConfig: secretObj.Name,
+		},
+	}
+
+	backupLocation, err = storkops.Instance().CreateBackupLocation(backupLocation)
+	if err != nil {
+		return nil, err
+	}
+
+	// Doing a "Get" on the backuplocation created to add any missing info from the secrets,
+	// that might be required to later get buckets from the cloud objectstore
+	backupLocation, err = storkops.Instance().GetBackupLocation(backupLocation.Name, backupLocation.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	return backupLocation, nil
+}
+
+func CreateApplicationBackup(
+	name string,
+	namespace string,
+	backupLocation *storkv1.BackupLocation,
+) (*storkv1.ApplicationBackup, error) {
+
+	appBackup := &storkv1.ApplicationBackup{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: storkv1.ApplicationBackupSpec{
+			Namespaces:     []string{namespace},
+			BackupLocation: backupLocation.Name,
+		},
+	}
+
+	return storkops.Instance().CreateApplicationBackup(appBackup)
+}
+
+func WaitForAppBackupCompletion(name, namespace string, timeout time.Duration) error {
+	getAppBackup := func() (interface{}, bool, error) {
+		appBackup, err := storkops.Instance().GetApplicationBackup(name, namespace)
+		if err != nil {
+			return "", false, err
+		}
+
+		if appBackup.Status.Status != storkv1.ApplicationBackupStatusSuccessful {
+			return "", true, fmt.Errorf("app backups %s in %s not complete yet.Retrying", name, namespace)
+		}
+		return "", false, nil
+	}
+	_, err := task.DoRetryWithTimeout(getAppBackup, timeout, applicationBackupScheduleRetryInterval)
+	return err
+
+}

--- a/pkg/applicationbackup/applicationbackup.go
+++ b/pkg/applicationbackup/applicationbackup.go
@@ -8,9 +8,11 @@ import (
 	"github.com/portworx/sched-ops/k8s/core"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/portworx/sched-ops/task"
-	"github.com/sirupsen/logrus"
+	"github.com/portworx/torpedo/pkg/aetosutil"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+var dash *aetosutil.Dashboard
 
 const (
 	configMapName                          = "secret-configmap"
@@ -26,7 +28,7 @@ func CreateBackupLocation(
 	namespace string,
 	secretName string,
 ) (*storkv1.BackupLocation, error) {
-	logrus.Infof("Using backup location type as %v", backupLocationType)
+	dash.Infof("Using backup location type as %v", backupLocationType)
 	secretObj, err := core.Instance().GetSecret(secretName, "default")
 	if err != nil {
 		return nil, fmt.Errorf("secret %v is not present in default namespace", secretName)

--- a/tests/basic/longevity_test.go
+++ b/tests/basic/longevity_test.go
@@ -64,38 +64,38 @@ var _ = Describe("{Longevity}", func() {
 		VolumeClone:      TriggerVolumeClone,
 		VolumeResize:     TriggerVolumeResize,
 		//EmailReporter:        TriggerEmailReporter,
-		AppTaskDown:           TriggerAppTaskDown,
-		AppTasksDown:          TriggerAppTasksDown,
-		AddDrive:              TriggerAddDrive,
-		CoreChecker:           TriggerCoreChecker,
-		CloudSnapShot:         TriggerCloudSnapShot,
-		LocalSnapShot:         TriggerLocalSnapShot,
-		DeleteLocalSnapShot:   TriggerDeleteLocalSnapShot,
-		PoolResizeDisk:        TriggerPoolResizeDisk,
-		PoolAddDisk:           TriggerPoolAddDisk,
-		UpgradeStork:          TriggerUpgradeStork,
-		VolumesDelete:         TriggerVolumeDelete,
-		UpgradeVolumeDriver:   TriggerUpgradeVolumeDriver,
-		AutoFsTrim:            TriggerAutoFsTrim,
-		UpdateVolume:          TriggerVolumeUpdate,
-		RestartManyVolDriver:  TriggerRestartManyVolDriver,
-		RebootManyNodes:       TriggerRebootManyNodes,
-		NodeDecommission:      TriggerNodeDecommission,
-		NodeRejoin:            TriggerNodeRejoin,
-		CsiSnapShot:           TriggerCsiSnapShot,
-		CsiSnapRestore:        TriggerCsiSnapRestore,
-		RelaxedReclaim:        TriggerRelaxedReclaim,
-		Trashcan:              TriggerTrashcan,
-		KVDBFailover:          TriggerKVDBFailover,
-		ValidateDeviceMapper:  TriggerValidateDeviceMapperCleanup,
-		AsyncDR:               TriggerAsyncDR,
-		AsyncDRVolumeOnly:     TriggerAsyncDRVolumeOnly,
-		RestartKvdbVolDriver:  TriggerRestartKvdbVolDriver,
-		HAIncreaseAndReboot:   TriggerHAIncreaseAndReboot,
-		AddDiskAndReboot:      TriggerPoolAddDiskAndReboot,
-		ResizeDiskAndReboot:   TriggerPoolResizeDiskAndReboot,
-		AutopilotRebalance:    TriggerAutopilotPoolRebalance,
-		VolumeCreatePxRestart: TriggerVolumeCreatePXRestart,
+		AppTaskDown:            TriggerAppTaskDown,
+		AppTasksDown:           TriggerAppTasksDown,
+		AddDrive:               TriggerAddDrive,
+		CoreChecker:            TriggerCoreChecker,
+		CloudSnapShot:          TriggerCloudSnapShot,
+		LocalSnapShot:          TriggerLocalSnapShot,
+		DeleteLocalSnapShot:    TriggerDeleteLocalSnapShot,
+		PoolResizeDisk:         TriggerPoolResizeDisk,
+		PoolAddDisk:            TriggerPoolAddDisk,
+		UpgradeStork:           TriggerUpgradeStork,
+		VolumesDelete:          TriggerVolumeDelete,
+		UpgradeVolumeDriver:    TriggerUpgradeVolumeDriver,
+		AutoFsTrim:             TriggerAutoFsTrim,
+		UpdateVolume:           TriggerVolumeUpdate,
+		RestartManyVolDriver:   TriggerRestartManyVolDriver,
+		RebootManyNodes:        TriggerRebootManyNodes,
+		NodeDecommission:       TriggerNodeDecommission,
+		NodeRejoin:             TriggerNodeRejoin,
+		CsiSnapShot:            TriggerCsiSnapShot,
+		CsiSnapRestore:         TriggerCsiSnapRestore,
+		RelaxedReclaim:         TriggerRelaxedReclaim,
+		Trashcan:               TriggerTrashcan,
+		KVDBFailover:           TriggerKVDBFailover,
+		ValidateDeviceMapper:   TriggerValidateDeviceMapperCleanup,
+		AsyncDR:                TriggerAsyncDR,
+		AsyncDRVolumeOnly:      TriggerAsyncDRVolumeOnly,
+		StorkApplicationBackup: TriggerStorkApplicationBackup,
+		RestartKvdbVolDriver:   TriggerRestartKvdbVolDriver,
+		HAIncreaseAndReboot:    TriggerHAIncreaseAndReboot,
+		AddDiskAndReboot:       TriggerPoolAddDiskAndReboot,
+		ResizeDiskAndReboot:    TriggerPoolResizeDiskAndReboot,
+		AutopilotRebalance:     TriggerAutopilotPoolRebalance,
 	}
 	//Creating a distinct trigger to make sure email triggers at regular intervals
 	emailTriggerFunction = map[string]func(){
@@ -592,6 +592,7 @@ func populateIntervals() {
 	triggerInterval[ValidateDeviceMapper] = make(map[int]time.Duration)
 	triggerInterval[AsyncDR] = make(map[int]time.Duration)
 	triggerInterval[AsyncDRVolumeOnly] = make(map[int]time.Duration)
+	triggerInterval[StorkApplicationBackup] = make(map[int]time.Duration)
 	triggerInterval[HAIncreaseAndReboot] = make(map[int]time.Duration)
 	triggerInterval[AddDrive] = make(map[int]time.Duration)
 	triggerInterval[AddDiskAndReboot] = make(map[int]time.Duration)
@@ -740,6 +741,17 @@ func populateIntervals() {
 	triggerInterval[AsyncDRVolumeOnly][3] = 21 * baseInterval
 	triggerInterval[AsyncDRVolumeOnly][2] = 24 * baseInterval
 	triggerInterval[AsyncDRVolumeOnly][1] = 27 * baseInterval
+
+	triggerInterval[StorkApplicationBackup][10] = 1 * baseInterval
+	triggerInterval[StorkApplicationBackup][9] = 3 * baseInterval
+	triggerInterval[StorkApplicationBackup][8] = 6 * baseInterval
+	triggerInterval[StorkApplicationBackup][7] = 9 * baseInterval
+	triggerInterval[StorkApplicationBackup][6] = 12 * baseInterval
+	triggerInterval[StorkApplicationBackup][5] = 15 * baseInterval
+	triggerInterval[StorkApplicationBackup][4] = 18 * baseInterval
+	triggerInterval[StorkApplicationBackup][3] = 21 * baseInterval
+	triggerInterval[StorkApplicationBackup][2] = 24 * baseInterval
+	triggerInterval[StorkApplicationBackup][1] = 27 * baseInterval
 
 	baseInterval = 60 * time.Minute
 
@@ -1221,6 +1233,7 @@ func populateIntervals() {
 	triggerInterval[ValidateDeviceMapper][0] = 0
 	triggerInterval[AsyncDR][0] = 0
 	triggerInterval[AsyncDRVolumeOnly][0] = 0
+	triggerInterval[StorkApplicationBackup][0] = 0
 	triggerInterval[HAIncreaseAndReboot][0] = 0
 	triggerInterval[AddDrive][0] = 0
 	triggerInterval[AddDiskAndReboot][0] = 0

--- a/tests/testTriggers.go
+++ b/tests/testTriggers.go
@@ -5971,6 +5971,7 @@ func TriggerStorkApplicationBackup(contexts *[]*scheduler.Context, recordChan *c
 			currBackupLocation, err := applicationbackup.CreateBackupLocation(taskNamePrefix+"-location", currbkNamespace, s3SecretName)
 			if err != nil {
 				UpdateOutcome(event, fmt.Errorf("backup location creation failed with %v", err))
+				return
 			}
 			bkp, bkp_create_err := applicationbackup.CreateApplicationBackup(taskNamePrefix+"-backup", currbkNamespace, currBackupLocation)
 			if bkp_create_err != nil {
@@ -5979,6 +5980,7 @@ func TriggerStorkApplicationBackup(contexts *[]*scheduler.Context, recordChan *c
 			bkp_comp_err := applicationbackup.WaitForAppBackupCompletion(taskNamePrefix+"-backup", currbkNamespace, timeout)
 			if bkp_comp_err != nil {
 				UpdateOutcome(event, fmt.Errorf("backup successful failed with %v", bkp_comp_err))
+				return
 			}
 			dash.Infof("backup successful, backup name - %v, backup location - %v", bkp.Name, currBackupLocation.Name)
 		}

--- a/tests/testTriggers.go
+++ b/tests/testTriggers.go
@@ -5958,8 +5958,6 @@ func TriggerStorkApplicationBackup(contexts *[]*scheduler.Context, recordChan *c
 			*contexts = append(*contexts, appContexts...)
 			ValidateApplications(*contexts)
 			for _, ctx := range appContexts {
-				// Override default App readiness time out of 5 mins with 10 mins
-				ctx.ReadinessTimeout = appReadinessTimeout
 				namespace := GetAppNamespace(ctx, taskName)
 				backupNamespaces = append(backupNamespaces, namespace)
 			}

--- a/tests/testTriggers.go
+++ b/tests/testTriggers.go
@@ -3,11 +3,6 @@ package tests
 import (
 	"bytes"
 	"fmt"
-	apapi "github.com/libopenstorage/autopilot-api/pkg/apis/autopilot/v1alpha1"
-	"github.com/portworx/torpedo/pkg/aututils"
-	"github.com/portworx/torpedo/pkg/log"
-	"github.com/portworx/torpedo/pkg/units"
-	"gopkg.in/natefinch/lumberjack.v2"
 	"io/ioutil"
 	"math"
 	"math/rand"
@@ -20,6 +15,13 @@ import (
 	"sync"
 	"text/template"
 	"time"
+
+	apapi "github.com/libopenstorage/autopilot-api/pkg/apis/autopilot/v1alpha1"
+	"github.com/portworx/torpedo/pkg/applicationbackup"
+	"github.com/portworx/torpedo/pkg/aututils"
+	"github.com/portworx/torpedo/pkg/log"
+	"github.com/portworx/torpedo/pkg/units"
+	"gopkg.in/natefinch/lumberjack.v2"
 
 	"container/ring"
 
@@ -377,6 +379,8 @@ const (
 	AsyncDR = "asyncdr"
 	// AsyncDR Volume Only runs Async DR volume only migration between two clusters
 	AsyncDRVolumeOnly = "asyncdrvolumeonly"
+	// AsyncDR Volume Only runs Async DR volume only migration between two clusters
+	StorkApplicationBackup = "storkapplicationbackup"
 	// HAIncreaseAndReboot performs repl-add
 	HAIncreaseAndReboot = "haIncreaseAndReboot"
 	// AddDrive performs drive add for on-prem cluster
@@ -5905,6 +5909,81 @@ func TriggerAsyncDRVolumeOnly(contexts *[]*scheduler.Context, recordChan *chan *
 		}
 	}
 	updateMetrics(*event)
+}
+
+func TriggerStorkApplicationBackup(contexts *[]*scheduler.Context, recordChan *chan *EventRecord) {
+	dash.Infof("Stork Appplication Backup triggered at: %v", time.Now())
+	defer endLongevityTest()
+	startLongevityTest(StorkApplicationBackup)
+	defer ginkgo.GinkgoRecover()
+	event := &EventRecord{
+		Event: Event{
+			ID:   GenerateUUID(),
+			Type: AppTasksDown,
+		},
+		Start:   time.Now().Format(time.RFC1123),
+		Outcome: []error{},
+	}
+	defer func() {
+		event.End = time.Now().Format(time.RFC1123)
+		*recordChan <- event
+	}()
+	setMetrics(*event)
+	chaosLevel := ChaosMap[StorkApplicationBackup]
+
+	var (
+		s3SecretName     = "s3secret"
+		backupNamespaces []string
+		timeout          = 5 * time.Minute
+		taskNamePrefix   = "stork-app-backup-"
+	)
+
+	Step(fmt.Sprintf("Deploy applications for for backup, with frequency: %v", chaosLevel), func() {
+
+		// Write kubeconfig files after reading from the config maps created by torpedo deploy script
+		err := asyncdr.WriteKubeconfigToFiles()
+		if err != nil {
+			dash.Errorf("Failed to write kubeconfig: %v", err)
+		}
+
+		err = SetSourceKubeConfig()
+		if err != nil {
+			dash.Errorf("Failed to Set source kubeconfig: %v", err)
+		}
+		UpdateOutcome(event, err)
+		for i := 0; i < Inst().GlobalScaleFactor; i++ {
+			taskName := fmt.Sprintf("%s-%d-%s", taskNamePrefix, i, time.Now().Format("15h03m05s"))
+			dash.Infof("Task name %s\n", taskName)
+			appContexts := ScheduleApplications(taskName)
+			*contexts = append(*contexts, appContexts...)
+			ValidateApplications(*contexts)
+			for _, ctx := range appContexts {
+				// Override default App readiness time out of 5 mins with 10 mins
+				ctx.ReadinessTimeout = appReadinessTimeout
+				namespace := GetAppNamespace(ctx, taskName)
+				backupNamespaces = append(backupNamespaces, namespace)
+			}
+		}
+		dash.Infof("Backup applications, present in namespaces - %v", backupNamespaces)
+		dash.Infof("Start backup application")
+		for i, currbkNamespace := range backupNamespaces {
+			taskNamePrefix = taskNamePrefix + fmt.Sprintf("%d", i)
+			currBackupLocation, err := applicationbackup.CreateBackupLocation(taskNamePrefix+"-location", currbkNamespace, s3SecretName)
+			if err != nil {
+				UpdateOutcome(event, fmt.Errorf("backup location creation failed with %v", err))
+			}
+			bkp, bkp_create_err := applicationbackup.CreateApplicationBackup(taskNamePrefix+"-backup", currbkNamespace, currBackupLocation)
+			if bkp_create_err != nil {
+				UpdateOutcome(event, fmt.Errorf("backup creation failed with %v", bkp_create_err))
+			}
+			bkp_comp_err := applicationbackup.WaitForAppBackupCompletion(taskNamePrefix+"-backup", currbkNamespace, timeout)
+			if bkp_comp_err != nil {
+				UpdateOutcome(event, fmt.Errorf("backup successful failed with %v", bkp_comp_err))
+			}
+			dash.Infof("backup successful, backup name - %v, backup location - %v", bkp.Name, currBackupLocation.Name)
+		}
+		updateMetrics(*event)
+	})
 }
 
 func prepareEmailBody(eventRecords emailData) (string, error) {


### PR DESCRIPTION
What this PR does / why we need it:
Added this to run stork application backup test as a part of Longevity test.

Which issue(s) this PR fixes (optional)
Closes #https://portworx.atlassian.net/browse/PTX-7607 (closing partially)

Special notes for your reviewer:
Ran this test locally -
Getting this from logs -
2022-11-17 22:05:29 +0530:[INFO dashboardutil.go::(*Dashboard).Infof:422]  backup successful, backup name - stork-app-backup-0-backup, backup location - stork-app-backup-0-location
 geet@DevBox  ~/torpedo   storkappbackup ?  s get backup -n elasticsearch-stork-app-backup--0-22h10m58s-11-17-21h47m54s
NAME                        STAGE   STATUS       VOLUMES   RESOURCES   CREATED               ELAPSED
stork-app-backup-0-backup   Final   Successful   3/3       11          17 Nov 22 22:04 IST   29s
 geet@DevBox  ~/torpedo   storkappbackup ?  s get backuplocation -n elasticsearch-stork-app-backup--0-22h10m58s-11-17-21h47m54s

S3:
---
NAME                          PATH       ACCESS-KEY-ID   SECRET-ACCESS-KEY   REGION      ENDPOINT                                SSL-DISABLED
stork-app-backup-0-location   testpath   admin           <HIDDEN>            us-east-1   https://minio.pwx.dev.purestorage.com   true
 geet@DevBox  ~/torpedo   storkappbackup ?  
