### PR TITLE
Fixing backup name issue in ReplicaChangeWhileRestore

### DIFF
--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -5409,15 +5409,15 @@ var _ = Describe("{ReplicaChangeWhileRestore}", func() {
 					restoreName = fmt.Sprintf("%s-%s-%v", restoreNamePrefix, backupName, time.Now().Unix())
 					scName := fmt.Sprintf("replica-sc-%v", time.Now().Unix())
 					pvcs, err := core.Instance().GetPersistentVolumeClaims(namespace, labelSelectors)
+					dash.VerifyFatal(err, nil, fmt.Sprintf("Getting all PVCs from namespace - %v", pvcs))
 					singlePvc := pvcs.Items[0]
-					dash.VerifyFatal(err, nil, "Getting PVC from namespace")
 					sourceScName, err := core.Instance().GetStorageClassForPVC(&singlePvc)
-					dash.VerifyFatal(err, nil, "Getting SC from PVC")
+					dash.VerifyFatal(err, nil, fmt.Sprintf("Getting SC from PVC - %s", singlePvc.GetName()))
 					storageClassMapping[sourceScName.Name] = scName
 					restoredNameSpace := fmt.Sprintf("%s-%s", namespace, "restored")
 					namespaceMapping[namespace] = restoredNameSpace
 					err = CreateRestore(restoreName, backupName, namespaceMapping, SourceClusterName, orgID, ctx, storageClassMapping)
-					dash.VerifyFatal(err, nil, "Restoring with custom Storage Class Mapping")
+					dash.VerifyFatal(err, nil, fmt.Sprintf("Restoring with custom Storage Class Mapping - %v", namespaceMapping))
 				}
 			}
 		})

--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -5409,7 +5409,7 @@ var _ = Describe("{ReplicaChangeWhileRestore}", func() {
 					restoreName = fmt.Sprintf("%s-%s-%v", restoreNamePrefix, backupName, time.Now().Unix())
 					scName := fmt.Sprintf("replica-sc-%v", time.Now().Unix())
 					pvcs, err := core.Instance().GetPersistentVolumeClaims(namespace, labelSelectors)
-					dash.VerifyFatal(err, nil, fmt.Sprintf("Getting all PVCs from namespace - %v", pvcs))
+					dash.VerifyFatal(err, nil, fmt.Sprintf("Getting all PVCs from namespace [%s]. Total PVCs - %d", namespace, len(pvcs.Items)))
 					singlePvc := pvcs.Items[0]
 					sourceScName, err := core.Instance().GetStorageClassForPVC(&singlePvc)
 					dash.VerifyFatal(err, nil, fmt.Sprintf("Getting SC from PVC - %s", singlePvc.GetName()))

--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -5317,6 +5317,7 @@ var _ = Describe("{ReplicaChangeWhileRestore}", func() {
 	bkpNamespaces = make([]string, 0)
 	labelSelectors := make(map[string]string)
 	params := make(map[string]string)
+	var backupNames []string
 
 	JustBeforeEach(func() {
 		StartTorpedoTest("ReplicaChangeWhileRestore", "Change replica while restoring backup", nil, 58043)
@@ -5375,6 +5376,7 @@ var _ = Describe("{ReplicaChangeWhileRestore}", func() {
 				backupName = fmt.Sprintf("%s-%s-%v", BackupNamePrefix, namespace, time.Now().Unix())
 				err = CreateBackup(backupName, SourceClusterName, backupLocation, backupLocationUID, []string{namespace}, labelSelectors, orgID, clusterUid, "", "", "", "", ctx)
 				dash.VerifyFatal(err, nil, "Verifying backup creation with custom resources")
+				backupNames = append(backupNames, backupName)
 			}
 		})
 		Step("Create new storage class for restore", func() {
@@ -5403,19 +5405,20 @@ var _ = Describe("{ReplicaChangeWhileRestore}", func() {
 			ctx, err := backup.GetAdminCtxFromSecret()
 			log.FailOnError(err, "Fetching px-central-admin ctx")
 			for _, namespace := range bkpNamespaces {
-				backupName = fmt.Sprintf("%s-%s-%v", BackupNamePrefix, namespace, time.Now().Unix())
-				restoreName = fmt.Sprintf("%s-%s-%v", restoreNamePrefix, backupName, time.Now().Unix())
-				scName := fmt.Sprintf("replica-sc-%v", time.Now().Unix())
-				pvcs, err := core.Instance().GetPersistentVolumeClaims(namespace, labelSelectors)
-				singlePvc := pvcs.Items[0]
-				dash.VerifyFatal(err, nil, "Getting PVC from namespace")
-				sourceScName, err := core.Instance().GetStorageClassForPVC(&singlePvc)
-				dash.VerifyFatal(err, nil, "Getting SC from PVC")
-				storageClassMapping[sourceScName.Name] = scName
-				restoredNameSpace := fmt.Sprintf("%s-%s", namespace, "restored")
-				namespaceMapping[namespace] = restoredNameSpace
-				err = CreateRestore(restoreName, backupName, namespaceMapping, SourceClusterName, orgID, ctx, storageClassMapping)
-				dash.VerifyFatal(err, nil, "Restoring with custom Storage Class Mapping")
+				for _, backupName := range backupNames {
+					restoreName = fmt.Sprintf("%s-%s-%v", restoreNamePrefix, backupName, time.Now().Unix())
+					scName := fmt.Sprintf("replica-sc-%v", time.Now().Unix())
+					pvcs, err := core.Instance().GetPersistentVolumeClaims(namespace, labelSelectors)
+					singlePvc := pvcs.Items[0]
+					dash.VerifyFatal(err, nil, "Getting PVC from namespace")
+					sourceScName, err := core.Instance().GetStorageClassForPVC(&singlePvc)
+					dash.VerifyFatal(err, nil, "Getting SC from PVC")
+					storageClassMapping[sourceScName.Name] = scName
+					restoredNameSpace := fmt.Sprintf("%s-%s", namespace, "restored")
+					namespaceMapping[namespace] = restoredNameSpace
+					err = CreateRestore(restoreName, backupName, namespaceMapping, SourceClusterName, orgID, ctx, storageClassMapping)
+					dash.VerifyFatal(err, nil, "Restoring with custom Storage Class Mapping")
+				}
 			}
 		})
 		Step("Validate applications", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
ReplicaChangeWhileRestore was failing because there was a mismatch between the backup name during the creation of backup and the one being used for restore.

**Which issue(s) this PR fixes** (optional)
Closes #[PA-572](https://portworx.atlassian.net/browse/PA-572)

**Special notes for your reviewer**:



[PA-572]: https://portworx.atlassian.net/browse/PA-572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ