### PR TITLE
Fixing node types check for IBM

### DIFF
--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -748,7 +748,8 @@ func (k *K8s) getAddressesForNode(n corev1.Node) []string {
 func (k *K8s) parseK8SNode(n corev1.Node) node.Node {
 	var nodeType node.Type
 	var zone, region string
-	if k8sCore.IsNodeMaster(n) {
+
+	if k8sCore.IsNodeMaster(n) && k.NodeDriverName != "ibm" {
 		nodeType = node.TypeMaster
 	} else {
 		nodeType = node.TypeWorker

--- a/go.mod
+++ b/go.mod
@@ -22,12 +22,12 @@ require (
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.0.0
 	github.com/kubernetes-incubator/external-storage v0.20.4-openstorage-rc7
 	github.com/libopenstorage/autopilot-api v1.3.0
-	github.com/libopenstorage/cloudops v0.0.0-20221107233229-3fa4664e96b1
+	github.com/libopenstorage/cloudops v0.0.0-20230220114907-3e63dce1b413
 	github.com/libopenstorage/openstorage v9.4.47+incompatible
 	github.com/libopenstorage/operator v0.0.0-20230202214252-140e2e1fd86a
 	github.com/libopenstorage/stork v1.4.1-0.20220414104250-3c18fd21ed95
 	github.com/onsi/ginkgo v1.16.5
-	github.com/onsi/gomega v1.20.1
+	github.com/onsi/gomega v1.21.1
 	github.com/openshift/api v0.0.0-20210105115604-44119421ec6b
 	github.com/oracle/oci-go-sdk/v65 v65.13.1
 	github.com/pborman/uuid v1.2.1
@@ -78,7 +78,7 @@ require (
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/BurntSushi/toml v1.2.1 // indirect
 	github.com/GoogleCloudPlatform/k8s-cloud-provider v1.18.1-0.20220218231025-f11817397a1b // indirect
-	github.com/IBM-Cloud/bluemix-go v0.0.0-20220329045155-d2a8118ac5c7 // indirect
+	github.com/IBM-Cloud/bluemix-go v0.0.0-20230120122421-afb48116b8f1 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -512,8 +512,9 @@ github.com/GoogleCloudPlatform/k8s-cloud-provider v1.18.1-0.20220218231025-f1181
 github.com/GoogleCloudPlatform/k8s-cloud-provider v1.18.1-0.20220218231025-f11817397a1b/go.mod h1:FNj4KYEAAHfYu68kRYolGoxkaJn+6mdEsaM12VTwuI0=
 github.com/GoogleCloudPlatform/testgrid v0.0.1-alpha.3/go.mod h1:f96W2HYy3tiBNV5zbbRc+NczwYHgG1PHXMQfoEWv680=
 github.com/IBM-Cloud/bluemix-go v0.0.0-20210408042812-96aaa47da4cd/go.mod h1:kqTYO0mts71aa8PVwviaKlCKYud/NbEkFIqU8aHH3/g=
-github.com/IBM-Cloud/bluemix-go v0.0.0-20220329045155-d2a8118ac5c7 h1:biEZPDv/ASmQfBHKB6WR7TO/xn6nBFkiwGEyvE0sJb4=
 github.com/IBM-Cloud/bluemix-go v0.0.0-20220329045155-d2a8118ac5c7/go.mod h1:UOhxo7T8CdX6sdTY9Dn7rJSgyoTlz1KM9641XcPraH0=
+github.com/IBM-Cloud/bluemix-go v0.0.0-20230120122421-afb48116b8f1 h1:5cVMU5MglJjwzoBsDOk3yuH6T/1EeDZyYbQDowL4nW8=
+github.com/IBM-Cloud/bluemix-go v0.0.0-20230120122421-afb48116b8f1/go.mod h1:cO5KCpiop9eP/pM/5W07TprYUkv/kHtajW1FiZgE59k=
 github.com/IBM/keyprotect-go-client v0.5.1/go.mod h1:5TwDM/4FRJq1ZOlwQL1xFahLWQ3TveR88VmL1u3njyI=
 github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab/go.mod h1:3VYc5hodBMJ5+l/7J4xAyMeuM2PNuepvHlGs8yilUCA=
 github.com/Jeffail/gabs v1.1.1/go.mod h1:6xMvQMK4k33lb7GUUpaAPh6nKMmemQeg5d4gn7/bOXc=
@@ -1105,6 +1106,7 @@ github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AE
 github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-openapi/errors v0.19.8/go.mod h1:cM//ZKUKyO06HSwqAelJ5NsEMMcpa6VpXe8DOa1Mi1M=
+github.com/go-openapi/errors v0.20.2/go.mod h1:cM//ZKUKyO06HSwqAelJ5NsEMMcpa6VpXe8DOa1Mi1M=
 github.com/go-openapi/inflect v0.19.0 h1:9jCH9scKIbHeV9m12SmPilScz6krDxKRasNNSNPXu/4=
 github.com/go-openapi/inflect v0.19.0/go.mod h1:lHpZVlpIQqLyKwJ4N+YSc9hchQy/i12fJykb83CRBH4=
 github.com/go-openapi/jsonpointer v0.19.2/go.mod h1:3akKfEdA7DF1sugOqz1dVQHBcuDBPKZGEoHC/NkiQRg=
@@ -1118,6 +1120,7 @@ github.com/go-openapi/jsonreference v0.19.5/go.mod h1:RdybgQwPxbL4UEjuAruzK1x3nE
 github.com/go-openapi/spec v0.19.3/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8Lj9mJglo=
 github.com/go-openapi/spec v0.19.4/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8Lj9mJglo=
 github.com/go-openapi/strfmt v0.20.0/go.mod h1:UukAYgTaQfqJuAFlNxxMWNvMYiwiXtLsF2VwmoFtbtc=
+github.com/go-openapi/strfmt v0.21.3/go.mod h1:k+RzNO0Da+k3FrrynSNN8F7n/peCmQQqbbXjtDfvmGg=
 github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.14 h1:gm3vOOXfiuw5i9p5N9xJvfjvuofpyvLA9Wr6QfK5Fng=
@@ -1777,8 +1780,9 @@ github.com/libopenstorage/autopilot-api v0.6.1-0.20210301232050-ca2633c6e114 h1:
 github.com/libopenstorage/autopilot-api v0.6.1-0.20210301232050-ca2633c6e114/go.mod h1:2RSNxzYtg9O7fCMZSuc9imAE4R8zhCi7azNbFkYLAuk=
 github.com/libopenstorage/cloudops v0.0.0-20190815012442-6e0d676b6c3e/go.mod h1:quSDXGC3Fhc+pBwMRIi1Gk+kaSfBDZo5rRsftapTzGE=
 github.com/libopenstorage/cloudops v0.0.0-20200604165016-9cc0977d745e/go.mod h1:5Qie78eVLLXqLkLCq1+0HyJzjpdRCHyeg9LWlU0WPfU=
-github.com/libopenstorage/cloudops v0.0.0-20221107233229-3fa4664e96b1 h1:VLRJE8pQnlyzIiWV6NRAYTAClzQ5ySmqkP6yW4f9RnM=
 github.com/libopenstorage/cloudops v0.0.0-20221107233229-3fa4664e96b1/go.mod h1:FkADW9gyVQyD6igV0keQ3nW9k+V3W88yhJ4faZP97wI=
+github.com/libopenstorage/cloudops v0.0.0-20230220114907-3e63dce1b413 h1:OOK0nxRDxGG4CkeiC0MCiFuKMsxiIGLS1WsLB4bZcLs=
+github.com/libopenstorage/cloudops v0.0.0-20230220114907-3e63dce1b413/go.mod h1:XDq7GKCnwg76NKMbLZ5Xe/er3iyGyB0BG9lQ65yB3Q8=
 github.com/libopenstorage/external-storage v0.20.4-openstorage-rc10 h1:q21CLGSi9DhNBBuJuitquA/T6FwLV3KNZxaJpxQbOLc=
 github.com/libopenstorage/external-storage v0.20.4-openstorage-rc10/go.mod h1:nffpoeodwwp+wwngmBGbLBCd7TZ9GxHLtxKoaLRW6K4=
 github.com/libopenstorage/gossip v0.0.0-20190507031959-c26073a01952/go.mod h1:TjXt2Iz2bTkpfc4Q6xN0ttiNipTVwEEYoZSMZHlfPek=
@@ -2050,8 +2054,9 @@ github.com/onsi/gomega v1.16.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAl
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
 github.com/onsi/gomega v1.20.0/go.mod h1:DtrZpjmvpn2mPm4YWQa0/ALMDj9v4YxLgojwPeREyVo=
-github.com/onsi/gomega v1.20.1 h1:PA/3qinGoukvymdIDV8pii6tiZgC8kbmJO6Z5+b002Q=
 github.com/onsi/gomega v1.20.1/go.mod h1:DtrZpjmvpn2mPm4YWQa0/ALMDj9v4YxLgojwPeREyVo=
+github.com/onsi/gomega v1.21.1 h1:OB/euWYIExnPBohllTicTHmGTrMaqJ67nIu80j0/uEM=
+github.com/onsi/gomega v1.21.1/go.mod h1:iYAIXgPSaDHak0LCMA+AWBpIKBr8WZicMxnE8luStNc=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
@@ -2511,6 +2516,9 @@ github.com/vmware/govmomi v0.22.2/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAu
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
+github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
+github.com/xdg-go/scram v1.1.1/go.mod h1:RaEWvsqvNKKvBPvcKeFjrG2cJqOkHTiyTpzz23ni57g=
+github.com/xdg-go/stringprep v1.0.3/go.mod h1:W3f5j4i+9rC0kuIEJL0ky1VpHXQU3ocBgklLGvcBnW8=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v0.0.0-20180714160509-73f8eece6fdc/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
@@ -2531,6 +2539,7 @@ github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1z
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yagipy/maintidx v1.0.0/go.mod h1:0qNf/I/CCZXSMhsRsrEPDZ+DkekpKLXAJfsTACwgXLk=
 github.com/yeya24/promlinter v0.2.0/go.mod h1:u54lkmBOZrpEbQQ6gox2zWKKLKu2SGe+2KOiextY+IA=
+github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
 github.com/yudai/gojsondiff v1.0.0/go.mod h1:AY32+k2cwILAkW1fbgxQ5mUmMiZFgLIV+FBNExI05xg=
 github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82/go.mod h1:lgjkn3NuSvDfVJdfcVVdX+jpBxNmX4rDAzaS45IcYoM=
 github.com/yudai/pp v2.0.1+incompatible/go.mod h1:PuxR/8QJ7cyCkFp/aUDS+JY727OFEZkTdatxwunjIkc=
@@ -2579,6 +2588,7 @@ go.etcd.io/etcd/raft/v3 v3.5.4/go.mod h1:SCuunjYvZFC0fBX0vxMSPjuZmpcSk+XaAcMrD6D
 go.etcd.io/etcd/server/v3 v3.5.4/go.mod h1:S5/YTU15KxymM5l3T6b09sNOHPXqGYIZStpuuGbb65c=
 go.mongodb.org/mongo-driver v1.2.1/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 go.mongodb.org/mongo-driver v1.4.3/go.mod h1:WcMNYLx/IlOxLe6JRJiv2uXuCz6zBLndR4SoGjYphSc=
+go.mongodb.org/mongo-driver v1.10.0/go.mod h1:wsihk0Kdgv8Kqu1Anit4sfK+22vSFbUrAVEYRhCXrA8=
 go.mozilla.org/mozlog v0.0.0-20170222151521-4bb13139d403/go.mod h1:jHoPAGnDrCy6kaI2tAze5Prf0Nr0w/oNkROt2lw3n3o=
 go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1/go.mod h1:SNgMg+EgDFwmvSmLRTNKC5fegJjB7v23qTQ0XLGUNHk=
 go.opencensus.io v0.15.0/go.mod h1:UffZAU+4sDEINUGP/B7UfBBkq4fqLu9zXAX7ke6CHW0=
@@ -2693,6 +2703,7 @@ golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=
 golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
@@ -2839,6 +2850,7 @@ golang.org/x/net v0.0.0-20220617184016-355a448f1bc9/go.mod h1:XRhObCWvk6IyKnWLug
 golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.0.0-20220909164309-bea034e7d591/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
+golang.org/x/net v0.0.0-20221004154528-8021a29435af/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/net v0.0.0-20221012135044-0b7e1fb9d458/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/net v0.0.0-20221014081412-f15817d10f9b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/net v0.1.0 h1:hZ/3BUoy5aId7sCpA/Tc5lt8DkFgdVS2onTpJsZ/fl0=

--- a/vendor/github.com/IBM-Cloud/bluemix-go/api/container/containerv1/clusters.go
+++ b/vendor/github.com/IBM-Cloud/bluemix-go/api/container/containerv1/clusters.go
@@ -198,6 +198,7 @@ func (c ClusterSoftlayerHeader) ToMap() map[string]string {
 type ClusterCreateRequest struct {
 	GatewayEnabled               bool   `json:"GatewayEnabled" description:"true for gateway enabled cluster"`
 	Datacenter                   string `json:"dataCenter" description:"The worker's data center"`
+	OperatingSystem              string `json:"operatingSystem,omitempty"`
 	Isolation                    string `json:"isolation" description:"Can be 'public' or 'private'"`
 	MachineType                  string `json:"machineType" description:"The worker's machine type"`
 	Name                         string `json:"name" binding:"required" description:"The cluster's name"`

--- a/vendor/github.com/IBM-Cloud/bluemix-go/api/container/containerv1/worker_pool.go
+++ b/vendor/github.com/IBM-Cloud/bluemix-go/api/container/containerv1/worker_pool.go
@@ -8,12 +8,13 @@ import (
 
 // WorkerPoolConfig common worker pool data
 type WorkerPoolConfig struct {
-	Name        string            `json:"name" binding:"required"`
-	Size        int               `json:"sizePerZone" binding:"required"`
-	MachineType string            `json:"machineType" binding:"required"`
-	Isolation   string            `json:"isolation"`
-	Labels      map[string]string `json:"labels"`
-	Entitlement string            `json:"entitlement"`
+	Name            string            `json:"name" binding:"required"`
+	Size            int               `json:"sizePerZone" binding:"required"`
+	MachineType     string            `json:"machineType" binding:"required"`
+	Isolation       string            `json:"isolation"`
+	Labels          map[string]string `json:"labels"`
+	OperatingSystem string            `json:"operatingSystem,omitempty"`
+	Entitlement     string            `json:"entitlement"`
 }
 
 // WorkerPoolRequest provides worker pool data

--- a/vendor/github.com/IBM-Cloud/bluemix-go/api/container/containerv2/api_service.go
+++ b/vendor/github.com/IBM-Cloud/bluemix-go/api/container/containerv2/api_service.go
@@ -28,6 +28,9 @@ type ContainerServiceAPI interface {
 	Subnets() Subnets
 	NlbDns() Nlbdns
 	Satellite() Satellite
+	DedicatedHost() DedicatedHost
+	DedicatedHostPool() DedicatedHostPool
+	DedicatedHostFlavor() DedicatedHostFlavor
 
 	//TODO Add other services
 }
@@ -128,4 +131,19 @@ func (c *csService) Workers() Workers {
 //Subnets implements Cluster Subnets API
 func (c *csService) Subnets() Subnets {
 	return newSubnetsAPI(c.Client)
+}
+
+//DedicatedHost implements DedicatedHost API
+func (c *csService) DedicatedHost() DedicatedHost {
+	return newDedicatedHostAPI(c.Client)
+}
+
+//DedicatedHostPool implements DedicatedHostPool API
+func (c *csService) DedicatedHostPool() DedicatedHostPool {
+	return newDedicatedHostPoolAPI(c.Client)
+}
+
+//DedicatedHostFlavor implements DedicatedHostFlavor API
+func (c *csService) DedicatedHostFlavor() DedicatedHostFlavor {
+	return newDedicatedHostFlavorAPI(c.Client)
 }

--- a/vendor/github.com/IBM-Cloud/bluemix-go/api/container/containerv2/clusters.go
+++ b/vendor/github.com/IBM-Cloud/bluemix-go/api/container/containerv2/clusters.go
@@ -33,15 +33,14 @@ type ClusterCreateRequest struct {
 }
 
 type WorkerPoolConfig struct {
-	DiskEncryption bool              `json:"diskEncryption,omitempty"`
-	Entitlement    string            `json:"entitlement"`
-	Flavor         string            `json:"flavor"`
-	Isolation      string            `json:"isolation,omitempty"`
-	Labels         map[string]string `json:"labels,omitempty"`
-	Name           string            `json:"name" binding:"required" description:"The workerpool's name"`
-	VpcID          string            `json:"vpcID"`
-	WorkerCount    int               `json:"workerCount"`
-	Zones          []Zone            `json:"zones"`
+	HostPoolID string `json:"hostPoolID,omitempty"`
+	CommonWorkerPoolConfig
+}
+
+type WorkerVolumeEncryption struct {
+	KmsInstanceID     string `json:"kmsInstanceID,omitempty"`
+	WorkerVolumeCRKID string `json:"workerVolumeCRKID,omitempty"`
+	KMSAccountID      string `json:"kmsAccountID,omitempty"`
 }
 
 // type Label struct {

--- a/vendor/github.com/IBM-Cloud/bluemix-go/api/container/containerv2/dedicated_host.go
+++ b/vendor/github.com/IBM-Cloud/bluemix-go/api/container/containerv2/dedicated_host.go
@@ -1,0 +1,139 @@
+package containerv2
+
+import (
+	"fmt"
+
+	"github.com/IBM-Cloud/bluemix-go/client"
+)
+
+// CreateDedicatedHostRequest provides dedicated host data for create call
+// swagger:model
+type CreateDedicatedHostRequest struct {
+	Flavor     string `json:"flavor" description:""`
+	HostPoolID string `json:"hostPoolID" description:""`
+	Zone       string `json:"zone" description:""`
+}
+
+// CreateDedicatedHostResponse provides dedicated host id from create call
+// swagger:model
+type CreateDedicatedHostResponse struct {
+	ID string `json:"id"`
+}
+
+// GetDedicatedHostResponse provides dedicated host data from get call
+// swagger:model
+type GetDedicatedHostResponse struct {
+	Flavor           string                 `json:"flavor"`
+	ID               string                 `json:"id"`
+	Lifecycle        DedicatedHostLifecycle `json:"lifecycle"`
+	PlacementEnabled bool                   `json:"placementEnabled"`
+	Resources        DedicatedHostResources `json:"resources"`
+	Workers          []DedicatedHostWorker  `json:"workers"`
+	Zone             string                 `json:"zone"`
+}
+
+// DedicatedHostLifecycle ...
+type DedicatedHostLifecycle struct {
+	ActualState        string `json:"actualState"`
+	DesiredState       string `json:"desiredState"`
+	Message            string `json:"message"`
+	MessageDate        string `json:"messageDate"`
+	MessageDetails     string `json:"messageDetails"`
+	MessageDetailsDate string `json:"messageDetailsDate"`
+}
+
+// DedicatedHostWorker ...
+type DedicatedHostWorker struct {
+	ClusterID    string `json:"clusterID"`
+	Flavor       string `json:"flavor"`
+	WorkerID     string `json:"workerID"`
+	WorkerPoolID string `json:"workerPoolID"`
+}
+
+// DedicatedHostResources ...
+type DedicatedHostResources struct {
+	Capacity DedicatedHostResource `json:"capacity"`
+	Consumed DedicatedHostResource `json:"consumed"`
+}
+
+// DedicatedHostResource ...
+type DedicatedHostResource struct {
+	MemoryBytes int64 `json:"memoryBytes"`
+	VCPU        int64 `json:"vcpu"`
+}
+
+// RemoveDedicatedHostRequest provides dedicated host data for remove call
+// swagger:model
+type RemoveDedicatedHostRequest struct {
+	HostID     string `json:"host" description:""`
+	HostPoolID string `json:"hostPool" description:""`
+}
+
+// UpdateDedicatedHostPlacementRequest provides dedicated host data for update call
+// swagger:model
+type UpdateDedicatedHostPlacementRequest struct {
+	HostPoolID string `json:"hostPoolID"`
+	HostID     string `json:"hostID"`
+}
+
+//DedicatedHost ...
+type DedicatedHost interface {
+	CreateDedicatedHost(dedicatedHostReq CreateDedicatedHostRequest, target ClusterTargetHeader) (CreateDedicatedHostResponse, error)
+	GetDedicatedHost(dedicatedHostID, dedicatedHostPoolID string, target ClusterTargetHeader) (GetDedicatedHostResponse, error)
+	ListDedicatedHosts(dedicatedHostPoolID string, target ClusterTargetHeader) ([]GetDedicatedHostResponse, error)
+	RemoveDedicatedHost(dedicatedHostReq RemoveDedicatedHostRequest, target ClusterTargetHeader) error
+	EnableDedicatedHostPlacement(dedicatedHostReq UpdateDedicatedHostPlacementRequest, target ClusterTargetHeader) error
+	DisableDedicatedHostPlacement(dedicatedHostReq UpdateDedicatedHostPlacementRequest, target ClusterTargetHeader) error
+}
+
+type dedicatedhost struct {
+	client *client.Client
+}
+
+func newDedicatedHostAPI(c *client.Client) DedicatedHost {
+	return &dedicatedhost{
+		client: c,
+	}
+}
+
+// GetDedicatedHost calls the API to list dedicated host s
+func (w *dedicatedhost) ListDedicatedHosts(dedicatedHostPoolID string, target ClusterTargetHeader) ([]GetDedicatedHostResponse, error) {
+	successV := []GetDedicatedHostResponse{}
+	_, err := w.client.Get(fmt.Sprintf("/v2/getDedicatedHosts?dedicatedhostpool=%s", dedicatedHostPoolID), &successV, target.ToMap())
+	return successV, err
+}
+
+// GetDedicatedHost calls the API to get a dedicated host
+func (w *dedicatedhost) GetDedicatedHost(dedicatedHostID, dedicatedHostPoolID string, target ClusterTargetHeader) (GetDedicatedHostResponse, error) {
+	var successV GetDedicatedHostResponse
+	_, err := w.client.Get(fmt.Sprintf("/v2/getDedicatedHost?dedicatedhost=%s&dedicatedhostpool=%s", dedicatedHostID, dedicatedHostPoolID), &successV, target.ToMap())
+	return successV, err
+}
+
+// CreateDedicatedHost calls the API to create a dedicated host
+func (w *dedicatedhost) CreateDedicatedHost(createDedicatedHostReq CreateDedicatedHostRequest, target ClusterTargetHeader) (CreateDedicatedHostResponse, error) {
+	var successV CreateDedicatedHostResponse
+	_, err := w.client.Post("/v2/createDedicatedHost", createDedicatedHostReq, &successV, target.ToMap())
+	return successV, err
+}
+
+// RemoveDedicatedHost calls the API to remove a dedicated host
+func (w *dedicatedhost) RemoveDedicatedHost(removeDedicatedHostReq RemoveDedicatedHostRequest, target ClusterTargetHeader) error {
+	// Make the request, don't care about return value
+	_, err := w.client.Post("/v2/removeDedicatedHost", removeDedicatedHostReq, nil, target.ToMap())
+	return err
+}
+
+// EnableDedicatedHostPlacement calls the API to enable placement on a dedicated host
+func (w *dedicatedhost) EnableDedicatedHostPlacement(updateDedicatedHostReq UpdateDedicatedHostPlacementRequest, target ClusterTargetHeader) error {
+	// Make the request, don't care about return value
+	_, err := w.client.Post("/v2/enableDedicatedHostPlacement", updateDedicatedHostReq, nil, target.ToMap())
+	return err
+}
+
+// DisableDedicatedHostPlacement calls the API to disable placement on a dedicated host
+func (w *dedicatedhost) DisableDedicatedHostPlacement(updateDedicatedHostReq UpdateDedicatedHostPlacementRequest, target ClusterTargetHeader) error {
+	// Make the request, don't care about return value
+	_, err := w.client.Post("/v2/disableDedicatedHostPlacement", updateDedicatedHostReq, nil, target.ToMap())
+	return err
+}

--- a/vendor/github.com/IBM-Cloud/bluemix-go/api/container/containerv2/dedicated_host_flavors.go
+++ b/vendor/github.com/IBM-Cloud/bluemix-go/api/container/containerv2/dedicated_host_flavors.go
@@ -1,0 +1,54 @@
+package containerv2
+
+import (
+	"fmt"
+
+	"github.com/IBM-Cloud/bluemix-go/client"
+)
+
+// GetDedicatedHostFlavor is a response to a dedicated host pool get request.
+// swagger:model
+type GetDedicatedHostFlavor struct {
+	ID              string            `json:"id"`
+	FlavorClass     string            `json:"flavorClass"`
+	Region          string            `json:"region"`
+	Zone            string            `json:"zone"`
+	Deprecated      bool              `json:"deprecated"`
+	MaxVCPUs        int               `json:"maxVCPUs"`
+	MaxMemory       int               `json:"maxMemory"`
+	InstanceStorage []InstanceStorage `json:"instanceStorage"`
+}
+
+// GetDedicatedHostFlavors is a response to a dedicated host pool list request.
+// swagger:model
+type GetDedicatedHostFlavors []GetDedicatedHostFlavor
+
+// InstanceStorage type for describing an instance disk configuration
+// swagger:model
+type InstanceStorage struct {
+	Count int `json:"count"`
+	// the size of each individual device in GB
+	Size int `json:"size"`
+}
+
+//DedicatedHostFlavor ...
+type DedicatedHostFlavor interface {
+	ListDedicatedHostFlavors(zone string, target ClusterTargetHeader) (GetDedicatedHostFlavors, error)
+}
+
+type dedicatedhostflavor struct {
+	client *client.Client
+}
+
+func newDedicatedHostFlavorAPI(c *client.Client) DedicatedHostFlavor {
+	return &dedicatedhostflavor{
+		client: c,
+	}
+}
+
+// GetDedicatedHostFlavor calls the API to list dedicated host s
+func (w *dedicatedhostflavor) ListDedicatedHostFlavors(zone string, target ClusterTargetHeader) (GetDedicatedHostFlavors, error) {
+	successV := GetDedicatedHostFlavors{}
+	_, err := w.client.Get(fmt.Sprintf("/v2/getDedicatedHostFlavors?provider=vpc-gen2&zone=%s", zone), &successV, target.ToMap())
+	return successV, err
+}

--- a/vendor/github.com/IBM-Cloud/bluemix-go/api/container/containerv2/dedicated_host_pool.go
+++ b/vendor/github.com/IBM-Cloud/bluemix-go/api/container/containerv2/dedicated_host_pool.go
@@ -1,0 +1,99 @@
+package containerv2
+
+import (
+	"fmt"
+
+	"github.com/IBM-Cloud/bluemix-go/client"
+)
+
+// CreateDedicatedHostPoolRequest provides dedicated host pool data for create call
+// swagger:model
+type CreateDedicatedHostPoolRequest struct {
+	FlavorClass string `json:"flavorClass" description:""`
+	Metro       string `json:"metro" description:""`
+	Name        string `json:"name" description:""`
+}
+
+// CreateDedicatedHostPoolResponse provides dedicated host pool id from create call
+// swagger:model
+type CreateDedicatedHostPoolResponse struct {
+	ID string `json:"id"`
+}
+
+// GetDedicatedHostPoolResponse provides dedicated host pool data from get call
+// swagger:model
+type GetDedicatedHostPoolResponse struct {
+	FlavorClass string                        `json:"flavorClass"`
+	HostCount   int64                         `json:"hostCount"`
+	ID          string                        `json:"id"`
+	Metro       string                        `json:"metro"`
+	Name        string                        `json:"name"`
+	State       string                        `json:"state"`
+	WorkerPools []DedicatedHostPoolWorkerPool `json:"workerPools"`
+	Zones       []DedicatedHostZoneResources  `json:"zones"`
+}
+
+// DedicatedHostPoolWorkerPool ...
+type DedicatedHostPoolWorkerPool struct {
+	ClusterID    string `json:"clusterID"`
+	WorkerPoolID string `json:"workerPoolID"`
+}
+
+// DedicatedHostZoneResources ...
+type DedicatedHostZoneResources struct {
+	Capacity  DedicatedHostResource `json:"capacity"`
+	HostCount int64                 `json:"hostCount"`
+	Zone      string                `json:"zone"`
+}
+
+// RemoveDedicatedHostPoolRequest provides dedicated host pool data for remove call
+// swagger:model
+type RemoveDedicatedHostPoolRequest struct {
+	HostPoolID string `json:"hostPool" description:""`
+}
+
+//DedicatedHostPool ...
+type DedicatedHostPool interface {
+	CreateDedicatedHostPool(dedicatedHostPoolReq CreateDedicatedHostPoolRequest, target ClusterTargetHeader) (CreateDedicatedHostPoolResponse, error)
+	GetDedicatedHostPool(dedicatedHostPoolID string, target ClusterTargetHeader) (GetDedicatedHostPoolResponse, error)
+	ListDedicatedHostPools(target ClusterTargetHeader) ([]GetDedicatedHostPoolResponse, error)
+	RemoveDedicatedHostPool(dedicatedHostPoolReq RemoveDedicatedHostPoolRequest, target ClusterTargetHeader) error
+}
+
+type dedicatedhostpool struct {
+	client *client.Client
+}
+
+func newDedicatedHostPoolAPI(c *client.Client) DedicatedHostPool {
+	return &dedicatedhostpool{
+		client: c,
+	}
+}
+
+// GetDedicatedHostPool calls the API to list dedicated host pools
+func (w *dedicatedhostpool) ListDedicatedHostPools(target ClusterTargetHeader) ([]GetDedicatedHostPoolResponse, error) {
+	successV := []GetDedicatedHostPoolResponse{}
+	_, err := w.client.Get("/v2/getDedicatedHostPools", &successV, target.ToMap())
+	return successV, err
+}
+
+// GetDedicatedHostPool calls the API to get a dedicated host pool
+func (w *dedicatedhostpool) GetDedicatedHostPool(dedicatedHostPoolID string, target ClusterTargetHeader) (GetDedicatedHostPoolResponse, error) {
+	var successV GetDedicatedHostPoolResponse
+	_, err := w.client.Get(fmt.Sprintf("/v2/getDedicatedHostPool?dedicatedhostpool=%s", dedicatedHostPoolID), &successV, target.ToMap())
+	return successV, err
+}
+
+// CreateDedicatedHostPool calls the API to create a dedicated host pool
+func (w *dedicatedhostpool) CreateDedicatedHostPool(createDedicatedHostPoolReq CreateDedicatedHostPoolRequest, target ClusterTargetHeader) (CreateDedicatedHostPoolResponse, error) {
+	var successV CreateDedicatedHostPoolResponse
+	_, err := w.client.Post("/v2/createDedicatedHostPool", createDedicatedHostPoolReq, &successV, target.ToMap())
+	return successV, err
+}
+
+// RemoveDedicatedHostPool calls the API to remove a dedicated host pool
+func (w *dedicatedhostpool) RemoveDedicatedHostPool(removeDedicatedHostPoolReq RemoveDedicatedHostPoolRequest, target ClusterTargetHeader) error {
+	// Make the request, don't care about return value
+	_, err := w.client.Post("/v2/removeDedicatedHostPool", removeDedicatedHostPoolReq, nil, target.ToMap())
+	return err
+}

--- a/vendor/github.com/IBM-Cloud/bluemix-go/api/container/containerv2/ingress.go
+++ b/vendor/github.com/IBM-Cloud/bluemix-go/api/container/containerv2/ingress.go
@@ -9,27 +9,57 @@ import (
 
 // Secret struct holding details for a single secret
 type Secret struct {
-	Cluster     string `json:"cluster" description:"name of secret"`
-	Name        string `json:"name" description:"name of secret"`
-	Namespace   string `json:"namespace" description:"namespace of secret"`
-	Domain      string `json:"domain" description:"domain the cert belongs to"`
-	CRN         string `json:"crn" description:"crn of the certificate in certificate manager"`
-	ExpiresOn   string `json:"expiresOn" description:"expiration date of the certificate"`
-	Status      string `json:"status" description:"status of  Will be used for displaying callback operations to user"`
-	UserManaged bool   `json:"userManaged" description:"true or false. Used to show which certs and secrets are system generated and which are not"`
-	Persistence bool   `json:"persistence" description:"true or false. Persist the secret even if a user attempts to delete it"`
+	Cluster              string `json:"cluster" description:"name of secret"`
+	Name                 string `json:"name" description:"name of secret"`
+	Namespace            string `json:"namespace" description:"namespace of secret"`
+	Domain               string `json:"domain" description:"domain the cert belongs to"`
+	CRN                  string `json:"crn" description:"crn of the certificate in certificate manager"`
+	ExpiresOn            string `json:"expiresOn" description:"expiration date of the certificate"`
+	Status               string `json:"status" description:"status of secret. Will be used for displaying callback operations to user"`
+	UserManaged          bool   `json:"userManaged" description:"true or false. Used to show which certs and secrets are system generated and which are not"`
+	Persistence          bool   `json:"persistence" description:"true or false. Persist the secret even if a user attempts to delete it"`
+	Type                 string `json:"type" description:"supported types include TLS and Opaque"`
+	SecretType           string `json:"secretType" description:"secrets manager type for secret"`
+	LastUpdatedTimestamp string `json:"lastUpdatedTimestamp" description:"last updated timestamp for type tls secrets"`
+	Fields               Fields `json:"fields" description:"fields in secret"`
 }
+
+// Secret struct holding details for a single secret field
+type Field struct {
+	Name                 string `json:"name" description:"name of secret field"`
+	CRN                  string `json:"crn" description:"crn of secret field"`
+	ExpiresOn            string `json:"expiresOn" description:"expiration date of the secret"`
+	SecretType           string `json:"secretType" description:"secrets manager type for secret"`
+	LastUpdatedTimestamp string `json:"lastUpdatedTimestamp" description:"last updated timestamp for type tls secrets"`
+}
+
+// Secrets struct for a secret array
+type Fields []Field
 
 // Secrets struct for a secret array
 type Secrets []Secret
 
 // SecretCreateConfig the secret create request
 type SecretCreateConfig struct {
-	Cluster     string `json:"cluster" description:"name of secret" binding:"required"`
-	Name        string `json:"name" description:"name of secret" binding:"required"`
-	Namespace   string `json:"namespace" description:"namespace of  Optional, if none specified it will be placed in the ibm-cert-store namespace"`
-	CRN         string `json:"crn" description:"crn of the certificate in certificate manager"`
-	Persistence bool   `json:"persistence" description:"true or false. Persist the secret even if a user attempts to delete it"`
+	Cluster     string     `json:"cluster" description:"name of secret" binding:"required"`
+	Name        string     `json:"name" description:"name of secret" binding:"required"`
+	Namespace   string     `json:"namespace" description:"namespace of secret. Optional, if none specified it will be placed in the ibm-cert-store namespace"`
+	CRN         string     `json:"crn" description:"crn of the certificate in secret manager"`
+	Persistence bool       `json:"persistence" description:"true or false. Persist the secret even if a user attempts to delete it"`
+	Type        string     `json:"type" description:"TLS or Opaque. Defaults to TLS if none specified."`
+	FieldsToAdd []FieldAdd `json:"add" description:"fields to add to secret of type opaque."`
+}
+
+// FieldAdd the secret field add request
+type FieldAdd struct {
+	Name         string `json:"name" description:"name of secret field. Cannot append prefix when setting this."`
+	CRN          string `json:"crn" description:"crn of secret field"`
+	AppendPrefix bool   `json:"append_prefix" description:"true or false. Append the secret name in secret manager as a prefix to secret type. Cannot set name when appending prefix."`
+}
+
+// FieldRemove the secret field remove request
+type FieldRemove struct {
+	Name string `json:"name" description:"name of secret field"`
 }
 
 // SecretDeleteConfig the secret delete request
@@ -41,23 +71,69 @@ type SecretDeleteConfig struct {
 
 // SecretUpdateConfig secret update request
 type SecretUpdateConfig struct {
-	Cluster   string `json:"cluster" description:"name of secret" binding:"required"`
-	Name      string `json:"name" description:"name of secret" binding:"required"`
-	Namespace string `json:"namespace" description:"namespace of secret" binding:"required"`
-	CRN       string `json:"crn" description:"crn of the certificate in certificate manager"`
+	Cluster        string        `json:"cluster" description:"name of secret" binding:"required"`
+	Name           string        `json:"name" description:"name of secret" binding:"required"`
+	Namespace      string        `json:"namespace" description:"namespace of secret" binding:"required"`
+	CRN            string        `json:"crn" description:"crn of the certificate in secret manager"`
+	FieldsToAdd    []FieldAdd    `json:"add" description:"fields to add to secret"`
+	FieldsToRemove []FieldRemove `json:"remove" description:"fields to remove from secret"`
+}
+
+// Instance struct holding details for a single instance
+type Instance struct {
+	Cluster         string `json:"cluster" description:"id of cluster"`
+	Name            string `json:"name" description:"name of instance"`
+	CRN             string `json:"crn" description:"crn of the instance"`
+	SecretGroupID   string `json:"secretGroupID" description:"ID of the secret group where secrets will be stored"`
+	SecretGroupName string `json:"secretGroupName" description:"name of the secret group where secrets will be stored"`
+	CallbackChannel string `json:"callbackChannel" description:"callback channel of the instance"`
+	UserManaged     bool   `json:"userManaged" description:"true or false. Used to show which certs and secrets are system generated and which are not"`
+	IsDefault       bool   `json:"isDefault" description:"true or false. Used to show which instance subdomains certificates are uploaded into"`
+	Type            string `json:"type" description:"designates instance type as either certificate manager instance or secrets manager instance"`
+	Status          string `json:"status" description:"Used to show the status indicating if the instance is registered to the cluster or not"`
+}
+
+// Instances struct for a secret array
+type Instances []Instance
+
+// InstanceRegisterConfig the instance register request
+type InstanceRegisterConfig struct {
+	Cluster       string `json:"cluster" description:"id of cluster" binding:"required"`
+	CRN           string `json:"crn" description:"crn of the instance"`
+	IsDefault     bool   `json:"isDefault" description:"true or false. Used to show which instance subdomains certificates are uploaded into"`
+	SecretGroupID string `json:"secretGroupID" description:"ID of the secret group where secrets will be stored"`
+}
+
+// InstanceDeleteConfig the instance delete request
+type InstanceDeleteConfig struct {
+	Cluster string `json:"cluster" description:"id of cluster" binding:"required"`
+	Name    string `json:"name" description:"name of instance" binding:"required"`
+}
+
+// InstanceUpdateConfig instance update request
+type InstanceUpdateConfig struct {
+	Cluster       string `json:"cluster" description:"id of cluster" binding:"required"`
+	Name          string `json:"name" description:"name of instance" binding:"required"`
+	IsDefault     bool   `json:"isDefault" description:"true or false. Used to show which instance subdomains certificates are uploaded into"`
+	SecretGroupID string `json:"secretGroupID" description:"ID of the secret group where secrets will be stored"`
 }
 
 type ingress struct {
 	client *client.Client
 }
 
-//Ingress interface
+// Ingress interface
 type Ingress interface {
 	CreateIngressSecret(req SecretCreateConfig) (response Secret, err error)
 	UpdateIngressSecret(req SecretUpdateConfig) (response Secret, err error)
 	DeleteIngressSecret(req SecretDeleteConfig) (err error)
 	GetIngressSecretList(clusterNameOrID string, showDeleted bool) (response Secrets, err error)
 	GetIngressSecret(clusterNameOrID, secretName, secretNamespace string) (response Secret, err error)
+	RegisterIngressInstance(req InstanceRegisterConfig) (response Instance, err error)
+	UpdateIngressInstance(req InstanceUpdateConfig) (err error)
+	DeleteIngressInstance(req InstanceDeleteConfig) (err error)
+	GetIngressInstance(clusterNameOrID, instanceName string) (response Instance, err error)
+	GetIngressInstanceList(clusterNameOrID string, showDeleted bool) (response Instances, err error)
 }
 
 func newIngressAPI(c *client.Client) Ingress {
@@ -94,5 +170,31 @@ func (r *ingress) UpdateIngressSecret(req SecretUpdateConfig) (response Secret, 
 // DeleteIngressSecret deletes the ingress secret from the cluster
 func (r *ingress) DeleteIngressSecret(req SecretDeleteConfig) (err error) {
 	_, err = r.client.Post("/ingress/v2/secret/deleteSecret", req, nil)
+	return
+}
+
+func (r *ingress) RegisterIngressInstance(req InstanceRegisterConfig) (response Instance, err error) {
+	_, err = r.client.Post("/ingress/v2/secret/registerInstance", req, &response)
+	return
+}
+
+func (r *ingress) UpdateIngressInstance(req InstanceUpdateConfig) (err error) {
+	_, err = r.client.Post("/ingress/v2/secret/updateInstance", req, nil)
+	return
+}
+
+func (r *ingress) DeleteIngressInstance(req InstanceDeleteConfig) (err error) {
+	_, err = r.client.Post("/ingress/v2/secret/unregisterInstance", req, nil)
+	return
+}
+
+func (r *ingress) GetIngressInstance(clusterNameOrID, instanceName string) (response Instance, err error) {
+	_, err = r.client.Get(fmt.Sprintf("/ingress/v2/secret/getInstance?cluster=%s&name=%s", clusterNameOrID, instanceName), &response)
+	return
+}
+
+func (r *ingress) GetIngressInstanceList(clusterNameOrID string, showDeleted bool) (response Instances, err error) {
+	deleted := strconv.FormatBool(showDeleted)
+	_, err = r.client.Get(fmt.Sprintf("/ingress/v2/secret/getInstances?cluster=%s&showDeleted=%s", clusterNameOrID, deleted), &response)
 	return
 }

--- a/vendor/github.com/IBM-Cloud/bluemix-go/api/container/containerv2/worker_pool.go
+++ b/vendor/github.com/IBM-Cloud/bluemix-go/api/container/containerv2/worker_pool.go
@@ -6,11 +6,28 @@ import (
 	"github.com/IBM-Cloud/bluemix-go/client"
 )
 
+// CommonWorkerPoolConfig provides common worker pool data for cluster and workerpool operations
+type CommonWorkerPoolConfig struct {
+	DiskEncryption         bool                    `json:"diskEncryption,omitempty"`
+	Entitlement            string                  `json:"entitlement"`
+	Flavor                 string                  `json:"flavor"`
+	Isolation              string                  `json:"isolation,omitempty"`
+	Labels                 map[string]string       `json:"labels,omitempty"`
+	Name                   string                  `json:"name" binding:"required" description:"The workerpool's name"`
+	OperatingSystem        string                  `json:"operatingSystem,omitempty"`
+	VpcID                  string                  `json:"vpcID"`
+	WorkerCount            int                     `json:"workerCount"`
+	Zones                  []Zone                  `json:"zones"`
+	WorkerVolumeEncryption *WorkerVolumeEncryption `json:"workerVolumeEncryption,omitempty"`
+	SecondaryStorageOption string                  `json:"secondaryStorageOption,omitempty"`
+}
+
 // WorkerPoolRequest provides worker pool data
 // swagger:model
 type WorkerPoolRequest struct {
-	Cluster string `json:"cluster" description:"cluster name where the worker pool will be created"`
-	WorkerPoolConfig
+	Cluster    string `json:"cluster" description:"cluster name where the worker pool will be created"`
+	HostPoolID string `json:"hostPool,omitempty"`
+	CommonWorkerPoolConfig
 }
 type WorkerPoolTaintRequest struct {
 	Cluster    string            `json:"cluster" description:"cluster name"`
@@ -32,17 +49,33 @@ type WorkerPoolZone struct {
 }
 
 type GetWorkerPoolResponse struct {
-	Flavor      string            `json:"flavor"`
-	ID          string            `json:"id"`
-	Isolation   string            `json:"isolation"`
-	Labels      map[string]string `json:"labels,omitempty"`
-	Taints      map[string]string `json:"taints,omitempty"`
-	Lifecycle   `json:"lifecycle"`
-	VpcID       string     `json:"vpcID"`
-	WorkerCount int        `json:"workerCount"`
-	PoolName    string     `json:"poolName"`
-	Provider    string     `json:"provider"`
-	Zones       []ZoneResp `json:"zones"`
+	HostPoolID             string            `json:"dedicatedHostPoolId,omitempty"`
+	Flavor                 string            `json:"flavor"`
+	ID                     string            `json:"id"`
+	Isolation              string            `json:"isolation"`
+	Labels                 map[string]string `json:"labels,omitempty"`
+	OperatingSystem        string            `json:"operatingSystem,omitempty"`
+	Taints                 map[string]string `json:"taints,omitempty"`
+	Lifecycle              `json:"lifecycle"`
+	VpcID                  string                  `json:"vpcID"`
+	WorkerCount            int                     `json:"workerCount"`
+	PoolName               string                  `json:"poolName"`
+	Provider               string                  `json:"provider"`
+	Zones                  []ZoneResp              `json:"zones"`
+	WorkerVolumeEncryption *WorkerVolumeEncryption `json:"workerVolumeEncryption,omitempty"`
+	SecondaryStorageOption *DiskConfigResp         `json:"secondaryStorageOption,omitempty"`
+}
+
+// DiskConfigResp response type for describing a disk configuration
+// swagger:model
+type DiskConfigResp struct {
+	Name  string `json:"name,omitempty"`
+	Count int
+	// the size of each individual device in GB
+	Size              int
+	DeviceType        string
+	RAIDConfiguration string
+	Profile           string `json:"profile,omitempty"`
 }
 
 type Lifecycle struct {

--- a/vendor/github.com/IBM-Cloud/bluemix-go/api/container/containerv2/workers.go
+++ b/vendor/github.com/IBM-Cloud/bluemix-go/api/container/containerv2/workers.go
@@ -9,6 +9,8 @@ import (
 //Worker ...
 type Worker struct {
 	Billing           string `json:"billing,omitempty"`
+	HostID            string `json:"dedicatedHostId,omitempty"`
+	HostPoolID        string `json:"dedicatedHostPoolId,omitempty"`
 	Flavor            string `json:"flavor"`
 	ID                string `json:"id"`
 	KubeVersion       KubeDetails

--- a/vendor/github.com/IBM-Cloud/bluemix-go/http/http.go
+++ b/vendor/github.com/IBM-Cloud/bluemix-go/http/http.go
@@ -20,8 +20,14 @@ func NewHTTPClient(config *bluemix.Config) *http.Client {
 }
 
 func makeTransport(config *bluemix.Config) http.RoundTripper {
+	proxyFunc := http.ProxyFromEnvironment
+	if config.HTTPClient != nil && config.HTTPClient.Transport != nil {
+		if t, ok := config.HTTPClient.Transport.(*http.Transport); ok {
+			proxyFunc = t.Proxy
+		}
+	}
 	return NewTraceLoggingTransport(&http.Transport{
-		Proxy: http.ProxyFromEnvironment,
+		Proxy: proxyFunc,
 		Dial: (&net.Dialer{
 			Timeout:   50 * time.Second,
 			KeepAlive: 30 * time.Second,

--- a/vendor/github.com/libopenstorage/cloudops/azure/azure.go
+++ b/vendor/github.com/libopenstorage/cloudops/azure/azure.go
@@ -371,7 +371,7 @@ func (a *azureOps) Create(
 	options map[string]string,
 ) (interface{}, error) {
 	d, ok := template.(*compute.Disk)
-	if !ok {
+	if !ok || d.DiskProperties == nil || d.DiskProperties.DiskSizeGB == nil {
 		return nil, cloudops.NewStorageError(
 			cloudops.ErrVolInval,
 			"Invalid volume template given",
@@ -578,6 +578,12 @@ func (a *azureOps) Delete(diskName string, options map[string]string) error {
 
 func (a *azureOps) DeleteFrom(diskName, _ string) error {
 	return a.Delete(diskName, nil)
+}
+
+func (a *azureOps) AreVolumesReadyToExpand(volumeIDs []*string) (bool, error) {
+	return true, &cloudops.ErrNotSupported{
+		Operation: "azureOps.IsVolumesReadyToExpand",
+	}
 }
 
 func (a *azureOps) Expand(

--- a/vendor/github.com/libopenstorage/cloudops/backoff/exponential.go
+++ b/vendor/github.com/libopenstorage/cloudops/backoff/exponential.go
@@ -436,6 +436,10 @@ func (e *exponentialBackoff) DevicePath(volumeID string) (string, error) {
 	return devicePath, origErr
 }
 
+func (e *exponentialBackoff) AreVolumesReadyToExpand(volumeIDs []*string) (bool, error) {
+	return e.cloudOps.AreVolumesReadyToExpand(volumeIDs)
+}
+
 func (e *exponentialBackoff) Expand(volumeID string, targetSize uint64, options map[string]string) (uint64, error) {
 	var (
 		actualSize uint64

--- a/vendor/github.com/libopenstorage/cloudops/cloudops.go
+++ b/vendor/github.com/libopenstorage/cloudops/cloudops.go
@@ -129,6 +129,9 @@ type Storage interface {
 	// Attach volumeID, accepts attachoOptions as opaque data
 	// Return attach path.
 	Attach(volumeID string, options map[string]string) (string, error)
+	// IsVolumeReadyToExpand pre-checks if a pool of volumes are in a state that can
+	// be modified. Should be called before sending an expand request to the cloud provider.
+	AreVolumesReadyToExpand(volumeIDs []*string) (bool, error)
 	// Expand expands the provided device from the existing size to the new size
 	// It returns the new size of the device. It is a blocking API where it will
 	// only return once the requested size is validated with the cloud provider or

--- a/vendor/github.com/libopenstorage/cloudops/errors.go
+++ b/vendor/github.com/libopenstorage/cloudops/errors.go
@@ -112,3 +112,15 @@ type ErrCurrentCapacityHigherThanDesired struct {
 func (e *ErrCurrentCapacityHigherThanDesired) Error() string {
 	return fmt.Sprintf("current capacity (%d) is higher than desired capacity: %d", e.Current, e.Desired)
 }
+
+// ErrCloudProviderRequestFailure is returned when an unknown API request failure occurred.
+type ErrCloudProviderRequestFailure struct {
+    // Request is the API function name
+	Request string
+    // Message is the error message returned by the cloud provider
+	Message string
+}
+
+func (e *ErrCloudProviderRequestFailure) Error() string {
+	return fmt.Sprintf("Request %s returns %s", e.Request, e.Message)
+}

--- a/vendor/github.com/libopenstorage/cloudops/gce/gce.go
+++ b/vendor/github.com/libopenstorage/cloudops/gce/gce.go
@@ -664,6 +664,12 @@ func (s *gceOps) GetDeviceID(disk interface{}) (string, error) {
 	}
 }
 
+func (s *gceOps) AreVolumesReadyToExpand(volumeIDs []*string) (bool, error) {
+	return true, &cloudops.ErrNotSupported{
+		Operation: "gceOps:IsVolumesReadyToExpand",
+	}
+}
+
 func (s *gceOps) Expand(
 	volumeID string,
 	newSizeInGiB uint64,

--- a/vendor/github.com/libopenstorage/cloudops/oracle/oracle.go
+++ b/vendor/github.com/libopenstorage/cloudops/oracle/oracle.go
@@ -293,7 +293,7 @@ func (o *oracleOps) GetInstance(displayName string) (interface{}, error) {
 	if len(listInstanceResp.Items) == 0 {
 		return nil, fmt.Errorf("no oracle instance found with display name: %s", displayName)
 	}
-	// Currently, torpedo uses this API to fetch details of the instance created 
+	// Currently, torpedo uses this API to fetch details of the instance created
 	// by OKE. OKE ensures that all the worker nodes created, have unique display
 	// names. In future, if we require to use this API to get details of vanilla
 	// compute instances, then we can modify below array indexing.
@@ -439,6 +439,7 @@ func (o *oracleOps) Create(template interface{}, labels map[string]string, optio
 			SizeInGBs:          vol.SizeInGBs,
 			VpusPerGB:          vol.VpusPerGB,
 			DisplayName:        vol.DisplayName,
+			KmsKeyId:           vol.KmsKeyId,
 			FreeformTags:       labels,
 		},
 	}
@@ -827,6 +828,12 @@ func nodePoolContainsNode(s []containerengine.Node, e string) bool {
 		}
 	}
 	return false
+}
+
+func (o *oracleOps) AreVolumesReadyToExpand(volumeIDs []*string) (bool, error) {
+	return true, &cloudops.ErrNotSupported{
+		Operation: "oracleOps:IsVolumesReadyToExpand",
+	}
 }
 
 func (o *oracleOps) Expand(volumeID string, newSizeInGiB uint64, options map[string]string) (uint64, error) {

--- a/vendor/github.com/libopenstorage/cloudops/unsupported/unsupported.go
+++ b/vendor/github.com/libopenstorage/cloudops/unsupported/unsupported.go
@@ -99,6 +99,13 @@ func (u *unsupportedStorage) Attach(volumeID string, options map[string]string) 
 		Operation: "Attach",
 	}
 }
+
+func (u *unsupportedStorage) AreVolumesReadyToExpand(volumeIDs []*string) (bool, error) {
+	return true, &cloudops.ErrNotSupported{
+		Operation: "unsupportedStorage:IsVolumesReadyToExpand",
+	}
+}
+
 func (u *unsupportedStorage) Expand(volumeID string, newSizeInGiB uint64, options map[string]string) (uint64, error) {
 	return 0, &cloudops.ErrNotSupported{
 		Operation: "Expand",

--- a/vendor/github.com/onsi/gomega/CHANGELOG.md
+++ b/vendor/github.com/onsi/gomega/CHANGELOG.md
@@ -1,3 +1,37 @@
+## v1.21.1
+
+### Features
+- Eventually and Consistently that are passed a SpecContext can provide reports when an interrupt occurs [0d063c9]
+
+## 1.21.0
+
+### Features
+- Eventually and Consistently can take a context.Context [65c01bc]
+  This enables integration with Ginkgo 2.3.0's interruptible nodes and node timeouts.
+- Introduces Eventually.Within.ProbeEvery with tests and documentation (#591) [f633800]
+- New BeKeyOf matcher with documentation and unit tests (#590) [fb586b3]
+    
+## Fixes
+- Cover the entire gmeasure suite with leak detection [8c54344]
+- Fix gmeasure leak [119d4ce]
+- Ignore new Ginkgo ProgressSignal goroutine in gleak [ba548e2]
+
+## Maintenance
+
+- Fixes crashes on newer Ruby 3 installations by upgrading github-pages gem dependency (#596) [12469a0]
+
+
+## 1.20.2
+
+## Fixes
+- label specs that rely on remote access; bump timeout on short-circuit test to make it less flaky [35eeadf]
+- gexec: allow more headroom for SIGABRT-related unit tests (#581) [5b78f40]
+- Enable reading from a closed gbytes.Buffer (#575) [061fd26]
+
+## Maintenance
+- Bump github.com/onsi/ginkgo/v2 from 2.1.5 to 2.1.6 (#583) [55d895b]
+- Bump github.com/onsi/ginkgo/v2 from 2.1.4 to 2.1.5 (#582) [346de7c]
+
 ## 1.20.1
 
 ## Fixes

--- a/vendor/github.com/onsi/gomega/RELEASING.md
+++ b/vendor/github.com/onsi/gomega/RELEASING.md
@@ -1,7 +1,13 @@
 A Gomega release is a tagged sha and a GitHub release.  To cut a release:
 
 1. Ensure CHANGELOG.md is up to date.
-  - Use `git log --pretty=format:'- %s [%h]' HEAD...vX.X.X` to list all the commits since the last release
+  - Use 
+    ```bash
+    LAST_VERSION=$(git tag --sort=version:refname | tail -n1)
+    CHANGES=$(git log --pretty=format:'- %s [%h]' HEAD...$LAST_VERSION)
+    echo -e "## NEXT\n\n$CHANGES\n\n### Features\n\n## Fixes\n\n## Maintenance\n\n$(cat CHANGELOG.md)" > CHANGELOG.md
+    ```
+   to update the changelog
   - Categorize the changes into
     - Breaking Changes (requires a major version)
     - New Features (minor version)

--- a/vendor/github.com/onsi/gomega/gomega_dsl.go
+++ b/vendor/github.com/onsi/gomega/gomega_dsl.go
@@ -22,7 +22,7 @@ import (
 	"github.com/onsi/gomega/types"
 )
 
-const GOMEGA_VERSION = "1.20.1"
+const GOMEGA_VERSION = "1.21.1"
 
 const nilGomegaPanic = `You are trying to make an assertion, but haven't registered Gomega's fail handler.
 If you're using Ginkgo then you probably forgot to put your assertion in an It().
@@ -233,7 +233,7 @@ func ExpectWithOffset(offset int, actual interface{}, extra ...interface{}) Asse
 Eventually enables making assertions on asynchronous behavior.
 
 Eventually checks that an assertion *eventually* passes.  Eventually blocks when called and attempts an assertion periodically until it passes or a timeout occurs.  Both the timeout and polling interval are configurable as optional arguments.
-The first optional argument is the timeout (which defaults to 1s), the second is the polling interval (which defaults to 10ms).  Both intervals can be specified as time.Duration, parsable duration strings or floats/integers (in which case they are interpreted as seconds).
+The first optional argument is the timeout (which defaults to 1s), the second is the polling interval (which defaults to 10ms).  Both intervals can be specified as time.Duration, parsable duration strings or floats/integers (in which case they are interpreted as seconds).  In addition an optional context.Context can be passed in - Eventually will keep trying until either the timeout epxires or the context is cancelled, whichever comes first.
 
 Eventually works with any Gomega compatible matcher and supports making assertions against three categories of actual value:
 
@@ -286,7 +286,15 @@ Then
 
 will pass only if and when the returned error is nil *and* the returned string satisfies the matcher.
 
-It is important to note that the function passed into Eventually is invoked *synchronously* when polled.  Eventually does not (in fact, it cannot) kill the function if it takes longer to return than Eventually's configured timeout.  You should design your functions with this in mind.
+It is important to note that the function passed into Eventually is invoked *synchronously* when polled.  Eventually does not (in fact, it cannot) kill the function if it takes longer to return than Eventually's configured timeout.  A common practice here is to use a context.  Here's an example that combines Ginkgo's spec timeout support with Eventually:
+
+	It("fetches the correct count", func(ctx SpecContext) {
+		Eventually(func() int {
+			return client.FetchCount(ctx)
+		}, ctx).Should(BeNumerically(">=", 17))
+	}, SpecTimeout(time.Second))
+
+now, when Ginkgo cancels the context both the FetchCount client and Gomega will be informed and can exit.
 
 **Category 3: Making assertions _in_ the function passed into Eventually**
 
@@ -316,12 +324,17 @@ For example:
 
 will rerun the function until all assertions pass.
 
-`Eventually` specifying a timeout interval (and an optional polling interval) are
-the same as `Eventually(...).WithTimeout` or `Eventually(...).WithTimeout(...).WithPolling`.
+Finally, in addition to passing timeouts and a context to Eventually you can be more explicit with Eventually's chaining configuration methods:
+
+	Eventually(..., "1s", "2s", ctx).Should(...)
+
+is equivalent to
+
+    Eventually(...).WithTimeout(time.Second).WithPolling(2*time.Second).WithContext(ctx).Should(...)
 */
-func Eventually(actual interface{}, intervals ...interface{}) AsyncAssertion {
+func Eventually(actual interface{}, args ...interface{}) AsyncAssertion {
 	ensureDefaultGomegaIsConfigured()
-	return Default.Eventually(actual, intervals...)
+	return Default.Eventually(actual, args...)
 }
 
 // EventuallyWithOffset operates like Eventually but takes an additional
@@ -333,9 +346,9 @@ func Eventually(actual interface{}, intervals ...interface{}) AsyncAssertion {
 // `EventuallyWithOffset` specifying a timeout interval (and an optional polling interval) are
 // the same as `Eventually(...).WithOffset(...).WithTimeout` or
 // `Eventually(...).WithOffset(...).WithTimeout(...).WithPolling`.
-func EventuallyWithOffset(offset int, actual interface{}, intervals ...interface{}) AsyncAssertion {
+func EventuallyWithOffset(offset int, actual interface{}, args ...interface{}) AsyncAssertion {
 	ensureDefaultGomegaIsConfigured()
-	return Default.EventuallyWithOffset(offset, actual, intervals...)
+	return Default.EventuallyWithOffset(offset, actual, args...)
 }
 
 /*
@@ -343,7 +356,7 @@ Consistently, like Eventually, enables making assertions on asynchronous behavio
 
 Consistently blocks when called for a specified duration.  During that duration Consistently repeatedly polls its matcher and ensures that it is satisfied.  If the matcher is consistently satisfied, then Consistently will pass.  Otherwise Consistently will fail.
 
-Both the total waiting duration and the polling interval are configurable as optional arguments.  The first optional argument is the duration that Consistently will run for (defaults to 100ms), and the second argument is the polling interval (defaults to 10ms).  As with Eventually, these intervals can be passed in as time.Duration, parsable duration strings or an integer or float number of seconds.
+Both the total waiting duration and the polling interval are configurable as optional arguments.  The first optional argument is the duration that Consistently will run for (defaults to 100ms), and the second argument is the polling interval (defaults to 10ms).  As with Eventually, these intervals can be passed in as time.Duration, parsable duration strings or an integer or float number of seconds.  You can also pass in an optional context.Context - Consistently will exit early (with a failure) if the context is cancelled before the waiting duration expires.
 
 Consistently accepts the same three categories of actual as Eventually, check the Eventually docs to learn more.
 
@@ -353,9 +366,9 @@ Consistently is useful in cases where you want to assert that something *does no
 
 This will block for 200 milliseconds and repeatedly check the channel and ensure nothing has been received.
 */
-func Consistently(actual interface{}, intervals ...interface{}) AsyncAssertion {
+func Consistently(actual interface{}, args ...interface{}) AsyncAssertion {
 	ensureDefaultGomegaIsConfigured()
-	return Default.Consistently(actual, intervals...)
+	return Default.Consistently(actual, args...)
 }
 
 // ConsistentlyWithOffset operates like Consistently but takes an additional
@@ -364,9 +377,9 @@ func Consistently(actual interface{}, intervals ...interface{}) AsyncAssertion {
 //
 // `ConsistentlyWithOffset` is the same as `Consistently(...).WithOffset` and
 // optional `WithTimeout` and `WithPolling`.
-func ConsistentlyWithOffset(offset int, actual interface{}, intervals ...interface{}) AsyncAssertion {
+func ConsistentlyWithOffset(offset int, actual interface{}, args ...interface{}) AsyncAssertion {
 	ensureDefaultGomegaIsConfigured()
-	return Default.ConsistentlyWithOffset(offset, actual, intervals...)
+	return Default.ConsistentlyWithOffset(offset, actual, args...)
 }
 
 // SetDefaultEventuallyTimeout sets the default timeout duration for Eventually. Eventually will repeatedly poll your condition until it succeeds, or until this timeout elapses.

--- a/vendor/github.com/onsi/gomega/internal/gomega.go
+++ b/vendor/github.com/onsi/gomega/internal/gomega.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"context"
 	"time"
 
 	"github.com/onsi/gomega/types"
@@ -55,9 +56,19 @@ func (g *Gomega) Eventually(actual interface{}, intervals ...interface{}) types.
 	return g.EventuallyWithOffset(0, actual, intervals...)
 }
 
-func (g *Gomega) EventuallyWithOffset(offset int, actual interface{}, intervals ...interface{}) types.AsyncAssertion {
+func (g *Gomega) EventuallyWithOffset(offset int, actual interface{}, args ...interface{}) types.AsyncAssertion {
 	timeoutInterval := g.DurationBundle.EventuallyTimeout
 	pollingInterval := g.DurationBundle.EventuallyPollingInterval
+	intervals := []interface{}{}
+	var ctx context.Context
+	for _, arg := range args {
+		switch v := arg.(type) {
+		case context.Context:
+			ctx = v
+		default:
+			intervals = append(intervals, arg)
+		}
+	}
 	if len(intervals) > 0 {
 		timeoutInterval = toDuration(intervals[0])
 	}
@@ -65,16 +76,26 @@ func (g *Gomega) EventuallyWithOffset(offset int, actual interface{}, intervals 
 		pollingInterval = toDuration(intervals[1])
 	}
 
-	return NewAsyncAssertion(AsyncAssertionTypeEventually, actual, g, timeoutInterval, pollingInterval, offset)
+	return NewAsyncAssertion(AsyncAssertionTypeEventually, actual, g, timeoutInterval, pollingInterval, ctx, offset)
 }
 
 func (g *Gomega) Consistently(actual interface{}, intervals ...interface{}) types.AsyncAssertion {
 	return g.ConsistentlyWithOffset(0, actual, intervals...)
 }
 
-func (g *Gomega) ConsistentlyWithOffset(offset int, actual interface{}, intervals ...interface{}) types.AsyncAssertion {
+func (g *Gomega) ConsistentlyWithOffset(offset int, actual interface{}, args ...interface{}) types.AsyncAssertion {
 	timeoutInterval := g.DurationBundle.ConsistentlyDuration
 	pollingInterval := g.DurationBundle.ConsistentlyPollingInterval
+	intervals := []interface{}{}
+	var ctx context.Context
+	for _, arg := range args {
+		switch v := arg.(type) {
+		case context.Context:
+			ctx = v
+		default:
+			intervals = append(intervals, arg)
+		}
+	}
 	if len(intervals) > 0 {
 		timeoutInterval = toDuration(intervals[0])
 	}
@@ -82,7 +103,7 @@ func (g *Gomega) ConsistentlyWithOffset(offset int, actual interface{}, interval
 		pollingInterval = toDuration(intervals[1])
 	}
 
-	return NewAsyncAssertion(AsyncAssertionTypeConsistently, actual, g, timeoutInterval, pollingInterval, offset)
+	return NewAsyncAssertion(AsyncAssertionTypeConsistently, actual, g, timeoutInterval, pollingInterval, ctx, offset)
 }
 
 func (g *Gomega) SetDefaultEventuallyTimeout(t time.Duration) {

--- a/vendor/github.com/onsi/gomega/matchers.go
+++ b/vendor/github.com/onsi/gomega/matchers.go
@@ -8,27 +8,27 @@ import (
 	"github.com/onsi/gomega/types"
 )
 
-//Equal uses reflect.DeepEqual to compare actual with expected.  Equal is strict about
-//types when performing comparisons.
-//It is an error for both actual and expected to be nil.  Use BeNil() instead.
+// Equal uses reflect.DeepEqual to compare actual with expected.  Equal is strict about
+// types when performing comparisons.
+// It is an error for both actual and expected to be nil.  Use BeNil() instead.
 func Equal(expected interface{}) types.GomegaMatcher {
 	return &matchers.EqualMatcher{
 		Expected: expected,
 	}
 }
 
-//BeEquivalentTo is more lax than Equal, allowing equality between different types.
-//This is done by converting actual to have the type of expected before
-//attempting equality with reflect.DeepEqual.
-//It is an error for actual and expected to be nil.  Use BeNil() instead.
+// BeEquivalentTo is more lax than Equal, allowing equality between different types.
+// This is done by converting actual to have the type of expected before
+// attempting equality with reflect.DeepEqual.
+// It is an error for actual and expected to be nil.  Use BeNil() instead.
 func BeEquivalentTo(expected interface{}) types.GomegaMatcher {
 	return &matchers.BeEquivalentToMatcher{
 		Expected: expected,
 	}
 }
 
-//BeComparableTo uses gocmp.Equal to compare. You can pass cmp.Option as options.
-//It is an error for actual and expected to be nil.  Use BeNil() instead.
+// BeComparableTo uses gocmp.Equal to compare. You can pass cmp.Option as options.
+// It is an error for actual and expected to be nil.  Use BeNil() instead.
 func BeComparableTo(expected interface{}, opts ...cmp.Option) types.GomegaMatcher {
 	return &matchers.BeComparableToMatcher{
 		Expected: expected,
@@ -36,116 +36,124 @@ func BeComparableTo(expected interface{}, opts ...cmp.Option) types.GomegaMatche
 	}
 }
 
-//BeIdenticalTo uses the == operator to compare actual with expected.
-//BeIdenticalTo is strict about types when performing comparisons.
-//It is an error for both actual and expected to be nil.  Use BeNil() instead.
+// BeIdenticalTo uses the == operator to compare actual with expected.
+// BeIdenticalTo is strict about types when performing comparisons.
+// It is an error for both actual and expected to be nil.  Use BeNil() instead.
 func BeIdenticalTo(expected interface{}) types.GomegaMatcher {
 	return &matchers.BeIdenticalToMatcher{
 		Expected: expected,
 	}
 }
 
-//BeNil succeeds if actual is nil
+// BeNil succeeds if actual is nil
 func BeNil() types.GomegaMatcher {
 	return &matchers.BeNilMatcher{}
 }
 
-//BeTrue succeeds if actual is true
+// BeTrue succeeds if actual is true
 func BeTrue() types.GomegaMatcher {
 	return &matchers.BeTrueMatcher{}
 }
 
-//BeFalse succeeds if actual is false
+// BeFalse succeeds if actual is false
 func BeFalse() types.GomegaMatcher {
 	return &matchers.BeFalseMatcher{}
 }
 
-//HaveOccurred succeeds if actual is a non-nil error
-//The typical Go error checking pattern looks like:
-//    err := SomethingThatMightFail()
-//    Expect(err).ShouldNot(HaveOccurred())
+// HaveOccurred succeeds if actual is a non-nil error
+// The typical Go error checking pattern looks like:
+//
+//	err := SomethingThatMightFail()
+//	Expect(err).ShouldNot(HaveOccurred())
 func HaveOccurred() types.GomegaMatcher {
 	return &matchers.HaveOccurredMatcher{}
 }
 
-//Succeed passes if actual is a nil error
-//Succeed is intended to be used with functions that return a single error value. Instead of
-//    err := SomethingThatMightFail()
-//    Expect(err).ShouldNot(HaveOccurred())
+// Succeed passes if actual is a nil error
+// Succeed is intended to be used with functions that return a single error value. Instead of
 //
-//You can write:
-//    Expect(SomethingThatMightFail()).Should(Succeed())
+//	err := SomethingThatMightFail()
+//	Expect(err).ShouldNot(HaveOccurred())
 //
-//It is a mistake to use Succeed with a function that has multiple return values.  Gomega's Ω and Expect
-//functions automatically trigger failure if any return values after the first return value are non-zero/non-nil.
-//This means that Ω(MultiReturnFunc()).ShouldNot(Succeed()) can never pass.
+// You can write:
+//
+//	Expect(SomethingThatMightFail()).Should(Succeed())
+//
+// It is a mistake to use Succeed with a function that has multiple return values.  Gomega's Ω and Expect
+// functions automatically trigger failure if any return values after the first return value are non-zero/non-nil.
+// This means that Ω(MultiReturnFunc()).ShouldNot(Succeed()) can never pass.
 func Succeed() types.GomegaMatcher {
 	return &matchers.SucceedMatcher{}
 }
 
-//MatchError succeeds if actual is a non-nil error that matches the passed in string/error.
+// MatchError succeeds if actual is a non-nil error that matches the passed in string/error.
 //
-//These are valid use-cases:
-//  Expect(err).Should(MatchError("an error")) //asserts that err.Error() == "an error"
-//  Expect(err).Should(MatchError(SomeError)) //asserts that err == SomeError (via reflect.DeepEqual)
+// These are valid use-cases:
 //
-//It is an error for err to be nil or an object that does not implement the Error interface
+//	Expect(err).Should(MatchError("an error")) //asserts that err.Error() == "an error"
+//	Expect(err).Should(MatchError(SomeError)) //asserts that err == SomeError (via reflect.DeepEqual)
+//
+// It is an error for err to be nil or an object that does not implement the Error interface
 func MatchError(expected interface{}) types.GomegaMatcher {
 	return &matchers.MatchErrorMatcher{
 		Expected: expected,
 	}
 }
 
-//BeClosed succeeds if actual is a closed channel.
-//It is an error to pass a non-channel to BeClosed, it is also an error to pass nil
+// BeClosed succeeds if actual is a closed channel.
+// It is an error to pass a non-channel to BeClosed, it is also an error to pass nil
 //
-//In order to check whether or not the channel is closed, Gomega must try to read from the channel
-//(even in the `ShouldNot(BeClosed())` case).  You should keep this in mind if you wish to make subsequent assertions about
-//values coming down the channel.
+// In order to check whether or not the channel is closed, Gomega must try to read from the channel
+// (even in the `ShouldNot(BeClosed())` case).  You should keep this in mind if you wish to make subsequent assertions about
+// values coming down the channel.
 //
-//Also, if you are testing that a *buffered* channel is closed you must first read all values out of the channel before
-//asserting that it is closed (it is not possible to detect that a buffered-channel has been closed until all its buffered values are read).
+// Also, if you are testing that a *buffered* channel is closed you must first read all values out of the channel before
+// asserting that it is closed (it is not possible to detect that a buffered-channel has been closed until all its buffered values are read).
 //
-//Finally, as a corollary: it is an error to check whether or not a send-only channel is closed.
+// Finally, as a corollary: it is an error to check whether or not a send-only channel is closed.
 func BeClosed() types.GomegaMatcher {
 	return &matchers.BeClosedMatcher{}
 }
 
-//Receive succeeds if there is a value to be received on actual.
-//Actual must be a channel (and cannot be a send-only channel) -- anything else is an error.
+// Receive succeeds if there is a value to be received on actual.
+// Actual must be a channel (and cannot be a send-only channel) -- anything else is an error.
 //
-//Receive returns immediately and never blocks:
+// Receive returns immediately and never blocks:
 //
-//- If there is nothing on the channel `c` then Expect(c).Should(Receive()) will fail and Ω(c).ShouldNot(Receive()) will pass.
+// - If there is nothing on the channel `c` then Expect(c).Should(Receive()) will fail and Ω(c).ShouldNot(Receive()) will pass.
 //
-//- If the channel `c` is closed then Expect(c).Should(Receive()) will fail and Ω(c).ShouldNot(Receive()) will pass.
+// - If the channel `c` is closed then Expect(c).Should(Receive()) will fail and Ω(c).ShouldNot(Receive()) will pass.
 //
-//- If there is something on the channel `c` ready to be read, then Expect(c).Should(Receive()) will pass and Ω(c).ShouldNot(Receive()) will fail.
+// - If there is something on the channel `c` ready to be read, then Expect(c).Should(Receive()) will pass and Ω(c).ShouldNot(Receive()) will fail.
 //
-//If you have a go-routine running in the background that will write to channel `c` you can:
-//    Eventually(c).Should(Receive())
+// If you have a go-routine running in the background that will write to channel `c` you can:
 //
-//This will timeout if nothing gets sent to `c` (you can modify the timeout interval as you normally do with `Eventually`)
+//	Eventually(c).Should(Receive())
 //
-//A similar use-case is to assert that no go-routine writes to a channel (for a period of time).  You can do this with `Consistently`:
-//    Consistently(c).ShouldNot(Receive())
+// This will timeout if nothing gets sent to `c` (you can modify the timeout interval as you normally do with `Eventually`)
 //
-//You can pass `Receive` a matcher.  If you do so, it will match the received object against the matcher.  For example:
-//    Expect(c).Should(Receive(Equal("foo")))
+// A similar use-case is to assert that no go-routine writes to a channel (for a period of time).  You can do this with `Consistently`:
 //
-//When given a matcher, `Receive` will always fail if there is nothing to be received on the channel.
+//	Consistently(c).ShouldNot(Receive())
 //
-//Passing Receive a matcher is especially useful when paired with Eventually:
+// You can pass `Receive` a matcher.  If you do so, it will match the received object against the matcher.  For example:
 //
-//    Eventually(c).Should(Receive(ContainSubstring("bar")))
+//	Expect(c).Should(Receive(Equal("foo")))
 //
-//will repeatedly attempt to pull values out of `c` until a value matching "bar" is received.
+// When given a matcher, `Receive` will always fail if there is nothing to be received on the channel.
 //
-//Finally, if you want to have a reference to the value *sent* to the channel you can pass the `Receive` matcher a pointer to a variable of the appropriate type:
-//    var myThing thing
-//    Eventually(thingChan).Should(Receive(&myThing))
-//    Expect(myThing.Sprocket).Should(Equal("foo"))
-//    Expect(myThing.IsValid()).Should(BeTrue())
+// Passing Receive a matcher is especially useful when paired with Eventually:
+//
+//	Eventually(c).Should(Receive(ContainSubstring("bar")))
+//
+// will repeatedly attempt to pull values out of `c` until a value matching "bar" is received.
+//
+// Finally, if you want to have a reference to the value *sent* to the channel you can pass the `Receive` matcher a pointer to a variable of the appropriate type:
+//
+//	var myThing thing
+//	Eventually(thingChan).Should(Receive(&myThing))
+//	Expect(myThing.Sprocket).Should(Equal("foo"))
+//	Expect(myThing.IsValid()).Should(BeTrue())
 func Receive(args ...interface{}) types.GomegaMatcher {
 	var arg interface{}
 	if len(args) > 0 {
@@ -157,27 +165,27 @@ func Receive(args ...interface{}) types.GomegaMatcher {
 	}
 }
 
-//BeSent succeeds if a value can be sent to actual.
-//Actual must be a channel (and cannot be a receive-only channel) that can sent the type of the value passed into BeSent -- anything else is an error.
-//In addition, actual must not be closed.
+// BeSent succeeds if a value can be sent to actual.
+// Actual must be a channel (and cannot be a receive-only channel) that can sent the type of the value passed into BeSent -- anything else is an error.
+// In addition, actual must not be closed.
 //
-//BeSent never blocks:
+// BeSent never blocks:
 //
-//- If the channel `c` is not ready to receive then Expect(c).Should(BeSent("foo")) will fail immediately
-//- If the channel `c` is eventually ready to receive then Eventually(c).Should(BeSent("foo")) will succeed.. presuming the channel becomes ready to receive  before Eventually's timeout
-//- If the channel `c` is closed then Expect(c).Should(BeSent("foo")) and Ω(c).ShouldNot(BeSent("foo")) will both fail immediately
+// - If the channel `c` is not ready to receive then Expect(c).Should(BeSent("foo")) will fail immediately
+// - If the channel `c` is eventually ready to receive then Eventually(c).Should(BeSent("foo")) will succeed.. presuming the channel becomes ready to receive  before Eventually's timeout
+// - If the channel `c` is closed then Expect(c).Should(BeSent("foo")) and Ω(c).ShouldNot(BeSent("foo")) will both fail immediately
 //
-//Of course, the value is actually sent to the channel.  The point of `BeSent` is less to make an assertion about the availability of the channel (which is typically an implementation detail that your test should not be concerned with).
-//Rather, the point of `BeSent` is to make it possible to easily and expressively write tests that can timeout on blocked channel sends.
+// Of course, the value is actually sent to the channel.  The point of `BeSent` is less to make an assertion about the availability of the channel (which is typically an implementation detail that your test should not be concerned with).
+// Rather, the point of `BeSent` is to make it possible to easily and expressively write tests that can timeout on blocked channel sends.
 func BeSent(arg interface{}) types.GomegaMatcher {
 	return &matchers.BeSentMatcher{
 		Arg: arg,
 	}
 }
 
-//MatchRegexp succeeds if actual is a string or stringer that matches the
-//passed-in regexp.  Optional arguments can be provided to construct a regexp
-//via fmt.Sprintf().
+// MatchRegexp succeeds if actual is a string or stringer that matches the
+// passed-in regexp.  Optional arguments can be provided to construct a regexp
+// via fmt.Sprintf().
 func MatchRegexp(regexp string, args ...interface{}) types.GomegaMatcher {
 	return &matchers.MatchRegexpMatcher{
 		Regexp: regexp,
@@ -185,9 +193,9 @@ func MatchRegexp(regexp string, args ...interface{}) types.GomegaMatcher {
 	}
 }
 
-//ContainSubstring succeeds if actual is a string or stringer that contains the
-//passed-in substring.  Optional arguments can be provided to construct the substring
-//via fmt.Sprintf().
+// ContainSubstring succeeds if actual is a string or stringer that contains the
+// passed-in substring.  Optional arguments can be provided to construct the substring
+// via fmt.Sprintf().
 func ContainSubstring(substr string, args ...interface{}) types.GomegaMatcher {
 	return &matchers.ContainSubstringMatcher{
 		Substr: substr,
@@ -195,9 +203,9 @@ func ContainSubstring(substr string, args ...interface{}) types.GomegaMatcher {
 	}
 }
 
-//HavePrefix succeeds if actual is a string or stringer that contains the
-//passed-in string as a prefix.  Optional arguments can be provided to construct
-//via fmt.Sprintf().
+// HavePrefix succeeds if actual is a string or stringer that contains the
+// passed-in string as a prefix.  Optional arguments can be provided to construct
+// via fmt.Sprintf().
 func HavePrefix(prefix string, args ...interface{}) types.GomegaMatcher {
 	return &matchers.HavePrefixMatcher{
 		Prefix: prefix,
@@ -205,9 +213,9 @@ func HavePrefix(prefix string, args ...interface{}) types.GomegaMatcher {
 	}
 }
 
-//HaveSuffix succeeds if actual is a string or stringer that contains the
-//passed-in string as a suffix.  Optional arguments can be provided to construct
-//via fmt.Sprintf().
+// HaveSuffix succeeds if actual is a string or stringer that contains the
+// passed-in string as a suffix.  Optional arguments can be provided to construct
+// via fmt.Sprintf().
 func HaveSuffix(suffix string, args ...interface{}) types.GomegaMatcher {
 	return &matchers.HaveSuffixMatcher{
 		Suffix: suffix,
@@ -215,73 +223,74 @@ func HaveSuffix(suffix string, args ...interface{}) types.GomegaMatcher {
 	}
 }
 
-//MatchJSON succeeds if actual is a string or stringer of JSON that matches
-//the expected JSON.  The JSONs are decoded and the resulting objects are compared via
-//reflect.DeepEqual so things like key-ordering and whitespace shouldn't matter.
+// MatchJSON succeeds if actual is a string or stringer of JSON that matches
+// the expected JSON.  The JSONs are decoded and the resulting objects are compared via
+// reflect.DeepEqual so things like key-ordering and whitespace shouldn't matter.
 func MatchJSON(json interface{}) types.GomegaMatcher {
 	return &matchers.MatchJSONMatcher{
 		JSONToMatch: json,
 	}
 }
 
-//MatchXML succeeds if actual is a string or stringer of XML that matches
-//the expected XML.  The XMLs are decoded and the resulting objects are compared via
-//reflect.DeepEqual so things like whitespaces shouldn't matter.
+// MatchXML succeeds if actual is a string or stringer of XML that matches
+// the expected XML.  The XMLs are decoded and the resulting objects are compared via
+// reflect.DeepEqual so things like whitespaces shouldn't matter.
 func MatchXML(xml interface{}) types.GomegaMatcher {
 	return &matchers.MatchXMLMatcher{
 		XMLToMatch: xml,
 	}
 }
 
-//MatchYAML succeeds if actual is a string or stringer of YAML that matches
-//the expected YAML.  The YAML's are decoded and the resulting objects are compared via
-//reflect.DeepEqual so things like key-ordering and whitespace shouldn't matter.
+// MatchYAML succeeds if actual is a string or stringer of YAML that matches
+// the expected YAML.  The YAML's are decoded and the resulting objects are compared via
+// reflect.DeepEqual so things like key-ordering and whitespace shouldn't matter.
 func MatchYAML(yaml interface{}) types.GomegaMatcher {
 	return &matchers.MatchYAMLMatcher{
 		YAMLToMatch: yaml,
 	}
 }
 
-//BeEmpty succeeds if actual is empty.  Actual must be of type string, array, map, chan, or slice.
+// BeEmpty succeeds if actual is empty.  Actual must be of type string, array, map, chan, or slice.
 func BeEmpty() types.GomegaMatcher {
 	return &matchers.BeEmptyMatcher{}
 }
 
-//HaveLen succeeds if actual has the passed-in length.  Actual must be of type string, array, map, chan, or slice.
+// HaveLen succeeds if actual has the passed-in length.  Actual must be of type string, array, map, chan, or slice.
 func HaveLen(count int) types.GomegaMatcher {
 	return &matchers.HaveLenMatcher{
 		Count: count,
 	}
 }
 
-//HaveCap succeeds if actual has the passed-in capacity.  Actual must be of type array, chan, or slice.
+// HaveCap succeeds if actual has the passed-in capacity.  Actual must be of type array, chan, or slice.
 func HaveCap(count int) types.GomegaMatcher {
 	return &matchers.HaveCapMatcher{
 		Count: count,
 	}
 }
 
-//BeZero succeeds if actual is the zero value for its type or if actual is nil.
+// BeZero succeeds if actual is the zero value for its type or if actual is nil.
 func BeZero() types.GomegaMatcher {
 	return &matchers.BeZeroMatcher{}
 }
 
-//ContainElement succeeds if actual contains the passed in element. By default
-//ContainElement() uses Equal() to perform the match, however a matcher can be
-//passed in instead:
-//    Expect([]string{"Foo", "FooBar"}).Should(ContainElement(ContainSubstring("Bar")))
+// ContainElement succeeds if actual contains the passed in element. By default
+// ContainElement() uses Equal() to perform the match, however a matcher can be
+// passed in instead:
 //
-//Actual must be an array, slice or map. For maps, ContainElement searches
-//through the map's values.
+//	Expect([]string{"Foo", "FooBar"}).Should(ContainElement(ContainSubstring("Bar")))
 //
-//If you want to have a copy of the matching element(s) found you can pass a
-//pointer to a variable of the appropriate type. If the variable isn't a slice
-//or map, then exactly one match will be expected and returned. If the variable
-//is a slice or map, then at least one match is expected and all matches will be
-//stored in the variable.
+// Actual must be an array, slice or map. For maps, ContainElement searches
+// through the map's values.
 //
-//    var findings []string
-//    Expect([]string{"Foo", "FooBar"}).Should(ContainElement(ContainSubString("Bar", &findings)))
+// If you want to have a copy of the matching element(s) found you can pass a
+// pointer to a variable of the appropriate type. If the variable isn't a slice
+// or map, then exactly one match will be expected and returned. If the variable
+// is a slice or map, then at least one match is expected and all matches will be
+// stored in the variable.
+//
+//	var findings []string
+//	Expect([]string{"Foo", "FooBar"}).Should(ContainElement(ContainSubString("Bar", &findings)))
 func ContainElement(element interface{}, result ...interface{}) types.GomegaMatcher {
 	return &matchers.ContainElementMatcher{
 		Element: element,
@@ -289,86 +298,102 @@ func ContainElement(element interface{}, result ...interface{}) types.GomegaMatc
 	}
 }
 
-//BeElementOf succeeds if actual is contained in the passed in elements.
-//BeElementOf() always uses Equal() to perform the match.
-//When the passed in elements are comprised of a single element that is either an Array or Slice, BeElementOf() behaves
-//as the reverse of ContainElement() that operates with Equal() to perform the match.
-//    Expect(2).Should(BeElementOf([]int{1, 2}))
-//    Expect(2).Should(BeElementOf([2]int{1, 2}))
-//Otherwise, BeElementOf() provides a syntactic sugar for Or(Equal(_), Equal(_), ...):
-//    Expect(2).Should(BeElementOf(1, 2))
+// BeElementOf succeeds if actual is contained in the passed in elements.
+// BeElementOf() always uses Equal() to perform the match.
+// When the passed in elements are comprised of a single element that is either an Array or Slice, BeElementOf() behaves
+// as the reverse of ContainElement() that operates with Equal() to perform the match.
 //
-//Actual must be typed.
+//	Expect(2).Should(BeElementOf([]int{1, 2}))
+//	Expect(2).Should(BeElementOf([2]int{1, 2}))
+//
+// Otherwise, BeElementOf() provides a syntactic sugar for Or(Equal(_), Equal(_), ...):
+//
+//	Expect(2).Should(BeElementOf(1, 2))
+//
+// Actual must be typed.
 func BeElementOf(elements ...interface{}) types.GomegaMatcher {
 	return &matchers.BeElementOfMatcher{
 		Elements: elements,
 	}
 }
 
-//ConsistOf succeeds if actual contains precisely the elements passed into the matcher.  The ordering of the elements does not matter.
-//By default ConsistOf() uses Equal() to match the elements, however custom matchers can be passed in instead.  Here are some examples:
+// BeKeyOf succeeds if actual is contained in the keys of the passed in map.
+// BeKeyOf() always uses Equal() to perform the match between actual and the map keys.
 //
-//    Expect([]string{"Foo", "FooBar"}).Should(ConsistOf("FooBar", "Foo"))
-//    Expect([]string{"Foo", "FooBar"}).Should(ConsistOf(ContainSubstring("Bar"), "Foo"))
-//    Expect([]string{"Foo", "FooBar"}).Should(ConsistOf(ContainSubstring("Foo"), ContainSubstring("Foo")))
+//	Expect("foo").Should(BeKeyOf(map[string]bool{"foo": true, "bar": false}))
+func BeKeyOf(element interface{}) types.GomegaMatcher {
+	return &matchers.BeKeyOfMatcher{
+		Map: element,
+	}
+}
+
+// ConsistOf succeeds if actual contains precisely the elements passed into the matcher.  The ordering of the elements does not matter.
+// By default ConsistOf() uses Equal() to match the elements, however custom matchers can be passed in instead.  Here are some examples:
 //
-//Actual must be an array, slice or map.  For maps, ConsistOf matches against the map's values.
+//	Expect([]string{"Foo", "FooBar"}).Should(ConsistOf("FooBar", "Foo"))
+//	Expect([]string{"Foo", "FooBar"}).Should(ConsistOf(ContainSubstring("Bar"), "Foo"))
+//	Expect([]string{"Foo", "FooBar"}).Should(ConsistOf(ContainSubstring("Foo"), ContainSubstring("Foo")))
 //
-//You typically pass variadic arguments to ConsistOf (as in the examples above).  However, if you need to pass in a slice you can provided that it
-//is the only element passed in to ConsistOf:
+// Actual must be an array, slice or map.  For maps, ConsistOf matches against the map's values.
 //
-//    Expect([]string{"Foo", "FooBar"}).Should(ConsistOf([]string{"FooBar", "Foo"}))
+// You typically pass variadic arguments to ConsistOf (as in the examples above).  However, if you need to pass in a slice you can provided that it
+// is the only element passed in to ConsistOf:
 //
-//Note that Go's type system does not allow you to write this as ConsistOf([]string{"FooBar", "Foo"}...) as []string and []interface{} are different types - hence the need for this special rule.
+//	Expect([]string{"Foo", "FooBar"}).Should(ConsistOf([]string{"FooBar", "Foo"}))
+//
+// Note that Go's type system does not allow you to write this as ConsistOf([]string{"FooBar", "Foo"}...) as []string and []interface{} are different types - hence the need for this special rule.
 func ConsistOf(elements ...interface{}) types.GomegaMatcher {
 	return &matchers.ConsistOfMatcher{
 		Elements: elements,
 	}
 }
 
-//ContainElements succeeds if actual contains the passed in elements. The ordering of the elements does not matter.
-//By default ContainElements() uses Equal() to match the elements, however custom matchers can be passed in instead. Here are some examples:
+// ContainElements succeeds if actual contains the passed in elements. The ordering of the elements does not matter.
+// By default ContainElements() uses Equal() to match the elements, however custom matchers can be passed in instead. Here are some examples:
 //
-//    Expect([]string{"Foo", "FooBar"}).Should(ContainElements("FooBar"))
-//    Expect([]string{"Foo", "FooBar"}).Should(ContainElements(ContainSubstring("Bar"), "Foo"))
+//	Expect([]string{"Foo", "FooBar"}).Should(ContainElements("FooBar"))
+//	Expect([]string{"Foo", "FooBar"}).Should(ContainElements(ContainSubstring("Bar"), "Foo"))
 //
-//Actual must be an array, slice or map.
-//For maps, ContainElements searches through the map's values.
+// Actual must be an array, slice or map.
+// For maps, ContainElements searches through the map's values.
 func ContainElements(elements ...interface{}) types.GomegaMatcher {
 	return &matchers.ContainElementsMatcher{
 		Elements: elements,
 	}
 }
 
-//HaveEach succeeds if actual solely contains elements that match the passed in element.
-//Please note that if actual is empty, HaveEach always will succeed.
-//By default HaveEach() uses Equal() to perform the match, however a
-//matcher can be passed in instead:
-//    Expect([]string{"Foo", "FooBar"}).Should(HaveEach(ContainSubstring("Foo")))
+// HaveEach succeeds if actual solely contains elements that match the passed in element.
+// Please note that if actual is empty, HaveEach always will succeed.
+// By default HaveEach() uses Equal() to perform the match, however a
+// matcher can be passed in instead:
 //
-//Actual must be an array, slice or map.
-//For maps, HaveEach searches through the map's values.
+//	Expect([]string{"Foo", "FooBar"}).Should(HaveEach(ContainSubstring("Foo")))
+//
+// Actual must be an array, slice or map.
+// For maps, HaveEach searches through the map's values.
 func HaveEach(element interface{}) types.GomegaMatcher {
 	return &matchers.HaveEachMatcher{
 		Element: element,
 	}
 }
 
-//HaveKey succeeds if actual is a map with the passed in key.
-//By default HaveKey uses Equal() to perform the match, however a
-//matcher can be passed in instead:
-//    Expect(map[string]string{"Foo": "Bar", "BazFoo": "Duck"}).Should(HaveKey(MatchRegexp(`.+Foo$`)))
+// HaveKey succeeds if actual is a map with the passed in key.
+// By default HaveKey uses Equal() to perform the match, however a
+// matcher can be passed in instead:
+//
+//	Expect(map[string]string{"Foo": "Bar", "BazFoo": "Duck"}).Should(HaveKey(MatchRegexp(`.+Foo$`)))
 func HaveKey(key interface{}) types.GomegaMatcher {
 	return &matchers.HaveKeyMatcher{
 		Key: key,
 	}
 }
 
-//HaveKeyWithValue succeeds if actual is a map with the passed in key and value.
-//By default HaveKeyWithValue uses Equal() to perform the match, however a
-//matcher can be passed in instead:
-//    Expect(map[string]string{"Foo": "Bar", "BazFoo": "Duck"}).Should(HaveKeyWithValue("Foo", "Bar"))
-//    Expect(map[string]string{"Foo": "Bar", "BazFoo": "Duck"}).Should(HaveKeyWithValue(MatchRegexp(`.+Foo$`), "Bar"))
+// HaveKeyWithValue succeeds if actual is a map with the passed in key and value.
+// By default HaveKeyWithValue uses Equal() to perform the match, however a
+// matcher can be passed in instead:
+//
+//	Expect(map[string]string{"Foo": "Bar", "BazFoo": "Duck"}).Should(HaveKeyWithValue("Foo", "Bar"))
+//	Expect(map[string]string{"Foo": "Bar", "BazFoo": "Duck"}).Should(HaveKeyWithValue(MatchRegexp(`.+Foo$`), "Bar"))
 func HaveKeyWithValue(key interface{}, value interface{}) types.GomegaMatcher {
 	return &matchers.HaveKeyWithValueMatcher{
 		Key:   key,
@@ -376,27 +401,27 @@ func HaveKeyWithValue(key interface{}, value interface{}) types.GomegaMatcher {
 	}
 }
 
-//HaveField succeeds if actual is a struct and the value at the passed in field
-//matches the passed in matcher.  By default HaveField used Equal() to perform the match,
-//however a matcher can be passed in in stead.
+// HaveField succeeds if actual is a struct and the value at the passed in field
+// matches the passed in matcher.  By default HaveField used Equal() to perform the match,
+// however a matcher can be passed in in stead.
 //
-//The field must be a string that resolves to the name of a field in the struct.  Structs can be traversed
-//using the '.' delimiter.  If the field ends with '()' a method named field is assumed to exist on the struct and is invoked.
-//Such methods must take no arguments and return a single value:
+// The field must be a string that resolves to the name of a field in the struct.  Structs can be traversed
+// using the '.' delimiter.  If the field ends with '()' a method named field is assumed to exist on the struct and is invoked.
+// Such methods must take no arguments and return a single value:
 //
-//    type Book struct {
-//        Title string
-//        Author Person
-//    }
-//    type Person struct {
-//        FirstName string
-//        LastName string
-//        DOB time.Time
-//    }
-//    Expect(book).To(HaveField("Title", "Les Miserables"))
-//    Expect(book).To(HaveField("Title", ContainSubstring("Les"))
-//    Expect(book).To(HaveField("Author.FirstName", Equal("Victor"))
-//    Expect(book).To(HaveField("Author.DOB.Year()", BeNumerically("<", 1900))
+//	type Book struct {
+//	    Title string
+//	    Author Person
+//	}
+//	type Person struct {
+//	    FirstName string
+//	    LastName string
+//	    DOB time.Time
+//	}
+//	Expect(book).To(HaveField("Title", "Les Miserables"))
+//	Expect(book).To(HaveField("Title", ContainSubstring("Les"))
+//	Expect(book).To(HaveField("Author.FirstName", Equal("Victor"))
+//	Expect(book).To(HaveField("Author.DOB.Year()", BeNumerically("<", 1900))
 func HaveField(field string, expected interface{}) types.GomegaMatcher {
 	return &matchers.HaveFieldMatcher{
 		Field:    field,
@@ -410,7 +435,7 @@ func HaveField(field string, expected interface{}) types.GomegaMatcher {
 // HaveExistingField can be combined with HaveField in order to cover use cases
 // with optional fields. HaveField alone would trigger an error in such situations.
 //
-//     Expect(MrHarmless).NotTo(And(HaveExistingField("Title"), HaveField("Title", "Supervillain")))
+//	Expect(MrHarmless).NotTo(And(HaveExistingField("Title"), HaveField("Title", "Supervillain")))
 func HaveExistingField(field string) types.GomegaMatcher {
 	return &matchers.HaveExistingFieldMatcher{
 		Field: field,
@@ -428,26 +453,27 @@ func HaveExistingField(field string) types.GomegaMatcher {
 // be a pointer (as gstruct.PointTo does) but instead also accepts non-pointer
 // and even interface values.
 //
-//   actual := 42
-//   Expect(actual).To(HaveValue(42))
-//   Expect(&actual).To(HaveValue(42))
+//	actual := 42
+//	Expect(actual).To(HaveValue(42))
+//	Expect(&actual).To(HaveValue(42))
 func HaveValue(matcher types.GomegaMatcher) types.GomegaMatcher {
 	return &matchers.HaveValueMatcher{
 		Matcher: matcher,
 	}
 }
 
-//BeNumerically performs numerical assertions in a type-agnostic way.
-//Actual and expected should be numbers, though the specific type of
-//number is irrelevant (float32, float64, uint8, etc...).
+// BeNumerically performs numerical assertions in a type-agnostic way.
+// Actual and expected should be numbers, though the specific type of
+// number is irrelevant (float32, float64, uint8, etc...).
 //
-//There are six, self-explanatory, supported comparators:
-//    Expect(1.0).Should(BeNumerically("==", 1))
-//    Expect(1.0).Should(BeNumerically("~", 0.999, 0.01))
-//    Expect(1.0).Should(BeNumerically(">", 0.9))
-//    Expect(1.0).Should(BeNumerically(">=", 1.0))
-//    Expect(1.0).Should(BeNumerically("<", 3))
-//    Expect(1.0).Should(BeNumerically("<=", 1.0))
+// There are six, self-explanatory, supported comparators:
+//
+//	Expect(1.0).Should(BeNumerically("==", 1))
+//	Expect(1.0).Should(BeNumerically("~", 0.999, 0.01))
+//	Expect(1.0).Should(BeNumerically(">", 0.9))
+//	Expect(1.0).Should(BeNumerically(">=", 1.0))
+//	Expect(1.0).Should(BeNumerically("<", 3))
+//	Expect(1.0).Should(BeNumerically("<=", 1.0))
 func BeNumerically(comparator string, compareTo ...interface{}) types.GomegaMatcher {
 	return &matchers.BeNumericallyMatcher{
 		Comparator: comparator,
@@ -455,10 +481,11 @@ func BeNumerically(comparator string, compareTo ...interface{}) types.GomegaMatc
 	}
 }
 
-//BeTemporally compares time.Time's like BeNumerically
-//Actual and expected must be time.Time. The comparators are the same as for BeNumerically
-//    Expect(time.Now()).Should(BeTemporally(">", time.Time{}))
-//    Expect(time.Now()).Should(BeTemporally("~", time.Now(), time.Second))
+// BeTemporally compares time.Time's like BeNumerically
+// Actual and expected must be time.Time. The comparators are the same as for BeNumerically
+//
+//	Expect(time.Now()).Should(BeTemporally(">", time.Time{}))
+//	Expect(time.Now()).Should(BeTemporally("~", time.Now(), time.Second))
 func BeTemporally(comparator string, compareTo time.Time, threshold ...time.Duration) types.GomegaMatcher {
 	return &matchers.BeTemporallyMatcher{
 		Comparator: comparator,
@@ -467,58 +494,61 @@ func BeTemporally(comparator string, compareTo time.Time, threshold ...time.Dura
 	}
 }
 
-//BeAssignableToTypeOf succeeds if actual is assignable to the type of expected.
-//It will return an error when one of the values is nil.
-//    Expect(0).Should(BeAssignableToTypeOf(0))         // Same values
-//    Expect(5).Should(BeAssignableToTypeOf(-1))        // different values same type
-//    Expect("foo").Should(BeAssignableToTypeOf("bar")) // different values same type
-//    Expect(struct{ Foo string }{}).Should(BeAssignableToTypeOf(struct{ Foo string }{}))
+// BeAssignableToTypeOf succeeds if actual is assignable to the type of expected.
+// It will return an error when one of the values is nil.
+//
+//	Expect(0).Should(BeAssignableToTypeOf(0))         // Same values
+//	Expect(5).Should(BeAssignableToTypeOf(-1))        // different values same type
+//	Expect("foo").Should(BeAssignableToTypeOf("bar")) // different values same type
+//	Expect(struct{ Foo string }{}).Should(BeAssignableToTypeOf(struct{ Foo string }{}))
 func BeAssignableToTypeOf(expected interface{}) types.GomegaMatcher {
 	return &matchers.AssignableToTypeOfMatcher{
 		Expected: expected,
 	}
 }
 
-//Panic succeeds if actual is a function that, when invoked, panics.
-//Actual must be a function that takes no arguments and returns no results.
+// Panic succeeds if actual is a function that, when invoked, panics.
+// Actual must be a function that takes no arguments and returns no results.
 func Panic() types.GomegaMatcher {
 	return &matchers.PanicMatcher{}
 }
 
-//PanicWith succeeds if actual is a function that, when invoked, panics with a specific value.
-//Actual must be a function that takes no arguments and returns no results.
+// PanicWith succeeds if actual is a function that, when invoked, panics with a specific value.
+// Actual must be a function that takes no arguments and returns no results.
 //
-//By default PanicWith uses Equal() to perform the match, however a
-//matcher can be passed in instead:
-//    Expect(fn).Should(PanicWith(MatchRegexp(`.+Foo$`)))
+// By default PanicWith uses Equal() to perform the match, however a
+// matcher can be passed in instead:
+//
+//	Expect(fn).Should(PanicWith(MatchRegexp(`.+Foo$`)))
 func PanicWith(expected interface{}) types.GomegaMatcher {
 	return &matchers.PanicMatcher{Expected: expected}
 }
 
-//BeAnExistingFile succeeds if a file exists.
-//Actual must be a string representing the abs path to the file being checked.
+// BeAnExistingFile succeeds if a file exists.
+// Actual must be a string representing the abs path to the file being checked.
 func BeAnExistingFile() types.GomegaMatcher {
 	return &matchers.BeAnExistingFileMatcher{}
 }
 
-//BeARegularFile succeeds if a file exists and is a regular file.
-//Actual must be a string representing the abs path to the file being checked.
+// BeARegularFile succeeds if a file exists and is a regular file.
+// Actual must be a string representing the abs path to the file being checked.
 func BeARegularFile() types.GomegaMatcher {
 	return &matchers.BeARegularFileMatcher{}
 }
 
-//BeADirectory succeeds if a file exists and is a directory.
-//Actual must be a string representing the abs path to the file being checked.
+// BeADirectory succeeds if a file exists and is a directory.
+// Actual must be a string representing the abs path to the file being checked.
 func BeADirectory() types.GomegaMatcher {
 	return &matchers.BeADirectoryMatcher{}
 }
 
-//HaveHTTPStatus succeeds if the Status or StatusCode field of an HTTP response matches.
-//Actual must be either a *http.Response or *httptest.ResponseRecorder.
-//Expected must be either an int or a string.
-//  Expect(resp).Should(HaveHTTPStatus(http.StatusOK))   // asserts that resp.StatusCode == 200
-//  Expect(resp).Should(HaveHTTPStatus("404 Not Found")) // asserts that resp.Status == "404 Not Found"
-//  Expect(resp).Should(HaveHTTPStatus(http.StatusOK, http.StatusNoContent))   // asserts that resp.StatusCode == 200 || resp.StatusCode == 204
+// HaveHTTPStatus succeeds if the Status or StatusCode field of an HTTP response matches.
+// Actual must be either a *http.Response or *httptest.ResponseRecorder.
+// Expected must be either an int or a string.
+//
+//	Expect(resp).Should(HaveHTTPStatus(http.StatusOK))   // asserts that resp.StatusCode == 200
+//	Expect(resp).Should(HaveHTTPStatus("404 Not Found")) // asserts that resp.Status == "404 Not Found"
+//	Expect(resp).Should(HaveHTTPStatus(http.StatusOK, http.StatusNoContent))   // asserts that resp.StatusCode == 200 || resp.StatusCode == 204
 func HaveHTTPStatus(expected ...interface{}) types.GomegaMatcher {
 	return &matchers.HaveHTTPStatusMatcher{Expected: expected}
 }
@@ -541,63 +571,70 @@ func HaveHTTPBody(expected interface{}) types.GomegaMatcher {
 	return &matchers.HaveHTTPBodyMatcher{Expected: expected}
 }
 
-//And succeeds only if all of the given matchers succeed.
-//The matchers are tried in order, and will fail-fast if one doesn't succeed.
-//  Expect("hi").To(And(HaveLen(2), Equal("hi"))
+// And succeeds only if all of the given matchers succeed.
+// The matchers are tried in order, and will fail-fast if one doesn't succeed.
 //
-//And(), Or(), Not() and WithTransform() allow matchers to be composed into complex expressions.
+//	Expect("hi").To(And(HaveLen(2), Equal("hi"))
+//
+// And(), Or(), Not() and WithTransform() allow matchers to be composed into complex expressions.
 func And(ms ...types.GomegaMatcher) types.GomegaMatcher {
 	return &matchers.AndMatcher{Matchers: ms}
 }
 
-//SatisfyAll is an alias for And().
-//  Expect("hi").Should(SatisfyAll(HaveLen(2), Equal("hi")))
+// SatisfyAll is an alias for And().
+//
+//	Expect("hi").Should(SatisfyAll(HaveLen(2), Equal("hi")))
 func SatisfyAll(matchers ...types.GomegaMatcher) types.GomegaMatcher {
 	return And(matchers...)
 }
 
-//Or succeeds if any of the given matchers succeed.
-//The matchers are tried in order and will return immediately upon the first successful match.
-//  Expect("hi").To(Or(HaveLen(3), HaveLen(2))
+// Or succeeds if any of the given matchers succeed.
+// The matchers are tried in order and will return immediately upon the first successful match.
 //
-//And(), Or(), Not() and WithTransform() allow matchers to be composed into complex expressions.
+//	Expect("hi").To(Or(HaveLen(3), HaveLen(2))
+//
+// And(), Or(), Not() and WithTransform() allow matchers to be composed into complex expressions.
 func Or(ms ...types.GomegaMatcher) types.GomegaMatcher {
 	return &matchers.OrMatcher{Matchers: ms}
 }
 
-//SatisfyAny is an alias for Or().
-//  Expect("hi").SatisfyAny(Or(HaveLen(3), HaveLen(2))
+// SatisfyAny is an alias for Or().
+//
+//	Expect("hi").SatisfyAny(Or(HaveLen(3), HaveLen(2))
 func SatisfyAny(matchers ...types.GomegaMatcher) types.GomegaMatcher {
 	return Or(matchers...)
 }
 
-//Not negates the given matcher; it succeeds if the given matcher fails.
-//  Expect(1).To(Not(Equal(2))
+// Not negates the given matcher; it succeeds if the given matcher fails.
 //
-//And(), Or(), Not() and WithTransform() allow matchers to be composed into complex expressions.
+//	Expect(1).To(Not(Equal(2))
+//
+// And(), Or(), Not() and WithTransform() allow matchers to be composed into complex expressions.
 func Not(matcher types.GomegaMatcher) types.GomegaMatcher {
 	return &matchers.NotMatcher{Matcher: matcher}
 }
 
-//WithTransform applies the `transform` to the actual value and matches it against `matcher`.
-//The given transform must be either a function of one parameter that returns one value or a
+// WithTransform applies the `transform` to the actual value and matches it against `matcher`.
+// The given transform must be either a function of one parameter that returns one value or a
 // function of one parameter that returns two values, where the second value must be of the
 // error type.
-//  var plus1 = func(i int) int { return i + 1 }
-//  Expect(1).To(WithTransform(plus1, Equal(2))
 //
-//   var failingplus1 = func(i int) (int, error) { return 42, "this does not compute" }
-//   Expect(1).To(WithTransform(failingplus1, Equal(2)))
+//	var plus1 = func(i int) int { return i + 1 }
+//	Expect(1).To(WithTransform(plus1, Equal(2))
 //
-//And(), Or(), Not() and WithTransform() allow matchers to be composed into complex expressions.
+//	 var failingplus1 = func(i int) (int, error) { return 42, "this does not compute" }
+//	 Expect(1).To(WithTransform(failingplus1, Equal(2)))
+//
+// And(), Or(), Not() and WithTransform() allow matchers to be composed into complex expressions.
 func WithTransform(transform interface{}, matcher types.GomegaMatcher) types.GomegaMatcher {
 	return matchers.NewWithTransformMatcher(transform, matcher)
 }
 
-//Satisfy matches the actual value against the `predicate` function.
-//The given predicate must be a function of one paramter that returns bool.
-//  var isEven = func(i int) bool { return i%2 == 0 }
-//  Expect(2).To(Satisfy(isEven))
+// Satisfy matches the actual value against the `predicate` function.
+// The given predicate must be a function of one paramter that returns bool.
+//
+//	var isEven = func(i int) bool { return i%2 == 0 }
+//	Expect(2).To(Satisfy(isEven))
 func Satisfy(predicate interface{}) types.GomegaMatcher {
 	return matchers.NewSatisfyMatcher(predicate)
 }

--- a/vendor/github.com/onsi/gomega/matchers/be_key_of_matcher.go
+++ b/vendor/github.com/onsi/gomega/matchers/be_key_of_matcher.go
@@ -1,0 +1,45 @@
+package matchers
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/onsi/gomega/format"
+)
+
+type BeKeyOfMatcher struct {
+	Map interface{}
+}
+
+func (matcher *BeKeyOfMatcher) Match(actual interface{}) (success bool, err error) {
+	if !isMap(matcher.Map) {
+		return false, fmt.Errorf("BeKeyOf matcher needs expected to be a map type")
+	}
+
+	if reflect.TypeOf(actual) == nil {
+		return false, fmt.Errorf("BeKeyOf matcher expects actual to be typed")
+	}
+
+	var lastError error
+	for _, key := range reflect.ValueOf(matcher.Map).MapKeys() {
+		matcher := &EqualMatcher{Expected: key.Interface()}
+		success, err := matcher.Match(actual)
+		if err != nil {
+			lastError = err
+			continue
+		}
+		if success {
+			return true, nil
+		}
+	}
+
+	return false, lastError
+}
+
+func (matcher *BeKeyOfMatcher) FailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "to be a key of", presentable(valuesOf(matcher.Map)))
+}
+
+func (matcher *BeKeyOfMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "not to be a key of", presentable(valuesOf(matcher.Map)))
+}

--- a/vendor/github.com/onsi/gomega/types/types.go
+++ b/vendor/github.com/onsi/gomega/types/types.go
@@ -1,12 +1,13 @@
 package types
 
 import (
+	"context"
 	"time"
 )
 
 type GomegaFailHandler func(message string, callerSkip ...int)
 
-//A simple *testing.T interface wrapper
+// A simple *testing.T interface wrapper
 type GomegaTestingT interface {
 	Helper()
 	Fatalf(format string, args ...interface{})
@@ -30,9 +31,9 @@ type Gomega interface {
 	SetDefaultConsistentlyPollingInterval(time.Duration)
 }
 
-//All Gomega matchers must implement the GomegaMatcher interface
+// All Gomega matchers must implement the GomegaMatcher interface
 //
-//For details on writing custom matchers, check out: http://onsi.github.io/gomega/#adding-your-own-matchers
+// For details on writing custom matchers, check out: http://onsi.github.io/gomega/#adding-your-own-matchers
 type GomegaMatcher interface {
 	Match(actual interface{}) (success bool, err error)
 	FailureMessage(actual interface{}) (message string)
@@ -70,6 +71,9 @@ type AsyncAssertion interface {
 	WithOffset(offset int) AsyncAssertion
 	WithTimeout(interval time.Duration) AsyncAssertion
 	WithPolling(interval time.Duration) AsyncAssertion
+	Within(timeout time.Duration) AsyncAssertion
+	ProbeEvery(interval time.Duration) AsyncAssertion
+	WithContext(ctx context.Context) AsyncAssertion
 }
 
 // Assertions are returned by Ω and Expect and enable assertions against Gomega matchers

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -76,7 +76,7 @@ github.com/BurntSushi/toml/internal
 # github.com/GoogleCloudPlatform/k8s-cloud-provider v1.18.1-0.20220218231025-f11817397a1b
 ## explicit; go 1.13
 github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta
-# github.com/IBM-Cloud/bluemix-go v0.0.0-20220329045155-d2a8118ac5c7
+# github.com/IBM-Cloud/bluemix-go v0.0.0-20230120122421-afb48116b8f1
 ## explicit; go 1.13
 github.com/IBM-Cloud/bluemix-go
 github.com/IBM-Cloud/bluemix-go/api/container/containerv1
@@ -602,7 +602,7 @@ github.com/libopenstorage/autopilot-api/pkg/apis/autopilot/v1alpha1
 github.com/libopenstorage/autopilot-api/pkg/client/clientset/versioned
 github.com/libopenstorage/autopilot-api/pkg/client/clientset/versioned/scheme
 github.com/libopenstorage/autopilot-api/pkg/client/clientset/versioned/typed/autopilot/v1alpha1
-# github.com/libopenstorage/cloudops v0.0.0-20221107233229-3fa4664e96b1
+# github.com/libopenstorage/cloudops v0.0.0-20230220114907-3e63dce1b413
 ## explicit; go 1.13
 github.com/libopenstorage/cloudops
 github.com/libopenstorage/cloudops/azure
@@ -796,7 +796,7 @@ github.com/onsi/ginkgo/reporters/stenographer
 github.com/onsi/ginkgo/reporters/stenographer/support/go-colorable
 github.com/onsi/ginkgo/reporters/stenographer/support/go-isatty
 github.com/onsi/ginkgo/types
-# github.com/onsi/gomega v1.20.1
+# github.com/onsi/gomega v1.21.1
 ## explicit; go 1.18
 github.com/onsi/gomega
 github.com/onsi/gomega/format


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
In IBM cluster nodes are marked as both master and worker. This change will mark ibm nodes are worker nodes

**Which issue(s) this PR fixes** (optional)
Closes #PWX-28943

**Special notes for your reviewer**:

```
{SetupTeardown} 
  has to setup, validate and teardown apps
  /go/src/github.com/portworx/torpedo/tests/basic/misc_test.go:32
2023-02-09 09:02:30 +0000:[INFO log.go:#237]  Error creating log file. Err: open /testresults//SetupTeardown.log: permission denied
INFO[2023-02-09 09:02:30] --------Test Start------                     
INFO[2023-02-09 09:02:30] #Test: SetupTeardown                         
INFO[2023-02-09 09:02:30] #Description: Validate setup tear down       
INFO[2023-02-09 09:02:30] ------------------------                     
STEP: schedule applications
2023-02-09 09:02:30 +0000:[INFO log.go:#237]  Scheduling Apps with hyper-converged
2023-02-09 09:02:30 +0000:[INFO log.go:#237]  Setting provisioner of px-nginx-sc-v4 to kubernetes.io/portworx-volume
2023-02-09 09:02:30 +0000:[INFO log.go:#237]  [nginx-sharedv4] Found existing storage class: px-nginx-sc-v4
2023-02-09 09:02:30 +0000:[INFO log.go:#237]  [nginx-sharedv4] Created PVC: px-nginx-pvc-sharedv4
2023-02-09 09:02:30 +0000:[INFO log.go:#237]  [nginx-sharedv4] Created PVC: px-nginx-pvc-enc-sharedv4
2023-02-09 09:02:31 +0000:[INFO log.go:#237]  [nginx-sharedv4] Created Service: nginx-service
{Volumes:[{Name:nginx-persistent-storage VolumeSource:{HostPath:nil EmptyDir:nil GCEPersistentDisk:nil AWSElasticBlockStore:nil GitRepo:nil Secret:nil NFS:nil ISCSI:nil Glusterfs:nil PersistentVolumeClaim:&PersistentVolumeClaimVolumeSource{ClaimName:px-nginx-pvc-sharedv4,ReadOnly:false,} RBD:nil FlexVolume:nil Cinder:nil CephFS:nil Flocker:nil DownwardAPI:nil FC:nil AzureFile:nil ConfigMap:nil VsphereVolume:nil Quobyte:nil AzureDisk:nil PhotonPersistentDisk:nil Projected:nil PortworxVolume:nil ScaleIO:nil StorageOS:nil CSI:nil Ephemeral:nil}} {Name:nginx-persistent-storage-enc VolumeSource:{HostPath:nil EmptyDir:nil GCEPersistentDisk:nil AWSElasticBlockStore:nil GitRepo:nil Secret:nil NFS:nil ISCSI:nil Glusterfs:nil PersistentVolumeClaim:&PersistentVolumeClaimVolumeSource{ClaimName:px-nginx-pvc-enc-sharedv4,ReadOnly:false,} RBD:nil FlexVolume:nil Cinder:nil CephFS:nil Flocker:nil DownwardAPI:nil FC:nil AzureFile:nil ConfigMap:nil VsphereVolume:nil Quobyte:nil AzureDisk:nil PhotonPersistentDisk:nil Projected:nil PortworxVolume:nil ScaleIO:nil StorageOS:nil CSI:nil Ephemeral:nil}}] InitContainers:[] Containers:[{Name:nginx Image:bitnami/nginx Command:[] Args:[] WorkingDir: Ports:[{Name: HostPort:0 ContainerPort:80 Protocol: HostIP:}] EnvFrom:[] Env:[] Resources:{Limits:map[] Requests:map[]} VolumeMounts:[{Name:nginx-persistent-storage ReadOnly:false MountPath:/usr/share/nginx/html SubPath: MountPropagation:<nil> SubPathExpr:} {Name:nginx-persistent-storage-enc ReadOnly:false MountPath:/usr/share/nginx/html-enc SubPath: MountPropagation:<nil> SubPathExpr:}] VolumeDevices:[] LivenessProbe:nil ReadinessProbe:nil StartupProbe:nil Lifecycle:nil TerminationMessagePath: TerminationMessagePolicy: ImagePullPolicy:IfNotPresent SecurityContext:nil Stdin:false StdinOnce:false TTY:false}] EphemeralContainers:[] RestartPolicy: TerminationGracePeriodSeconds:<nil> ActiveDeadlineSeconds:<nil> DNSPolicy: NodeSelector:map[] ServiceAccountName: DeprecatedServiceAccount: AutomountServiceAccountToken:<nil> NodeName: HostNetwork:false HostPID:false HostIPC:false ShareProcessNamespace:<nil> SecurityContext:nil ImagePullSecrets:[] Hostname: Subdomain: Affinity:nil SchedulerName: Tolerations:[] HostAliases:[] PriorityClassName: Priority:<nil> DNSConfig:nil ReadinessGates:[] RuntimeClassName:<nil> EnableServiceLinks:<nil> PreemptionPolicy:<nil> Overhead:map[] TopologySpreadConstraints:[] SetHostnameAsFQDN:<nil> OS:nil HostUsers:<nil>}
2023-02-09 09:02:31 +0000:[INFO log.go:#237]  [nginx-sharedv4] Created deployment: nginx
2023-02-09 09:02:31 +0000:[INFO log.go:#237]  [nginx-sharedv4] Created Secret: volume-secrets
STEP: validate applications
2023-02-09 09:02:31 +0000:[INFO log.go:#242]  Validate applications
2023-02-09 09:02:31 +0000:[INFO log.go:#242]  Validating nginx-sharedv4 app
STEP: validate nginx-sharedv4 app's volumes
2023-02-09 09:02:31 +0000:[INFO log.go:#242]  Validating nginx-sharedv4 app's volumes
STEP: inspect nginx-sharedv4 app's volumes
2023-02-09 09:02:31 +0000:[INFO log.go:#237]  [nginx-sharedv4] Validated PVC: px-nginx-pvc-sharedv4, Namespace: nginx-sharedv4-setupteardown-0-02-09-09h02m19s
2023/02/09 09:02:31 PVC px-nginx-pvc-enc-sharedv4 is not ready yet. Cause: PVC expected status: Bound PVC actual status: Pending Next retry in: 10s
2023/02/09 09:02:41 PVC px-nginx-pvc-enc-sharedv4 is not ready yet. Cause: PVC expected status: Bound PVC actual status: Pending Next retry in: 10s
2023-02-09 09:02:51 +0000:[INFO log.go:#237]  [nginx-sharedv4] Validated PVC: px-nginx-pvc-enc-sharedv4, Namespace: nginx-sharedv4-setupteardown-0-02-09-09h02m19s
STEP: get nginx-sharedv4 app's volume's custom parameters
STEP: get nginx-sharedv4 app's volume: pvc-7aab86a8-8400-4dfd-b5b3-b3e9f68e755b inspected by the volume driver
2023-02-09 09:02:52 +0000:[INFO log.go:#237]  Successfully inspected volume [pvc-7aab86a8-8400-4dfd-b5b3-b3e9f68e755b] (894107288766240228)
STEP: get nginx-sharedv4 app's volume: pvc-32de0b6f-28ce-465b-8736-5e57cb70620f inspected by the volume driver
2023-02-09 09:02:52 +0000:[INFO log.go:#237]  Successfully inspected volume [pvc-32de0b6f-28ce-465b-8736-5e57cb70620f] (263874561109183422)
STEP: wait for nginx-sharedv4 app to start running
2023-02-09 09:02:52 +0000:[INFO log.go:#242]  wait for nginx-sharedv4 app to start running
2023-02-09 09:02:52 +0000:[INFO log.go:#237]  [nginx-sharedv4] Validated Service: nginx-service
2023/02/09 09:02:52 app nginx is not ready yet. Cause: Expected replicas: 3 Available replicas: 0 Current pods overview:
  pod name:nginx-64c74c648b-qxmwj namespace:nginx-sharedv4-setupteardown-0-02-09-09h02m19s running:false ready:false node:10.241.0.4
  pod name:nginx-64c74c648b-rhm7j namespace:nginx-sharedv4-setupteardown-0-02-09-09h02m19s running:false ready:false node:10.241.128.4
  pod name:nginx-64c74c648b-t2x7h namespace:nginx-sharedv4-setupteardown-0-02-09-09h02m19s running:false ready:false node:10.241.64.4
 Next retry in: 10s
2023-02-09 09:03:02 +0000:[INFO log.go:#237]  [nginx-sharedv4] Validated deployment: nginx
STEP: validate if nginx-sharedv4 app's volumes are setup
2023-02-09 09:03:02 +0000:[INFO log.go:#242]  validate if nginx-sharedv4 app's volumes are setup
STEP: validate if nginx-sharedv4 app's volume: px-nginx-pvc-sharedv4 is setup
2023-02-09 09:03:02 +0000:[INFO log.go:#237]  validate if nginx-sharedv4 app's volume: px-nginx-pvc-sharedv4 is setup
2023-02-09 09:03:02 +0000:[INFO log.go:#237]  Pod [nginx-sharedv4-setupteardown-0-02-09-09h02m19s] nginx-64c74c648b-qxmwj ready on node 10.241.0.4 - Initialized: True Ready: True Scheduled: True 
2023-02-09 09:03:02 +0000:[INFO log.go:#237]  Pod [nginx-sharedv4-setupteardown-0-02-09-09h02m19s] nginx-64c74c648b-rhm7j ready on node 10.241.128.4 - Initialized: True Ready: True Scheduled: True 
2023-02-09 09:03:02 +0000:[INFO log.go:#237]  Pod [nginx-sharedv4-setupteardown-0-02-09-09h02m19s] nginx-64c74c648b-t2x7h ready on node 10.241.64.4 - Initialized: True Ready: True Scheduled: True 
2023-02-09 09:03:02 +0000:[DEBUG log.go:#246]  validating the mounts in pod nginx-sharedv4-setupteardown-0-02-09-09h02m19s/nginx-64c74c648b-qxmwj
2023-02-09 09:03:02 +0000:[DEBUG log.go:#246]  pod: [nginx-sharedv4-setupteardown-0-02-09-09h02m19s] nginx-64c74c648b-qxmwj has PX mount: [10.241.128.4:/var/lib/osd/pxns/894107288766240228 /usr/share/nginx/html 10.241.128.4:/var/lib/osd/pxns/894107288766240228 ]
2023-02-09 09:03:02 +0000:[DEBUG log.go:#246]  pod: [nginx-sharedv4-setupteardown-0-02-09-09h02m19s] nginx-64c74c648b-qxmwj has PX mount: [10.241.128.4:/var/lib/osd/pxns/263874561109183422 /usr/share/nginx/html-enc 10.241.128.4:/var/lib/osd/pxns/263874561109183422 ]
2023-02-09 09:03:02 +0000:[DEBUG log.go:#246]  Finding the debug pod to run command on node 10.241.0.4
2023-02-09 09:03:02 +0000:[DEBUG log.go:#246]  Running command on pod debug-w7zsq [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-7aab86a8-8400-4dfd-b5b3-b3e9f68e755b]]
2023-02-09 09:03:03 +0000:[DEBUG log.go:#246]  validating the mounts in pod nginx-sharedv4-setupteardown-0-02-09-09h02m19s/nginx-64c74c648b-rhm7j
2023-02-09 09:03:03 +0000:[DEBUG log.go:#246]  pod: [nginx-sharedv4-setupteardown-0-02-09-09h02m19s] nginx-64c74c648b-rhm7j has PX mount: [/dev/pxd/pxd894107288766240228 /usr/share/nginx/html /dev/pxd/pxd894107288766240228 ]
2023-02-09 09:03:03 +0000:[DEBUG log.go:#246]  pod: [nginx-sharedv4-setupteardown-0-02-09-09h02m19s] nginx-64c74c648b-rhm7j has PX mount: [/dev/mapper/pxd-enc263874561109183422 /usr/share/nginx/html-enc /dev/mapper/pxd-enc263874561109183422 ]
2023-02-09 09:03:03 +0000:[DEBUG log.go:#246]  Finding the debug pod to run command on node 10.241.128.4
2023-02-09 09:03:03 +0000:[DEBUG log.go:#246]  Running command on pod debug-fnj48 [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-7aab86a8-8400-4dfd-b5b3-b3e9f68e755b]]
2023-02-09 09:03:03 +0000:[DEBUG log.go:#246]  validating the mounts in pod nginx-sharedv4-setupteardown-0-02-09-09h02m19s/nginx-64c74c648b-t2x7h
2023-02-09 09:03:03 +0000:[DEBUG log.go:#246]  pod: [nginx-sharedv4-setupteardown-0-02-09-09h02m19s] nginx-64c74c648b-t2x7h has PX mount: [10.241.128.4:/var/lib/osd/pxns/894107288766240228 /usr/share/nginx/html 10.241.128.4:/var/lib/osd/pxns/894107288766240228 ]
2023-02-09 09:03:03 +0000:[DEBUG log.go:#246]  pod: [nginx-sharedv4-setupteardown-0-02-09-09h02m19s] nginx-64c74c648b-t2x7h has PX mount: [10.241.128.4:/var/lib/osd/pxns/263874561109183422 /usr/share/nginx/html-enc 10.241.128.4:/var/lib/osd/pxns/263874561109183422 ]
2023-02-09 09:03:03 +0000:[DEBUG log.go:#246]  Finding the debug pod to run command on node 10.241.64.4
2023-02-09 09:03:03 +0000:[DEBUG log.go:#246]  Running command on pod debug-d7xfc [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-7aab86a8-8400-4dfd-b5b3-b3e9f68e755b]]
STEP: validate if nginx-sharedv4 app's volume: px-nginx-pvc-enc-sharedv4 is setup
2023-02-09 09:03:04 +0000:[INFO log.go:#237]  validate if nginx-sharedv4 app's volume: px-nginx-pvc-enc-sharedv4 is setup
2023-02-09 09:03:04 +0000:[INFO log.go:#237]  Pod [nginx-sharedv4-setupteardown-0-02-09-09h02m19s] nginx-64c74c648b-qxmwj ready on node 10.241.0.4 - Initialized: True Ready: True Scheduled: True 
2023-02-09 09:03:04 +0000:[INFO log.go:#237]  Pod [nginx-sharedv4-setupteardown-0-02-09-09h02m19s] nginx-64c74c648b-rhm7j ready on node 10.241.128.4 - Initialized: True Ready: True Scheduled: True 
2023-02-09 09:03:04 +0000:[INFO log.go:#237]  Pod [nginx-sharedv4-setupteardown-0-02-09-09h02m19s] nginx-64c74c648b-t2x7h ready on node 10.241.64.4 - Initialized: True Ready: True Scheduled: True 
2023-02-09 09:03:04 +0000:[DEBUG log.go:#246]  validating the mounts in pod nginx-sharedv4-setupteardown-0-02-09-09h02m19s/nginx-64c74c648b-qxmwj
2023-02-09 09:03:04 +0000:[DEBUG log.go:#246]  pod: [nginx-sharedv4-setupteardown-0-02-09-09h02m19s] nginx-64c74c648b-qxmwj has PX mount: [10.241.128.4:/var/lib/osd/pxns/894107288766240228 /usr/share/nginx/html 10.241.128.4:/var/lib/osd/pxns/894107288766240228 ]
2023-02-09 09:03:04 +0000:[DEBUG log.go:#246]  pod: [nginx-sharedv4-setupteardown-0-02-09-09h02m19s] nginx-64c74c648b-qxmwj has PX mount: [10.241.128.4:/var/lib/osd/pxns/263874561109183422 /usr/share/nginx/html-enc 10.241.128.4:/var/lib/osd/pxns/263874561109183422 ]
2023-02-09 09:03:04 +0000:[DEBUG log.go:#246]  Finding the debug pod to run command on node 10.241.0.4
2023-02-09 09:03:04 +0000:[DEBUG log.go:#246]  Running command on pod debug-w7zsq [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-32de0b6f-28ce-465b-8736-5e57cb70620f]]
2023-02-09 09:03:05 +0000:[DEBUG log.go:#246]  validating the mounts in pod nginx-sharedv4-setupteardown-0-02-09-09h02m19s/nginx-64c74c648b-rhm7j
2023-02-09 09:03:05 +0000:[DEBUG log.go:#246]  pod: [nginx-sharedv4-setupteardown-0-02-09-09h02m19s] nginx-64c74c648b-rhm7j has PX mount: [/dev/pxd/pxd894107288766240228 /usr/share/nginx/html /dev/pxd/pxd894107288766240228 ]
2023-02-09 09:03:05 +0000:[DEBUG log.go:#246]  pod: [nginx-sharedv4-setupteardown-0-02-09-09h02m19s] nginx-64c74c648b-rhm7j has PX mount: [/dev/mapper/pxd-enc263874561109183422 /usr/share/nginx/html-enc /dev/mapper/pxd-enc263874561109183422 ]
2023-02-09 09:03:05 +0000:[DEBUG log.go:#246]  Finding the debug pod to run command on node 10.241.128.4
2023-02-09 09:03:05 +0000:[DEBUG log.go:#246]  Running command on pod debug-fnj48 [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-32de0b6f-28ce-465b-8736-5e57cb70620f]]
2023-02-09 09:03:05 +0000:[DEBUG log.go:#246]  validating the mounts in pod nginx-sharedv4-setupteardown-0-02-09-09h02m19s/nginx-64c74c648b-t2x7h
2023-02-09 09:03:06 +0000:[DEBUG log.go:#246]  pod: [nginx-sharedv4-setupteardown-0-02-09-09h02m19s] nginx-64c74c648b-t2x7h has PX mount: [10.241.128.4:/var/lib/osd/pxns/894107288766240228 /usr/share/nginx/html 10.241.128.4:/var/lib/osd/pxns/894107288766240228 ]
2023-02-09 09:03:06 +0000:[DEBUG log.go:#246]  pod: [nginx-sharedv4-setupteardown-0-02-09-09h02m19s] nginx-64c74c648b-t2x7h has PX mount: [10.241.128.4:/var/lib/osd/pxns/263874561109183422 /usr/share/nginx/html-enc 10.241.128.4:/var/lib/osd/pxns/263874561109183422 ]
2023-02-09 09:03:06 +0000:[DEBUG log.go:#246]  Finding the debug pod to run command on node 10.241.64.4
2023-02-09 09:03:06 +0000:[DEBUG log.go:#246]  Running command on pod debug-d7xfc [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-32de0b6f-28ce-465b-8736-5e57cb70620f]]
STEP: Validate Px pod restart count
STEP: Getting current restart counts for portworx pods and matching
STEP: destroy the nginx-sharedv4 app's volumes
2023-02-09 09:03:07 +0000:[INFO log.go:#237]  destroy the nginx-sharedv4 app's volumes
2023-02-09 09:03:08 +0000:[INFO log.go:#237]  [nginx-sharedv4] Destroyed PVC: px-nginx-pvc-sharedv4
2023-02-09 09:03:08 +0000:[INFO log.go:#237]  [nginx-sharedv4] Destroyed PVC: px-nginx-pvc-enc-sharedv4
STEP: start destroying nginx-sharedv4 app
2023-02-09 09:03:08 +0000:[INFO log.go:#242]  start destroying nginx-sharedv4 app
2023-02-09 09:03:08 +0000:[INFO log.go:#237]  [nginx-sharedv4] Destroyed Service: nginx-service
2023-02-09 09:03:08 +0000:[INFO log.go:#237]  [nginx-sharedv4] Validated destroy of Service: nginx-service
2023/02/09 09:03:09 app nginx is not terminated yet. Cause: pods: [nginx-64c74c648b-qxmwj (node=10.241.0.4) nginx-64c74c648b-rhm7j (node=10.241.128.4) nginx-64c74c648b-t2x7h (node=10.241.64.4)] are still present Next retry in: 10s
2023-02-09 09:03:19 +0000:[INFO log.go:#237]  [nginx-sharedv4] Validated destroy of Deployment: nginx
STEP: validate nginx-sharedv4 app's volume px-nginx-pvc-sharedv4 has been deleted in the volume driver
2023-02-09 09:03:19 +0000:[INFO log.go:#242]  validate nginx-sharedv4 app's volume px-nginx-pvc-sharedv4 has been deleted in the volume driver
INFO[2023-02-09 09:03:19] Verifying : Description : nginx-sharedv4's volume px-nginx-pvc-sharedv4 deleted successfully? 
INFO[2023-02-09 09:03:19] Actual:true, Expected: true                  
STEP: validate nginx-sharedv4 app's volume px-nginx-pvc-enc-sharedv4 has been deleted in the volume driver
2023-02-09 09:03:19 +0000:[INFO log.go:#242]  validate nginx-sharedv4 app's volume px-nginx-pvc-enc-sharedv4 has been deleted in the volume driver
INFO[2023-02-09 09:03:19] Verifying : Description : nginx-sharedv4's volume px-nginx-pvc-enc-sharedv4 deleted successfully? 
INFO[2023-02-09 09:03:19] Actual:true, Expected: true                  
STEP: destroy the nginx-sharedv4 app's volumes
2023-02-09 09:03:19 +0000:[INFO log.go:#237]  destroy the nginx-sharedv4 app's volumes
2023-02-09 09:03:19 +0000:[INFO log.go:#237]  [nginx-sharedv4] Destroyed storage class: px-nginx-sc-v4
2023-02-09 09:03:19 +0000:[INFO log.go:#237]  [nginx-sharedv4] PVC is not found: px-nginx-pvc-sharedv4, skipping deletion
2023-02-09 09:03:19 +0000:[INFO log.go:#237]  [nginx-sharedv4] PVC is not found: px-nginx-pvc-enc-sharedv4, skipping deletion
2023-02-09 09:03:19 +0000:[DEBUG log.go:#246]  contexts: &[0xc000ef0dc0]
2023-02-09 09:03:19 +0000:[DEBUG log.go:#246]  Getting PX version on node [10.241.0.4]
2023-02-09 09:03:19 +0000:[INFO log.go:#237]  Using 172.21.180.255:9020 as endpoint for portworx volume driver
2023-02-09 09:03:19 +0000:[DEBUG log.go:#246]  Inspecting node [10.241.0.4] with volume driver node id [0159c9bd-2a14-43a7-b10b-3a467ffc8848]
INFO[2023-02-09 09:03:19] --------Test End------                       
INFO[2023-02-09 09:03:19] #Test:                                       
INFO[2023-02-09 09:03:19] #Description:                                
INFO[2023-02-09 09:03:19] ------------------------                     
•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS2023-02-09 09:03:19 +0000:[INFO log.go:#237]  Error creating log file. Err: open /testresults//SystemCheck.log: permission denied
INFO[2023-02-09 09:03:19] --------Test Start------                     
INFO[2023-02-09 09:03:19] #Test: System check                          
INFO[2023-02-09 09:03:19] #Description: validating system check and clean up  
INFO[2023-02-09 09:03:19] ------------------------                     
2023-02-09 09:03:19 +0000:[INFO log.go:#260]  checking for core files...
STEP: verifying if core files are present on each node
2023-02-09 09:03:19 +0000:[INFO log.go:#242]  verifying if core files are present on each node
2023-02-09 09:03:19 +0000:[INFO log.go:#242]  looking for core files on node 10.241.0.4
2023-02-09 09:03:19 +0000:[DEBUG log.go:#246]  Finding the debug pod to run command on node 10.241.0.4
2023-02-09 09:03:19 +0000:[DEBUG log.go:#246]  Running command on pod debug-w7zsq [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c sudo find /var/cores/ -name core-px* -type f]]
2023-02-09 09:03:19 +0000:[INFO log.go:#242]  looking for core files on node 10.241.128.4
2023-02-09 09:03:19 +0000:[DEBUG log.go:#246]  Finding the debug pod to run command on node 10.241.128.4
2023-02-09 09:03:19 +0000:[DEBUG log.go:#246]  Running command on pod debug-fnj48 [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c sudo find /var/cores/ -name core-px* -type f]]
2023-02-09 09:03:20 +0000:[INFO log.go:#242]  looking for core files on node 10.241.64.4
2023-02-09 09:03:20 +0000:[DEBUG log.go:#246]  Finding the debug pod to run command on node 10.241.64.4
2023-02-09 09:03:20 +0000:[DEBUG log.go:#246]  Running command on pod debug-d7xfc [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c sudo find /var/cores/ -name core-px* -type f]]
STEP: validate cleanup of resources used by the test suite
2023-02-09 09:03:20 +0000:[INFO log.go:#242]  validate cleanup of resources used by the test suite
2023-02-09 09:03:20 +0000:[DEBUG log.go:#246]  Finding the debug pod to run command on node 10.241.0.4
2023-02-09 09:03:21 +0000:[DEBUG log.go:#246]  Running command on pod debug-w7zsq [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c sudo find /var/lib/kubelet/pods -name *portworx-volume]]
2023-02-09 09:03:21 +0000:[DEBUG log.go:#246]  Finding the debug pod to run command on node 10.241.128.4
2023-02-09 09:03:21 +0000:[DEBUG log.go:#246]  Running command on pod debug-fnj48 [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c sudo find /var/lib/kubelet/pods -name *portworx-volume]]
2023-02-09 09:03:21 +0000:[DEBUG log.go:#246]  Finding the debug pod to run command on node 10.241.64.4
2023-02-09 09:03:21 +0000:[DEBUG log.go:#246]  Running command on pod debug-d7xfc [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c sudo find /var/lib/kubelet/pods -name *portworx-volume]]
2023-02-09 09:03:21 +0000:[DEBUG log.go:#246]  Finding the debug pod to run command on node 10.241.0.4
2023-02-09 09:03:21 +0000:[DEBUG log.go:#246]  Running command on pod debug-w7zsq [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c sudo find /var/lib/kubelet/pods/b7c3885c-a256-463f-8c34-dae5244b70de/volumes/kubernetes.io~portworx-volume -type d -empty]]
2023-02-09 09:03:22 +0000:[DEBUG log.go:#246]  Finding the debug pod to run command on node 10.241.128.4
2023-02-09 09:03:22 +0000:[DEBUG log.go:#246]  Running command on pod debug-fnj48 [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c sudo find /var/lib/kubelet/pods/ad409a99-4338-4835-ad49-dadecb0c3d3f/volumes/kubernetes.io~portworx-volume -type d -empty]]
2023-02-09 09:03:22 +0000:[DEBUG log.go:#246]  Finding the debug pod to run command on node 10.241.64.4
2023-02-09 09:03:22 +0000:[DEBUG log.go:#246]  Running command on pod debug-d7xfc [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c sudo find /var/lib/kubelet/pods/d10216df-6687-4fec-9759-f0fd1af6b82e/volumes/kubernetes.io~portworx-volume -type d -empty]]
INFO[2023-02-09 09:03:22] Verifying : Description : Validate cleanup operation successful? 
INFO[2023-02-09 09:03:22] Actual:true, Expected: true                  
INFO[2023-02-09 09:03:22] --------Test End------                       
INFO[2023-02-09 09:03:22] #Test:                                       
INFO[2023-02-09 09:03:22] #Description:                                
INFO[2023-02-09 09:03:22] ------------------------                     
Failed to create JUnit report file: /testresults/junit_basic.xml
        open /testresults/junit_basic.xml: permission denied

Failed to generate JUnit report data:
        invalid argumentRan 1 of 148 Specs in 62.908 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 147 Skipped
PASS
```
