### PR TITLE
Adding test for haupdate injection when app backup is in-progress

### DIFF
--- a/pkg/applicationbackup/applicationbackup.go
+++ b/pkg/applicationbackup/applicationbackup.go
@@ -31,16 +31,16 @@ func CreateBackupLocation(
 	if err != nil {
 		return nil, fmt.Errorf("secret %v is not present in default namespace", secretName)
 	}
-	// copy secret to the app namespace
-	newSecretObj := secretObj.DeepCopy()
-	newSecretObj.Namespace = namespace
-	newSecretObj.ResourceVersion = ""
-	_, err = core.Instance().CreateSecret(newSecretObj)
+	_, err = core.Instance().GetSecret(secretName, namespace)
 	if err != nil {
-		return nil, fmt.Errorf("failed to copy secret %v in required namespace %v", secretName, namespace)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("secret %v is not getting created  in default namespace", secretName)
+		// copy secret to the app namespace
+		newSecretObj := secretObj.DeepCopy()
+		newSecretObj.Namespace = namespace
+		newSecretObj.ResourceVersion = ""
+		_, err = core.Instance().CreateSecret(newSecretObj)
+		if err != nil {
+			return nil, fmt.Errorf("secret %v is not getting created in %v namespace", secretName, namespace)
+		}
 	}
 	backupLocation := &storkv1.BackupLocation{
 		ObjectMeta: meta.ObjectMeta{
@@ -114,7 +114,7 @@ func WaitForAppBackupToStart(name, namespace string, timeout time.Duration) erro
 		}
 
 		if appBackup.Status.Status != storkv1.ApplicationBackupStatusInProgress {
-			return "", true, fmt.Errorf("App backups %s in %s has not started yet.Retrying Status: %s", name, namespace, appBackup.Status.Status)
+			return "", true, fmt.Errorf("app backups %s in %s has not started yet.Retrying Status: %s", name, namespace, appBackup.Status.Status)
 		}
 		return "", false, nil
 	}

--- a/tests/basic/longevity_test.go
+++ b/tests/basic/longevity_test.go
@@ -607,7 +607,7 @@ func populateIntervals() {
 	triggerInterval[AutopilotRebalance] = make(map[int]time.Duration)
 	triggerInterval[VolumeCreatePxRestart] = make(map[int]time.Duration)
 
-	baseInterval := 1 * time.Minute
+	baseInterval := 10 * time.Minute
 	triggerInterval[BackupScaleMongo][10] = 1 * baseInterval
 	triggerInterval[BackupScaleMongo][9] = 2 * baseInterval
 	triggerInterval[BackupScaleMongo][8] = 3 * baseInterval
@@ -771,8 +771,6 @@ func populateIntervals() {
 	triggerInterval[StorkAppBkpVolResize][2] = 24 * baseInterval
 	triggerInterval[StorkAppBkpVolResize][1] = 27 * baseInterval
 
-	triggerInterval[StorkAppBkpHaUpdate][10] = 1 * baseInterval
-	triggerInterval[StorkAppBkpHaUpdate][10] = 1 * baseInterval
 	triggerInterval[StorkAppBkpHaUpdate][10] = 1 * baseInterval
 	triggerInterval[StorkAppBkpHaUpdate][9] = 3 * baseInterval
 	triggerInterval[StorkAppBkpHaUpdate][8] = 6 * baseInterval

--- a/tests/basic/longevity_test.go
+++ b/tests/basic/longevity_test.go
@@ -93,6 +93,8 @@ var _ = Describe("{Longevity}", func() {
 		AsyncDRVolumeOnly:      TriggerAsyncDRVolumeOnly,
 		StorkApplicationBackup: TriggerStorkApplicationBackup,
 		StorkAppBkpVolResize:   TriggerStorkAppBkpVolResize,
+		StorkAppBkpHaUpdate:    TriggerStorkAppBkpHaUpdate,
+		StorkAppBkpPxRestart:   TriggerStorkAppBkpPxRestart,
 		RestartKvdbVolDriver:   TriggerRestartKvdbVolDriver,
 		HAIncreaseAndReboot:    TriggerHAIncreaseAndReboot,
 		AddDiskAndReboot:       TriggerPoolAddDiskAndReboot,
@@ -596,6 +598,8 @@ func populateIntervals() {
 	triggerInterval[AsyncDRVolumeOnly] = make(map[int]time.Duration)
 	triggerInterval[StorkApplicationBackup] = make(map[int]time.Duration)
 	triggerInterval[StorkAppBkpVolResize] = make(map[int]time.Duration)
+	triggerInterval[StorkAppBkpHaUpdate] = make(map[int]time.Duration)
+	triggerInterval[StorkAppBkpPxRestart] = make(map[int]time.Duration)
 	triggerInterval[HAIncreaseAndReboot] = make(map[int]time.Duration)
 	triggerInterval[AddDrive] = make(map[int]time.Duration)
 	triggerInterval[AddDiskAndReboot] = make(map[int]time.Duration)
@@ -603,7 +607,7 @@ func populateIntervals() {
 	triggerInterval[AutopilotRebalance] = make(map[int]time.Duration)
 	triggerInterval[VolumeCreatePxRestart] = make(map[int]time.Duration)
 
-	baseInterval := 10 * time.Minute
+	baseInterval := 1 * time.Minute
 	triggerInterval[BackupScaleMongo][10] = 1 * baseInterval
 	triggerInterval[BackupScaleMongo][9] = 2 * baseInterval
 	triggerInterval[BackupScaleMongo][8] = 3 * baseInterval
@@ -766,6 +770,30 @@ func populateIntervals() {
 	triggerInterval[StorkAppBkpVolResize][3] = 21 * baseInterval
 	triggerInterval[StorkAppBkpVolResize][2] = 24 * baseInterval
 	triggerInterval[StorkAppBkpVolResize][1] = 27 * baseInterval
+
+	triggerInterval[StorkAppBkpHaUpdate][10] = 1 * baseInterval
+	triggerInterval[StorkAppBkpHaUpdate][10] = 1 * baseInterval
+	triggerInterval[StorkAppBkpHaUpdate][10] = 1 * baseInterval
+	triggerInterval[StorkAppBkpHaUpdate][9] = 3 * baseInterval
+	triggerInterval[StorkAppBkpHaUpdate][8] = 6 * baseInterval
+	triggerInterval[StorkAppBkpHaUpdate][7] = 9 * baseInterval
+	triggerInterval[StorkAppBkpHaUpdate][6] = 12 * baseInterval
+	triggerInterval[StorkAppBkpHaUpdate][5] = 15 * baseInterval
+	triggerInterval[StorkAppBkpHaUpdate][4] = 18 * baseInterval
+	triggerInterval[StorkAppBkpHaUpdate][3] = 21 * baseInterval
+	triggerInterval[StorkAppBkpHaUpdate][2] = 24 * baseInterval
+	triggerInterval[StorkAppBkpHaUpdate][1] = 27 * baseInterval
+
+	triggerInterval[StorkAppBkpPxRestart][10] = 1 * baseInterval
+	triggerInterval[StorkAppBkpPxRestart][9] = 3 * baseInterval
+	triggerInterval[StorkAppBkpPxRestart][8] = 6 * baseInterval
+	triggerInterval[StorkAppBkpPxRestart][7] = 9 * baseInterval
+	triggerInterval[StorkAppBkpPxRestart][6] = 12 * baseInterval
+	triggerInterval[StorkAppBkpPxRestart][5] = 15 * baseInterval
+	triggerInterval[StorkAppBkpPxRestart][4] = 18 * baseInterval
+	triggerInterval[StorkAppBkpPxRestart][3] = 21 * baseInterval
+	triggerInterval[StorkAppBkpPxRestart][2] = 24 * baseInterval
+	triggerInterval[StorkAppBkpPxRestart][1] = 27 * baseInterval
 
 	baseInterval = 60 * time.Minute
 
@@ -1249,6 +1277,8 @@ func populateIntervals() {
 	triggerInterval[AsyncDRVolumeOnly][0] = 0
 	triggerInterval[StorkApplicationBackup][0] = 0
 	triggerInterval[StorkAppBkpVolResize][0] = 0
+	triggerInterval[StorkAppBkpHaUpdate][0] = 0
+	triggerInterval[StorkAppBkpPxRestart][0] = 0
 	triggerInterval[HAIncreaseAndReboot][0] = 0
 	triggerInterval[AddDrive][0] = 0
 	triggerInterval[AddDiskAndReboot][0] = 0


### PR DESCRIPTION
**What this PR does / why we need it**:
It adds a Longevity test for haupdate injection when app backup is in-progress

**Which issue(s) this PR fixes** (optional)
Closes #https://portworx.atlassian.net/browse/PTX-14189
Closes #https://portworx.atlassian.net/browse/PTX-14670

**Special notes for your reviewer**:
Test passes and fails as per the Replication factor -

Test Pass -
http://aetos.pwx.purestorage.com/resultSet/testSetID/51598

All added tests are running successful from below job -
http://aetos.pwx.purestorage.com/resultSet/testSetID/51856
