### PR TITLE
fix:delete backup validation

### DIFF
--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -2791,6 +2791,7 @@ var _ = Describe("{ClusterBackupShareToggle}", func() {
 				}
 				_, err = task.DoRetryWithTimeout(clusterShareCheck, 2*time.Minute, 10*time.Second)
 				log.FailOnError(err, "Unable to fetch backup from shared cluster for user %s", username)
+				log.Infof("fetched user backups %v", userBackups)
 
 				restoreName := fmt.Sprintf("%s-%v", RestoreNamePrefix, time.Now().Unix())
 				ValidateSharedBackupWithUsers(username, accessLevel, userBackups[len(userBackups)-1], restoreName)

--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -2783,8 +2783,10 @@ var _ = Describe("{ClusterBackupShareToggle}", func() {
 				log.FailOnError(err, "Fail on Fetching backups for %s", username)
 				if len(userBackups) == 0 {
 					time.Sleep(2 * time.Minute)
+					userBackups, err = GetAllBackupsForUser(username, password)
+					log.FailOnError(err, "Fail on Fetching backups for %s", username)
 				}
-				dash.VerifyFatal(len(userBackups), len(userBackups) > 0, fmt.Sprintf("Verifying backups are shared with user %s", username))
+				dash.VerifyFatal(true, len(userBackups) > 0, fmt.Sprintf("Verifying backups are shared with user %s", username))
 				restoreName := fmt.Sprintf("%s-%v", RestoreNamePrefix, time.Now().Unix())
 				ValidateSharedBackupWithUsers(username, accessLevel, userBackups[len(userBackups)-1], restoreName)
 				if accessLevel != ViewOnlyAccess {

--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -2780,7 +2780,7 @@ var _ = Describe("{ClusterBackupShareToggle}", func() {
 				err := ClusterUpdateBackupShare(SourceClusterName, nil, []string{username}, accessLevel, true, ctx)
 				log.FailOnError(err, "Failed sharing all backups for cluster [%s]", SourceClusterName)
 				clusterShareCheck := func() (interface{}, bool, error) {
-					userBackups, err := GetAllBackupsForUser(username, password)
+					userBackups, err = GetAllBackupsForUser(username, password)
 					if err != nil {
 						return "", true, fmt.Errorf("Fail on Fetching backups for %s with error %v", username, err)
 					}

--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -2787,7 +2787,7 @@ var _ = Describe("{ClusterBackupShareToggle}", func() {
 					if len(userBackups) == 0 {
 						return "", true, fmt.Errorf("Unable to fetch backup from shared cluster for user %s", username)
 					}
-					return userBackups, false, nil
+					return "", false, nil
 				}
 				_, err = task.DoRetryWithTimeout(clusterShareCheck, 2*time.Minute, 10*time.Second)
 				log.FailOnError(err, "Unable to fetch backup from shared cluster for user %s", username)


### PR DESCRIPTION
-Added fix for following functions 


**CreateMultipleUsersAndGroups**:
 - Printing username and group name instead of keycloak response
 
**DeleteSharedBackup** :
- deleted backup validation change

**ClusterBackupShareToggle**:
- Validating cluster share with user

Jenkins link - 
https://jenkins.pwx.dev.purestorage.com/job/Users/job/Sumit/job/PX-Backup/job/system-tests/job/px-backup-system-test/86/consoleFull
