### PR TITLE
Fix: Service Name Resolution for Keycloak

### DIFF
--- a/drivers/backup/auth.go
+++ b/drivers/backup/auth.go
@@ -165,15 +165,20 @@ func getKeycloakEndPoint(admin bool) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	url := string(secret.Data[Issuer])
+	// Expand the service name for K8S DNS resolution, for keycloak requests from different ns
+	splitURL := strings.Split(url, ":")
+	splitURL[1] = fmt.Sprintf("%s.%s.svc.cluster.local", splitURL[1], ns)
+	url = strings.Join(splitURL, ":")
+	// url: http://pxcentral-keycloak-http.px-backup.svc.cluster.local:80/auth/realms/master
 	if admin {
-		url := string(secret.Data[Issuer])
-		// admin url: http://pxcentral-keycloak-http:80/auth/realms/master
-		// non-adming url: http://pxcentral-keycloak-http:80/auth/admin/realms/master
+		// admin url: http://pxcentral-keycloak-http.px-backup.svc.cluster.local:80/auth/realms/master
+		// non-adming url: http://pxcentral-keycloak-http.px-backup.svc.cluster.local:80/auth/admin/realms/master
 		split := strings.Split(url, "auth")
 		newURL := fmt.Sprintf("%sauth/admin%s", split[0], split[1])
 		return newURL, nil
 	}
-	return string(secret.Data[Issuer]), nil
+	return string(url), nil
 
 }
 


### PR DESCRIPTION
Signed-off-by: Sumit Das <sudas@purestorage.com>

**What this PR does / why we need it**:
Currently, the Backup Auth Driver assumes that the call to the PX KeyCloak Service is made from the same namespace. e.g. `px-backup` namespace, where px-backup is deployed. But the `torpedo` pod is deployed in the `default` namespace which was not able to access the keycloak service.
- Changed the service name to full expansion with namespace, e.g. `http://pxcentral-keycloak-http.px-backup.svc.cluster.local:80/auth/realms/master` adhering to KubeDNS Nomenclature. This will resolve the service not found issue.

**Special notes for your reviewer**:
Jenkins Pipeline Failure Log: [a35e2044](https://jenkins.pwx.dev.purestorage.com/blue/rest/organizations/jenkins/pipelines/Users/pipelines/Sumit/pipelines/PX-Backup/pipelines/px-backup-system-test/runs/29/nodes/249/steps/252/log/?start=0)
Jenkins Pipeline Log after fix: [577e220a](https://jenkins.pwx.dev.purestorage.com/blue/rest/organizations/jenkins/pipelines/Users/pipelines/Sumit/pipelines/PX-Backup/pipelines/px-backup-system-test/runs/30/nodes/249/steps/252/log/?start=0)

