### PR TITLE
Adding helper methods BackupSuccessCheck and RestoreSuccessCheck

### DIFF
--- a/tests/backup/backup_basic_test.go
+++ b/tests/backup/backup_basic_test.go
@@ -2,6 +2,11 @@ package tests
 
 import (
 	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
@@ -12,10 +17,6 @@ import (
 	"github.com/portworx/torpedo/pkg/aetosutil"
 	"github.com/portworx/torpedo/pkg/log"
 	. "github.com/portworx/torpedo/tests"
-	"os"
-	"strings"
-	"testing"
-	"time"
 )
 
 func getBucketNameSuffix() string {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Added seperate method for inspecting backup and restore status after creation.

**Which issue(s) this PR fixes** (optional)
Closes #
https://portworx.atlassian.net/browse/PA-562
https://portworx.atlassian.net/browse/PA-563


**Special notes for your reviewer**:
https://jenkins.pwx.dev.purestorage.com/blue/organizations/jenkins/Users%2FSumit%2FPX-Backup%2Fsystem-tests%2Fpx-backup-system-test/detail/px-backup-system-test/106/tests/
