### PR TITLE
Create context before running PXCTL command and make sure PX is running on the node before running pxctl command

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -3751,18 +3751,10 @@ func (d *portworx) SetClusterOpts(n node.Node, clusterOpts map[string]string) er
 	for k, v := range clusterOpts {
 		clusteropts += k + "=" + v + " "
 	}
-
 	clusteropts = strings.TrimSuffix(clusteropts, " ")
-	//Create context with admin token if PX security is enabled.
-	if len(d.token) > 0 {
-		_, err := d.nodeDriver.RunCommand(n, fmt.Sprintf("%s context create admin --token=%s", d.getPxctlPath(n), d.token), opts)
-		if err != nil {
-			return fmt.Errorf("failed to create pxctl context. cause: %v", err)
-		}
-	}
 	cmd := fmt.Sprintf("%s cluster options update %s", d.getPxctlPath(n), clusteropts)
-
-	out, err := d.nodeDriver.RunCommand(n, cmd, opts)
+	//Create context with admin token if PX security is enabled, later delete the token
+	out, err := d.GetPxctlCmdOutputConnectionOpts(n, cmd, opts, false)
 	if err != nil {
 		return fmt.Errorf("failed to set cluster options, Err: %v %v", err, out)
 	}

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -3753,6 +3753,13 @@ func (d *portworx) SetClusterOpts(n node.Node, clusterOpts map[string]string) er
 	}
 
 	clusteropts = strings.TrimSuffix(clusteropts, " ")
+	//Create context with admin token if PX security is enabled.
+	if len(d.token) > 0 {
+		_, err := d.nodeDriver.RunCommand(n, fmt.Sprintf("%s context create admin --token=%s", d.getPxctlPath(n), d.token), opts)
+		if err != nil {
+			return fmt.Errorf("failed to create pxctl context. cause: %v", err)
+		}
+	}
 	cmd := fmt.Sprintf("%s cluster options update %s", d.getPxctlPath(n), clusteropts)
 
 	out, err := d.nodeDriver.RunCommand(n, cmd, opts)

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -3752,9 +3752,9 @@ func (d *portworx) SetClusterOpts(n node.Node, clusterOpts map[string]string) er
 		clusteropts += k + "=" + v + " "
 	}
 	clusteropts = strings.TrimSuffix(clusteropts, " ")
-	cmd := fmt.Sprintf("%s cluster options update %s", d.getPxctlPath(n), clusteropts)
+	cmd := fmt.Sprintf(" cluster options update %s", clusteropts)
 	//Create context with admin token if PX security is enabled, later delete the token
-	out, err := d.GetPxctlCmdOutputConnectionOpts(n, cmd, opts, false)
+	out, err := d.GetPxctlCmdOutputConnectionOpts(n, cmd, opts, true)
 	if err != nil {
 		return fmt.Errorf("failed to set cluster options, Err: %v %v", err, out)
 	}
@@ -4029,7 +4029,6 @@ func (d *portworx) getPxctlStatus(n node.Node) (string, error) {
 // GetPxctlCmdOutputConnectionOpts returns the command output run on the given node with ConnectionOpts and any error
 func (d *portworx) GetPxctlCmdOutputConnectionOpts(n node.Node, command string, opts node.ConnectionOpts, retry bool) (string, error) {
 	pxctlPath := d.getPxctlPath(n)
-
 	// create context
 	if len(d.token) > 0 {
 		_, err := d.nodeDriver.RunCommand(n, fmt.Sprintf("%s context create admin --token=%s", pxctlPath, d.token), opts)

--- a/tests/common.go
+++ b/tests/common.go
@@ -5051,7 +5051,7 @@ func EnableAutoFSTrim() {
 		if isPxInstalled {
 			isPXNodeAvailable = true
 			pxVersion, err := Inst().V.GetPxVersionOnNode(pxNode)
-			log.FailOnError(err, "Is autofstrim supported on the cluster ?")
+			log.FailOnError(err, "Unable to get pxversion on node %s",pxNode.Name)
 			log.Infof("PX version %s", pxVersion)
 			pxVersionList := []string{}
 			pxVersionList = strings.Split(pxVersion, ".")

--- a/tests/common.go
+++ b/tests/common.go
@@ -5043,10 +5043,14 @@ func StartTorpedoTest(testName, testDescription string, tags map[string]string, 
 func EnableAutoFSTrim() {
 	nodes := node.GetWorkerNodes()
 	var isPXNodeAvailable bool
-	for _, n := range nodes {
-		if n.IsStorageDriverInstalled {
+	for _, pxNode := range nodes {
+		isPxInstalled, err := Inst().V.IsPxInstalled(pxNode)
+		if err != nil {
+			log.Debugf("Could not get PX status on %s", pxNode.Name)
+		}
+		if isPxInstalled {
 			isPXNodeAvailable = true
-			pxVersion, err := Inst().V.GetPxVersionOnNode(nodes[0])
+			pxVersion, err := Inst().V.GetPxVersionOnNode(pxNode)
 			log.FailOnError(err, "Is autofstrim supported on the cluster ?")
 			log.Infof("PX version %s", pxVersion)
 			pxVersionList := []string{}
@@ -5056,7 +5060,7 @@ func EnableAutoFSTrim() {
 			if majorVer < 2 || (majorVer == 2 && minorVer < 10) {
 				log.Warnf("Auto FSTrim cannot be enabled on PX version %s", pxVersion)
 			} else {
-				err = Inst().V.SetClusterOpts(nodes[0], map[string]string{
+				err = Inst().V.SetClusterOpts(pxNode, map[string]string{
 					"--auto-fstrim": "on"})
 				log.FailOnError(err, "Autofstrim is enabled on the cluster ?")
 				log.Infof("Auto FSTrim enabled on the cluster")


### PR DESCRIPTION
Create context before running PXCTL command and make sure PX is running on the node before running pxctl command

Signed-off-by: santhosh marakala <smarakala@purestorage.com>


**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes # PTX-14596 and PTX-14595

**Special notes for your reviewer**:

