### PR TITLE
PWX-28770 Add pod metric test template

### DIFF
--- a/tests/basic/podmetric_test.go
+++ b/tests/basic/podmetric_test.go
@@ -42,10 +42,11 @@ var _ = Describe("{PodMetricFunctional}", func() {
 		// shared test function for pod metric functional tests
 		sharedTestFunction := func() {
 			It("has to fetch the logs from loggly", func() {
-				_, code, err := getLogglyData("q=tag:meteringData&from=-60m&until=now&size=1")
+				resp, code, err := getLogglyData("q=tag:meteringData&from=-60m&until=now&size=1")
 
 				log.FailOnError(err, "Failed to make request to loggly")
 				dash.VerifyFatal(code, 200, fmt.Sprintf("loggly return code %v not equal to 200", code))
+				dash.VerifyFatal(len(resp) == 0, false, "loggy return empty response")
 			})
 		}
 

--- a/tests/basic/podmetric_test.go
+++ b/tests/basic/podmetric_test.go
@@ -42,16 +42,15 @@ var _ = Describe("{PodMetricFunctional}", func() {
 		// shared test function for pod metric functional tests
 		sharedTestFunction := func() {
 			It("has to fetch the logs from loggly", func() {
-				resp, code, err := getLogglyData("q=tag:meteringData&from=-60m&until=now&size=1")
+				_, code, err := getLogglyData("q=tag:meteringData&from=-60m&until=now&size=1")
 
-				Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("error calling to loggly %v", err))
-				Expect(code).To(Equal(200), fmt.Sprintf("loggly return code %v not equal to 200", code))
-				Expect(resp).NotTo(BeEmpty())
+				log.FailOnError(err, "Failed to make request to loggly")
+				dash.VerifyFatal(code, 200, fmt.Sprintf("loggly return code %v not equal to 200", code))
 			})
 		}
 
 		// Sample pod metric tests
-		Context("{SamplePodMetricTest}", func() {
+		Describe("{SamplePodMetricTest}", func() {
 			JustBeforeEach(func() {
 				// testrailID =
 			})

--- a/tests/basic/podmetric_test.go
+++ b/tests/basic/podmetric_test.go
@@ -1,0 +1,84 @@
+package tests
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/portworx/torpedo/drivers/scheduler"
+	"github.com/portworx/torpedo/pkg/log"
+	rest "github.com/portworx/torpedo/pkg/restutil"
+	"github.com/portworx/torpedo/pkg/testrailuttils"
+	. "github.com/portworx/torpedo/tests"
+)
+
+const (
+	logglyIterateUrl = "https://pxlite.loggly.com/apiv2/events/iterate"
+)
+
+var _ = Describe("{PodMetricFunctional}", func() {
+	var testrailID, runID int
+	var contexts []*scheduler.Context
+	var namespacePrefix string
+
+	JustBeforeEach(func() {
+		runID = testrailuttils.AddRunsToMilestone(testrailID)
+
+		StartTorpedoTest("PodMetricFunctional", "Functional Tests for Pod Metrics", nil, testrailID)
+		log.InfoD("Deploy applications")
+		contexts = make([]*scheduler.Context, 0)
+		for i := 0; i < Inst().GlobalScaleFactor; i++ {
+			contexts = append(contexts, ScheduleApplications(fmt.Sprintf("%s-%d", namespacePrefix, i))...)
+		}
+
+		log.InfoD("Validate applications")
+		ValidateApplications(contexts)
+	})
+
+	Context("{PodMetricsSample}", func() {
+		namespacePrefix = "podmetricsample"
+
+		// shared test function for pod metric functional tests
+		sharedTestFunction := func() {
+			It("has to fetch the logs from loggly", func() {
+				resp, code, err := getLogglyData("q=tag:meteringData&from=-60m&until=now&size=1")
+
+				Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("error calling to loggly %v", err))
+				Expect(code).To(Equal(200), fmt.Sprintf("loggly return code %v not equal to 200", code))
+				Expect(resp).NotTo(BeEmpty())
+			})
+		}
+
+		// Sample pod metric tests
+		Context("{SamplePodMetricTest}", func() {
+			JustBeforeEach(func() {
+				// testrailID =
+			})
+			sharedTestFunction()
+		})
+
+	})
+
+	AfterEach(func() {
+		Step("destroy apps", func() {
+			if CurrentGinkgoTestDescription().Failed {
+				log.Info("not destroying apps because the test failed\n")
+				return
+			}
+			for _, ctx := range contexts {
+				TearDownContext(ctx, map[string]bool{scheduler.OptionsWaitForResourceLeakCleanup: true})
+			}
+		})
+	})
+
+	AfterEach(func() {
+		AfterEachTest(contexts, testrailID, runID)
+		defer EndTorpedoTest()
+	})
+})
+
+func getLogglyData(query string) ([]byte, int, error) {
+	headers := make(map[string]string)
+	headers["Authorization"] = fmt.Sprintf("Bearer %v", logglyToken)
+	return rest.Get(fmt.Sprintf("%v?%v", logglyIterateUrl, query), nil, headers)
+}

--- a/tests/basic/podmetric_test.go
+++ b/tests/basic/podmetric_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+	"os"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -13,7 +14,6 @@ import (
 )
 
 const (
-	logglyToken      = ""
 	logglyIterateUrl = "https://pxlite.loggly.com/apiv2/events/iterate"
 )
 
@@ -79,6 +79,8 @@ var _ = Describe("{PodMetricFunctional}", func() {
 })
 
 func getLogglyData(query string) ([]byte, int, error) {
+	logglyToken, ok := os.LookupEnv("LOGGLY_API_TOKEN")
+	Expect(ok).To(BeTrue())
 	headers := make(map[string]string)
 	headers["Authorization"] = fmt.Sprintf("Bearer %v", logglyToken)
 	return rest.Get(fmt.Sprintf("%v?%v", logglyIterateUrl, query), nil, headers)

--- a/tests/basic/podmetric_test.go
+++ b/tests/basic/podmetric_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 const (
+	logglyToken      = ""
 	logglyIterateUrl = "https://pxlite.loggly.com/apiv2/events/iterate"
 )
 

--- a/tests/basic/podmetric_test.go
+++ b/tests/basic/podmetric_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"github.com/portworx/torpedo/drivers/scheduler"
 	"github.com/portworx/torpedo/pkg/log"
 	rest "github.com/portworx/torpedo/pkg/restutil"
@@ -42,6 +41,7 @@ var _ = Describe("{PodMetricFunctional}", func() {
 		// shared test function for pod metric functional tests
 		sharedTestFunction := func() {
 			It("has to fetch the logs from loggly", func() {
+				log.InfoD("fetching logs from loggly")
 				resp, code, err := getLogglyData("q=tag:meteringData&from=-60m&until=now&size=1")
 
 				log.FailOnError(err, "Failed to make request to loggly")
@@ -62,8 +62,9 @@ var _ = Describe("{PodMetricFunctional}", func() {
 
 	AfterEach(func() {
 		Step("destroy apps", func() {
+			log.InfoD("destroying apps")
 			if CurrentGinkgoTestDescription().Failed {
-				log.Info("not destroying apps because the test failed\n")
+				log.InfoD("not destroying apps because the test failed\n")
 				return
 			}
 			for _, ctx := range contexts {
@@ -80,7 +81,7 @@ var _ = Describe("{PodMetricFunctional}", func() {
 
 func getLogglyData(query string) ([]byte, int, error) {
 	logglyToken, ok := os.LookupEnv("LOGGLY_API_TOKEN")
-	Expect(ok).To(BeTrue())
+	dash.VerifyFatal(ok, true, "failed to fetch loggly api token")
 	headers := make(map[string]string)
 	headers["Authorization"] = fmt.Sprintf("Bearer %v", logglyToken)
 	return rest.Get(fmt.Sprintf("%v?%v", logglyIterateUrl, query), nil, headers)


### PR DESCRIPTION
Signed-off-by: dahuang <dahuang@purestorage.com>



**What this PR does / why we need it**:
Adds a sample test that fetches data from loggly. 
Eventually we will use the loggly data to compute pod hour based on the deployed application. 

**Which issue(s) this PR fixes** (optional)
Closes # PWX-28770

**Special notes for your reviewer**:
Local test passed. 

