### PR TITLE
Helper functions to create schedule backup and to get schedule policy…

### DIFF
--- a/drivers/backup/backup.go
+++ b/drivers/backup/backup.go
@@ -267,6 +267,9 @@ type SchedulePolicy interface {
 
 	// DeleteBackupSchedulePolicy deletes the list of schedule policies
 	DeleteBackupSchedulePolicy(orgID string, policyList []string) error
+
+	// GetSchedulePolicyUid gets the uid for the given schedule policy
+	GetSchedulePolicyUid(orgID string, tx context.Context, schPolicyName string) (string, error)
 }
 
 // ScheduleBackup interface

--- a/drivers/backup/portworx/portworx.go
+++ b/drivers/backup/portworx/portworx.go
@@ -1317,6 +1317,24 @@ func (p *portworx) BackupSchedulePolicy(name string, uid string, orgId string, s
 	return nil
 }
 
+// GetSchedulePolicyUid gets the uid for the given schedule policy
+func (p *portworx) GetSchedulePolicyUid(orgID string, ctx context.Context, schPolicyName string) (string, error) {
+	SchedulePolicyEnumerateReq := &api.SchedulePolicyEnumerateRequest{
+		OrgId: orgID,
+	}
+	schPolicyList, err := p.EnumerateSchedulePolicy(ctx, SchedulePolicyEnumerateReq)
+	if err != nil {
+		return "", fmt.Errorf("Failed to enumerate schedule policies with error: [%v]", err)
+	}
+	for i := 0; i < len(schPolicyList.SchedulePolicies); i++ {
+		if schPolicyList.SchedulePolicies[i].Metadata.Name == schPolicyName {
+			schPolicyUid := schPolicyList.SchedulePolicies[i].Metadata.Uid
+			return schPolicyUid, nil
+		}
+	}
+        return "", fmt.Errorf("Unable to find schedule policy Uid")
+}
+
 func (p *portworx) RegisterBackupCluster(orgID, clusterName, uid string) (api.ClusterInfo_StatusInfo_Status, string) {
 	ctx, err := backup.GetAdminCtxFromSecret()
 	log.FailOnError(err, "Failed to fetch px-central-admin ctx")

--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -5137,6 +5137,84 @@ func CreateBackupWithCustomResourceType(backupName string, clusterName string, b
 	return nil
 }
 
+// CreateScheduleBackup creates a scheduled backup
+func CreateScheduleBackup(backupName string, clusterName string, bLocation string, bLocationUID string,
+	namespaces []string, labelSelectors map[string]string, orgID string, preRuleName string,
+	preRuleUid string, postRuleName string, postRuleUid string, schPolicyName string, schPolicyUID string, ctx context.Context) (*api.BackupScheduleInfo_StatusInfo_Status, error) {
+	var bkpUid string
+	backupDriver := Inst().Backup
+	bkpSchCreateRequest := &api.BackupScheduleCreateRequest{
+		CreateMetadata: &api.CreateMetadata{
+			Name:  backupName,
+			OrgId: orgID,
+		},
+		SchedulePolicyRef: &api.ObjectRef{
+			Name: schPolicyName,
+			Uid:  schPolicyUID,
+		},
+		BackupLocationRef: &api.ObjectRef{
+			Name: bLocation,
+			Uid:  bLocationUID,
+		},
+		SchedulePolicy: schPolicyName,
+		Cluster:        clusterName,
+		Namespaces:     namespaces,
+		LabelSelectors: labelSelectors,
+		PreExecRuleRef: &api.ObjectRef{
+			Name: preRuleName,
+			Uid:  preRuleUid,
+		},
+		PostExecRuleRef: &api.ObjectRef{
+			Name: postRuleName,
+			Uid:  postRuleUid,
+		},
+	}
+	_, err := backupDriver.CreateBackupSchedule(ctx, bkpSchCreateRequest)
+	if err != nil {
+		return nil, err
+	}
+	backupSuccessCheck := func() (interface{}, bool, error) {
+		bkpUid, err = backupDriver.GetBackupUID(ctx, backupName, orgID)
+		if err != nil {
+			return "", true, err
+		}
+		backupSchInspectRequest := &api.BackupScheduleInspectRequest{
+			Name:  backupName,
+			Uid:   bkpUid,
+			OrgId: orgID,
+		}
+		resp, err := backupDriver.InspectBackupSchedule(ctx, backupSchInspectRequest)
+		if err != nil {
+			return "", true, err
+		}
+		actual := resp.GetBackupSchedule().GetStatus().Status
+		expected := api.BackupScheduleInfo_StatusInfo_Success
+		if actual != expected {
+			return "", true, fmt.Errorf("backup status for [%s] expected was [%s] but got [%s]", backupName, expected, actual)
+		}
+		return "", false, nil
+	}
+
+	_, err = task.DoRetryWithTimeout(backupSuccessCheck, 10*time.Minute, 30*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	bkpUid, err = backupDriver.GetBackupUID(ctx, backupName, orgID)
+	if err != nil {
+		return nil, err
+	}
+	backupSchInspectRequest := &api.BackupScheduleInspectRequest{
+		Name:  backupName,
+		Uid:   bkpUid,
+		OrgId: orgID,
+	}
+	resp, err := backupDriver.InspectBackupSchedule(ctx, backupSchInspectRequest)
+	if err != nil {
+		return nil, err
+	}
+	return &resp.GetBackupSchedule().GetStatus().Status, nil
+}
+
 // CreateBackupWithoutCheck creates backup without waiting for success
 func CreateBackupWithoutCheck(backupName string, clusterName string, bLocation string, bLocationUID string,
 	namespaces []string, labelSelectors map[string]string, orgID string, uid string, preRuleName string,


### PR DESCRIPTION
**What this PR does / why we need it**:
Helper functions to create scheduled backups and to get schedule policy Uid.

**Which issue(s) this PR fixes** (optional)
https://portworx.atlassian.net/browse/PA-522

**Special notes for your reviewer**:
Currently @apimpalgaonkar blocked due to these helper function. Hence raised this PR to unblock her.

Below are the compilation logs
```
vpinisetti--MacBookPro18:~/gitspace/torpedo$ make build-backup
mkdir -p /Users/vpinisetti/gitspace/torpedo/bin
go build -tags "daemon"  github.com/portworx/torpedo/drivers github.com/portworx/torpedo/drivers/api github.com/portworx/torpedo/drivers/backup github.com/portworx/torpedo/drivers/backup/portworx github.com/portworx/torpedo/drivers/monitor github.com/portworx/torpedo/drivers/monitor/prometheus github.com/portworx/torpedo/drivers/node github.com/portworx/torpedo/drivers/node/aks github.com/portworx/torpedo/drivers/node/aws github.com/portworx/torpedo/drivers/node/gke github.com/portworx/torpedo/drivers/node/ibm github.com/portworx/torpedo/drivers/node/oracle github.com/portworx/torpedo/drivers/node/ssh github.com/portworx/torpedo/drivers/node/vsphere github.com/portworx/torpedo/drivers/objectstore github.com/portworx/torpedo/drivers/pds/api github.com/portworx/torpedo/drivers/pds/controlplane github.com/portworx/torpedo/drivers/pds/lib github.com/portworx/torpedo/drivers/pds/pdsutils github.com/portworx/torpedo/drivers/pds/targetcluster github.com/portworx/torpedo/drivers/scheduler github.com/portworx/torpedo/drivers/scheduler/dcos github.com/portworx/torpedo/drivers/scheduler/k8s github.com/portworx/torpedo/drivers/scheduler/openshift github.com/portworx/torpedo/drivers/scheduler/rke github.com/portworx/torpedo/drivers/scheduler/spec github.com/portworx/torpedo/drivers/volume github.com/portworx/torpedo/drivers/volume/aws github.com/portworx/torpedo/drivers/volume/azure github.com/portworx/torpedo/drivers/volume/gce github.com/portworx/torpedo/drivers/volume/generic_csi github.com/portworx/torpedo/drivers/volume/linstor github.com/portworx/torpedo/drivers/volume/portworx github.com/portworx/torpedo/drivers/volume/portworx/schedops github.com/portworx/torpedo/pkg/aetosutil github.com/portworx/torpedo/pkg/applicationbackup github.com/portworx/torpedo/pkg/asyncdr github.com/portworx/torpedo/pkg/aututils github.com/portworx/torpedo/pkg/email github.com/portworx/torpedo/pkg/errors github.com/portworx/torpedo/pkg/ipv6util github.com/portworx/torpedo/pkg/jirautils github.com/portworx/torpedo/pkg/kvdbutils github.com/portworx/torpedo/pkg/log github.com/portworx/torpedo/pkg/netutil github.com/portworx/torpedo/pkg/osutils github.com/portworx/torpedo/pkg/pureutils github.com/portworx/torpedo/pkg/restutil github.com/portworx/torpedo/pkg/s3utils github.com/portworx/torpedo/pkg/snapshotutils github.com/portworx/torpedo/pkg/testrailuttils github.com/portworx/torpedo/pkg/units github.com/portworx/torpedo/porx/px/api
ginkgo build -r ./tests/backup
Compiling backup...
    compiled backup.test
find ./tests/backup -name '*.test' | awk '{cmd="cp  "$1"  /Users/vpinisetti/gitspace/torpedo/bin"; system(cmd)}'
chmod -R 755 bin/*
vpinisetti--MacBookPro18:~/gitspace/torpedo$ date
Fri Jan 27 16:14:51 IST 2023
vpinisetti--MacBookPro18:~/gitspace/torpedo$
```
