### PR TITLE
Enabling TPCC Workload for Postgres and MySQL

### DIFF
--- a/drivers/pds/lib/utils.go
+++ b/drivers/pds/lib/utils.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/url"
@@ -956,8 +957,10 @@ func RunTpccWorkload(dbUser string, pdsPassword string, dnsEndpoint string, dbNa
 	flag := false
 	// Hard sleep for 10 seconds for deployment to come up
 	time.Sleep(10 * time.Second)
+	var newPods []corev1.Pod
 	for i := 1; i <= 200; i++ {
-		newPods, err := GetPods(namespace)
+		newPodList, _ := GetPods(namespace)
+		newPods = append(newPods, newPodList.Items...)
 		for _, pod := range newPods {
 			if strings.Contains(pod.Name, deployment.Name) {
 				log.InfoD("Will check for status of Init Container Once......")
@@ -982,7 +985,8 @@ func RunTpccWorkload(dbUser string, pdsPassword string, dnsEndpoint string, dbNa
 	}
 	flag = false
 	for i := 1; i <= int((timeAskedToRun+300)/60); i++ {
-		newPods, err := GetPods(namespace)
+		newPodList, _ := GetPods(namespace)
+		newPods = append(newPods, newPodList.Items...)
 		for _, pod := range newPods {
 			if strings.Contains(pod.Name, deployment.Name) {
 				log.InfoD("Waiting for TPCC Workload Container to finish")

--- a/drivers/pds/lib/utils.go
+++ b/drivers/pds/lib/utils.go
@@ -136,7 +136,7 @@ const (
 	redis                 = "Redis"
 	cassandraStresImage   = "scylladb/scylla:4.1.11"
 	postgresqlStressImage = "portworx/torpedo-pgbench:pdsloadTest"
-	pdsTpccImage          = "pwxbuild/pds-tpcc-automation:v1"
+	pdsTpccImage          = "portworx/torpedo-tpcc-automation:v1"
 	redisStressImage      = "redis:latest"
 	rmqStressImage        = "pivotalrabbitmq/perf-test:latest"
 	postgresql            = "PostgreSQL"

--- a/drivers/pds/lib/utils.go
+++ b/drivers/pds/lib/utils.go
@@ -880,16 +880,16 @@ func RunTpccWorkload(dbUser string, pdsPassword string, dnsEndpoint string, dbNa
 		dbUser = "pds"
 	}
 	if timeToRun == "" {
-		timeToRun = "60"
+		timeToRun = "600"
 	}
 	if numOfThreads == "" {
 		numOfThreads = "64"
 	}
 	if numOfCustomers == "" {
-		numOfCustomers = "2"
+		numOfCustomers = "5"
 	}
 	if numOfWarehouses == "" {
-		numOfWarehouses = "1"
+		numOfWarehouses = "5"
 	}
 
 	var replicas int32 = 1
@@ -937,17 +937,17 @@ func RunTpccWorkload(dbUser string, pdsPassword string, dnsEndpoint string, dbNa
 		log.Errorf("An Error Occured while creating deployment %v", err)
 		return nil, err
 	}
-	totalTime, err := strconv.Atoi(timeToRun)
-	newTimeOut := time.Duration(totalTime*2) * time.Second // Multiplying by 2 to have both prepare and run containers executed
+	timeAskedToRun, err := strconv.Atoi(timeToRun)
+	totalNumCust, err := strconv.Atoi(numOfCustomers)
+	totalNumWarehouses, err := strconv.Atoi(numOfWarehouses)
+	totalTime := timeAskedToRun + (totalNumCust * totalNumWarehouses * 60)
+	newTimeOut := time.Duration(totalTime) * time.Second // Multiplying by 2 to have both prepare and run containers executed
 	err = k8sApps.ValidateDeployment(deployment, newTimeOut, timeInterval)
 	if err != nil {
 		log.Errorf("An Error Occured while validating the pod %v", err)
 		return nil, err
 	}
-
-	//TODO: Remove static sleep and verify the injected data
-	time.Sleep(5 * time.Minute)
-
+	
 	return deployment, err
 }
 

--- a/drivers/pds/lib/utils.go
+++ b/drivers/pds/lib/utils.go
@@ -880,16 +880,16 @@ func RunTpccWorkload(dbUser string, pdsPassword string, dnsEndpoint string, dbNa
 		dbUser = "pds"
 	}
 	if timeToRun == "" {
-		timeToRun = "600"
+		timeToRun = "120"
 	}
 	if numOfThreads == "" {
 		numOfThreads = "64"
 	}
 	if numOfCustomers == "" {
-		numOfCustomers = "5"
+		numOfCustomers = "4"
 	}
 	if numOfWarehouses == "" {
-		numOfWarehouses = "5"
+		numOfWarehouses = "2"
 	}
 
 	var replicas int32 = 1
@@ -941,13 +941,13 @@ func RunTpccWorkload(dbUser string, pdsPassword string, dnsEndpoint string, dbNa
 	totalNumCust, err := strconv.Atoi(numOfCustomers)
 	totalNumWarehouses, err := strconv.Atoi(numOfWarehouses)
 	totalTime := timeAskedToRun + (totalNumCust * totalNumWarehouses * 60)
-	newTimeOut := time.Duration(totalTime) * time.Second // Multiplying by 2 to have both prepare and run containers executed
+	newTimeOut := time.Duration(totalTime) * time.Second 
 	err = k8sApps.ValidateDeployment(deployment, newTimeOut, timeInterval)
 	if err != nil {
 		log.Errorf("An Error Occured while validating the pod %v", err)
 		return nil, err
 	}
-	
+
 	return deployment, err
 }
 

--- a/drivers/pds/lib/utils.go
+++ b/drivers/pds/lib/utils.go
@@ -844,7 +844,7 @@ func SetupMysqlDatabaseForTpcc(dbUser string, pdsPassword string, dnsEndpoint st
 	}
 	_, err := k8sCore.CreatePod(podSpec)
 	if err != nil {
-		log.ErrorD("An Error Occured while creating %v", err)
+		log.Errorf("An Error Occured while creating %v", err)
 		return false
 	}
 
@@ -948,7 +948,7 @@ func RunTpccWorkload(dbUser string, pdsPassword string, dnsEndpoint string, dbNa
 	log.Info("Going to Trigger TPCC Workload for the Deployment")
 	deployment, err := k8sApps.CreateDeployment(deploymentSpec, metav1.CreateOptions{})
 	if err != nil {
-		log.ErrorD("An Error Occured while creating deployment %v", err)
+		log.Errorf("An Error Occured while creating deployment %v", err)
 		return false
 	}
 
@@ -977,7 +977,7 @@ func RunTpccWorkload(dbUser string, pdsPassword string, dnsEndpoint string, dbNa
 		}
 	}
 	if !flag {
-		log.ErrorD("TPCC Schema couldn't be prepared in 100 minutes. Timing Out. Please check manually.")
+		log.Errorf("TPCC Schema couldn't be prepared in 100 minutes. Timing Out. Please check manually.")
 		return false
 	}
 	flag = false
@@ -1227,13 +1227,13 @@ func CreateTpccWorkloads(dataServiceName string, deploymentID string, scalefacto
 
 	dnsEndpoint, err := GetDeploymentConnectionInfo(deploymentID)
 	if err != nil {
-		log.ErrorD("An Error Occured while getting connection info %v", err)
+		log.Errorf("An Error Occured while getting connection info %v", err)
 		return false, err
 	}
 	log.Infof("Dataservice DNS endpoint %s", dnsEndpoint)
 	pdsPassword, err := GetDeploymentCredentials(deploymentID)
 	if err != nil {
-		log.ErrorD("An Error Occured while getting credentials info %v", err)
+		log.Errorf("An Error Occured while getting credentials info %v", err)
 		return false, err
 	}
 
@@ -1262,8 +1262,8 @@ func CreateTpccWorkloads(dataServiceName string, deploymentID string, scalefacto
 			}
 		}
 		if !wasMysqlConfigured {
-			log.ErrorD("Something went wrong and DB Couldn't be prepared for TPCC workload. Exiting.")
-			return wasMysqlConfigured
+			log.Errorf("Something went wrong and DB Couldn't be prepared for TPCC workload. Exiting.")
+			return wasMysqlConfigured, nil
 		}
 		wasTpccRunSuccessful := RunTpccWorkload(dbUser, "password", dnsEndpoint, dbName,
 			timeToRun, numOfThreads, numOfCustomers, numOfWarehouses,

--- a/drivers/pds/lib/utils.go
+++ b/drivers/pds/lib/utils.go
@@ -995,6 +995,13 @@ func RunTpccWorkload(dbUser string, pdsPassword string, dnsEndpoint string, dbNa
 						flag = true
 						if c.State.Terminated != nil && c.State.Terminated.ExitCode != 0 && c.State.Terminated.Reason != "Completed" {
 							log.Errorf("Something went wrong and Run Container Exited abruptly. Leaving the TPCC deployment as is - pls check manually")
+							log.InfoD("Printing TPCC Deployment Describe Status here .....")
+							depStatus, err := k8sApps.DescribeDeployment(deployment.Name, namespace)
+							if err != nil {
+								log.Errorf("Could not print TPCC Deployment status due to some reason. Please check manually.")
+								return false
+							}
+							log.InfoD("%+v\n", *depStatus)
 							return false
 						}
 						break
@@ -1259,7 +1266,7 @@ func CreateTpccWorkloads(dataServiceName string, deploymentID string, scalefacto
 				break
 			} else {
 				log.InfoD("MySQL deployment is not yet configured for TPCC. It may still be starting up or there could be some error")
-				log.InfoD("Waiting for some more time to see if it can be reached within 30 minutes")
+				log.InfoD("Waiting for 30 seconds to retry if MySQL deployment can be configured or not")
 				time.Sleep(30 * time.Second)
 			}
 		}

--- a/drivers/pds/parameters/pds_default_parameters.json
+++ b/drivers/pds/parameters/pds_default_parameters.json
@@ -11,8 +11,8 @@
     },
     {
       "Name": "MySQL",
-      "Version": "8.0.30",
-      "Image": "a7bc638",
+      "Version": "8.0.31",
+      "Image": "033c060",
       "Replicas": 3,
       "ScaleReplicas": 6,
       "OldVersion": "8.0.30",

--- a/tests/pds/dataservice_test.go
+++ b/tests/pds/dataservice_test.go
@@ -293,6 +293,14 @@ var _ = Describe("{ScaleUPDataServices}", func() {
 	})
 })
 
+var _ = Describe("{TestTPCCDhruv}", func() {
+	JustBeforeEach(func() {
+		StartTorpedoTest("TestTPCCDhruv", "Runs TPC-C Workload on Postgres Deployment", nil, 0)
+	})
+	pdslib.CreatepostgresqlTpccWorkload("", "V5C1MSGd87BXZb881Lfl2lKGPlt4crHXsUJQHTk3", "pg-dhruv-test-xqz93n-ns1.portworx.pds-dns.io",
+		"", "", "", "", "", "dhruv-depl", "ns1")
+})
+
 var _ = Describe("{UpgradeDataServiceVersion}", func() {
 	JustBeforeEach(func() {
 		StartTorpedoTest("UpgradeDataServiceVersion", "Upgrades the dataservice version", nil, 0)

--- a/tests/pds/dataservice_test.go
+++ b/tests/pds/dataservice_test.go
@@ -352,7 +352,7 @@ func deployAndTriggerTpcc(dataservice, Version, Image, dsVersion, dsBuild string
 			Image,
 			namespace,
 		)
-		Expect(err).NotTo(HaveOccurred())
+		log.FailOnError(err, "Error while deploying data services")
 
 		Step("Validate Storage Configurations", func() {
 			resourceTemp, storageOp, config, err := pdslib.ValidateDataServiceVolumes(deployment, dataservice, dataServiceDefaultResourceTemplateID, storageTemplateID, namespace)

--- a/tests/pds/dataservice_test.go
+++ b/tests/pds/dataservice_test.go
@@ -386,8 +386,6 @@ func deployAndTriggerTpcc(dataservice, Version, Image, dsVersion, dsBuild string
 			}
 			if dataservice == mysql {
 				deploymentName := "my-tpcc"
-				// static sleep of 20 minutes as mysql is causing some dns issues as of now. We will change it later to polling of connection status
-				time.Sleep(20 * time.Minute)
 				pod, dep, err = pdslib.CreateTpccWorkloads(dataservice, deployment.GetId(), "100", "1", deploymentName, namespace)
 				Expect(err).NotTo(HaveOccurred())
 			}

--- a/tests/pds/dataservice_test.go
+++ b/tests/pds/dataservice_test.go
@@ -300,17 +300,19 @@ var _ = Describe("{RunTpccWorkloadOnDataServices}", func() {
 
 	It("Deploy , Validate and start TPCC Workload", func() {
 		for _, ds := range params.DataServiceToTest {
-			if ds.Name == "PostgreSQL" {
+			if ds.Name == postgresql {
 				log.InfoD("Deploying, Validating and Running TPCC Workload on %v Data Service ", ds.Name)
 				deployAndTriggerTpcc(ds.Name, ds.Version, ds.Image, ds.Version, ds.Image, int32(ds.Replicas))
 			}
-			if ds.Name == "MySQL" {
+			if ds.Name == mysql {
 				log.InfoD("Deploying, Validating and Running TPCC Workload on %v Data Service ", ds.Name)
 				deployAndTriggerTpcc(ds.Name, ds.Version, ds.Image, ds.Version, ds.Image, int32(ds.Replicas))
 			}
 		}
 	})
 	JustAfterEach(func() {
+		defer EndTorpedoTest()
+
 		defer func() {
 			if !isDeploymentsDeleted {
 				Step("Delete created deployments")
@@ -319,8 +321,6 @@ var _ = Describe("{RunTpccWorkloadOnDataServices}", func() {
 				dash.VerifyFatal(resp.StatusCode, http.StatusAccepted, "validating the status response")
 			}
 		}()
-
-		defer EndTorpedoTest()
 	})
 })
 

--- a/tests/pds/dataservice_test.go
+++ b/tests/pds/dataservice_test.go
@@ -293,13 +293,6 @@ var _ = Describe("{ScaleUPDataServices}", func() {
 	})
 })
 
-var _ = Describe("{testmysqlDB}", func() {
-	JustBeforeEach(func() {
-		StartTorpedoTest("testmysqlDB", "Runs TPC-C Workload on Postgres and MySQL Deployment", nil, 0)
-	})
-	pdslib.setupMysqlDatabaseForTpcc("pds", "qIn4pBdzjc3vr3QxKYuw8ZZRH25ai4i0P8D0kkWY", "my-dhruv-1-k58c90-ns1.portworx.pds-dns.io")
-})
-
 var _ = Describe("{RunTpccWorkloadOnDataServices}", func() {
 	JustBeforeEach(func() {
 		StartTorpedoTest("RunTpccWorkloadOnDataServices", "Runs TPC-C Workload on Postgres and MySQL Deployment", nil, 0)
@@ -307,10 +300,10 @@ var _ = Describe("{RunTpccWorkloadOnDataServices}", func() {
 
 	It("Deploy , Validate and start TPCC Workload", func() {
 		for _, ds := range params.DataServiceToTest {
-			if ds.Name == "PostgreSQL" {
-				log.InfoD("Deploying, Validating and Running TPCC Workload on %v Data Service ", ds.Name)
-				deployAndTriggerTpcc(ds.Name, ds.Version, ds.Image, ds.Version, ds.Image, int32(ds.Replicas))
-			}
+			// if ds.Name == "PostgreSQL" {
+			// 	log.InfoD("Deploying, Validating and Running TPCC Workload on %v Data Service ", ds.Name)
+			// 	deployAndTriggerTpcc(ds.Name, ds.Version, ds.Image, ds.Version, ds.Image, int32(ds.Replicas))
+			// }
 			if ds.Name == "MySQL" {
 				log.InfoD("Deploying, Validating and Running TPCC Workload on %v Data Service ", ds.Name)
 				deployAndTriggerTpcc(ds.Name, ds.Version, ds.Image, ds.Version, ds.Image, int32(ds.Replicas))
@@ -387,12 +380,12 @@ func deployAndTriggerTpcc(dataservice, Version, Image, dsVersion, dsBuild string
 
 		Step("Running TPCC Workloads - ", func() {
 			if dataservice == postgresql {
-				deploymentName := "PostgresTpcc"
+				deploymentName := "pg-tpcc"
 				pod, dep, err = pdslib.CreateTpccWorkloads(dataservice, deployment.GetId(), "100", "1", deploymentName, namespace)
 				Expect(err).NotTo(HaveOccurred())
 			}
 			if dataservice == mysql {
-				deploymentName := "MySQLTpcc"
+				deploymentName := "my-tpcc"
 				pod, dep, err = pdslib.CreateTpccWorkloads(dataservice, deployment.GetId(), "100", "1", deploymentName, namespace)
 				Expect(err).NotTo(HaveOccurred())
 			}

--- a/tests/pds/dataservice_test.go
+++ b/tests/pds/dataservice_test.go
@@ -330,8 +330,7 @@ func deployAndTriggerTpcc(dataservice, Version, Image, dsVersion, dsBuild string
 	Step("Deploy and Validate Data Service and run TPCC Workload", func() {
 		isDeploymentsDeleted = false
 		dataServiceDefaultResourceTemplateID, err = pdslib.GetResourceTemplate(tenantID, dataservice)
-		Expect(err).NotTo(HaveOccurred())
-
+		log.FailOnError(err, "Error while getting resource template")
 		log.InfoD("dataServiceDefaultResourceTemplateID %v ", dataServiceDefaultResourceTemplateID)
 
 		dataServiceDefaultAppConfigID, err = pdslib.GetAppConfTemplate(tenantID, dataservice)

--- a/tests/pds/dataservice_test.go
+++ b/tests/pds/dataservice_test.go
@@ -297,8 +297,8 @@ var _ = Describe("{testmysqlDB}", func() {
 	JustBeforeEach(func() {
 		StartTorpedoTest("testmysqlDB", "Runs TPC-C Workload on Postgres and MySQL Deployment", nil, 0)
 	})
-	pwd, err := pdslib.setupMysqlDatabaseForTpcc("pds", "qIn4pBdzjc3vr3QxKYuw8ZZRH25ai4i0P8D0kkWY", "my-dhruv-1-k58c90-ns1.portworx.pds-dns.io")
-}
+	pdslib.setupMysqlDatabaseForTpcc("pds", "qIn4pBdzjc3vr3QxKYuw8ZZRH25ai4i0P8D0kkWY", "my-dhruv-1-k58c90-ns1.portworx.pds-dns.io")
+})
 
 var _ = Describe("{RunTpccWorkloadOnDataServices}", func() {
 	JustBeforeEach(func() {

--- a/tests/pds/dataservice_test.go
+++ b/tests/pds/dataservice_test.go
@@ -324,6 +324,8 @@ var _ = Describe("{RunTpccWorkloadOnDataServices}", func() {
 	})
 })
 
+// This module deploys a data service, validates it, Prepares the data service with 4 districts and 2 warehouses
+// and runs TPCC Workload for a default time of 2 minutes
 func deployAndTriggerTpcc(dataservice, Version, Image, dsVersion, dsBuild string, replicas int32) {
 	Step("Deploy and Validate Data Service and run TPCC Workload", func() {
 		isDeploymentsDeleted = false

--- a/tests/pds/dataservice_test.go
+++ b/tests/pds/dataservice_test.go
@@ -386,6 +386,8 @@ func deployAndTriggerTpcc(dataservice, Version, Image, dsVersion, dsBuild string
 			}
 			if dataservice == mysql {
 				deploymentName := "my-tpcc"
+				// static sleep of 20 minutes as mysql is causing some dns issues as of now. We will change it later to polling of connection status
+				time.Sleep(20 * time.Minute)
 				pod, dep, err = pdslib.CreateTpccWorkloads(dataservice, deployment.GetId(), "100", "1", deploymentName, namespace)
 				Expect(err).NotTo(HaveOccurred())
 			}

--- a/tests/pds/dataservice_test.go
+++ b/tests/pds/dataservice_test.go
@@ -300,10 +300,10 @@ var _ = Describe("{RunTpccWorkloadOnDataServices}", func() {
 
 	It("Deploy , Validate and start TPCC Workload", func() {
 		for _, ds := range params.DataServiceToTest {
-			// if ds.Name == "PostgreSQL" {
-			// 	log.InfoD("Deploying, Validating and Running TPCC Workload on %v Data Service ", ds.Name)
-			// 	deployAndTriggerTpcc(ds.Name, ds.Version, ds.Image, ds.Version, ds.Image, int32(ds.Replicas))
-			// }
+			if ds.Name == "PostgreSQL" {
+				log.InfoD("Deploying, Validating and Running TPCC Workload on %v Data Service ", ds.Name)
+				deployAndTriggerTpcc(ds.Name, ds.Version, ds.Image, ds.Version, ds.Image, int32(ds.Replicas))
+			}
 			if ds.Name == "MySQL" {
 				log.InfoD("Deploying, Validating and Running TPCC Workload on %v Data Service ", ds.Name)
 				deployAndTriggerTpcc(ds.Name, ds.Version, ds.Image, ds.Version, ds.Image, int32(ds.Replicas))

--- a/tests/pds/dataservice_test.go
+++ b/tests/pds/dataservice_test.go
@@ -383,13 +383,17 @@ func deployAndTriggerTpcc(dataservice, Version, Image, dsVersion, dsBuild string
 		Step("Running TPCC Workloads - ", func() {
 			if dataservice == postgresql {
 				deploymentName := "pg-tpcc"
-				pod, dep, err = pdslib.CreateTpccWorkloads(dataservice, deployment.GetId(), "100", "1", deploymentName, namespace)
-				Expect(err).NotTo(HaveOccurred())
+				tpccRunResult := pdslib.CreateTpccWorkloads(dataservice, deployment.GetId(), "100", "1", deploymentName, namespace)
+				if !tpccRunResult {
+					Expect(err).NotTo(HaveOccurred())
+				}
 			}
 			if dataservice == mysql {
 				deploymentName := "my-tpcc"
-				pod, dep, err = pdslib.CreateTpccWorkloads(dataservice, deployment.GetId(), "100", "1", deploymentName, namespace)
-				Expect(err).NotTo(HaveOccurred())
+				tpccRunResult := pdslib.CreateTpccWorkloads(dataservice, deployment.GetId(), "100", "1", deploymentName, namespace)
+				if !tpccRunResult {
+					Expect(err).NotTo(HaveOccurred())
+				}
 			}
 		})
 		Step("Delete Deployments", func() {
@@ -398,19 +402,6 @@ func deployAndTriggerTpcc(dataservice, Version, Image, dsVersion, dsBuild string
 			Expect(resp.StatusCode).Should(BeEquivalentTo(http.StatusAccepted))
 			isDeploymentsDeleted = true
 		})
-
-		defer func() {
-			Step("Delete the workload generating deployments", func() {
-				if !(dataservice == mysql || dataservice == kafka || dataservice == zookeeper || dataservice == mongodb) {
-					if dataservice == cassandra || dataservice == postgresql {
-						err = pdslib.DeleteK8sDeployments(dep.Name, namespace)
-					} else {
-						err = pdslib.DeleteK8sPods(pod.Name, namespace)
-					}
-					Expect(err).NotTo(HaveOccurred())
-				}
-			})
-		}()
 	})
 }
 


### PR DESCRIPTION
This PR takes care of tickets : https://portworx.atlassian.net/browse/PA-339 and https://portworx.atlassian.net/browse/PA-340

This enables our framework to run TPC-C workload for MySQL and Postgres data services. For Postgres it's a straight forward test but for MySQL, we need to first configure it for TPC-C. That is also being taken care of in this PR.
General Steps for these test scenarios are:

Deploy Data service (Postgres / MySQL)
Configure Data service for TPCC Workload
Execute TPCC Workload for a set amount of time
Delete Data service
Test fails if any of the above steps fail.

BAT Run: 
https://jenkins.pwx.dev.purestorage.com/job/Users/job/Dhruv/job/dhruv-pds-bat/11/