### PR TITLE
Fixed CancelClusterBackupShare 

### DIFF
--- a/drivers/backup/auth.go
+++ b/drivers/backup/auth.go
@@ -982,7 +982,7 @@ func DeleteMultipleGroups(groups []string) error {
 			defer wg.Done()
 			err := DeleteGroup(group)
 			log.FailOnError(err, "Failed to create group - %v", group)
-			
+
 		}(group)
 		log.Infof("Deleted Group - %s", group)
 	}
@@ -1001,7 +1001,7 @@ func DeleteMultipleUsers(users []string) error {
 			defer wg.Done()
 			err := DeleteUser(user)
 			log.FailOnError(err, "Failed to create group - %v", user)
-			
+
 		}(user)
 		log.Infof("Deleted User - %s", user)
 	}

--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -1773,15 +1773,16 @@ var _ = Describe("{CancelClusterBackupShare}", func() {
 		Step("Validate that no groups or users have access to backups shared at cluster level", func() {
 			log.InfoD("Validate no groups or users have access to backups shared at cluster level")
 			log.Infof("User chosen to validate no access - %s", chosenUser)
-
-			// Enumerate all the backups available to the user
-			userBackups, err := GetAllBackupsForUser(chosenUser, "Password1")
-			log.FailOnError(err, "Failed to get all backups for user - [%s]", chosenUser)
-			log.Infof("Backups user [%s] has access to - %v", chosenUser, userBackups)
 			log.InfoD("Checking backups user [%s] has after revoking", chosenUser)
+			var userBackups []string
+			var err error
 			noAccessCheck := func() (interface{}, bool, error) {
+				// Enumerate all the backups available to the user
+				userBackups, err = GetAllBackupsForUser(chosenUser, "Password1")
+				log.FailOnError(err, "Failed to get all backups for user - [%s]", chosenUser)
+				log.Infof("Backups user [%s] has access to - %v", chosenUser, userBackups)
 				if len(userBackups) > 0 {
-					return "", true, fmt.Errorf("Waiting for all backup access - [%v] to be revoked for user = [%s]",
+					return "", true, fmt.Errorf("waiting for all backup access - [%v] to be revoked for user = [%s]",
 						userBackups, chosenUser)
 				}
 				return "", false, nil
@@ -2684,11 +2685,11 @@ var _ = Describe("{ShareBackupWithDifferentRoleUsers}", func() {
 				email := fmt.Sprintf("testuser%v@cnbu.com", i)
 				wg.Add(1)
 				go func(userName, firstName, lastName, email string) {
-				defer wg.Done()
+					defer wg.Done()
 					err := backup.AddUser(userName, firstName, lastName, email, "Password1")
 					log.FailOnError(err, "Failed to create user - %s", userName)
 					users = append(users, userName)
-					
+
 				}(userName, firstName, lastName, email)
 			}
 			wg.Wait()


### PR DESCRIPTION
**What this PR does / why we need it**:

- `CancelClusterBackupShare` was failing because the function being passed to `task.DoRetryWithTimeout` did not have the enumerate call inside it
- Log messages pushed to aetos will now have more info about the backup name and restore name
- Formatting changes   

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

[Aetos Dashboard](http://aetos.pwx.purestorage.com/resultSet/testSetID/80974)
[Jenkins Run](https://jenkins.pwx.dev.purestorage.com/job/Users/job/Sumit/job/Custom-Pipelines/job/px-backup-on-demand-system-test/31/)

