### PR TITLE
Adding   fs: xfs, aggregation_level: 2

### DIFF
--- a/drivers/scheduler/k8s/specs/postgres/pxd/px-storage-class.yaml
+++ b/drivers/scheduler/k8s/specs/postgres/pxd/px-storage-class.yaml
@@ -6,7 +6,7 @@ metadata:
 provisioner: kubernetes.io/portworx-volume
 parameters:
   {{ if .Repl }}
-  repl: "2"
+  repl: "{{ .Repl }}"
   {{ else }}
   repl: "3"{{ end }}
   priority_io: "high"
@@ -15,5 +15,5 @@ parameters:
   {{ else }}
   fs: "ext4"{{ end }}
   {{ if .AggregationLevel }}
-  aggregation_level: "2"{{ end }}
+  aggregation_level: "{{ .AggregationLevel }}"{{ end }}
 allowVolumeExpansion: true

--- a/drivers/scheduler/k8s/specs/postgres/pxd/px-storage-class.yaml
+++ b/drivers/scheduler/k8s/specs/postgres/pxd/px-storage-class.yaml
@@ -5,6 +5,15 @@ metadata:
   name: postgres-sc
 provisioner: kubernetes.io/portworx-volume
 parameters:
-  repl: "3"
+  {{ if .Repl }}
+  repl: "2"
+  {{ else }}
+  repl: "3"{{ end }}
   priority_io: "high"
+  {{ if .Fs }}
+  fs: {{ .Fs }}
+  {{ else }}
+  fs: "ext4"{{ end }}
+  {{ if .AggregationLevel }}
+  aggregation_level: "2"{{ end }}
 allowVolumeExpansion: true

--- a/drivers/scheduler/k8s/specs/postgres/pxd/px-storage-class.yaml
+++ b/drivers/scheduler/k8s/specs/postgres/pxd/px-storage-class.yaml
@@ -11,9 +11,7 @@ parameters:
   repl: "3"{{ end }}
   priority_io: "high"
   {{ if .Fs }}
-  fs: {{ .Fs }}
-  {{ else }}
-  fs: "ext4"{{ end }}
+  fs: {{ .Fs }}{{ end }}
   {{ if .AggregationLevel }}
   aggregation_level: "{{ .AggregationLevel }}"{{ end }}
 allowVolumeExpansion: true

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -75,6 +75,9 @@ type AppConfig struct {
 	CustomArgs           []string `yaml:"custom_args"`
 	StorageClassSharedv4 string   `yaml:"storage_class_sharedv4"`
 	PVCAccessMode        string   `yaml:"pvc_access_mode"`
+	Repl                 string   `yaml:"repl"`
+	Fs                   string   `yaml:"fs"`
+	AggregationLevel     string   `yaml:"aggregation_level"`
 }
 
 // InitOptions initialization options


### PR DESCRIPTION
Signed-off-by: santhosh marakala <smarakala@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
https://portworx.atlassian.net/browse/PTX-13945
https://portworx.atlassian.net/browse/PTX-13950
This changes are made to improve test coverage in Torpedo testing.
https://jenkins.pwx.dev.purestorage.com/job/Users/job/Santosh/job/BasicTorpedo-custom/55/console
**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
Currently some of the parameters in storage class has to be in double quote string format example : repl: "3", aggregate_level: "2"
But currently I am unable to pass double quoted string to jenkins job, let me know is there any easy way to solve this issue (passing double quote or appending double quote in yaml file), hardcoding this values until we have a solution for the same. 
