### PR TITLE
Added Longevity test for stork application backup with volume resize

### DIFF
--- a/tests/basic/longevity_test.go
+++ b/tests/basic/longevity_test.go
@@ -3,12 +3,13 @@ package tests
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/portworx/torpedo/pkg/log"
 	"os"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/portworx/torpedo/pkg/log"
 
 	. "github.com/onsi/ginkgo"
 	"github.com/portworx/sched-ops/k8s/core"
@@ -91,6 +92,7 @@ var _ = Describe("{Longevity}", func() {
 		AsyncDR:                TriggerAsyncDR,
 		AsyncDRVolumeOnly:      TriggerAsyncDRVolumeOnly,
 		StorkApplicationBackup: TriggerStorkApplicationBackup,
+		StorkAppBkpVolResize:   TriggerStorkAppBkpVolResize,
 		RestartKvdbVolDriver:   TriggerRestartKvdbVolDriver,
 		HAIncreaseAndReboot:    TriggerHAIncreaseAndReboot,
 		AddDiskAndReboot:       TriggerPoolAddDiskAndReboot,
@@ -593,6 +595,7 @@ func populateIntervals() {
 	triggerInterval[AsyncDR] = make(map[int]time.Duration)
 	triggerInterval[AsyncDRVolumeOnly] = make(map[int]time.Duration)
 	triggerInterval[StorkApplicationBackup] = make(map[int]time.Duration)
+	triggerInterval[StorkAppBkpVolResize] = make(map[int]time.Duration)
 	triggerInterval[HAIncreaseAndReboot] = make(map[int]time.Duration)
 	triggerInterval[AddDrive] = make(map[int]time.Duration)
 	triggerInterval[AddDiskAndReboot] = make(map[int]time.Duration)
@@ -752,6 +755,17 @@ func populateIntervals() {
 	triggerInterval[StorkApplicationBackup][3] = 21 * baseInterval
 	triggerInterval[StorkApplicationBackup][2] = 24 * baseInterval
 	triggerInterval[StorkApplicationBackup][1] = 27 * baseInterval
+
+	triggerInterval[StorkAppBkpVolResize][10] = 1 * baseInterval
+	triggerInterval[StorkAppBkpVolResize][9] = 3 * baseInterval
+	triggerInterval[StorkAppBkpVolResize][8] = 6 * baseInterval
+	triggerInterval[StorkAppBkpVolResize][7] = 9 * baseInterval
+	triggerInterval[StorkAppBkpVolResize][6] = 12 * baseInterval
+	triggerInterval[StorkAppBkpVolResize][5] = 15 * baseInterval
+	triggerInterval[StorkAppBkpVolResize][4] = 18 * baseInterval
+	triggerInterval[StorkAppBkpVolResize][3] = 21 * baseInterval
+	triggerInterval[StorkAppBkpVolResize][2] = 24 * baseInterval
+	triggerInterval[StorkAppBkpVolResize][1] = 27 * baseInterval
 
 	baseInterval = 60 * time.Minute
 
@@ -1234,6 +1248,7 @@ func populateIntervals() {
 	triggerInterval[AsyncDR][0] = 0
 	triggerInterval[AsyncDRVolumeOnly][0] = 0
 	triggerInterval[StorkApplicationBackup][0] = 0
+	triggerInterval[StorkAppBkpVolResize][0] = 0
 	triggerInterval[HAIncreaseAndReboot][0] = 0
 	triggerInterval[AddDrive][0] = 0
 	triggerInterval[AddDiskAndReboot][0] = 0

--- a/tests/testTriggers.go
+++ b/tests/testTriggers.go
@@ -379,8 +379,10 @@ const (
 	AsyncDR = "asyncdr"
 	// AsyncDR Volume Only runs Async DR volume only migration between two clusters
 	AsyncDRVolumeOnly = "asyncdrvolumeonly"
-	// AsyncDR Volume Only runs Async DR volume only migration between two clusters
+	// stork application backup runs stork backups for applications
 	StorkApplicationBackup = "storkapplicationbackup"
+	// stork application backup volume resize runs stork backups for applications and inject volume resize in between
+	StorkAppBkpVolResize = "storkappbkpvolresize"
 	// HAIncreaseAndReboot performs repl-add
 	HAIncreaseAndReboot = "haIncreaseAndReboot"
 	// AddDrive performs drive add for on-prem cluster
@@ -5912,7 +5914,7 @@ func TriggerAsyncDRVolumeOnly(contexts *[]*scheduler.Context, recordChan *chan *
 }
 
 func TriggerStorkApplicationBackup(contexts *[]*scheduler.Context, recordChan *chan *EventRecord) {
-	dash.Infof("Stork Appplication Backup triggered at: %v", time.Now())
+	log.Infof("Stork Appplication Backup triggered at: %v", time.Now())
 	defer endLongevityTest()
 	startLongevityTest(StorkApplicationBackup)
 	defer ginkgo.GinkgoRecover()
@@ -5943,17 +5945,17 @@ func TriggerStorkApplicationBackup(contexts *[]*scheduler.Context, recordChan *c
 		// Write kubeconfig files after reading from the config maps created by torpedo deploy script
 		err := asyncdr.WriteKubeconfigToFiles()
 		if err != nil {
-			dash.Errorf("Failed to write kubeconfig: %v", err)
+			log.Errorf("Failed to write kubeconfig: %v", err)
 		}
 
 		err = SetSourceKubeConfig()
 		if err != nil {
-			dash.Errorf("Failed to Set source kubeconfig: %v", err)
+			log.Errorf("Failed to Set source kubeconfig: %v", err)
 		}
 		UpdateOutcome(event, err)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
-			taskName := fmt.Sprintf("%s-%d-%s", taskNamePrefix, i, time.Now().Format("15h03m05s"))
-			dash.Infof("Task name %s\n", taskName)
+			taskName := fmt.Sprintf("%s-%d", taskNamePrefix, i)
+			log.Infof("Task name %s\n", taskName)
 			appContexts := ScheduleApplications(taskName)
 			*contexts = append(*contexts, appContexts...)
 			ValidateApplications(*contexts)
@@ -5962,8 +5964,8 @@ func TriggerStorkApplicationBackup(contexts *[]*scheduler.Context, recordChan *c
 				backupNamespaces = append(backupNamespaces, namespace)
 			}
 		}
-		dash.Infof("Backup applications, present in namespaces - %v", backupNamespaces)
-		dash.Infof("Start backup application")
+		log.Infof("Backup applications, present in namespaces - %v", backupNamespaces)
+		log.Infof("Start backup application")
 		for i, currbkNamespace := range backupNamespaces {
 			taskNamePrefix = taskNamePrefix + fmt.Sprintf("%d", i)
 			currBackupLocation, err := applicationbackup.CreateBackupLocation(taskNamePrefix+"-location", currbkNamespace, s3SecretName)
@@ -5980,9 +5982,103 @@ func TriggerStorkApplicationBackup(contexts *[]*scheduler.Context, recordChan *c
 				UpdateOutcome(event, fmt.Errorf("backup successful failed with %v", bkp_comp_err))
 				return
 			}
-			dash.Infof("backup successful, backup name - %v, backup location - %v", bkp.Name, currBackupLocation.Name)
+			log.Infof("backup successful, backup name - %v, backup location - %v", bkp.Name, currBackupLocation.Name)
 		}
 		updateMetrics(*event)
+	})
+}
+
+func TriggerStorkAppBkpVolResize(contexts *[]*scheduler.Context, recordChan *chan *EventRecord) {
+	log.Infof("Stork Appplication Backup triggered at: %v", time.Now())
+	defer endLongevityTest()
+	startLongevityTest(StorkAppBkpVolResize)
+	defer ginkgo.GinkgoRecover()
+	event := &EventRecord{
+		Event: Event{
+			ID:   GenerateUUID(),
+			Type: AppTasksDown,
+		},
+		Start:   time.Now().Format(time.RFC1123),
+		Outcome: []error{},
+	}
+	defer func() {
+		event.End = time.Now().Format(time.RFC1123)
+		*recordChan <- event
+	}()
+	setMetrics(*event)
+	chaosLevel := ChaosMap[StorkAppBkpVolResize]
+
+	var (
+		s3SecretName   = "s3secret"
+		timeout        = 5 * time.Minute
+		taskNamePrefix = "stork-app-backup"
+		appVolumes     []*volume.Volume
+		requestedVols  []*volume.Volume
+	)
+
+	Step(fmt.Sprintf("Deploy applications for for backup, with frequency: %v", chaosLevel), func() {
+
+		// Write kubeconfig files after reading from the config maps created by torpedo deploy script
+		err := asyncdr.WriteKubeconfigToFiles()
+		if err != nil {
+			log.Errorf("Failed to write kubeconfig: %v", err)
+		}
+
+		err = SetSourceKubeConfig()
+		if err != nil {
+			log.Errorf("Failed to Set source kubeconfig: %v", err)
+		}
+		UpdateOutcome(event, err)
+		for i := 0; i < Inst().GlobalScaleFactor; i++ {
+			taskName := fmt.Sprintf("%s-%d", taskNamePrefix, i)
+			log.Infof("Task name %s\n", taskName)
+			appContexts := ScheduleApplications(taskName)
+			*contexts = append(*contexts, appContexts...)
+			ValidateApplications(*contexts)
+			for _, ctx := range appContexts {
+				currbkNamespace := GetAppNamespace(ctx, taskName)
+				log.Infof("Backup applications, present in namespaces - %v", currbkNamespace)
+				appVolumes, err = Inst().S.GetVolumes(ctx)
+				log.Infof("len of app volumes is : %v", len(appVolumes))
+				UpdateOutcome(event, err)
+				if len(appVolumes) == 0 {
+					UpdateOutcome(event, fmt.Errorf("found no volumes for app %s", ctx.App.Key))
+				}
+				log.Infof("Start backup application")
+				taskNamePrefix = taskNamePrefix + fmt.Sprintf("%d", i)
+				currBackupLocation, err := applicationbackup.CreateBackupLocation(taskNamePrefix+"-location", currbkNamespace, s3SecretName)
+				if err != nil {
+					UpdateOutcome(event, fmt.Errorf("backup location creation failed with %v", err))
+					return
+				}
+				bkp, bkp_create_err := applicationbackup.CreateApplicationBackup(taskNamePrefix+"-backup", currbkNamespace, currBackupLocation)
+				if bkp_create_err != nil {
+					UpdateOutcome(event, fmt.Errorf("backup creation failed with %v", bkp_create_err))
+					return
+				}
+				bkp_start_err := applicationbackup.WaitForAppBackupToStart(bkp.Name, currbkNamespace, timeout)
+				if bkp_start_err == nil {
+					log.Info("Application backup is in progress, starting volume resize")
+					requestedVols, _ = Inst().S.ResizeVolume(ctx, "")
+					log.Info("verify application backup successful")
+					bkp_comp_err := applicationbackup.WaitForAppBackupCompletion(taskNamePrefix+"-backup", currbkNamespace, timeout)
+					if bkp_comp_err != nil {
+						UpdateOutcome(event, fmt.Errorf("backup successful failed with %v", bkp_comp_err))
+						return
+					}
+					log.Info("application backup successful, verify volume resize successful")
+					for _, v := range requestedVols {
+						params := make(map[string]string)
+						err := Inst().V.ValidateUpdateVolume(v, params)
+						if err != nil {
+							UpdateOutcome(event, fmt.Errorf("volume resize failed for %v volume", v))
+						}
+					}
+				}
+				log.Infof("backup successful and volume resize injected during backup successfully, backup name - %v, backup location - %v", bkp.Name, currBackupLocation.Name)
+			}
+			updateMetrics(*event)
+		}
 	})
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
It will be used to run longevity trigger for stork application backup with volume resize event injection

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PTX-14190

**Special notes for your reviewer**:
Ran it locally, please find logs below -

Logs from local run -

2022-12-08 20:00:57 +0530:[INFO log.go:#258]  application backup successful, verify volume resize successful
2022-12-08 20:00:58 +0530:[INFO log.go:#235]  backup successful and volume resize injected during backup successfully, backup name - stork-app-backup-0-backup, backup location - stork-app-backup-0-location
INFO[2022-12-08 20:01:01] Verifying : Description : Test completed successfully ? 
INFO[2022-12-08 20:01:01] Actual:PASS, Expected: PASS         
INFO[2022-12-08 20:01:01] --------Test End------                       
INFO[2022-12-08 20:01:01] #Test: storkappbkpvolresize                  
INFO[2022-12-08 20:01:01] #Description: validating storkappbkpvolresize in longevity cluster  
INFO[2022-12-08 20:01:01] ------------------------                     
2022-12-08 20:01:01 +0530:[INFO log.go:#235]  Trigger Function completed for [storkappbkpvolresize]
2022-12-08 20:01:01 +0530:[INFO log.go:#235]  Successfully released lock for trigger [storkappbkpvolresize]

Logs from cluster -

geet@DevBox  ~/torpedo   namespacelength ● ?  s get backuplocation -n elasticsearch-stork-app-backup--0-12-08-19h41m08s
S3:
---
NAME                          PATH       ACCESS-KEY-ID   SECRET-ACCESS-KEY   REGION      ENDPOINT                                SSL-DISABLED
stork-app-backup-0-location   testpath   admin           <HIDDEN>            us-east-1   https://minio.pwx.dev.purestorage.com   true

geet@DevBox  ~/torpedo   namespacelength ● ?  s get backup -n elasticsearch-stork-app-backup--0-12-08-19h41m08s 
NAME                        STAGE   STATUS       VOLUMES   RESOURCES   CREATED               ELAPSED
stork-app-backup-0-backup   Final   Successful   3/3       11          08 Dec 22 20:00 IST   47s

geet@DevBox  ~/torpedo   namespacelength ● ?  k get pvc -n elasticsearch-stork-app-backup--0-12-08-19h41m08s
NAME               STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS       AGE
es-data-esnode-0   Bound    pvc-27e21f80-3b4e-4f1b-9020-a05bd650c517   6Gi        RWO            elasticsearch-sc   7m58s
es-data-esnode-1   Bound    pvc-0e7c71fb-1881-46e4-a0ee-58e98f567ac8   6Gi        RWO            elasticsearch-sc   6m55s
es-data-esnode-2   Bound    pvc-62b85430-63f5-48da-9a09-2c9e47f5df03   6Gi        RWO            elasticsearch-sc   5m46s
 geet@DevBox  ~/torpedo   namespacelength ● ?  