### PR TITLE
Adding stats for upgrade test and updating to aetos

### DIFF
--- a/pkg/aetosutil/dashboardutil.go
+++ b/pkg/aetosutil/dashboardutil.go
@@ -119,6 +119,14 @@ type comment struct {
 	ResultType  string `json:"type"`
 }
 
+type stats struct {
+	Name      string            `json:"name"`
+	Product   string            `json:"product"`
+	StatsType string            `json:"statsType"`
+	Version   string            `json:"version"`
+	Data      map[string]string `json:"data"`
+}
+
 // TestSetBegin start testset and push data to dashboard DB
 func (d *Dashboard) TestSetBegin(testSet *TestSet) {
 	dashURL := "Dash is disabled"
@@ -184,7 +192,7 @@ func (d *Dashboard) TestSetEnd() {
 		} else if respStatusCode != http.StatusOK {
 			logrus.Errorf("Failed to end TestSet, Resp : %s", string(resp))
 		}
-		logrus.Infof("Dashboard URL : %s", fmt.Sprintf("http://aetos.pwx.purestorage.com/resultSet/testSetID/%d", d.TestSetID))
+		logrus.Infof("Dashboard URL : %s", fmt.Sprintf("%s/resultSet/testSetID/%d", AetosBaseURL, d.TestSetID))
 	}
 }
 
@@ -512,4 +520,27 @@ func Get() *Dashboard {
 		}
 	}
 	return dash
+}
+
+func (d *Dashboard) UpdateStats(name, product, statType, version string, dashStats map[string]string) {
+	if d.IsEnabled {
+
+		dashStats["dash-url"] = fmt.Sprintf("%s/resultSet/testSetID/%d", AetosBaseURL, d.TestSetID)
+		st := stats{
+			Name:      name,
+			Product:   product,
+			StatsType: statType,
+			Version:   version,
+			Data:      dashStats,
+		}
+
+		statsURL := fmt.Sprintf("%s/stats", DashBoardBaseURL)
+
+		resp, respStatusCode, err := rest.POST(statsURL, st, nil, nil)
+		if err != nil {
+			logrus.Errorf("Error in updating stats to dashboard, Cause: %v", err)
+		} else if respStatusCode != http.StatusOK {
+			logrus.Errorf("Error updating the stats, resp : %s", string(resp))
+		}
+	}
 }

--- a/tests/basic/upgrade_cluster_test.go
+++ b/tests/basic/upgrade_cluster_test.go
@@ -14,7 +14,7 @@ import (
 var _ = Describe("{UpgradeCluster}", func() {
 	var contexts []*scheduler.Context
 
-	JustAfterEach(func() {
+	JustBeforeEach(func() {
 		StartTorpedoTest("UpgradeCluster", "Upgrade cluster test", nil, 0)
 	})
 	It("upgrade scheduler and ensure everything is running fine", func() {

--- a/tests/basic/upgrade_test.go
+++ b/tests/basic/upgrade_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"fmt"
-	"github.com/portworx/torpedo/pkg/testrailuttils"
 	"strings"
 	"time"
 
@@ -24,120 +23,6 @@ const (
 )
 
 // UpgradeStork test performs upgrade hops of Stork based on a given list of upgradeEndpoints
-
-var _ = Describe("{UpgradeVolumeDriver}", func() {
-	var testrailID = 35269
-	// testrailID corresponds to: https://portworx.testrail.net/index.php?/cases/view/35269
-	var runID int
-	JustBeforeEach(func() {
-		tags := make(map[string]string)
-		tags["upgradeTo"] = Inst().StorageDriverUpgradeEndpointVersion
-		StartTorpedoTest("UpgradeVolumeDriver", "Validating volume driver upgrade", tags, testrailID)
-		runID = testrailuttils.AddRunsToMilestone(testrailID)
-	})
-	var contexts []*scheduler.Context
-
-	It("upgrade volume driver and ensure everything is running fine", func() {
-		log.InfoD("upgrade volume driver and ensure everything is running fine")
-		contexts = make([]*scheduler.Context, 0)
-
-		storageNodes := node.GetStorageNodes()
-
-		isCloudDrive, err := IsCloudDriveInitialised(storageNodes[0])
-		log.FailOnError(err, "Cloud drive installation failed")
-
-		if !isCloudDrive {
-			for _, storageNode := range storageNodes {
-				err := Inst().V.AddBlockDrives(&storageNode, nil)
-				if err != nil && strings.Contains(err.Error(), "no block drives available to add") {
-					continue
-				}
-				log.FailOnError(err, "Adding block drive(s) failed.")
-			}
-		}
-		log.InfoD("Scheduling applications and validating")
-		for i := 0; i < Inst().GlobalScaleFactor; i++ {
-			contexts = append(contexts, ScheduleApplications(fmt.Sprintf("upgradevolumedriver-%d", i))...)
-		}
-
-		ValidateApplications(contexts)
-		currPXVersion, err := Inst().V.GetPxVersionOnNode(storageNodes[0])
-		if err != nil {
-			log.Warnf(fmt.Sprintf("error getting px version, err %v", err))
-		}
-
-		var timeBeforeUpgrade time.Time
-		var timeAfterUpgrade time.Time
-
-		Step("start the upgrade of volume driver", func() {
-			log.InfoD("start the upgrade of volume driver")
-
-			IsOperatorBasedInstall, _ := Inst().V.IsOperatorBasedInstall()
-			if IsOperatorBasedInstall {
-				timeBeforeUpgrade = time.Now()
-				status, err := UpgradePxStorageCluster()
-				timeAfterUpgrade = time.Now()
-				if err != nil {
-					log.Fatalf("Failed to Upgrade Px Storage Cluster. ERR: %v", err)
-				}
-				dash.VerifyFatal(status, true, "Volume driver upgrade successful?")
-
-			} else {
-				timeBeforeUpgrade = time.Now()
-				err := Inst().V.UpgradeDriver(Inst().StorageDriverUpgradeEndpointURL,
-					Inst().StorageDriverUpgradeEndpointVersion,
-					false)
-				timeAfterUpgrade = time.Now()
-				dash.VerifyFatal(err, nil, "Volume drive upgrade for daemon set based set up successful?")
-			}
-
-			durationInMins := int(timeAfterUpgrade.Sub(timeBeforeUpgrade).Minutes())
-			expectedUpgradeTime := 9 * len(node.GetStorageDriverNodes())
-			dash.VerifySafely(durationInMins <= expectedUpgradeTime, true, "Verify volume drive upgrade within expected time")
-			upgradeStatus := "PASS"
-			if durationInMins <= expectedUpgradeTime {
-				log.InfoD("Upgrade successfully completed in %d minutes which is within %d minutes", durationInMins, expectedUpgradeTime)
-			} else {
-				log.Errorf("Upgrade took %d minutes to completed which is greater than expected time %d minutes", durationInMins, expectedUpgradeTime)
-				dash.VerifySafely(durationInMins <= expectedUpgradeTime, true, "Upgrade took more than expected time to complete")
-				upgradeStatus = "FAIL"
-			}
-			updatedPXVersion, err := Inst().V.GetPxVersionOnNode(storageNodes[0])
-			if err != nil {
-				log.Warnf(fmt.Sprintf("error getting px version, err %v", err))
-			}
-			majorVersion := strings.Split(currPXVersion, "-")[0]
-			statsData := make(map[string]string)
-			statsData["fromVersion"] = currPXVersion
-			statsData["toVersion"] = updatedPXVersion
-			statsData["duration"] = fmt.Sprintf("%d mins", durationInMins)
-			statsData["status"] = upgradeStatus
-			dash.UpdateStats("px-upgrade-stats", "px-enterprise", "upgrade", majorVersion, statsData)
-		})
-
-		Step("reinstall and validate all apps after upgrade", func() {
-			log.InfoD("reinstall and validate all apps after upgrade")
-			for i := 0; i < Inst().GlobalScaleFactor; i++ {
-				contexts = append(contexts, ScheduleApplications(fmt.Sprintf("upgradedvolumedriver-%d", i))...)
-			}
-			ValidateApplications(contexts)
-		})
-
-		Step("Destroy apps", func() {
-			log.InfoD("Destroy apps")
-			opts := make(map[string]bool)
-			opts[scheduler.OptionsWaitForResourceLeakCleanup] = true
-			for _, ctx := range contexts {
-				TearDownContext(ctx, opts)
-			}
-		})
-	})
-	JustAfterEach(func() {
-		defer EndTorpedoTest()
-		AfterEachTest(contexts, testrailID, runID)
-	})
-})
-
 var _ = Describe("{UpgradeStork}", func() {
 	// testrailID corresponds to: https://portworx.testrail.net/index.php?/cases/view/35269
 	JustBeforeEach(func() {
@@ -181,7 +66,7 @@ var _ = Describe("{UpgradeStork}", func() {
 					k8sApps := apps.Instance()
 
 					storkDeploy, err := k8sApps.GetDeployment(storkDeploymentName, storkDeploymentNamespace)
-					Expect(err).NotTo(HaveOccurred())
+					log.FailOnError(err, "error getting stork deployment spec")
 
 					err = k8sApps.ValidateDeployment(storkDeploy, k8s.DefaultTimeout, k8s.DefaultRetryInterval)
 					dash.VerifyFatal(err, nil, "Stork deployment successful?")
@@ -195,17 +80,6 @@ var _ = Describe("{UpgradeStork}", func() {
 				for _, ctx := range contexts {
 					TearDownContext(ctx, opts)
 				}
-			})
-
-			Step("validate stork pods after upgrade", func() {
-				log.InfoD("validate stork pods after upgrade")
-				k8sApps := apps.Instance()
-
-				storkDeploy, err := k8sApps.GetDeployment(storkDeploymentName, storkDeploymentNamespace)
-				log.FailOnError(err, "Error getting stork deployment")
-
-				err = k8sApps.ValidateDeployment(storkDeploy, k8s.DefaultTimeout, k8s.DefaultRetryInterval)
-				dash.VerifyFatal(err, nil, "Stork deployment successful?")
 			})
 
 		})
@@ -231,12 +105,32 @@ var _ = Describe("{UpgradeVolumeDriver}", func() {
 		log.InfoD("upgrade volume driver and ensure everything is running fine")
 		contexts = make([]*scheduler.Context, 0)
 
+		storageNodes := node.GetStorageNodes()
+
+		//AddDrive is added to test to Vsphere Cloud drive upgrades when kvdb-device is part of storage in non-kvdb nodes
+		isCloudDrive, err := IsCloudDriveInitialised(storageNodes[0])
+		log.FailOnError(err, "Cloud drive installation failed")
+
+		if !isCloudDrive {
+			for _, storageNode := range storageNodes {
+				err := Inst().V.AddBlockDrives(&storageNode, nil)
+				if err != nil && strings.Contains(err.Error(), "no block drives available to add") {
+					continue
+				}
+				log.FailOnError(err, "Adding block drive(s) failed.")
+			}
+		}
+
 		log.InfoD("Scheduling applications and validating")
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
 			contexts = append(contexts, ScheduleApplications(fmt.Sprintf("upgradevolumedriver-%d", i))...)
 		}
 
 		ValidateApplications(contexts)
+		currPXVersion, err := Inst().V.GetDriverVersionOnNode(storageNodes[0])
+		if err != nil {
+			log.Warnf(fmt.Sprintf("error getting driver version, err %v", err))
+		}
 		var timeBeforeUpgrade time.Time
 		var timeAfterUpgrade time.Time
 
@@ -263,6 +157,25 @@ var _ = Describe("{UpgradeVolumeDriver}", func() {
 					log.Errorf("Upgrade took %d minutes to completed which is greater than expected time %d minutes", durationInMins, expectedUpgradeTime)
 					dash.VerifySafely(durationInMins <= expectedUpgradeTime, true, "Upgrade took more than expected time to complete")
 				}
+				upgradeStatus := "PASS"
+				if durationInMins <= expectedUpgradeTime {
+					log.InfoD("Upgrade successfully completed in %d minutes which is within %d minutes", durationInMins, expectedUpgradeTime)
+				} else {
+					log.Errorf("Upgrade took %d minutes to completed which is greater than expected time %d minutes", durationInMins, expectedUpgradeTime)
+					dash.VerifySafely(durationInMins <= expectedUpgradeTime, true, "Upgrade took more than expected time to complete")
+					upgradeStatus = "FAIL"
+				}
+				updatedPXVersion, err := Inst().V.GetDriverVersionOnNode(storageNodes[0])
+				if err != nil {
+					log.Warnf(fmt.Sprintf("error getting driver version, err %v", err))
+				}
+				majorVersion := strings.Split(currPXVersion, "-")[0]
+				statsData := make(map[string]string)
+				statsData["fromVersion"] = currPXVersion
+				statsData["toVersion"] = updatedPXVersion
+				statsData["duration"] = fmt.Sprintf("%d mins", durationInMins)
+				statsData["status"] = upgradeStatus
+				dash.UpdateStats("px-upgrade-stats", "px-enterprise", "upgrade", majorVersion, statsData)
 
 				// Validate Apps after volume driver upgrade
 				ValidateApplications(contexts)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Created a stats struct and push data to aetos for PX upgrade

**Which issue(s) this PR fixes** (optional)
Closes #PTX-14872

**Special notes for your reviewer**:
http://aetos.pwx.purestorage.com/resultSet/testSetID/67685 

sample result from aetos

```
{
    "_id": {
      "$oid": "63c050a31c575913d7ce0846"
    },
    "name": "px-upgrade-stats",
    "product": "px-enterprise",
    "statsType": "upgrade",
    "version": "0cc6b62",
    "data": {
      "dash-url": "http://aetos.pwx.purestorage.com/resultSet/testSetID/67685",
      "duration": "2 mins",
      "fromVersion": "2.12.2-0cc6b62",
      "status": "PASS",
      "toVersion": "2.12.2-0cc6b62"
    },
    "dateTime": "2023-01-12 18:25:39+00:00"
  }
```
