### PR TITLE
PA-470: Add testcase to take alternating backups locked and unlocked

### DIFF
--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -294,14 +294,12 @@ func TeardownForTestcase(contexts []*scheduler.Context, providers []string, Clou
 		}
 		dash.VerifySafely(err, nil, fmt.Sprintf("Verify destroying app %s, Err: %v", taskName, err))
 	}
-	log.InfoD("Deleting bucket,backup location and cloud setting")
+	log.InfoD("Deleting backup location and cloud setting")
 	for i, provider := range providers {
-		bucketName := fmt.Sprintf("%s-%s", "bucket", provider)
-		DeleteBucket(provider, bucketName)
 		CredName := fmt.Sprintf("%s-%s", "cred", provider)
-		DeleteCloudCredential(CredName, orgID, CloudCredUID_list[i])
 		// Need to add backup location UID for Delete Backup Location call
 		DeleteBackupLocation(backupLocation, "", orgID)
+		DeleteCloudCredential(CredName, orgID, CloudCredUID_list[i])
 	}
 	DeleteCluster(destinationClusterName, OrgID)
 	DeleteCluster(SourceClusterName, OrgID)
@@ -546,6 +544,179 @@ var _ = Describe("{ShareBackupWithUsersAndGroups}", func() {
 
 	})
 })
+
+
+// This testcase verifies alternating backups between locked and unlocked bucket
+var _ = Describe("{BackupAlternatingBetweenLockedAndUnlockedBuckets}", func() {
+	var (
+		appList = Inst().AppList
+	)
+	var preRuleNameList []string
+	var postRuleNameList []string
+	var contexts []*scheduler.Context
+	labelSelectors := make(map[string]string)
+	CloudCredUIDMap := make(map[string]string)
+	BackupLocationMap := make(map[string]string)
+	var backupList []string
+	var appContexts []*scheduler.Context
+	var backupLocation string
+	var bkpNamespaces []string
+	var clusterUid string
+	var clusterStatus api.ClusterInfo_StatusInfo_Status
+	bkpNamespaces = make([]string, 0)
+	providers := getProviders()
+	JustBeforeEach(func() {
+		StartTorpedoTest("Backup: BackupAlternatingBetweenLockedAndUnlockedBucket", "Deploying backup", nil, 0)
+		log.InfoD("Verifying if the pre/post rules for the required apps are present in the list or not")
+		for i := 0; i < len(appList); i++ {
+			if Contains(postRuleApp, appList[i]) {
+				if _, ok := portworx.AppParameters[appList[i]]["post_action_list"]; ok {
+					dash.VerifyFatal(ok, true, "Post Rule details mentioned for the apps")
+				}
+			}
+			if Contains(preRuleApp, appList[i]) {
+				if _, ok := portworx.AppParameters[appList[i]]["pre_action_list"]; ok {
+					dash.VerifyFatal(ok, true, "Pre Rule details mentioned for the apps")
+				}
+			}
+		}
+		log.InfoD("Deploy applications")
+		contexts = make([]*scheduler.Context, 0)
+		for i := 0; i < Inst().GlobalScaleFactor; i++ {
+			taskName := fmt.Sprintf("%s-%d", taskNamePrefix, i)
+			appContexts = ScheduleApplications(taskName)
+			contexts = append(contexts, appContexts...)
+			for _, ctx := range appContexts {
+				ctx.ReadinessTimeout = appReadinessTimeout
+				namespace := GetAppNamespace(ctx, taskName)
+				bkpNamespaces = append(bkpNamespaces, namespace)
+			}
+		}
+	})
+	It("Backup alternating between locked and unlocked buckets", func() {
+		Step("Validate applications", func() {
+			ValidateApplications(contexts)
+		})
+
+		Step("Creating rules for backup", func() {
+			log.InfoD("Creating pre rule for deployed apps")
+			for i := 0; i < len(appList); i++ {
+				preRuleStatus, ruleName, err := Inst().Backup.CreateRuleForBackup(appList[i], orgID, "pre")
+				log.FailOnError(err, "Creating pre rule for deployed apps failed")
+				dash.VerifyFatal(preRuleStatus, true, "Verifying pre rule for backup")
+				preRuleNameList = append(preRuleNameList, ruleName)
+			}
+			log.InfoD("Creating post rule for deployed apps")
+			for i := 0; i < len(appList); i++ {
+				postRuleStatus, ruleName, err := Inst().Backup.CreateRuleForBackup(appList[i], orgID, "post")
+				log.FailOnError(err, "Creating post rule for deployed apps failed")
+				dash.VerifyFatal(postRuleStatus, true, "Verifying Post rule for backup")
+				postRuleNameList = append(postRuleNameList, ruleName)
+			}
+		})
+
+		Step("Creating cloud credentials", func(){
+			log.InfoD("Creating cloud credentials")
+			for _, provider := range providers {
+				CredName := fmt.Sprintf("%s-%s", "cred", provider)
+				CloudCredUID = uuid.New()
+				CloudCredUIDMap[CloudCredUID] = CredName
+				CreateCloudCredential(provider, CredName, CloudCredUID, orgID)
+				time.Sleep(time.Minute * 1)
+			}
+		})
+
+		Step("Creating a locked bucket and backup location", func() {
+			log.InfoD("Creating locked buckets and backup location")
+			bucketNames := getBucketName()
+			modes := [2]string{"GOVERNANCE", "COMPLIANCE"}
+			for _, provider := range providers {
+				for _, mode := range modes {
+					CredName := fmt.Sprintf("%s-%s", "cred", provider)
+					bucketName := fmt.Sprintf("%s-%s-%s-locked", provider, bucketNames[1], strings.ToLower(mode))
+					backupLocation = fmt.Sprintf("%s-%s-%s-lock", provider, bucketNames[1], strings.ToLower(mode))
+					err := CreateS3Bucket(bucketName, true, 3, mode)
+					log.FailOnError(err, "Unable to create locked s3 bucket %s", bucketName)
+					BackupLocationUID = uuid.New()
+					BackupLocationMap[BackupLocationUID] = backupLocation
+					time.Sleep(time.Minute * 1)
+					CreateBackupLocation(provider, backupLocation, BackupLocationUID, CredName, CloudCredUID,
+						bucketName, orgID, "")
+				}
+			}
+			log.InfoD("Successfully created locked buckets and backup location")
+		})
+
+		Step("Creating backup location for unlocked bucket", func() {
+			log.InfoD("Creating backup location for unlocked bucket")
+			bucketNames := getBucketName()
+			for _, provider := range providers {
+				CredName := fmt.Sprintf("%s-%s", "cred", provider)
+				bucketName := fmt.Sprintf("%s-%s", provider, bucketNames[0])
+				backupLocation = fmt.Sprintf("%s-%s-unlockedbucket", provider, bucketNames[0])
+				BackupLocationUID = uuid.New()
+				BackupLocationMap[BackupLocationUID] = backupLocation
+				time.Sleep(time.Minute * 1)
+				CreateBackupLocation(provider, backupLocation, BackupLocationUID, CredName, CloudCredUID,
+					bucketName, orgID, "")
+			}
+		})
+
+		Step("Register cluster for backup", func() {
+			CreateSourceAndDestClusters(orgID, "", "")
+			clusterStatus, clusterUid = Inst().Backup.RegisterBackupCluster(orgID, SourceClusterName, "")
+			dash.VerifyFatal(clusterStatus, api.ClusterInfo_StatusInfo_Online, "Verifying backup cluster")
+		})
+
+		Step("Taking backup of application to locked and unlocked bucket", func() {
+			for _, namespace := range bkpNamespaces {
+				for backupLocationUID, backupLocationName := range BackupLocationMap{
+					ctx, err := backup.GetAdminCtxFromSecret()
+					dash.VerifyFatal(err, nil, "Getting context")
+					preRuleUid, _ := Inst().Backup.GetRuleUid(orgID, ctx, preRuleNameList[0])
+					postRuleUid, _ := Inst().Backup.GetRuleUid(orgID, ctx, postRuleNameList[0])
+					backupName := fmt.Sprintf("%s-%s-%s", BackupNamePrefix, namespace, backupLocationName)
+					backupList = append(backupList, backupName)
+					CreateBackup(backupName, SourceClusterName, backupLocationName, backupLocationUID, []string{namespace},
+						labelSelectors, orgID, clusterUid, preRuleNameList[0], preRuleUid, postRuleNameList[0], postRuleUid, ctx)
+				}
+			}
+		})
+		Step("Restoring the backups application", func() {
+			for _, _ = range bkpNamespaces {
+				for _, backupName := range backupList{
+					CreateRestore(fmt.Sprintf("%s-restore",backupName), backupName, nil, SourceClusterName, orgID)
+				}
+			}
+		})
+	})
+	JustAfterEach(func() {
+		defer EndTorpedoTest()
+		log.InfoD("Deleting the deployed apps after the testcase")
+		for i := 0; i < len(contexts); i++ {
+			opts := make(map[string]bool)
+			opts[SkipClusterScopedObjects] = true
+			taskName := fmt.Sprintf("%s-%d", taskNamePrefix, i)
+			err := Inst().S.Destroy(contexts[i], opts)
+			dash.VerifySafely(err, nil, fmt.Sprintf("Verify destroying app %s, Err: %v", taskName, err))
+		}
+
+		log.InfoD("Deleting backup location and cloud setting")
+		for backupLocationUID, backupLocationName := range BackupLocationMap{
+			DeleteBackupLocation(backupLocationName, backupLocationUID, orgID)
+		}
+		// Need sleep as it takes some time for
+		time.Sleep(time.Minute * 1)
+		for CloudCredUID, CredName := range CloudCredUIDMap{
+				DeleteCloudCredential(CredName, orgID, CloudCredUID)	
+		}
+		DeleteCluster(destinationClusterName, OrgID)
+		DeleteCluster(SourceClusterName, OrgID)
+	})
+})
+
+
+
 
 // This test performs basic test of starting an application, backing it up and killing stork while
 // performing backup.

--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -566,7 +566,7 @@ var _ = Describe("{BackupAlternatingBetweenLockedAndUnlockedBuckets}", func() {
 	bkpNamespaces = make([]string, 0)
 	providers := getProviders()
 	JustBeforeEach(func() {
-		StartTorpedoTest("Backup: BackupAlternatingBetweenLockedAndUnlockedBucket", "Deploying backup", nil, 0)
+		StartTorpedoTest("BackupAlternatingBetweenLockedAndUnlockedBucket", "Deploying backup", nil, 0)
 		log.InfoD("Verifying if the pre/post rules for the required apps are present in the list or not")
 		for i := 0; i < len(appList); i++ {
 			if Contains(postRuleApp, appList[i]) {
@@ -615,14 +615,13 @@ var _ = Describe("{BackupAlternatingBetweenLockedAndUnlockedBuckets}", func() {
 			}
 		})
 
-		Step("Creating cloud credentials", func(){
+		Step("Creating cloud credentials", func() {
 			log.InfoD("Creating cloud credentials")
 			for _, provider := range providers {
 				CredName := fmt.Sprintf("%s-%s", "cred", provider)
 				CloudCredUID = uuid.New()
 				CloudCredUIDMap[CloudCredUID] = CredName
 				CreateCloudCredential(provider, CredName, CloudCredUID, orgID)
-				time.Sleep(time.Minute * 1)
 			}
 		})
 
@@ -639,7 +638,6 @@ var _ = Describe("{BackupAlternatingBetweenLockedAndUnlockedBuckets}", func() {
 					log.FailOnError(err, "Unable to create locked s3 bucket %s", bucketName)
 					BackupLocationUID = uuid.New()
 					BackupLocationMap[BackupLocationUID] = backupLocation
-					time.Sleep(time.Minute * 1)
 					CreateBackupLocation(provider, backupLocation, BackupLocationUID, CredName, CloudCredUID,
 						bucketName, orgID, "")
 				}
@@ -656,7 +654,6 @@ var _ = Describe("{BackupAlternatingBetweenLockedAndUnlockedBuckets}", func() {
 				backupLocation = fmt.Sprintf("%s-%s-unlockedbucket", provider, bucketNames[0])
 				BackupLocationUID = uuid.New()
 				BackupLocationMap[BackupLocationUID] = backupLocation
-				time.Sleep(time.Minute * 1)
 				CreateBackupLocation(provider, backupLocation, BackupLocationUID, CredName, CloudCredUID,
 					bucketName, orgID, "")
 			}
@@ -670,7 +667,7 @@ var _ = Describe("{BackupAlternatingBetweenLockedAndUnlockedBuckets}", func() {
 
 		Step("Taking backup of application to locked and unlocked bucket", func() {
 			for _, namespace := range bkpNamespaces {
-				for backupLocationUID, backupLocationName := range BackupLocationMap{
+				for backupLocationUID, backupLocationName := range BackupLocationMap {
 					ctx, err := backup.GetAdminCtxFromSecret()
 					dash.VerifyFatal(err, nil, "Getting context")
 					preRuleUid, _ := Inst().Backup.GetRuleUid(orgID, ctx, preRuleNameList[0])
@@ -683,9 +680,9 @@ var _ = Describe("{BackupAlternatingBetweenLockedAndUnlockedBuckets}", func() {
 			}
 		})
 		Step("Restoring the backups application", func() {
-			for _, _ = range bkpNamespaces {
-				for _, backupName := range backupList{
-					CreateRestore(fmt.Sprintf("%s-restore",backupName), backupName, nil, SourceClusterName, orgID)
+			for range bkpNamespaces {
+				for _, backupName := range backupList {
+					CreateRestore(fmt.Sprintf("%s-restore", backupName), backupName, nil, SourceClusterName, orgID)
 				}
 			}
 		})
@@ -702,13 +699,13 @@ var _ = Describe("{BackupAlternatingBetweenLockedAndUnlockedBuckets}", func() {
 		}
 
 		log.InfoD("Deleting backup location and cloud setting")
-		for backupLocationUID, backupLocationName := range BackupLocationMap{
+		for backupLocationUID, backupLocationName := range BackupLocationMap {
 			DeleteBackupLocation(backupLocationName, backupLocationUID, orgID)
 		}
 		// Need sleep as it takes some time for
 		time.Sleep(time.Minute * 1)
-		for CloudCredUID, CredName := range CloudCredUIDMap{
-				DeleteCloudCredential(CredName, orgID, CloudCredUID)	
+		for CloudCredUID, CredName := range CloudCredUIDMap {
+				DeleteCloudCredential(CredName, orgID, CloudCredUID)
 		}
 		DeleteCluster(destinationClusterName, OrgID)
 		DeleteCluster(SourceClusterName, OrgID)

--- a/tests/common.go
+++ b/tests/common.go
@@ -3711,7 +3711,9 @@ func CreateS3Bucket(bucketName string, objectLock bool, retainCount int64, objec
 					DefaultRetention: &s3.DefaultRetention{
 							Days: aws.Int64(retainCount),
 							Mode: aws.String(objectLockMode)}}}})
-		err = fmt.Errorf("Failed to update Objectlock config with Retain Count [%v] and Mode [%v]. Error: [%v]", retainCount, objectLockMode, err)
+						if err != nil{
+								err = fmt.Errorf("Failed to update Objectlock config with Retain Count [%v] and Mode [%v]. Error: [%v]", retainCount, objectLockMode, err)	
+						}
 	}
 	return err
 }


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
- [x] Adding testcase to take alternating backups between locked and unlocked bucket
- [x] Fixing minior issue with library 

**Which issue(s) this PR fixes** (optional)
Closes # PA-470

Aetos link: http://aetos.pwx.purestorage.com/resultSet/testSetID/75508/testCaseID/271872 

Additional config needed from px-backup side to run this testcase:
Changes needed in stork configmap:
```
$ kubectl get cm stork-objlock-config -oyaml -n kube-system
apiVersion: v1
data:
  object-lock-incr-backup-count: "1"
kind: ConfigMap
metadata:
  creationTimestamp: "2022-07-13T06:32:12Z"
  name: stork-objlock-config
  namespace: kube-system
  resourceVersion: "17624"
  uid: 6f51f632-c625-4d1e-b67e-aacc88cfcbd0
```

Changes needed in backup configmap: 
```
$ kubectl get cm px-backup-config -oyaml -n px-backup
apiVersion: v1
data:
  KDMP_KOPIAEXECUTOR_IMAGE: portworx/kopiaexecutor:1.2.2
  KDMP_KOPIAEXECUTOR_IMAGE_SECRET: ""
  OBJECT-LOCK-INCR-BACKUP-COUNT: "1"
  OBJECT-LOCK-RETAIN-COUNT: "1"
kind: ConfigMap
metadata:
  creationTimestamp: "2022-11-07T18:27:34Z"
  name: px-backup-config
  namespace: px-backup
  resourceVersion: "169279"
  uid: 674039c8-28d0-4ff8-9d55-ef5d2ea2880a
```

**Special notes for your reviewer**:
We might need an auto clean job outside torpedo to cleanup buckets post the retention is met. 