### PR TITLE
PWX-27845 : Fix for Torpedo CSICloneTest test intermittent failure

### DIFF
--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -125,7 +125,7 @@ const (
 const (
 	k8sNodeReadyTimeout    = 5 * time.Minute
 	volDirCleanupTimeout   = 5 * time.Minute
-	k8sObjectCreateTimeout = 2 * time.Minute
+	k8sObjectCreateTimeout = 4 * time.Minute
 	k8sDestroyTimeout      = 5 * time.Minute
 	// FindFilesOnWorkerTimeout timeout for find files on worker
 	FindFilesOnWorkerTimeout = 1 * time.Minute

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -125,7 +125,8 @@ const (
 const (
 	k8sNodeReadyTimeout    = 5 * time.Minute
 	volDirCleanupTimeout   = 5 * time.Minute
-	k8sObjectCreateTimeout = 4 * time.Minute
+	k8sObjectCreateTimeout = 2 * time.Minute
+	k8sObjectCloneSnapshotTimeout = 4 * time.Minute
 	k8sDestroyTimeout      = 5 * time.Minute
 	// FindFilesOnWorkerTimeout timeout for find files on worker
 	FindFilesOnWorkerTimeout = 1 * time.Minute
@@ -5961,7 +5962,7 @@ func (k *K8s) waitForPodToBeReady(podname string, namespace string) error {
 		}
 		return "", false, nil
 	}
-	if _, err := task.DoRetryWithTimeout(t, k8sObjectCreateTimeout, DefaultRetryInterval); err != nil {
+	if _, err := task.DoRetryWithTimeout(t, k8sObjectCloneSnapshotTimeout, DefaultRetryInterval); err != nil {
 		return err
 	}
 	log.Infof("Pod is up and running: %s", pod.Name)

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -126,7 +126,7 @@ const (
 	k8sNodeReadyTimeout    = 5 * time.Minute
 	volDirCleanupTimeout   = 5 * time.Minute
 	k8sObjectCreateTimeout = 2 * time.Minute
-	k8sObjectCloneSnapshotTimeout = 4 * time.Minute
+	k8sPodCreateTimeout = 4 * time.Minute
 	k8sDestroyTimeout      = 5 * time.Minute
 	// FindFilesOnWorkerTimeout timeout for find files on worker
 	FindFilesOnWorkerTimeout = 1 * time.Minute
@@ -5962,7 +5962,7 @@ func (k *K8s) waitForPodToBeReady(podname string, namespace string) error {
 		}
 		return "", false, nil
 	}
-	if _, err := task.DoRetryWithTimeout(t, k8sObjectCloneSnapshotTimeout, DefaultRetryInterval); err != nil {
+	if _, err := task.DoRetryWithTimeout(t, k8sPodCreateTimeout, DefaultRetryInterval); err != nil {
 		return err
 	}
 	log.Infof("Pod is up and running: %s", pod.Name)


### PR DESCRIPTION
Signed-off-by: Amol Shinde <ashinde@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Torpedo CSICloneTest test intermittent failure, changed k8sObjectCreateTimeout to 4 minutes

**Which issue(s) this PR fixes** (optional)
Closes #PWX-27845

**Special notes for your reviewer**:

