### PR TITLE
Multi drive pool resize and px restart

### DIFF
--- a/drivers/volume/common.go
+++ b/drivers/volume/common.go
@@ -424,7 +424,7 @@ func (d *DefaultDriver) GetReplicationFactor(vol *Volume) (int64, error) {
 }
 
 // SetReplicationFactor sets the volume's replication factor to the passed param rf.
-func (d *DefaultDriver) SetReplicationFactor(vol *Volume, replFactor int64, nodesToBeUpdated []string, waitForUpdateToFinish bool, opts ...Options) error {
+func (d *DefaultDriver) SetReplicationFactor(vol *Volume, replFactor int64, nodesToBeUpdated []string, poolsToBeUpdated []string, waitForUpdateToFinish bool, opts ...Options) error {
 	return &errors.ErrNotSupported{
 		Type:      "Function",
 		Operation: "SetReplicationFactor()",

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -2244,7 +2244,7 @@ func (d *portworx) GetReplicationFactor(vol *torpedovolume.Volume) (int64, error
 	return replFactor, nil
 }
 
-func (d *portworx) SetReplicationFactor(vol *torpedovolume.Volume, replFactor int64, nodesToBeUpdated []string, waitForUpdateToFinish bool, opts ...torpedovolume.Options) error {
+func (d *portworx) SetReplicationFactor(vol *torpedovolume.Volume, replFactor int64, nodesToBeUpdated []string, poolsToBeUpdated []string, waitForUpdateToFinish bool, opts ...torpedovolume.Options) error {
 	volumeName := d.schedOps.GetVolumeName(vol)
 	var replicationUpdateTimeout time.Duration
 	if len(opts) > 0 {
@@ -2268,8 +2268,11 @@ func (d *portworx) SetReplicationFactor(vol *torpedovolume.Volume, replFactor in
 		if len(nodesToBeUpdated) > 0 {
 			replicaSet = &api.ReplicaSet{Nodes: nodesToBeUpdated}
 			log.Infof("Updating ReplicaSet of node(s): %v", nodesToBeUpdated)
-		} else {
-			log.Infof("Nodes not passed, random node will be choosen")
+		}
+
+		if len(poolsToBeUpdated) > 0 {
+			replicaSet.PoolUuids = append(replicaSet.PoolUuids, poolsToBeUpdated...)
+			log.Infof("Updating ReplicaSet of pool: %v", poolsToBeUpdated)
 		}
 
 		volumeSpecUpdate := &api.VolumeSpecUpdate{

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -200,7 +200,7 @@ type Driver interface {
 	GetReplicationFactor(vol *Volume) (int64, error)
 
 	// SetReplicationFactor sets the volume's replication factor to the passed param rf and nodes.
-	SetReplicationFactor(vol *Volume, rf int64, nodesToBeUpdated []string, waitForUpdateToFinish bool, opts ...Options) error
+	SetReplicationFactor(vol *Volume, rf int64, nodesToBeUpdated []string, poolsToBeUpdated []string, waitForUpdateToFinish bool, opts ...Options) error
 
 	//WaitForReplicationToComplete waits for replication factor change to complete
 	WaitForReplicationToComplete(vol *Volume, replFactor int64, replicationUpdateTimeout time.Duration) error

--- a/tests/basic/ha_update_test.go
+++ b/tests/basic/ha_update_test.go
@@ -94,7 +94,7 @@ func performHaIncreaseRebootTest(testName string) {
 							opts := volume.Options{
 								ValidateReplicationUpdateTimeout: validateReplicationUpdateTimeout,
 							}
-							err = Inst().V.SetReplicationFactor(v, currRep-1, nil, true, opts)
+							err = Inst().V.SetReplicationFactor(v, currRep-1, nil, nil, true, opts)
 							dash.VerifyFatal(err, nil, fmt.Sprintf("Validate set repl factor to %d", currRep-1))
 						}
 					}

--- a/tests/basic/sharedv4_svc_test.go
+++ b/tests/basic/sharedv4_svc_test.go
@@ -1582,7 +1582,7 @@ func setHALevel(vol *volume.Volume, haLevel int64) {
 	}
 
 	log.Infof("setting HA level to 2 on volume %s", vol.ID)
-	err = Inst().V.SetReplicationFactor(vol, haLevel, nil, true)
+	err = Inst().V.SetReplicationFactor(vol, haLevel, nil, nil, true)
 	Expect(err).NotTo(HaveOccurred())
 
 	log.Infof("validating successful update of HA level on volume %s", vol.ID)

--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -1795,7 +1795,7 @@ var _ = Describe("{ResizeDiskVolUpdate}", func() {
 		}
 		selectedPool := stNode.Pools[0]
 		var poolToBeResized *api.StoragePool
-		stepLog := "Initiate pool expansion drive and restart PX"
+		stepLog := "Initiate pool expansion using resize-disk"
 		Step(stepLog, func() {
 			log.InfoD(stepLog)
 
@@ -1809,10 +1809,6 @@ var _ = Describe("{ResizeDiskVolUpdate}", func() {
 			log.InfoD("Current Size of the pool %s is %d", selectedPool.Uuid, poolToBeResized.TotalSize/units.GiB)
 			err = Inst().V.ExpandPool(selectedPool.Uuid, api.SdkStoragePool_RESIZE_TYPE_RESIZE_DISK, expectedSize)
 			dash.VerifyFatal(err, nil, "Pool expansion init successful?")
-
-			time.Sleep(3 * time.Second)
-			err = Inst().V.RestartDriver(stNode, nil)
-			log.FailOnError(err, fmt.Sprintf("error restarting px on node %s", stNode.Name))
 
 			resizeErr := waitForPoolToBeResized(expectedSize, selectedPool.Uuid, isjournal)
 			dash.VerifyFatal(resizeErr, nil, fmt.Sprintf("Verify pool %s on node %s expansion using resize-disk", selectedPool.Uuid, stNode.Name))
@@ -1838,6 +1834,210 @@ var _ = Describe("{ResizeDiskVolUpdate}", func() {
 			dash.VerifyFatal(err == nil, true, fmt.Sprintf("vol %s expanded successfully on node %s", volSelected.Name, stNode.Name))
 		})
 
+		for _, ctx := range contexts {
+			ctx.SkipVolumeValidation = true
+			ValidateContext(ctx)
+		}
+		opts := make(map[string]bool)
+		opts[scheduler.OptionsWaitForResourceLeakCleanup] = true
+		for _, ctx := range contexts {
+			TearDownContext(ctx, opts)
+		}
+	})
+	JustAfterEach(func() {
+		defer EndTorpedoTest()
+		AfterEachTest(contexts, testrailID, runID)
+	})
+})
+
+var _ = Describe("{VolUpdateResizeDisk}", func() {
+	//1) Deploy px with cloud drive.
+	//2) Create a volume on that pool and write some data on the volume.
+	//3) expand the volume to the pool
+	//4) perform resize disk operation on the pool
+	var testrailID = 51284
+	// testrailID corresponds to: https://portworx.testrail.net/index.php?/cases/view/51284
+	var runID int
+	JustBeforeEach(func() {
+		StartTorpedoTest("VolUpdateResizeDisk", "expand volume to the pool and pool expansion using resize-disk", nil, testrailID)
+		runID = testrailuttils.AddRunsToMilestone(testrailID)
+	})
+	var contexts []*scheduler.Context
+
+	stepLog := "should get the existing storage node and expand the pool by resize-disk"
+
+	It(stepLog, func() {
+		log.InfoD(stepLog)
+		contexts = make([]*scheduler.Context, 0)
+		for i := 0; i < Inst().GlobalScaleFactor; i++ {
+			contexts = append(contexts, ScheduleApplications(fmt.Sprintf("volupdtplrsz-%d", i))...)
+		}
+		//	ValidateApplications(contexts)
+
+		stNodes := node.GetStorageNodes()
+		if len(stNodes) == 0 {
+			dash.VerifyFatal(len(stNodes) > 0, true, "Storage nodes found?")
+		}
+		volSelected, err := getVolumeWithMinimumSize(contexts, 10)
+		log.FailOnError(err, "error identifying volume")
+		appVol, err := Inst().V.InspectVolume(volSelected.ID)
+		log.FailOnError(err, fmt.Sprintf("err inspecting vol : %s", volSelected.ID))
+		volNodes := appVol.ReplicaSets[0].Nodes
+		var stNode node.Node
+		for _, n := range stNodes {
+			nodeExist := false
+			for _, vn := range volNodes {
+				if n.Id == vn {
+					nodeExist = true
+				}
+			}
+			if !nodeExist {
+				stNode = n
+				break
+			}
+		}
+		selectedPool := stNode.Pools[0]
+		var poolToBeResized *api.StoragePool
+		poolToBeResized, err = GetStoragePoolByUUID(selectedPool.Uuid)
+		log.FailOnError(err, "Failed to get pool using UUID ")
+
+		stepLog = "Expand volume to the expanded pool"
+		var newRep int64
+		Step(stepLog, func() {
+			log.InfoD(stepLog)
+			currRep, err := Inst().V.GetReplicationFactor(volSelected)
+			log.FailOnError(err, fmt.Sprintf("err getting repl factor for  vol : %s", volSelected.Name))
+			opts := volume.Options{
+				ValidateReplicationUpdateTimeout: validateReplicationUpdateTimeout,
+			}
+			newRep = currRep
+			if currRep == 3 {
+				newRep = currRep - 1
+				err = Inst().V.SetReplicationFactor(volSelected, newRep, nil, nil, true, opts)
+				log.FailOnError(err, fmt.Sprintf("err setting repl factor  to %d for  vol : %s", newRep, volSelected.Name))
+			}
+			log.InfoD(fmt.Sprintf("setting repl factor  to %d for  vol : %s", newRep+1, volSelected.Name))
+			err = Inst().V.SetReplicationFactor(volSelected, newRep+1, []string{stNode.Id}, []string{poolToBeResized.Uuid}, false, opts)
+			log.FailOnError(err, fmt.Sprintf("err setting repl factor  to %d for  vol : %s", newRep+1, volSelected.Name))
+			dash.VerifyFatal(err == nil, true, fmt.Sprintf("vol %s expansion triggered successfully on node %s", volSelected.Name, stNode.Name))
+		})
+
+		stepLog := "Initiate pool expansion using resize-disk"
+		Step(stepLog, func() {
+			log.InfoD(stepLog)
+
+			expectedSize := poolToBeResized.TotalSize * 2 / units.GiB
+
+			isjournal, err := isJournalEnabled()
+			log.FailOnError(err, "Failed to check if Journal enabled")
+
+			log.InfoD("Current Size of the pool %s is %d", selectedPool.Uuid, poolToBeResized.TotalSize/units.GiB)
+			err = Inst().V.ExpandPool(selectedPool.Uuid, api.SdkStoragePool_RESIZE_TYPE_RESIZE_DISK, expectedSize)
+			dash.VerifyFatal(err, nil, "Pool expansion init successful?")
+
+			resizeErr := waitForPoolToBeResized(expectedSize, selectedPool.Uuid, isjournal)
+			dash.VerifyFatal(resizeErr, nil, fmt.Sprintf("Verify pool %s on node %s expansion using resize-disk", selectedPool.Uuid, stNode.Name))
+
+		})
+		ValidateReplFactorUpdate(volSelected, newRep+1)
+
+		for _, ctx := range contexts {
+			ctx.SkipVolumeValidation = true
+			ValidateContext(ctx)
+		}
+		opts := make(map[string]bool)
+		opts[scheduler.OptionsWaitForResourceLeakCleanup] = true
+		for _, ctx := range contexts {
+			TearDownContext(ctx, opts)
+		}
+	})
+	JustAfterEach(func() {
+		defer EndTorpedoTest()
+		AfterEachTest(contexts, testrailID, runID)
+	})
+})
+
+var _ = Describe("{VolUpdateAddDrive}", func() {
+	//1) Deploy px with cloud drive.
+	//2) Create a volume on that pool and write some data on the volume.
+	//3) expand the volume to the pool
+	//4) perform add drive on the pool
+	var testrailID = 50635
+	// testrailID corresponds to: https://portworx.testrail.net/index.php?/cases/view/50635
+	var runID int
+	JustBeforeEach(func() {
+		StartTorpedoTest("VolUpdateAddDrive", "expand volume to the pool and pool expansion using add drive", nil, testrailID)
+		runID = testrailuttils.AddRunsToMilestone(testrailID)
+	})
+	var contexts []*scheduler.Context
+
+	stepLog := "should get the existing storage node and expand the pool by resize-disk"
+
+	It(stepLog, func() {
+		log.InfoD(stepLog)
+		contexts = make([]*scheduler.Context, 0)
+		for i := 0; i < Inst().GlobalScaleFactor; i++ {
+			contexts = append(contexts, ScheduleApplications(fmt.Sprintf("plrszvolupdt-%d", i))...)
+		}
+		ValidateApplications(contexts)
+
+		stNodes := node.GetStorageNodes()
+		if len(stNodes) == 0 {
+			dash.VerifyFatal(len(stNodes) > 0, true, "Storage nodes found?")
+		}
+		volSelected, err := getVolumeWithMinimumSize(contexts, 10)
+		log.FailOnError(err, "error identifying volume")
+		appVol, err := Inst().V.InspectVolume(volSelected.ID)
+		log.FailOnError(err, fmt.Sprintf("err inspecting vol : %s", volSelected.ID))
+		volNodes := appVol.ReplicaSets[0].Nodes
+		var stNode node.Node
+		for _, n := range stNodes {
+			nodeExist := false
+			for _, vn := range volNodes {
+				if n.Id == vn {
+					nodeExist = true
+				}
+			}
+			if !nodeExist {
+				stNode = n
+				break
+			}
+		}
+		selectedPool := stNode.Pools[0]
+		var poolToBeResized *api.StoragePool
+		poolToBeResized, err = GetStoragePoolByUUID(selectedPool.Uuid)
+		log.FailOnError(err, "Failed to get pool using UUID ")
+
+		stepLog = "Expand volume to the expanded pool"
+		var newRep int64
+		Step(stepLog, func() {
+			log.InfoD(stepLog)
+			currRep, err := Inst().V.GetReplicationFactor(volSelected)
+			log.FailOnError(err, fmt.Sprintf("err getting repl factor for  vol : %s", volSelected.Name))
+			opts := volume.Options{
+				ValidateReplicationUpdateTimeout: validateReplicationUpdateTimeout,
+			}
+			newRep = currRep
+			if currRep == 3 {
+				newRep = currRep - 1
+				err = Inst().V.SetReplicationFactor(volSelected, newRep, nil, nil, true, opts)
+				log.FailOnError(err, fmt.Sprintf("err setting repl factor  to %d for  vol : %s", newRep, volSelected.Name))
+			}
+			log.InfoD(fmt.Sprintf("setting repl factor  to %d for  vol : %s", newRep+1, volSelected.Name))
+			err = Inst().V.SetReplicationFactor(volSelected, newRep+1, []string{stNode.Id}, []string{poolToBeResized.Uuid}, false, opts)
+			log.FailOnError(err, fmt.Sprintf("err setting repl factor  to %d for  vol : %s", newRep+1, volSelected.Name))
+			dash.VerifyFatal(err == nil, true, fmt.Sprintf("vol %s expansion triggered successfully on node %s", volSelected.Name, stNode.Name))
+		})
+
+		stepLog := "Initiate pool expansion using add drive"
+		Step(stepLog, func() {
+			log.InfoD(stepLog)
+			err = addCloudDrive(stNode, poolToBeResized.ID)
+			log.FailOnError(err, "error adding cloud drive")
+			dash.VerifyFatal(err == nil, true, fmt.Sprintf("Verify pool %s on node %s expansion using add drive", poolToBeResized.Uuid, stNode.Name))
+
+		})
+		ValidateReplFactorUpdate(volSelected, newRep+1)
 		for _, ctx := range contexts {
 			ctx.SkipVolumeValidation = true
 			ValidateContext(ctx)

--- a/tests/basic/volume_ops_test.go
+++ b/tests/basic/volume_ops_test.go
@@ -72,7 +72,7 @@ var _ = Describe("{VolumeUpdate}", func() {
 							currRep, err := Inst().V.GetReplicationFactor(v)
 							log.FailOnError(err, "Failed to get volume  %s repl factor", v.Name)
 							expReplMap[v] = int64(math.Max(float64(MinRF), float64(currRep)-1))
-							err = Inst().V.SetReplicationFactor(v, currRep-1, nil, true)
+							err = Inst().V.SetReplicationFactor(v, currRep-1, nil, nil, true)
 							log.FailOnError(err, "Failed to set volume  %s repl factor", v.Name)
 							dash.VerifyFatal(err == nil, true, fmt.Sprintf("Set volume  %s repl factor successful ?", v.Name))
 						})
@@ -101,7 +101,7 @@ var _ = Describe("{VolumeUpdate}", func() {
 								MaxRF = int64(len(node.GetWorkerNodes())) / currAggr
 							}
 							expReplMap[v] = int64(math.Min(float64(MaxRF), float64(currRep)+1))
-							err = Inst().V.SetReplicationFactor(v, currRep+1, nil, true)
+							err = Inst().V.SetReplicationFactor(v, currRep+1, nil, nil, true)
 							log.FailOnError(err, "Failed to set volume  %s repl factor", v.Name)
 							dash.VerifyFatal(err == nil, true, fmt.Sprintf("Repl factor set succesfully on volume  %s repl", v.Name))
 						})
@@ -315,7 +315,7 @@ var _ = Describe("{VolumeUpdateForAttachedNode}", func() {
 							}
 
 							expReplMap[v] = int64(math.Max(float64(MinRF), float64(currRep)-1))
-							err = Inst().V.SetReplicationFactor(v, currRep-1, updateReplicaSet, true)
+							err = Inst().V.SetReplicationFactor(v, currRep-1, updateReplicaSet, nil, true)
 							log.FailOnError(err, "Failed to set repl factor")
 							dash.VerifyFatal(err == nil, true, "Repl factor set successfully?")
 						})
@@ -365,7 +365,7 @@ var _ = Describe("{VolumeUpdateForAttachedNode}", func() {
 								MaxRF = int64(len(node.GetWorkerNodes())) / currAggr
 							}
 							expReplMap[v] = int64(math.Min(float64(MaxRF), float64(currRep)+1))
-							err = Inst().V.SetReplicationFactor(v, currRep+1, updateReplicaSet, true)
+							err = Inst().V.SetReplicationFactor(v, currRep+1, updateReplicaSet, nil, true)
 							log.FailOnError(err, "Failed to set vol %s repl factor", v.Name)
 							dash.VerifyFatal(err == nil, true, fmt.Sprintf("Vol %s repl factor set as expected?", v.Name))
 						})

--- a/tests/common.go
+++ b/tests/common.go
@@ -5203,6 +5203,8 @@ func GetPoolWithIOsInGivenNode(stNode node.Node) (*opsapi.StoragePool, error) {
 	if err != nil {
 		return nil, err
 	}
+	fmt.Printf("Node: %s\n", stNode.Name)
+	fmt.Printf("Before: %v\n", poolsDataBfr)
 
 	time.Sleep(5 * time.Second)
 
@@ -5210,6 +5212,8 @@ func GetPoolWithIOsInGivenNode(stNode node.Node) (*opsapi.StoragePool, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	fmt.Printf("After: %v\n", poolsDataAfr)
 
 	for k, v := range poolsDataBfr {
 		if v2, ok := poolsDataAfr[k]; ok {

--- a/tests/common.go
+++ b/tests/common.go
@@ -5185,15 +5185,12 @@ func GetPoolIDWithIOs() (string, error) {
 	stNodes := node.GetStorageNodes()
 	for _, stNode := range stNodes {
 		selectedPool, err = GetPoolWithIOsInGivenNode(stNode)
-		if err != nil && !strings.Contains(err.Error(), "no pools have IOs running") {
-			return "", err
-		}
 		if selectedPool != nil {
 			return selectedPool.Uuid, nil
 		}
 	}
 
-	return "", fmt.Errorf("no pools have IOs running")
+	return "", fmt.Errorf("no pools have IOs running,Err: %v", err)
 }
 
 // GetPoolWithIOsInGivenNode returns the poolID in the given node with IOs happening
@@ -5207,7 +5204,7 @@ func GetPoolWithIOsInGivenNode(stNode node.Node) (*opsapi.StoragePool, error) {
 			return nil, false, err
 		}
 
-		time.Sleep(5 * time.Second)
+		time.Sleep(10 * time.Second)
 
 		poolsDataAfr, err := Inst().V.GetPoolsUsedSize(&stNode)
 		if err != nil {
@@ -5241,16 +5238,15 @@ func GetPoolWithIOsInGivenNode(stNode node.Node) (*opsapi.StoragePool, error) {
 //GetRandomNodeWithPoolIOs returns node with IOs running
 func GetRandomNodeWithPoolIOs(stNodes []node.Node) (node.Node, error) {
 	// pick a storage node with pool having IOs
+	var err error
+	var pool *opsapi.StoragePool
 	for _, stNode := range stNodes {
-		pool, err := GetPoolWithIOsInGivenNode(stNode)
-		if err != nil && !strings.Contains(err.Error(), "no pools have IOs running") {
-			return node.Node{}, err
-		}
+		pool, err = GetPoolWithIOsInGivenNode(stNode)
 		if pool != nil {
 			return stNode, nil
 		}
 	}
-	return node.Node{}, fmt.Errorf("no node with IOs running identified")
+	return node.Node{}, fmt.Errorf("no node with IOs running identified,err: %v", err)
 }
 
 func GetRandomStorageLessNode(slNodes []node.Node) node.Node {

--- a/tests/common.go
+++ b/tests/common.go
@@ -3522,7 +3522,7 @@ func HaIncreaseRebootTargetNode(event *EventRecord, ctx *scheduler.Context, v *v
 
 							}
 							log.InfoD("Increasing repl with target node  [%v]", newReplID)
-							err = Inst().V.SetReplicationFactor(v, currRep+1, []string{newReplID}, false)
+							err = Inst().V.SetReplicationFactor(v, currRep+1, []string{newReplID}, nil, false)
 							if err != nil {
 								log.Errorf("There is an error increasing repl [%v]", err.Error())
 								UpdateOutcome(event, err)
@@ -3561,7 +3561,7 @@ func HaIncreaseRebootTargetNode(event *EventRecord, ctx *scheduler.Context, v *v
 								if strings.Contains(ctx.App.Key, fastpathAppName) {
 									err := ValidateFastpathVolume(ctx, opsapi.FastpathStatus_FASTPATH_INACTIVE)
 									UpdateOutcome(event, err)
-									err = Inst().V.SetReplicationFactor(v, currRep-1, nil, true)
+									err = Inst().V.SetReplicationFactor(v, currRep-1, nil, nil, true)
 								}
 							})
 					}
@@ -3615,7 +3615,7 @@ func HaIncreaseRebootSourceNode(event *EventRecord, ctx *scheduler.Context, v *v
 								}
 								UpdateOutcome(event, err)
 							}
-							err = Inst().V.SetReplicationFactor(v, currRep+1, nil, false)
+							err = Inst().V.SetReplicationFactor(v, currRep+1, nil, nil, false)
 							if err != nil {
 								log.Errorf("There is an error increasing repl [%v]", err.Error())
 								UpdateOutcome(event, err)
@@ -3648,7 +3648,7 @@ func HaIncreaseRebootSourceNode(event *EventRecord, ctx *scheduler.Context, v *v
 								if strings.Contains(ctx.App.Key, fastpathAppName) {
 									err := ValidateFastpathVolume(ctx, opsapi.FastpathStatus_FASTPATH_INACTIVE)
 									UpdateOutcome(event, err)
-									err = Inst().V.SetReplicationFactor(v, currRep-1, nil, true)
+									err = Inst().V.SetReplicationFactor(v, currRep-1, nil, nil, true)
 								}
 							}
 						} else {

--- a/tests/common.go
+++ b/tests/common.go
@@ -3550,7 +3550,7 @@ func HaIncreaseRebootTargetNode(event *EventRecord, ctx *scheduler.Context, v *v
 									UpdateOutcome(event, err)
 								}
 
-								err = validateReplFactorUpdate(v, currRep+1)
+								err = ValidateReplFactorUpdate(v, currRep+1)
 								if err != nil {
 									err = fmt.Errorf("error in ha-increse after  target node reboot. Error: %v", err)
 									log.Error(err)
@@ -3637,7 +3637,7 @@ func HaIncreaseRebootSourceNode(event *EventRecord, ctx *scheduler.Context, v *v
 										UpdateOutcome(event, err)
 									}
 								}
-								err = validateReplFactorUpdate(v, currRep+1)
+								err = ValidateReplFactorUpdate(v, currRep+1)
 								if err != nil {
 									err = fmt.Errorf("error in ha-increse after  source node reboot. Error: %v", err)
 									log.Error(err)
@@ -3682,7 +3682,7 @@ func AddFastPathLabel(ctx *scheduler.Context) (*node.Node, error) {
 	return nil, err
 }
 
-func validateReplFactorUpdate(v *volume.Volume, expaectedReplFactor int64) error {
+func ValidateReplFactorUpdate(v *volume.Volume, expaectedReplFactor int64) error {
 	t := func() (interface{}, bool, error) {
 		err := Inst().V.WaitForReplicationToComplete(v, expaectedReplFactor, validateReplicationUpdateTimeout)
 		if err != nil {

--- a/tests/testTriggers.go
+++ b/tests/testTriggers.go
@@ -693,7 +693,7 @@ func TriggerHAIncreaseAndReboot(contexts *[]*scheduler.Context, recordChan *chan
 							}
 							rep := currRep
 							for rep > 1 {
-								err = Inst().V.SetReplicationFactor(v, rep-1, nil, true, opts)
+								err = Inst().V.SetReplicationFactor(v, rep-1, nil, nil, true, opts)
 								if err != nil {
 									log.Errorf("There is an error decreasing repl [%v]", err.Error())
 									UpdateOutcome(event, err)
@@ -814,7 +814,7 @@ func TriggerHAIncrease(contexts *[]*scheduler.Context, recordChan *chan *EventRe
 							if err != nil {
 								log.Infof("Replica Set before ha-increase : %+v", replSets[0].Nodes)
 							}
-							err = Inst().V.SetReplicationFactor(v, expRF, nil, true, opts)
+							err = Inst().V.SetReplicationFactor(v, expRF, nil, nil, true, opts)
 							if err != nil {
 								log.Errorf("There is a error setting repl [%v]", err.Error())
 							}
@@ -936,7 +936,7 @@ func TriggerHADecrease(contexts *[]*scheduler.Context, recordChan *chan *EventRe
 							if err != nil {
 								log.Infof("Replica Set before ha-decrease : %+v", replSets[0].Nodes)
 							}
-							err = Inst().V.SetReplicationFactor(v, currRep-1, nil, true, opts)
+							err = Inst().V.SetReplicationFactor(v, currRep-1, nil, nil, true, opts)
 							if err != nil {
 								log.Errorf("There is an error decreasing repl [%v]", err.Error())
 							}


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Added below scenarios
- Multi drive pool resize
- pool resize and px restart when resize is in progress
- pool resize and volume update on the expanded pool
- volume update and pool resize on the same pool

- Stablised pool with IOs selection

**Which issue(s) this PR fixes** (optional)
Closes #PTX-14477,PTX-14478,PTX-13768,PTX-13762


**Special notes for your reviewer**:
[MultiDriveResizeDisk.log](https://github.com/portworx/torpedo/files/10219038/MultiDriveResizeDisk.log)
[ResizeWithPXRestart.log](https://github.com/portworx/torpedo/files/10219039/ResizeWithPXRestart.log)
[ResizeDiskVolUpdate.log](https://github.com/portworx/torpedo/files/10221231/ResizeDiskVolUpdate.log)
[VolUpdateResizeDisk.log](https://github.com/portworx/torpedo/files/10228502/VolUpdateResizeDisk.log)


http://aetos.pwx.purestorage.com/resultSet/testSetID/39666/testCaseID/83809
http://aetos.pwx.purestorage.com/resultSet/testSetID/39694/testCaseID/83878
http://aetos.pwx.purestorage.com/resultSet/testSetID/39818/testCaseID/84135
http://aetos.pwx.purestorage.com/resultSet/testSetID/40778/testCaseID/86354

Please note tests are marked failed as pod restart counts are not matching