### PR TITLE
Increasing time out for PVC validations

### DIFF
--- a/tests/common.go
+++ b/tests/common.go
@@ -247,7 +247,7 @@ const (
 const (
 	waitResourceCleanup       = 2 * time.Minute
 	defaultTimeout            = 5 * time.Minute
-	defaultVolScaleTimeout    = 2 * time.Minute
+	defaultVolScaleTimeout    = 4 * time.Minute
 	defaultRetryInterval      = 10 * time.Second
 	defaultCmdTimeout         = 20 * time.Second
 	defaultCmdRetryInterval   = 5 * time.Second


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Increasing time out for pVC validations ,where somrtime it is taking more than 2 mins to PVC to bound in case mulipe volumes
**Which issue(s) this PR fixes** (optional)
Closes #PTX-15210

**Special notes for your reviewer**:
http://aetos.pwx.purestorage.com/resultSet/testSetID/87207

