### PR TITLE
PA-505: Add test to restart px with running backup

### DIFF
--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -1851,7 +1851,7 @@ var _ = Describe("{BackupRestartPX}", func() {
 	bkpNamespaces = make([]string, 0)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("BackupRestartPX", "Deploying backup", nil, 0)
+		StartTorpedoTest("BackupRestartPX", "Restart PX when backup in progress", nil, 0)
 		log.InfoD("Verifying if the pre/post rules for the required apps are present in the list or not")
 		for i := 0; i < len(appList); i++ {
 			if Contains(postRuleApp, appList[i]) {
@@ -1947,6 +1947,7 @@ var _ = Describe("{BackupRestartPX}", func() {
 
 		storageNodes := node.GetWorkerNodes()
 		Step(fmt.Sprintf("Restart volume driver nodes starts"), func() {
+			log.InfoD("Restart PX on nodes")
 			for index, _ := range storageNodes {
 				// Just restart storage driver on one of the node where volume backup is in progress
 				Inst().V.RestartDriver(storageNodes[index], nil)
@@ -1954,6 +1955,7 @@ var _ = Describe("{BackupRestartPX}", func() {
 			})
 
 		Step("Check if backup is successful when the PX restart happened", func() {
+			log.InfoD("Check if backup is successful post px restarts")
 			var bkpUid string
 			backupDriver := Inst().Backup
 			ctx, err := backup.GetAdminCtxFromSecret()


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
- [x] Add `CreateBackupWithoutCheck()` function to do ops when backup in progress.
- [x] Add testcase `BackupRestartPX`. 

Sample implementation  of the function call:
```
		Step("Start backup of application to bucket", func() {
			for _, namespace := range bkpNamespaces {
				ctx, err := backup.GetAdminCtxFromSecret()
				dash.VerifyFatal(err, nil, "Getting context")
				preRuleUid, _ := Inst().Backup.GetRuleUid(orgID, ctx, preRuleNameList[0])
				postRuleUid, _ := Inst().Backup.GetRuleUid(orgID, ctx, postRuleNameList[0])
				backupName := fmt.Sprintf("%s-%s-%s", BackupNamePrefix, namespace, backupLocationName)
				CreateBackupWithoutCheck(backupName, SourceClusterName, backupLocation, backupLocationUID, []string{namespace},
					labelSelectors, orgID, clusterUid, preRuleNameList[0], preRuleUid, postRuleNameList[0], postRuleUid, ctx)
			}
		})

 /// Op you want to do while backup is running


		Step("Check if backup is successful when the PX restart happened", func() {
			var bkpUid string
			backupDriver := Inst().Backup
			ctx, err := backup.GetAdminCtxFromSecret()
			for _, namespace := range bkpNamespaces {
				backupName := fmt.Sprintf("%s-%s-%s", BackupNamePrefix, namespace, backupLocationName)
				backupSuccessCheck := func() (interface{}, bool, error) {
					bkpUid, err = backupDriver.GetBackupUID(ctx, backupName, orgID)
					log.FailOnError(err, "Failed while trying to get backup UID for - %s", backupName)
					backupInspectRequest := &api.BackupInspectRequest{
						Name:  backupName,
						Uid:   bkpUid,
						OrgId: orgID,
					}
					resp, err := backupDriver.InspectBackup(ctx, backupInspectRequest)
					log.FailOnError(err, "Inspecting the backup taken with request:\n%v", backupInspectRequest)
					actual := resp.GetBackup().GetStatus().Status
					expected := api.BackupInfo_StatusInfo_Success
					if actual != expected {
						return "", true, fmt.Errorf("backup status expected was [%s] but got [%s]", expected, actual)
					}
					return "", false, nil
			}
			task.DoRetryWithTimeout(backupSuccessCheck, 10*time.Minute, 30*time.Second)
			bkpUid, err = backupDriver.GetBackupUID(ctx, backupName, orgID)
			log.FailOnError(err, "Failed while trying to get backup UID for - %s", backupName)
			backupInspectRequest := &api.BackupInspectRequest{
				Name:  backupName,
				Uid:   bkpUid,
				OrgId: orgID,
			}
			resp, err := backupDriver.InspectBackup(ctx, backupInspectRequest)
			log.FailOnError(err, "Inspecting the backup taken with request:\n%v", backupInspectRequest)
			dash.VerifyFatal(resp.GetBackup().GetStatus().Status, api.BackupInfo_StatusInfo_Success, "Inspecting the backup success for - "+resp.GetBackup().GetName())
		}
	})
})

```

**Which issue(s) this PR fixes** (optional)
Closes # PA-505

Atos link: http://aetos.pwx.purestorage.com/resultSet/testSetID/76018/testCaseID/275055

**Special notes for your reviewer**:
Feels nice to close this after so long 🙂

