### PR TITLE
PA-516: Fix px backup crash due to `.(int)` call

### DIFF
--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -1032,7 +1032,6 @@ var _ = Describe("{ShareBackupWithUsersAndGroups}", func() {
 })
 
 var _ = Describe("{ShareLargeNumberOfBackupsWithLargeNumberOfUsers}", func() {
-	numberOfUsers := getEnv(usersToBeCreated, "200").(int)
 	numberOfUsers, _ := strconv.Atoi(getEnv(usersToBeCreated, "200"))
 	numberOfGroups, _ := strconv.Atoi(getEnv(groupsToBeCreated, "100"))
 	groupSize, _ := strconv.Atoi(getEnv(maxUsersInGroup, "2"))

--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -1033,9 +1033,10 @@ var _ = Describe("{ShareBackupWithUsersAndGroups}", func() {
 
 var _ = Describe("{ShareLargeNumberOfBackupsWithLargeNumberOfUsers}", func() {
 	numberOfUsers := getEnv(usersToBeCreated, "200").(int)
-	numberOfGroups := getEnv(groupsToBeCreated, "100").(int)
-	groupSize := getEnv(maxUsersInGroup, "2").(int)
-	numberOfBackups := getEnv(maxBackupsToBeCreated, "100").(int)
+	numberOfUsers, _ := strconv.Atoi(getEnv(usersToBeCreated, "200"))
+	numberOfGroups, _ := strconv.Atoi(getEnv(groupsToBeCreated, "100"))
+	groupSize, _ := strconv.Atoi(getEnv(maxUsersInGroup, "2"))
+	numberOfBackups, _ := strconv.Atoi(getEnv(maxBackupsToBeCreated, "100"))
 	timeBetweenConsecutiveBackups := 4 * time.Second
 	users := make([]string, 0)
 	groups := make([]string, 0)
@@ -5325,7 +5326,7 @@ func TearDownBackupRestore(bkpNamespaces []string, restoreNamespaces []string) {
 	DeleteBackupLocation(backupLocationName, "", OrgID)
 	DeleteCloudCredential(CredName, OrgID, CloudCredUID)
 }
-func getEnv(environmentVariable string, defaultValue string) interface{} {
+func getEnv(environmentVariable string, defaultValue string) string {
 	value, present := os.LookupEnv(environmentVariable)
 	if !present {
 		value = defaultValue


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
PX-backup runs were crashing with the below panic:
```
-- FAIL: TestBasic (0.00s)
panic: interface conversion: interface {} is string, not int [recovered]
	panic: interface conversion: interface {} is string, not int

goroutine 93 [running]:
testing.tRunner.func1.2({0x5bb9860, 0xc0008d3d10})
	/usr/lib/golang/src/testing/testing.go:1389 +0x24e
testing.tRunner.func1()
	/usr/lib/golang/src/testing/testing.go:1392 +0x39f
panic({0x5bb9860, 0xc0008d3d10})
	/usr/lib/golang/src/runtime/panic.go:838 +0x207
github.com/portworx/torpedo/tests/backup.glob..func9()
	/root/torpedo/tests/backup/backup_test.go:1036 +0x3f
github.com/onsi/ginkgo/internal/suite.(*Suite).PushContainerNode(0xc0001b4cb0, {0x663d7ba, 0x31}, 0x67363c0, 0x0, {{0x7acb86d, 0x29}, 0x40b, {0xc000c550a0, 0x66}})
	/root/torpedo/vendor/github.com/onsi/ginkgo/internal/suite/suite.go:181 +0x366
github.com/onsi/ginkgo/internal/suite.(*Suite).Run(0xc0001b4cb0, {0x7f20e8106d08, 0xc0000e7860}, {0x6584d8f, 0x10}, {0xc00012bcc0, 0x2, 0x2}, {0x6d1bc20, 0xc0000c0900}, ...)
	/root/torpedo/vendor/github.com/onsi/ginkgo/internal/suite/suite.go:70 +0x5c5
github.com/onsi/ginkgo.runSpecsWithCustomReporters({0x6cf2220?, 0xc0000e7860}, {0x6584d8f, 0x10}, {0xc00012bbc0, 0x2, 0x65b0be9?})
	/root/torpedo/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go:245 +0x189
github.com/onsi/ginkgo.RunSpecsWithDefaultAndCustomReporters({0x6cf2220, 0xc0000e7860}, {0x6584d8f, 0x10}, {0xc0008875d0, 0x1, 0x1})
	/root/torpedo/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go:228 +0x1b6
github.com/portworx/torpedo/tests/backup.TestBasic(0x0?)
	/root/torpedo/tests/backup/backup_basic_test.go:61 +0xb9
testing.tRunner(0xc0000e7860, 0x6736230)
	/usr/lib/golang/src/testing/testing.go:1439 +0x102
created by testing.(*T).Run
	/usr/lib/golang/src/testing/testing.go:1486 +0x35f

Ginkgo ran 1 suite in 102.942641ms
Test Suite Failed
```

- [x] Fixing it by changing conversion to `strconv.Atoi(getEnv())`
- [x] Changing return type to `string`

**Which issue(s) this PR fixes** (optional)
Closes # PA-516

Dashboard URL : http://aetos.pwx.purestorage.com/resultSet/testSetID/8017

**Special notes for your reviewer**:


