### PR TITLE
Making Bucket name env variable

### DIFF
--- a/tests/backup/backup_basic_test.go
+++ b/tests/backup/backup_basic_test.go
@@ -4,9 +4,10 @@ import (
 	"os"
 	"testing"
 	"time"
+	"strings"
+	"fmt"
 
 	"github.com/portworx/torpedo/pkg/log"
-
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
@@ -47,6 +48,11 @@ var (
 	}
 )
 
+func getBucketName() []string{
+	bucketName := os.Getenv("BUCKET_NAME")
+	return strings.Split(bucketName, ",")
+}
+
 func TestBasic(t *testing.T) {
 	RegisterFailHandler(Fail)
 
@@ -62,9 +68,25 @@ var _ = BeforeSuite(func() {
 	log.Infof("Init instance")
 	InitInstance()
 	dash.TestSetBegin(dash.TestSet)
+	// Create the first bucket from the list to be used as generic bucket
+	providers := getProviders()
+	bucket_name := getBucketName()
+	for _, provider := range providers {
+		bucketName := fmt.Sprintf("%s-%s", provider, bucket_name[0])
+		CreateBucket(provider, bucketName)
+		}
 })
 
 var _ = AfterSuite(func() {
+	// Cleanup all bucket after suite
+	providers := getProviders()
+	bucket_name := getBucketName()
+	for _, provider := range providers{
+		for _, BucketName := range bucket_name{
+				bucketName := fmt.Sprintf("%s-%s", provider, BucketName)
+				DeleteBucket(provider, bucketName)
+		}
+	}
 	defer dash.TestSetEnd()
 })
 

--- a/tests/backup/backup_basic_test.go
+++ b/tests/backup/backup_basic_test.go
@@ -68,6 +68,7 @@ var _ = BeforeSuite(func() {
 	log.Infof("Init instance")
 	InitInstance()
 	dash.TestSetBegin(dash.TestSet)
+	StartTorpedoTest("Setup buckets:", "Creating one generic bucket to be used in all cases", nil, 0)
 	// Create the first bucket from the list to be used as generic bucket
 	providers := getProviders()
 	bucket_name := getBucketName()
@@ -87,6 +88,7 @@ var _ = AfterSuite(func() {
 				DeleteBucket(provider, bucketName)
 		}
 	}
+	defer EndTorpedoTest()
 	defer dash.TestSetEnd()
 })
 

--- a/tests/backup/backup_basic_test.go
+++ b/tests/backup/backup_basic_test.go
@@ -76,9 +76,11 @@ var _ = BeforeSuite(func() {
 		bucketName := fmt.Sprintf("%s-%s", provider, bucket_name[0])
 		CreateBucket(provider, bucketName)
 		}
+	defer EndTorpedoTest()
 })
 
 var _ = AfterSuite(func() {
+	StartTorpedoTest("Cleanup buckets:", "Removing buckets", nil, 0)
 	// Cleanup all bucket after suite
 	providers := getProviders()
 	bucket_name := getBucketName()

--- a/tests/backup/backup_basic_test.go
+++ b/tests/backup/backup_basic_test.go
@@ -69,6 +69,7 @@ var _ = BeforeSuite(func() {
 	InitInstance()
 	dash.TestSetBegin(dash.TestSet)
 	StartTorpedoTest("Setup buckets:", "Creating one generic bucket to be used in all cases", nil, 0)
+	defer EndTorpedoTest()
 	// Create the first bucket from the list to be used as generic bucket
 	providers := getProviders()
 	bucket_name := getBucketName()
@@ -76,11 +77,12 @@ var _ = BeforeSuite(func() {
 		bucketName := fmt.Sprintf("%s-%s", provider, bucket_name[0])
 		CreateBucket(provider, bucketName)
 		}
-	defer EndTorpedoTest()
 })
 
 var _ = AfterSuite(func() {
 	StartTorpedoTest("Cleanup buckets:", "Removing buckets", nil, 0)
+	defer EndTorpedoTest()
+	defer dash.TestSetEnd()
 	// Cleanup all bucket after suite
 	providers := getProviders()
 	bucket_name := getBucketName()
@@ -90,8 +92,7 @@ var _ = AfterSuite(func() {
 				DeleteBucket(provider, bucketName)
 		}
 	}
-	defer EndTorpedoTest()
-	defer dash.TestSetEnd()
+	
 })
 
 func TestMain(m *testing.M) {

--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -42,12 +42,10 @@ func TearDownBackupRestore(bkpNamespaces []string, restoreNamespaces []string) {
 		DeleteRestore(RestoreName, OrgID)
 	}
 
-	provider := GetProvider()
 	DeleteCluster(destinationClusterName, OrgID)
 	DeleteCluster(sourceClusterName, OrgID)
 	DeleteBackupLocation(backupLocationName, OrgID)
 	DeleteCloudCredential(CredName, OrgID, CloudCredUID)
-	DeleteBucket(provider, BucketName)
 }
 
 // This testcase verifies if the backup pods are in Ready state or not
@@ -143,7 +141,6 @@ var _ = Describe("{BasicBackupCreation}", func() {
 	var namespaceMapping map[string]string
 	namespaceMapping = make(map[string]string)
 	providers := getProviders()
-	bucket_name := getBucketName()
 	JustBeforeEach(func() {
 		StartTorpedoTest("Backup: BasicBackupCreation", "Deploying backup", nil, 0)
 		log.InfoD("Verifying if the pre/post rules for the required apps are present in the list or not ")
@@ -202,6 +199,7 @@ var _ = Describe("{BasicBackupCreation}", func() {
 
 		Step("Creating bucket,backup location and cloud setting", func() {
 			log.InfoD("Creating bucket,backup location and cloud setting")
+			bucket_name := getBucketName()
 			for _, provider := range providers {
 				bucketName := fmt.Sprintf("%s-%s", provider, bucket_name[0])
 				CredName := fmt.Sprintf("%s-%s", "cred", provider)
@@ -209,7 +207,6 @@ var _ = Describe("{BasicBackupCreation}", func() {
 				CloudCredUID = uuid.New()
 				CloudCredUID_list = append(CloudCredUID_list, CloudCredUID)
 				BackupLocationUID = uuid.New()
-				CreateBucket(provider, bucketName)
 				CreateCloudCredential(provider, CredName, CloudCredUID, orgID)
 				time.Sleep(time.Minute * 1)
 				CreateBackupLocation(provider, backup_location_name, BackupLocationUID, CredName, CloudCredUID, bucketName, orgID)
@@ -1975,11 +1972,6 @@ func CreateProviderClusterObject(provider string, kubeconfigList []string, cloud
 func getProviders() []string {
 	providersStr := os.Getenv("PROVIDERS")
 	return strings.Split(providersStr, ",")
-}
-
-func getBucketName() []string{
-	bucketName := os.Getenv("BUCKET_NAME")
-	return strings.Split(bucketName, ",")
 }
 
 func getProviderClusterConfigPath(provider string, kubeconfigs []string) (string, error) {

--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -143,6 +143,7 @@ var _ = Describe("{BasicBackupCreation}", func() {
 	var namespaceMapping map[string]string
 	namespaceMapping = make(map[string]string)
 	providers := getProviders()
+	bucket_name := getBucketName()
 	JustBeforeEach(func() {
 		StartTorpedoTest("Backup: BasicBackupCreation", "Deploying backup", nil, 0)
 		log.InfoD("Verifying if the pre/post rules for the required apps are present in the list or not ")
@@ -202,9 +203,9 @@ var _ = Describe("{BasicBackupCreation}", func() {
 		Step("Creating bucket,backup location and cloud setting", func() {
 			log.InfoD("Creating bucket,backup location and cloud setting")
 			for _, provider := range providers {
-				bucketName := fmt.Sprintf("%s-%s", "bucket", provider)
+				bucketName := fmt.Sprintf("%s-%s", provider, bucket_name[0])
 				CredName := fmt.Sprintf("%s-%s", "cred", provider)
-				backup_location_name = fmt.Sprintf("%s-%s", "location", provider)
+				backup_location_name = fmt.Sprintf("%s-%s-bl", provider, bucket_name[0])
 				CloudCredUID = uuid.New()
 				CloudCredUID_list = append(CloudCredUID_list, CloudCredUID)
 				BackupLocationUID = uuid.New()
@@ -1974,6 +1975,11 @@ func CreateProviderClusterObject(provider string, kubeconfigList []string, cloud
 func getProviders() []string {
 	providersStr := os.Getenv("PROVIDERS")
 	return strings.Split(providersStr, ",")
+}
+
+func getBucketName() []string{
+	bucketName := os.Getenv("BUCKET_NAME")
+	return strings.Split(bucketName, ",")
 }
 
 func getProviderClusterConfigPath(provider string, kubeconfigs []string) (string, error) {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->



**What this PR does / why we need it**:
Currently if multiple users run torpedo tests with same object store all the instances try to create the same bucket and it fails with the below trance: 
```
• Failure [93.714 seconds]
{BasicBackupCreation}
/root/torpedo/tests/backup/backup_test.go:125
  Basic Backup Creation [It]
  /root/torpedo/tests/backup/backup_test.go:174

  Failed to create bucket [bucket-aws]. Error: [BucketAlreadyOwnedByYou: Your previous request to create the named bucket succeeded and you already own it.
  	status code: 409, request id: 17397DE2EFAF9A3E, host id: ]
  Unexpected error:
      <*s3err.RequestFailure | 0xc001035ca0>: {
          RequestFailure: <*awserr.requestError | 0xc001096500>{
              awsError: <*awserr.baseError | 0xc0010964c0>{
                  code: "BucketAlreadyOwnedByYou",
                  message: "Your previous request to create the named bucket succeeded and you already own it.",
                  errs: nil,
              },
              statusCode: 409,
              requestID: "17397DE2EFAF9A3E",
              bytes: nil,
          },
          hostID: "",
      }
      BucketAlreadyOwnedByYou: Your previous request to create the named bucket succeeded and you already own it.
      	status code: 409, request id: 17397DE2EFAF9A3E, host id: 
```

**Changes done:**
- [x] Add `getBucketName()` to fetch bucket name from env. 
- [x] Make changes to` BasicBackupCreation` to pick bucket name from env. 
- [x] Moving `CreateBucket()` call to `BeforeSuite()` where one bucket is created which can be used in any testcase. 
- [x] Moving `DeleteBucket()` call  to `AfterSuite()` and adding logic to delete all buckets present.  

**Changes needed while running the test**:
You'll need to export backup name list as shown below:
```
export BUCKET_NAME="kiyer-test-bucket"
```

**Which issue(s) this PR fixes** (optional)
Closes # PA-491

**Special notes for your reviewer**:
The test might not run seamlessly @snigdha-px is working on the fixes to make it run. 
