### PR TITLE
Fix for BasicBackupCreation - Added pre rule for the new postgres-backup app in AppParameters

### DIFF
--- a/drivers/backup/portworx/portworx.go
+++ b/drivers/backup/portworx/portworx.go
@@ -1127,6 +1127,13 @@ var (
 			"container":         {"", ""},
 		},
 		},
+		"postgres-backup": {"pre": {"pre_action_list": {"PGPASSWORD=$POSTGRES_PASSWORD; psql -U \"$POSTGRES_USER\" -c \"CHECKPOINT\";"},
+			"background":        {"false"},
+			"runInSinglePod":    {"false"},
+			"pod_selector_list": {"app=postgres"},
+			"container":         {"", ""},
+		},
+		},
 	}
 )
 

--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -275,12 +275,10 @@ var _ = Describe("{BasicBackupCreation}", func() {
 		Step("Taking backup of applications", func() {
 			ctx, err := backup.GetAdminCtxFromSecret()
 			dash.VerifyFatal(err, nil, "Getting context")
-			preRuleUid, err := Inst().Backup.GetRuleUid(orgID, ctx, preRuleNameList[0])
-			log.FailOnError(err, "Error getting UID for pre-rule - [%s]", preRuleNameList[0])
 			for _, namespace := range bkpNamespaces {
 				backupName = fmt.Sprintf("%s-%s", BackupNamePrefix, namespace)
 				err = CreateBackup(backupName, SourceClusterName, bkpLocationName, backupLocationUID, []string{namespace},
-					labelSelectors, orgID, clusterUid, preRuleNameList[0], preRuleUid, "", "", ctx)
+					labelSelectors, orgID, clusterUid, "", "", "", "", ctx)
 				dash.VerifyFatal(err, nil, "Verifying backup creation")
 			}
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the [pipeline](https://jenkins.pwx.dev.purestorage.com/blue/organizations/jenkins/Users%2FSumit%2FPX-Backup%2Fpx-backup-system-test/detail/px-backup-system-test/54/pipeline/) failure caused because we created a new postgres-backup application for Px Backup tests but missed to add it in the `AppParameters` in `drivers/backup/portworx/portworx.go`

Also, removed providing the pre rule while taking backup for BasicBackupCreation since it is not necessary for this test

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

