### PR TITLE
Fix duplicate params

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -590,8 +590,6 @@ spec:
       value: "${PDS_PARAM_CM}"
     - name: PDS_ISSUER_URL
       value: "${PDS_ISSUER_URL}"
-    - name: PDS_PARAM_CM
-      value: "${PDS_PARAM_CM}"
     - name: CLUSTER_TYPE
       value: "${CLUSTER_TYPE}"
     - name: TARGET_KUBECONFIG


### PR DESCRIPTION
Removes duplicate param PDS_PARAM_CM from deploy-ssh.sh

before fix - https://jenkins.pwx.dev.purestorage.com/job/PDS/job/pds-branch-build-test/65/consoleFull
after fix - https://jenkins.pwx.dev.purestorage.com/job/PDS/job/pds-branch-build-test/68/console