### PR TITLE
PTX-15051: Add fix to have env inside torpedo deployment in deploy-ssh.sh

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -544,6 +544,8 @@ spec:
       value: "${S3_AWS_SECRET_ACCESS_KEY}"
     - name: S3_REGION
       value: "${S3_REGION}"
+    - name: BUCKET_NAME
+      value: "${BUCKET_NAME}"
     - name: S3_DISABLE_SSL
       value: "${S3_DISABLE_SSL}"
     - name: DIAGS_BUCKET


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Currently due to patch https://github.com/portworx/torpedo/pull/1003 the torpedo system test jobs fails with the below error:
```
[2023-01-19T16:32:31.436Z] [37m/go/src/github.com/portworx/torpedo/tests/backup/backup_basic_test.go:77[0m
[2023-01-19T16:32:31.436Z] 
[2023-01-19T16:32:31.436Z]   [91mUnable to delete objects from bucket "aws-", BatchedDeleteIncomplete: some objects have failed to be deleted.
[2023-01-19T16:32:31.436Z]   caused by: failed to perform batch operation on "" to "":
[2023-01-19T16:32:31.436Z]   NoSuchBucket: The specified bucket does not exist
[2023-01-19T16:32:31.436Z]   	status code: 404, request id: 173BC2DF68C916F1, host id: 
[2023-01-19T16:32:31.436Z]   Unexpected error:
[2023-01-19T16:32:31.436Z]       <*s3manager.BatchError | 0xc00116a100>: {
[2023-01-19T16:32:31.436Z]           Errors: [
[2023-01-19T16:32:31.436Z]               {
[2023-01-19T16:32:31.436Z]                   OrigErr: <*s3err.RequestFailure | 0xc000e14680>{
[2023-01-19T16:32:31.436Z]                       RequestFailure: <*awserr.requestError | 0xc00116a0c0>{
[2023-01-19T16:32:31.436Z]                           awsError: <*awserr.baseError | 0xc00116a080>{
[2023-01-19T16:32:31.436Z]                               code: "NoSuchBucket",
[2023-01-19T16:32:31.436Z]                               message: "The specified bucket does not exist",
[2023-01-19T16:32:31.436Z]                               errs: nil,
[2023-01-19T16:32:31.436Z]                           },
[2023-01-19T16:32:31.436Z]                           statusCode: 404,
[2023-01-19T16:32:31.436Z]                           requestID: "173BC2DF68C916F1",
[2023-01-19T16:32:31.436Z]                           bytes: nil,
[2023-01-19T16:32:31.436Z]                       },
[2023-01-19T16:32:31.436Z]                       hostID: "",
[2023-01-19T16:32:31.436Z]                   },
[2023-01-19T16:32:31.436Z]                   Bucket: nil,
[2023-01-19T16:32:31.436Z]                   Key: nil,
[2023-01-19T16:32:31.436Z]               },
[2023-01-19T16:32:31.436Z]           ],
[2023-01-19T16:32:31.436Z]           code: "BatchedDeleteIncomplete",
[2023-01-19T16:32:31.436Z]           message: "some objects have failed to be deleted.",
[2023-01-19T16:32:31.436Z]       }
[2023-01-19T16:32:31.436Z]       BatchedDeleteIncomplete: some objects have failed to be deleted.
[2023-01-19T16:32:31.436Z]       caused by: failed to perform batch operation on "" to "":
[2023-01-19T16:32:31.436Z]       NoSuchBucket: The specified bucket does not exist
[2023-01-19T16:32:31.436Z]       	status code: 404, request id: 173BC2DF68C916F1, host id: 
[2023-01-19T16:32:31.436Z]   occurred[0m
[2023-01-19T16:32:31.436Z] 
[2023-01-19T16:32:31.436Z]   /go/src/github.com/portworx/torpedo/tests/common.go:3293
[2023-01-19T16:32:31.436Z] 
[2023-01-19T16:32:31.436Z]   [91mFull Stack Trace[0m
[2023-01-19T16:32:31.436Z]   github.com/portworx/torpedo/tests.DeleteS3Bucket(0xc000fca988, 0x4)
[2023-01-19T16:32:31.436Z]   	/go/src/github.com/portworx/torpedo/tests/common.go:3293 +0x804
[2023-01-19T16:32:31.436Z]   github.com/portworx/torpedo/tests.DeleteBucket.func1()
[2023-01-19T16:32:31.436Z]   	/go/src/github.com/portworx/torpedo/tests/common.go:3331 +0x5a
[2023-01-19T16:32:31.436Z]   github.com/portworx/torpedo/tests.DeleteBucket(0xc0000760ca, 0x3, 0xc000fca988, 0x4)
[2023-01-19T16:32:31.436Z]   	/go/src/github.com/portworx/torpedo/tests/common.go:3327 +0x15d
[2023-01-19T16:32:31.436Z]   github.com/portworx/torpedo/tests/backup.glob..func2()
[2023-01-19T16:32:31.436Z]   	/go/src/github.com/portworx/torpedo/tests/backup/backup_basic_test.go:87 +0x274
[2023-01-19T16:32:31.436Z]   github.com/portworx/torpedo/tests/backup.TestBasic(0xc00028cc00)
[2023-01-19T16:32:31.436Z]   	/go/src/github.com/portworx/torpedo/tests/backup/backup_basic_test.go:57 +0xf9
[2023-01-19T16:32:31.436Z]   testing.tRunner(0xc00028cc00, 0x6cfa828)
[2023-01-19T16:32:31.436Z]   	/usr/local/go/src/testing/testing.go:1193 +0xef
[2023-01-19T16:32:31.436Z]   created by testing.(*T).Run
[2023-01-19T16:32:31.436Z]   	/usr/local/go/src/testing/testing.go:1238 +0x2b3
```


Things done in this patch:
- [x] Adding env for bucket name to torpedo spec in deploy-ssh.sh. 


**Which issue(s) this PR fixes** (optional)
Closes # PA-504

**Special notes for your reviewer**:
@sudas-px Please try out this fix on the CI and update me if it's working. 