### PR TITLE
Reduced size of fio-fa-clouddrive volume

### DIFF
--- a/drivers/scheduler/k8s/specs/fio-fa-cloud-drives/fio.yaml
+++ b/drivers/scheduler/k8s/specs/fio-fa-cloud-drives/fio.yaml
@@ -61,7 +61,7 @@ spec:
       - ReadWriteOnce
       resources:
         requests:
-          storage: 200Gi
+          storage: 10Gi
   - metadata:
       name: fio-log
     spec:

--- a/drivers/scheduler/k8s/specs/fio-fa-cloud-drives/fio.yaml
+++ b/drivers/scheduler/k8s/specs/fio-fa-cloud-drives/fio.yaml
@@ -61,7 +61,7 @@ spec:
       - ReadWriteOnce
       resources:
         requests:
-          storage: 10Gi
+          storage: {{ if .VolumeSize }}"{{ .VolumeSize }}"{ else }}"10Gi"{{ end }}
   - metadata:
       name: fio-log
     spec:

--- a/drivers/scheduler/k8s/specs/fio-fa-cloud-drives/fio.yaml
+++ b/drivers/scheduler/k8s/specs/fio-fa-cloud-drives/fio.yaml
@@ -61,7 +61,7 @@ spec:
       - ReadWriteOnce
       resources:
         requests:
-          storage: {{ if .VolumeSize }}"{{ .VolumeSize }}"{ else }}"10Gi"{{ end }}
+          storage: {{ if .VolumeSize }}"{{ .VolumeSize }}"{{ else }}"10Gi"{{ end }}
   - metadata:
       name: fio-log
     spec:


### PR DESCRIPTION
**What this PR does / why we need it**:
This addresses the issue where HA-update tests take too long to complete as the volume was much larger than it needed to be.


