### PR TITLE
Adding cloud scenarios for multi drive expansion

### DIFF
--- a/drivers/scheduler/k8s/specs/fio-fastpath/fio-config-map.yaml
+++ b/drivers/scheduler/k8s/specs/fio-fastpath/fio-config-map.yaml
@@ -1,0 +1,86 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fio-job-config
+data:
+    fio.job: |
+        [global]
+        name=fio-rand-RW
+        directory=/scratch/
+        rw=randwrite
+        rwmixread=75
+        randrepeat=1
+        blocksize_range=4k-512k
+        direct=1
+        end_fsync=1
+        do_verify=1
+        verify=crc32c
+        verify_pattern=0xdeadbeef
+        disable_lat=0
+        time_based=1
+        runtime=99999999
+        [file1]
+        filesize=1M-10M
+        nrfiles=10000
+        ioengine=libaio
+        iodepth=128
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grok-exporter
+data:
+  config.yml: |-
+    global:
+      config_version: 3
+    input:
+      type: file
+      path: /logs/fio.log
+      readall: false
+      fail_on_missing_logfile: true
+    imports:
+    - type: grok_patterns
+      dir: ./patterns
+    grok_patterns:
+    - 'FIO_IOPS [0-9]*[.][0-9]k$|[0-9]*'
+    metrics:
+        - type: gauge
+          name: iops
+          help: FIO IOPS Write Gauge Metrics
+          match: '  write: %{GREEDYDATA}, iops=%{NUMBER:val1}%{GREEDYDATA:thsd}, %{GREEDYDATA}'
+          value: '{{`{{if eq .thsd "k"}}{{multiply .val1 1000}}{{else}}{{.val1}}{{end}}`}}'
+          labels:
+              iops_suffix: '{{`{{.thsd}}`}}'
+          cumulative: false
+          retention: 1s
+        - type: gauge
+          name: bandwidth
+          help: FIO Bandwidth Write Gauge Metrics
+          match: '  write: io=%{GREEDYDATA}, bw=%{NUMBER:val2}%{GREEDYDATA:kbs}, %{GREEDYDATA}, %{GREEDYDATA}'
+          value: '{{`{{if eq .kbs "KB/s"}}{{divide .val2 1024}}{{else}}{{.val2}}{{end}}`}}'
+          labels:
+              bw_unit: '{{`{{.kbs}}`}}'
+          cumulative: false
+          retention: 1s
+        - type: gauge
+          name: avg_latency
+          help: FIO AVG Latency Write Gauge Metrics
+          match: '     lat (%{GREEDYDATA:nsec}): min=%{GREEDYDATA}, max=%{GREEDYDATA}, avg=%{NUMBER:val3}, stdev=%{GREEDYDATA}'
+          value: '{{`{{if eq .nsec "(usec)"}}{{divide .val3 1000}}{{else}}{{.val3}}{{end}}`}}'
+          labels:
+              lat_unit: '{{`{{.nsec}}`}}'
+          cumulative: false
+          retention: 1s
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fio-ready-probe
+data:
+  ready-probe.sh: |
+    #!/bin/bash
+    if [ `cat /root/fio.log | grep 'error\|bad magic header' | wc -l` -ge 1 ]; then 
+      exit 1; 
+    else 
+      exit 0; 
+    fi

--- a/drivers/scheduler/k8s/specs/fio-fastpath/fio.yaml
+++ b/drivers/scheduler/k8s/specs/fio-fastpath/fio.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: fio
+spec:
+  serviceName: fio
+  replicas: 10
+  selector:
+    matchLabels:
+      app: fio
+  template:
+    metadata:
+      labels:
+        app: fio
+    spec:
+      schedulerName: stork
+      containers:
+      - name: fio
+        image: portworx/fio_drv
+        command: ["fio"]
+        resources:
+          limits:
+            cpu: "2"
+            memory: 4Gi
+          requests:
+            cpu: "1"
+            memory: 4Gi
+        args: ["/configs/fio.job", "--status-interval=1", "--eta=never", "--output=/logs/fio.log"]
+        volumeMounts:
+        - name: fio-config-vol
+          mountPath: /configs
+        - name: fio-data
+          mountPath: /scratch
+        - name: fio-log
+          mountPath: /logs
+      - name: grok
+        image: pwxvin/grok-exporter:v1.0.0-RC4
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: grok-port
+          containerPort: 9144
+          protocol: TCP
+        volumeMounts:
+        - name: grok-config-volume
+          mountPath: /etc/grok_exporter
+        - name: fio-log
+          mountPath: /logs
+      volumes:
+      - name: fio-config-vol
+        configMap:
+          name: fio-job-config
+      - name: grok-config-volume
+        configMap:
+          name: grok-exporter
+  volumeClaimTemplates:
+  - metadata:
+      name: fio-data
+    spec:
+      storageClassName: fio-vps-sc
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 200Gi
+  - metadata:
+      name: fio-log
+    spec:
+      storageClassName: fio-vps-log
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 50Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grok-exporter-svc
+  labels:
+      app: fio
+spec:
+  clusterIP: None
+  selector: 
+    app: fio
+  ports:
+  - name: grok-port
+    port: 9144
+    targetPort: 9144

--- a/drivers/scheduler/k8s/specs/fio-fastpath/pxd/px-storage-class.yaml
+++ b/drivers/scheduler/k8s/specs/fio-fastpath/pxd/px-storage-class.yaml
@@ -1,0 +1,22 @@
+##### Portworx storage class
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: fio-vps-sc
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  placement_strategy: "fastpath-repl1-vdbench-vps"
+  repl: "2"
+  priority_io: "high"
+allowVolumeExpansion: true
+---
+##### Portworx storage class
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: fio-vps-log
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  repl: "2"
+  priority_io: "high"
+allowVolumeExpansion: true

--- a/drivers/volume/common.go
+++ b/drivers/volume/common.go
@@ -221,6 +221,32 @@ func (d *DefaultDriver) ExitMaintenance(n node.Node) error {
 	}
 }
 
+// RecoverPool will recover a pool from a failure/storage down state.
+// This could be used by a pool driver to recover itself from any underlying storage
+// failure.
+func (d *DefaultDriver) RecoverPool(n node.Node) error {
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "RecoverPool()",
+	}
+}
+
+// EnterPoolMaintenance puts pools in the given node in maintenance mode
+func (d *DefaultDriver) EnterPoolMaintenance(n node.Node) error {
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "EnterPoolMaintenance()",
+	}
+}
+
+// ExitPoolMaintenance exits pools in the given node from maintenance mode
+func (d *DefaultDriver) ExitPoolMaintenance(n node.Node) error {
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "ExitPoolMaintenance()",
+	}
+}
+
 // GetDriverVersion Returns the pxctl version
 func (d *DefaultDriver) GetDriverVersion() (string, error) {
 	return "", &errors.ErrNotSupported{

--- a/drivers/volume/common.go
+++ b/drivers/volume/common.go
@@ -231,7 +231,7 @@ func (d *DefaultDriver) RecoverPool(n node.Node) error {
 	}
 }
 
-// EnterPoolMaintenance puts pools in the given node in maintenance mode
+// EnterPoolMaintenance puts pools on the given node in maintenance mode
 func (d *DefaultDriver) EnterPoolMaintenance(n node.Node) error {
 	return &errors.ErrNotSupported{
 		Type:      "Function",
@@ -239,7 +239,7 @@ func (d *DefaultDriver) EnterPoolMaintenance(n node.Node) error {
 	}
 }
 
-// ExitPoolMaintenance exits pools in the given node from maintenance mode
+// ExitPoolMaintenance exits pools on the given node from maintenance mode
 func (d *DefaultDriver) ExitPoolMaintenance(n node.Node) error {
 	return &errors.ErrNotSupported{
 		Type:      "Function",

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -973,6 +973,53 @@ func (d *portworx) ExitMaintenance(n node.Node) error {
 	return nil
 }
 
+func (d *portworx) EnterPoolMaintenance(n node.Node) error {
+	cmd := fmt.Sprintf("pxctl sv pool maintenance -e -y")
+	out, err := d.nodeDriver.RunCommand(
+		n,
+		cmd,
+		node.ConnectionOpts{
+			Timeout:         maintenanceWaitTimeout,
+			TimeBeforeRetry: defaultRetryInterval,
+		})
+	if err != nil {
+		log.Errorf(fmt.Sprintf("error when entering pool maintenance, Err: %v", err))
+		return err
+	}
+	log.Infof("Enter pool maintenance %s", out)
+	return nil
+}
+
+func (d *portworx) ExitPoolMaintenance(n node.Node) error {
+	cmd := fmt.Sprintf("pxctl sv pool maintenance -x -y")
+	out, err := d.nodeDriver.RunCommand(
+		n,
+		cmd,
+		node.ConnectionOpts{
+			Timeout:         maintenanceWaitTimeout,
+			TimeBeforeRetry: defaultRetryInterval,
+		})
+	if err != nil {
+		log.Errorf(fmt.Sprintf("error when exiting pool maintenance, Err: %v", err))
+		return err
+	}
+	log.Infof("Exit pool maintenance %s", out)
+	return nil
+}
+
+func (d *portworx) RecoverPool(n node.Node) error {
+
+	if err := d.EnterPoolMaintenance(n); err != nil {
+		return err
+	}
+
+	if err := d.ExitPoolMaintenance(n); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (d *portworx) ValidateCreateVolume(volumeName string, params map[string]string) error {
 	var token string
 	token = d.getTokenForVolume(volumeName, params)
@@ -1485,7 +1532,8 @@ func (d *portworx) StopDriver(nodes []node.Node, force bool, triggerOpts *driver
 	stopFn := func() error {
 		var err error
 		for _, n := range nodes {
-			log.Infof("Stopping volume driver on node [%s]", n.Name)
+
+			log.InfoD("Stopping volume driver on [%s].", n.Name)
 			if force {
 				pxCrashCmd := "sudo pkill -9 px-storage"
 				_, err = d.nodeDriver.RunCommand(n, pxCrashCmd, node.ConnectionOpts{
@@ -2449,7 +2497,7 @@ func (d *portworx) getContext() context.Context {
 }
 
 func (d *portworx) StartDriver(n node.Node) error {
-	log.Infof("Starting volume driver on %s.", n.Name)
+	log.InfoD("Starting volume driver on %s.", n.Name)
 	err := d.schedOps.StartPxOnNode(n)
 	if err != nil {
 		return err
@@ -2869,7 +2917,20 @@ func (d *portworx) RejoinNode(n *node.Node) error {
 }
 
 func (d *portworx) GetNodeStatus(n node.Node) (*api.Status, error) {
-	nodeResponse, err := d.getNodeManager().Inspect(d.getContext(), &api.SdkNodeInspectRequest{NodeId: n.VolDriverNodeID})
+
+	f := func() (interface{}, bool, error) {
+		nodeResponse, err := d.getNodeManager().Inspect(d.getContext(), &api.SdkNodeInspectRequest{NodeId: n.VolDriverNodeID})
+		if err != nil {
+			if isNodeNotFound(err) {
+				return nil, false, err
+			}
+			return nil, true, err
+		}
+
+		return nodeResponse, false, nil
+	}
+	resp, err := task.DoRetryWithTimeout(f, 5*time.Minute, 1*time.Minute)
+
 	if err != nil {
 		if isNodeNotFound(err) {
 			apiSt := api.Status_STATUS_NONE
@@ -2880,6 +2941,8 @@ func (d *portworx) GetNodeStatus(n node.Node) (*api.Status, error) {
 			Cause: fmt.Sprintf("Failed to check status on node [%s], Err: %v", n.Name, err),
 		}
 	}
+	nodeResponse := resp.(*api.SdkNodeInspectResponse)
+
 	return &nodeResponse.Node.Status, nil
 }
 

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -983,8 +983,7 @@ func (d *portworx) EnterPoolMaintenance(n node.Node) error {
 			TimeBeforeRetry: defaultRetryInterval,
 		})
 	if err != nil {
-		log.Errorf(fmt.Sprintf("error when entering pool maintenance, Err: %v", err))
-		return err
+		return fmt.Errorf("error when entering pool maintenance on node [%s], Err: %v", n.Name, err)
 	}
 	log.Infof("Enter pool maintenance %s", out)
 	return nil
@@ -1000,8 +999,7 @@ func (d *portworx) ExitPoolMaintenance(n node.Node) error {
 			TimeBeforeRetry: defaultRetryInterval,
 		})
 	if err != nil {
-		log.Errorf(fmt.Sprintf("error when exiting pool maintenance, Err: %v", err))
-		return err
+		return fmt.Errorf("error when exiting pool maintenance on node [%s], Err: %v", n.Name, err)
 	}
 	log.Infof("Exit pool maintenance %s", out)
 	return nil

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -178,6 +178,17 @@ type Driver interface {
 	// ExitMaintenance exits the given node from maintenance mode
 	ExitMaintenance(n node.Node) error
 
+	// RecoverPool will recover a pool from a failure/storage down state.
+	// This could be used by a pool to recover itself from any underlying storage
+	// failure.
+	RecoverPool(n node.Node) error
+
+	// EnterPoolMaintenance puts pools in the given node in maintenance mode
+	EnterPoolMaintenance(n node.Node) error
+
+	// ExitPoolMaintenance exits pools in the given node from maintenance mode
+	ExitPoolMaintenance(n node.Node) error
+
 	// GetDriverVersion will return the pxctl version from the node
 	GetDriverVersion() (string, error)
 

--- a/tests/basic/scheduler_upgrade_test.go
+++ b/tests/basic/scheduler_upgrade_test.go
@@ -85,11 +85,11 @@ var _ = Describe("{UpgradeScheduler}", func() {
 			})
 			PerformSystemCheck()
 		}
-	})
-	Step("teardown all apps", func() {
-		for _, ctx := range contexts {
-			TearDownContext(ctx, nil)
-		}
+		Step("teardown all apps", func() {
+			for _, ctx := range contexts {
+				TearDownContext(ctx, nil)
+			}
+		})
 	})
 
 	JustAfterEach(func() {

--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -66,7 +66,7 @@ var _ = Describe("{StoragePoolExpandDiskResize}", func() {
 			if poolResizeIsInProgress(poolToBeResized) {
 				// wait until resize is completed and get the updated pool again
 				poolToBeResized, err = GetStoragePoolByUUID(poolIDToResize)
-				log.FailOnError(err, "Failed to get pool using UUID ")
+				log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", poolIDToResize))
 			}
 		})
 
@@ -100,7 +100,7 @@ var _ = Describe("{StoragePoolExpandDiskResize}", func() {
 			ValidateApplications(contexts)
 
 			resizedPool, err := GetStoragePoolByUUID(poolIDToResize)
-			log.FailOnError(err, "Failed to get pool using UUID ")
+			log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", poolIDToResize))
 			newPoolSize := resizedPool.TotalSize / units.GiB
 			isExpansionSuccess := false
 			if newPoolSize == expectedSize || newPoolSize == expectedSizeWithJournal {
@@ -164,7 +164,7 @@ var _ = Describe("{StoragePoolExpandDiskAdd}", func() {
 			if poolResizeIsInProgress(poolToBeResized) {
 				// wait until resize is completed and get the updated pool again
 				poolToBeResized, err = GetStoragePoolByUUID(poolIDToResize)
-				log.FailOnError(err, "Failed to get pool using UUID ")
+				log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", poolIDToResize))
 			}
 		})
 
@@ -198,7 +198,7 @@ var _ = Describe("{StoragePoolExpandDiskAdd}", func() {
 			ValidateApplications(contexts)
 
 			resizedPool, err := GetStoragePoolByUUID(poolIDToResize)
-			log.FailOnError(err, "Failed to get pool using UUID ")
+			log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", poolIDToResize))
 			newPoolSize := resizedPool.TotalSize / units.GiB
 			isExpansionSuccess := false
 			if newPoolSize >= expectedSizeWithJournal {
@@ -263,7 +263,7 @@ var _ = Describe("{StoragePoolExpandDiskAuto}", func() {
 			if poolResizeIsInProgress(poolToBeResized) {
 				// wait until resize is completed and get the updated pool again
 				poolToBeResized, err = GetStoragePoolByUUID(poolIDToResize)
-				log.FailOnError(err, "Failed to get pool using UUID ")
+				log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", poolIDToResize))
 			}
 		})
 
@@ -295,7 +295,7 @@ var _ = Describe("{StoragePoolExpandDiskAuto}", func() {
 			ValidateApplications(contexts)
 
 			resizedPool, err := GetStoragePoolByUUID(poolIDToResize)
-			log.FailOnError(err, "Failed to get pool using UUID ")
+			log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", poolIDToResize))
 			newPoolSize := resizedPool.TotalSize / units.GiB
 			isExpansionSuccess := false
 			if newPoolSize == expectedSize || newPoolSize == expectedSizeWithJournal {
@@ -365,7 +365,7 @@ var _ = Describe("{PoolResizeDiskReboot}", func() {
 			if poolResizeIsInProgress(poolToBeResized) {
 				// wait until resize is completed and get the updated pool again
 				poolToBeResized, err = GetStoragePoolByUUID(poolIDToResize)
-				log.FailOnError(err, "Failed to get pool using UUID ")
+				log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", poolIDToResize))
 			}
 		})
 
@@ -393,7 +393,7 @@ var _ = Describe("{PoolResizeDiskReboot}", func() {
 			log.FailOnError(err, "Expansion is not started")
 
 			storageNode, err := GetNodeWithGivenPoolID(poolIDToResize)
-			log.FailOnError(err, "Failed to get pool using UUID ")
+			log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", poolIDToResize))
 			err = RebootNodeAndWait(*storageNode)
 			log.FailOnError(err, "Failed to reboot node and wait till it is up")
 			resizeErr := waitForPoolToBeResized(expectedSize, poolIDToResize, isjournal)
@@ -406,7 +406,7 @@ var _ = Describe("{PoolResizeDiskReboot}", func() {
 			ValidateApplications(contexts)
 
 			resizedPool, err := GetStoragePoolByUUID(poolIDToResize)
-			log.FailOnError(err, "Failed to get pool using UUID ")
+			log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", poolIDToResize))
 			newPoolSize := resizedPool.TotalSize / units.GiB
 			isExpansionSuccess := false
 			if newPoolSize == expectedSize || newPoolSize == expectedSizeWithJournal {
@@ -475,7 +475,7 @@ var _ = Describe("{PoolAddDiskReboot}", func() {
 			if poolResizeIsInProgress(poolToBeResized) {
 				// wait until resize is completed and get the updated pool again
 				poolToBeResized, err = GetStoragePoolByUUID(poolIDToResize)
-				log.FailOnError(err, "Failed to get pool using UUID")
+				log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", poolIDToResize))
 			}
 		})
 
@@ -502,7 +502,7 @@ var _ = Describe("{PoolAddDiskReboot}", func() {
 			log.FailOnError(err, "Failed while waiting for expansion to start")
 
 			storageNode, err := GetNodeWithGivenPoolID(poolIDToResize)
-			log.FailOnError(err, " Failed to get pool using UUID")
+			log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", poolIDToResize))
 			err = RebootNodeAndWait(*storageNode)
 			log.FailOnError(err, "Failed to reboot node and wait till it is up")
 			resizeErr := waitForPoolToBeResized(expectedSize, poolIDToResize, isjournal)
@@ -514,7 +514,7 @@ var _ = Describe("{PoolAddDiskReboot}", func() {
 			ValidateApplications(contexts)
 
 			resizedPool, err := GetStoragePoolByUUID(poolIDToResize)
-			log.FailOnError(err, " Failed to get pool using UUID")
+			log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", poolIDToResize))
 			newPoolSize := resizedPool.TotalSize / units.GiB
 			isExpansionSuccess := false
 			if newPoolSize == expectedSize || newPoolSize == expectedSizeWithJournal {
@@ -1662,7 +1662,7 @@ var _ = Describe("{PoolResizeMul}", func() {
 		stepLog = fmt.Sprintf("Expanding pool  on node %s and pool UUID: %s using auto", selectedNode.Name, selectedPool.Uuid)
 		Step(stepLog, func() {
 			poolToBeResized, err := GetStoragePoolByUUID(selectedPool.Uuid)
-			log.FailOnError(err, "Failed to get pool using UUID ")
+			log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", selectedPool.Uuid))
 			expectedSize := poolToBeResized.TotalSize * 2 / units.GiB
 
 			isjournal, err := isJournalEnabled()
@@ -1746,7 +1746,7 @@ var _ = Describe("{MultiDriveResizeDisk}", func() {
 		stepLog = fmt.Sprintf("Expanding pool  on node %s and pool UUID: %s using resize-disk", selectedNode.Name, selectedPool.Uuid)
 		Step(stepLog, func() {
 			poolToBeResized, err := GetStoragePoolByUUID(selectedPool.Uuid)
-			log.FailOnError(err, "Failed to get pool using UUID ")
+			log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", selectedPool.Uuid))
 			expectedSize := poolToBeResized.TotalSize * 2 / units.GiB
 
 			log.InfoD("Current Size of the pool %s is %d", selectedPool.Uuid, poolToBeResized.TotalSize/units.GiB)
@@ -1806,7 +1806,7 @@ var _ = Describe("{ResizeWithPXRestart}", func() {
 			log.InfoD(stepLog)
 
 			poolToBeResized, err := GetStoragePoolByUUID(selectedPool.Uuid)
-			log.FailOnError(err, "Failed to get pool using UUID ")
+			log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", selectedPool.Uuid))
 			expectedSize := poolToBeResized.TotalSize * 2 / units.GiB
 
 			isjournal, err := isJournalEnabled()
@@ -1873,7 +1873,7 @@ var _ = Describe("{AddWithPXRestart}", func() {
 			log.InfoD(stepLog)
 
 			poolToBeResized, err := GetStoragePoolByUUID(selectedPool.Uuid)
-			log.FailOnError(err, "Failed to get pool using UUID ")
+			log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", selectedPool.Uuid))
 			expectedSize := poolToBeResized.TotalSize * 2 / units.GiB
 
 			isjournal, err := isJournalEnabled()
@@ -1957,7 +1957,7 @@ var _ = Describe("{ResizeDiskVolUpdate}", func() {
 			log.InfoD(stepLog)
 
 			poolToBeResized, err = GetStoragePoolByUUID(selectedPool.Uuid)
-			log.FailOnError(err, "Failed to get pool using UUID ")
+			log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", selectedPool.Uuid))
 			expectedSize := poolToBeResized.TotalSize * 2 / units.GiB
 
 			isjournal, err := isJournalEnabled()
@@ -2056,7 +2056,7 @@ var _ = Describe("{VolUpdateResizeDisk}", func() {
 		selectedPool := stNode.Pools[0]
 		var poolToBeResized *api.StoragePool
 		poolToBeResized, err = GetStoragePoolByUUID(selectedPool.Uuid)
-		log.FailOnError(err, "Failed to get pool using UUID ")
+		log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", selectedPool.Uuid))
 
 		stepLog = "Expand volume to the expanded pool"
 		var newRep int64
@@ -2163,7 +2163,7 @@ var _ = Describe("{VolUpdateAddDrive}", func() {
 		selectedPool := stNode.Pools[0]
 		var poolToBeResized *api.StoragePool
 		poolToBeResized, err = GetStoragePoolByUUID(selectedPool.Uuid)
-		log.FailOnError(err, "Failed to get pool using UUID ")
+		log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", selectedPool.Uuid))
 
 		stepLog = "Expand volume to the expanded pool"
 		var newRep int64
@@ -2345,7 +2345,7 @@ var _ = Describe("{MulPoolsResize}", func() {
 			resizedPoolsMap := make(map[string]uint64)
 			for _, selPool := range poolsToBeResized {
 				poolToBeResized, err := GetStoragePoolByUUID(selPool.Uuid)
-				log.FailOnError(err, "Failed to get pool using UUID ")
+				log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", selPool.Uuid))
 				expectedSize := poolToBeResized.TotalSize * 2 / units.GiB
 				resizedPoolsMap[poolToBeResized.Uuid] = expectedSize
 
@@ -2421,7 +2421,7 @@ var _ = Describe("{MulPoolsAddDisk}", func() {
 			resizedPoolsMap := make(map[string]uint64)
 			for _, selPool := range poolsToBeResized {
 				poolToBeResized, err := GetStoragePoolByUUID(selPool.Uuid)
-				log.FailOnError(err, "Failed to get pool using UUID ")
+				log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", selPool.Uuid))
 				expectedSize := poolToBeResized.TotalSize * 2 / units.GiB
 				resizedPoolsMap[poolToBeResized.Uuid] = expectedSize
 
@@ -2501,7 +2501,7 @@ var _ = Describe("{ResizeWithJrnlAndMeta}", func() {
 			log.InfoD(stepLog)
 
 			poolToBeResized, err := GetStoragePoolByUUID(selectedPool.Uuid)
-			log.FailOnError(err, "Failed to get pool using UUID ")
+			log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", selectedPool.Uuid))
 			expectedSize := poolToBeResized.TotalSize * 2 / units.GiB
 
 			log.FailOnError(err, "Failed to check if Journal enabled")
@@ -2568,7 +2568,7 @@ var _ = Describe("{PoolExpandWhileIOAndPXRestart}", func() {
 
 		var poolToBeResized *api.StoragePool
 		poolToBeResized, err = GetStoragePoolByUUID(selectedPool)
-		log.FailOnError(err, "Failed to get pool using UUID ")
+		log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", selectedPool))
 
 		stepLog := "Initiate pool expansion drive on n2 and restart PX on n1"
 		Step(stepLog, func() {
@@ -2648,7 +2648,7 @@ var _ = Describe("{ResizeNodeMaintenanceCycle}", func() {
 
 		var poolToBeResized *api.StoragePool
 		poolToBeResized, err = GetStoragePoolByUUID(selectedPool.Uuid)
-		log.FailOnError(err, "Failed to get pool using UUID ")
+		log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", selectedPool.Uuid))
 
 		stepLog := "Initiate pool expansion drive start node maintenance"
 		Step(stepLog, func() {
@@ -2731,7 +2731,7 @@ var _ = Describe("{AddDiskNodeMaintenanceCycle}", func() {
 
 		var poolToBeResized *api.StoragePool
 		poolToBeResized, err = GetStoragePoolByUUID(selectedPool.Uuid)
-		log.FailOnError(err, "Failed to get pool using UUID ")
+		log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", selectedPool.Uuid))
 
 		stepLog := "Initiate pool expansion drive start node maintenance"
 		Step(stepLog, func() {
@@ -2811,7 +2811,7 @@ var _ = Describe("{ResizePoolMaintenanceCycle}", func() {
 
 		var poolToBeResized *api.StoragePool
 		poolToBeResized, err = GetStoragePoolByUUID(selectedPool.Uuid)
-		log.FailOnError(err, "Failed to get pool using UUID ")
+		log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", selectedPool.Uuid))
 
 		stepLog := "Initiate pool expansion drive start pool maintenance"
 		Step(stepLog, func() {
@@ -2891,7 +2891,7 @@ var _ = Describe("{AddDiskPoolMaintenanceCycle}", func() {
 
 		var poolToBeResized *api.StoragePool
 		poolToBeResized, err = GetStoragePoolByUUID(selectedPool.Uuid)
-		log.FailOnError(err, "Failed to get pool using UUID ")
+		log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", selectedPool.Uuid))
 
 		stepLog := "Initiate pool expansion drive start pool maintenance"
 		Step(stepLog, func() {
@@ -2972,7 +2972,7 @@ var _ = Describe("{NodeMaintenanceResize}", func() {
 			if poolResizeIsInProgress(poolToBeResized) {
 				// wait until resize is completed and get the updated pool again
 				poolToBeResized, err = GetStoragePoolByUUID(poolIDToResize)
-				log.FailOnError(err, "Failed to get pool using UUID")
+				log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", poolIDToResize))
 			}
 		})
 
@@ -3070,7 +3070,7 @@ var _ = Describe("{NodeMaintenanceModeAddDisk}", func() {
 			if poolResizeIsInProgress(poolToBeResized) {
 				// wait until resize is completed and get the updated pool again
 				poolToBeResized, err = GetStoragePoolByUUID(poolIDToResize)
-				log.FailOnError(err, "Failed to get pool using UUID")
+				log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", poolIDToResize))
 			}
 		})
 
@@ -3163,7 +3163,7 @@ var _ = Describe("{PoolMaintenanceModeResize}", func() {
 			if poolResizeIsInProgress(poolToBeResized) {
 				// wait until resize is completed and get the updated pool again
 				poolToBeResized, err = GetStoragePoolByUUID(poolIDToResize)
-				log.FailOnError(err, "Failed to get pool using UUID")
+				log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", poolIDToResize))
 			}
 		})
 
@@ -3253,7 +3253,7 @@ var _ = Describe("{PoolMaintenanceModeAddDisk}", func() {
 			if poolResizeIsInProgress(poolToBeResized) {
 				// wait until resize is completed and get the updated pool again
 				poolToBeResized, err = GetStoragePoolByUUID(poolIDToResize)
-				log.FailOnError(err, "Failed to get pool using UUID")
+				log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", poolIDToResize))
 			}
 		})
 
@@ -3344,7 +3344,7 @@ var _ = Describe("{AddDiskNodeMaintenanceMode}", func() {
 			if poolResizeIsInProgress(poolToBeResized) {
 				// wait until resize is completed and get the updated pool again
 				poolToBeResized, err = GetStoragePoolByUUID(poolIDToResize)
-				log.FailOnError(err, "Failed to get pool using UUID")
+				log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", poolIDToResize))
 			}
 		})
 
@@ -3439,7 +3439,7 @@ var _ = Describe("{ResizeNodeMaintenanceMode}", func() {
 			if poolResizeIsInProgress(poolToBeResized) {
 				// wait until resize is completed and get the updated pool again
 				poolToBeResized, err = GetStoragePoolByUUID(poolIDToResize)
-				log.FailOnError(err, "Failed to get pool using UUID")
+				log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", poolIDToResize))
 			}
 		})
 
@@ -3534,7 +3534,7 @@ var _ = Describe("{ResizePoolMaintenanceMode}", func() {
 			if poolResizeIsInProgress(poolToBeResized) {
 				// wait until resize is completed and get the updated pool again
 				poolToBeResized, err = GetStoragePoolByUUID(poolIDToResize)
-				log.FailOnError(err, "Failed to get pool using UUID")
+				log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", poolIDToResize))
 			}
 		})
 
@@ -3628,7 +3628,7 @@ var _ = Describe("{AddDiskPoolMaintenanceMode}", func() {
 			if poolResizeIsInProgress(poolToBeResized) {
 				// wait until resize is completed and get the updated pool again
 				poolToBeResized, err = GetStoragePoolByUUID(poolIDToResize)
-				log.FailOnError(err, "Failed to get pool using UUID")
+				log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", poolIDToResize))
 			}
 		})
 
@@ -3720,7 +3720,7 @@ var _ = Describe("{PXRestartResize}", func() {
 			log.InfoD(stepLog)
 
 			poolToBeResized, err := GetStoragePoolByUUID(selectedPool.Uuid)
-			log.FailOnError(err, "Failed to get pool using UUID ")
+			log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", selectedPool.Uuid))
 			expectedSize := poolToBeResized.TotalSize * 2 / units.GiB
 
 			isjournal, err := isJournalEnabled()
@@ -3785,7 +3785,7 @@ var _ = Describe("{PXRestartAddDisk}", func() {
 			log.InfoD(stepLog)
 
 			poolToBeResized, err := GetStoragePoolByUUID(selectedPool.Uuid)
-			log.FailOnError(err, "Failed to get pool using UUID ")
+			log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", selectedPool.Uuid))
 			expectedSize := poolToBeResized.TotalSize * 2 / units.GiB
 
 			isjournal, err := isJournalEnabled()
@@ -3856,7 +3856,7 @@ var _ = Describe("{PoolExpandPendingUntilVolClean}", func() {
 
 		var poolToBeResized *api.StoragePool
 		poolToBeResized, err = GetStoragePoolByUUID(selectedPool)
-		log.FailOnError(err, "Failed to get pool using UUID ")
+		log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", selectedPool))
 
 		stepLog := "Stop PX on n1 and validate volume data and start PX on n1"
 		Step(stepLog, func() {

--- a/tests/common.go
+++ b/tests/common.go
@@ -14,7 +14,6 @@ import (
 	"github.com/portworx/torpedo/pkg/log"
 	"github.com/portworx/torpedo/pkg/units"
 	"github.com/sirupsen/logrus"
-
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -4407,7 +4406,7 @@ func WaitForExpansionToStart(poolID string) error {
 				return nil, false, fmt.Errorf("PoolResize has failed. Error: %s", expandedPool.LastOperation)
 			}
 
-			if expandedPool.LastOperation.Status == opsapi.SdkStoragePool_OPERATION_IN_PROGRESS {
+			if expandedPool.LastOperation.Status == opsapi.SdkStoragePool_OPERATION_IN_PROGRESS || expandedPool.LastOperation.Status == opsapi.SdkStoragePool_OPERATION_PENDING {
 				// storage pool resize has been triggered
 				log.InfoD("Pool %s expansion started", poolID)
 				return nil, true, nil
@@ -4711,7 +4710,8 @@ func EnableAutoFSTrim() {
 		if isPxInstalled {
 			isPXNodeAvailable = true
 			pxVersion, err := Inst().V.GetDriverVersionOnNode(pxNode)
-			log.FailOnError(err, "Unable to get pxversion on node %s", pxNode.Name)
+
+			log.FailOnError(err, "Unable to get driver version on node [%s]", pxNode.Name)
 			log.Infof("PX version %s", pxVersion)
 			pxVersionList := []string{}
 			pxVersionList = strings.Split(pxVersion, ".")
@@ -4809,7 +4809,7 @@ func GetPoolWithIOsInGivenNode(stNode node.Node) (*opsapi.StoragePool, error) {
 			return nil, false, err
 		}
 
-		time.Sleep(10 * time.Second)
+		time.Sleep(30 * time.Second)
 
 		poolsDataAfr, err := Inst().V.GetPoolsUsedSize(&stNode)
 		if err != nil {

--- a/tests/testTriggers.go
+++ b/tests/testTriggers.go
@@ -4523,7 +4523,8 @@ func TriggerAutoFsTrim(contexts *[]*scheduler.Context, recordChan *chan *EventRe
 							}
 
 							log.InfoD("volume %s is now attached on node %s [%s]", vol.ID, n2.SchedulerNodeName, n2.Addresses[0])
-							StartVolDriverAndWait([]node.Node{*n})
+							errorChan := make(chan error, errorChannelSize)
+							StartVolDriverAndWait([]node.Node{*n}, &errorChan)
 							Inst().S.EnableSchedulingOnNode(*n)
 
 						}


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Added below scnarios for pool expansion test
- [x] AddDriveAndNodeReboot - Add cloud drive using drive add and reboot node while it is in progress
- [x] MulPoolsResize - Multiple pools expansion using resize-disk parallely
- [x] MulPoolsAddDisk - Multiple pools expansion using add-disk parallely
- [x] ResizeWithJrnlAndMeta - Pool with metadata and journal expansion
- [x] PoolExpandWhileIOAndPXRestart - pools with repl 2 volume , expand one pool node and restart px on other node
- [x] ResizeNodeMaintenanceCycle - expansion using resize-disk and perform node maintenance cycle
- [x] AddDiskNodeMaintenanceCycle - expansion using add-disk and perform node maintenance cycle
- [x] ResizePoolMaintenanceCycle - expansion using resize-disk and perform pool maintenance cycle
- [x] AddDiskPoolMaintenanceCycle -  expansion using add-disk and perform pool maintenance cycle
- [x] NodeMaintenanceResize - pool expansion using resize-disk when node is in maintenance mode
- [x] NodeMaintenanceModeAddDisk - pool expansion using add-disk when node is in maintenance mode
- [x] ResizeNodeMaintenanceMode - pool expansion using resize-disk then  put node in maintenance mode
- [x] AddDiskNodeMaintenanceMode - pool expansion using add-disk then node in maintenance mode
- [x] PoolMaintenanceModeResize - pool expansion using resize-disk when pool is in maintenance mode
- [x] PoolMaintenanceModeAddDisk -  pool expansion using add-disk when pool is in maintenance mode
- [x] ResizePoolMaintenanceMode - pool expansion using resize-disk then put pool  in maintenance mode
- [x] AddDiskPoolMaintenanceMode - pool expansion using add-disk then put  pool in maintenance mode
- [x] PXRestartResize - Restart PX and trigger pool expansion using resize-disk
- [x] PXRestartAddDisk - Restart PX and trigger pool expansion using add-disk
- [x] PoolExpandPendingUntilVolClean - Expand pool should wait until volume gets clean

**Which issue(s) this PR fixes** (optional)
Closes #PTX-13767,PTX-13769,PTX-13786,PTX-13797,PTX-13780

**Special notes for your reviewer**:
http://aetos.pwx.purestorage.com/resultSet/testSetID/61712 
http://aetos.pwx.purestorage.com/resultSet/testSetID/62012
http://aetos.pwx.purestorage.com/resultSet/testSetID/63391
[AddDriveAndNodeReboot.log](https://github.com/portworx/torpedo/files/10371277/AddDriveAndNodeReboot.log)

[PoolExpandWhileIOAndPXRestart.log](https://github.com/portworx/torpedo/files/10371278/PoolExpandWhileIOAndPXRestart.log)





http://aetos.pwx.purestorage.com/resultSet/testSetID/63865
[AddDiskNodeMaintenanceCycle.log](https://github.com/portworx/torpedo/files/10373678/AddDiskNodeMaintenanceCycle.log)

http://aetos.pwx.purestorage.com/resultSet/testSetID/64038
[ResizePoolMaintenanceCycle.log](https://github.com/portworx/torpedo/files/10375770/ResizePoolMaintenanceCycle.log)
http://aetos.pwx.purestorage.com/resultSet/testSetID/64060 
[AddDiskMaintenanceMode.log](https://github.com/portworx/torpedo/files/10375995/AddDiskMaintenanceMode.log)

http://aetos.pwx.purestorage.com/resultSet/testSetID/64813
[PoolMaintenanceModeResize.log](https://github.com/portworx/torpedo/files/10380676/PoolMaintenanceModeResize.log)

http://aetos.pwx.purestorage.com/resultSet/testSetID/65319 
[PoolExpandPendingUntilVolClean.log](https://github.com/portworx/torpedo/files/10386473/PoolExpandPendingUntilVolClean.log)
