### PR TITLE
Adding Px-Backup version info to dashboard

### DIFF
--- a/drivers/backup/backup.go
+++ b/drivers/backup/backup.go
@@ -50,6 +50,8 @@ type Driver interface {
 	License
 	// Rule
 	Rule
+	// Version
+	Version
 
 	// Init initializes the backup driver under a given scheduler
 	Init(schedulerDriverName string, nodeDriverName string, volumeDriverName string, token string) error
@@ -62,6 +64,12 @@ type Driver interface {
 
 	// String returns the name of this driver
 	String() string
+}
+
+// Version object interface
+type Version interface {
+	// GetPxBackupVersion Gets version of Px-Backup API server
+	GetPxBackupVersion(ctx context.Context, req *api.VersionGetRequest) (*api.VersionGetResponse, error)
 }
 
 // Org object interface

--- a/drivers/backup/portworx/portworx.go
+++ b/drivers/backup/portworx/portworx.go
@@ -177,6 +177,7 @@ func (p *portworx) testAndSetEndpoint(endpoint string) error {
 	p.organizationManager = api.NewOrganizationClient(conn)
 	p.licenseManager = api.NewLicenseClient(conn)
 	p.ruleManager = api.NewRulesClient(conn)
+	p.versionManager = api.NewVersionClient(conn)
 
 	log.Infof("Using %v as endpoint for portworx backup driver", pxEndpoint)
 

--- a/drivers/backup/portworx/portworx.go
+++ b/drivers/backup/portworx/portworx.go
@@ -59,6 +59,7 @@ type portworx struct {
 	licenseManager         api.LicenseClient
 	healthManager          api.HealthClient
 	ruleManager            api.RulesClient
+	versionManager         api.VersionClient
 
 	schedulerDriver scheduler.Driver
 	nodeDriver      node.Driver
@@ -1078,6 +1079,10 @@ func (p *portworx) DeleteRule(ctx context.Context, req *api.RuleDeleteRequest) (
 
 func (p *portworx) UpdateOwnershipRule(ctx context.Context, req *api.RuleOwnershipUpdateRequest) (*api.RuleOwnershipUpdateResponse, error) {
 	return p.ruleManager.UpdateOwnership(ctx, req)
+}
+
+func (p *portworx) GetPxBackupVersion(ctx context.Context, req *api.VersionGetRequest) (*api.VersionGetResponse, error) {
+	return p.versionManager.Get(ctx, req)
 }
 
 func (p *portworx) GetBackupUID(ctx context.Context, backupName string, orgID string) (string, error) {

--- a/tests/backup/backup_basic_test.go
+++ b/tests/backup/backup_basic_test.go
@@ -64,15 +64,17 @@ var _ = BeforeSuite(func() {
 	dash = Inst().Dash
 	log.Infof("Init instance")
 	InitInstance()
+
+	// Getting Px-Backup server version info and setting Aetos Dashboard tags
 	ctx, err := backup.GetAdminCtxFromSecret()
 	log.FailOnError(err, "Fetching px-central-admin ctx")
-	//t := Inst().Dash.TestSet
-	log.Infof("Version get request - %s", (&api.VersionGetRequest{}).String())
-	log.Infof("Backup - %s", Inst().Backup.String())
 	versionResponse, err := Inst().Backup.GetPxBackupVersion(ctx, &api.VersionGetRequest{})
 	log.FailOnError(err, "Getting Px-Backup version")
-	log.Infof("Version response - %s", versionResponse.String())
-	//t.Tags["px-backup-version"] = pxVersion
+	version := versionResponse.GetVersion()
+	t := Inst().Dash.TestSet
+	t.Tags["px-backup-version"] = fmt.Sprintf("%s.%s.%s-%s", version.GetMajor(), version.GetMinor(), version.GetPatch(), version.GetGitCommit())
+	t.Tags["px-backup-build-date"] = fmt.Sprintf("%s", version.GetBuildDate())
+
 	dash.TestSetBegin(dash.TestSet)
 	StartTorpedoTest("Setup buckets", "Creating one generic bucket to be used in all cases", nil, 0)
 	defer EndTorpedoTest()

--- a/tests/backup/backup_basic_test.go
+++ b/tests/backup/backup_basic_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
+	api "github.com/portworx/px-backup-api/pkg/apis/v1"
 	"github.com/portworx/sched-ops/task"
 	"github.com/portworx/torpedo/drivers"
 	"github.com/portworx/torpedo/drivers/backup"
@@ -63,6 +64,15 @@ var _ = BeforeSuite(func() {
 	dash = Inst().Dash
 	log.Infof("Init instance")
 	InitInstance()
+	ctx, err := backup.GetAdminCtxFromSecret()
+	log.FailOnError(err, "Fetching px-central-admin ctx")
+	//t := Inst().Dash.TestSet
+	log.Infof("Version get request - %s", (&api.VersionGetRequest{}).String())
+	log.Infof("Backup - %s", Inst().Backup.String())
+	versionResponse, err := Inst().Backup.GetPxBackupVersion(ctx, &api.VersionGetRequest{})
+	log.FailOnError(err, "Getting Px-Backup version")
+	log.Infof("Version response - %s", versionResponse.String())
+	//t.Tags["px-backup-version"] = pxVersion
 	dash.TestSetBegin(dash.TestSet)
 	StartTorpedoTest("Setup buckets", "Creating one generic bucket to be used in all cases", nil, 0)
 	defer EndTorpedoTest()

--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -7407,3 +7407,39 @@ var _ = Describe("{ScheduleBackupCreationAllNS}", func() {
 		DeleteCloudAccounts(backupLocationMap, cloudAccountName, cloudCredUID, ctx)
 	})
 })
+
+var _ = Describe("{DummyTest}", func() {
+	JustBeforeEach(func() {
+		log.Infof("Just before each")
+	})
+	It("Dummy Test Verification", func() {
+		log.Infof("In It block")
+		By("Check the status of backup pods", func() {
+			//ctx, err := backup.GetAdminCtxFromSecret()
+			//log.FailOnError(err, "Fetching px-central-admin ctx")
+			////t := Inst().Dash.TestSet
+			//log.Infof("Version get request - %s", (&api.VersionGetRequest{}).String())
+			//log.Infof("Backup - %s", Inst().Backup.String())
+			//versionResponse, err := Inst().Backup.GetPxBackupVersion(ctx, &api.VersionGetRequest{})
+			//log.FailOnError(err, "Getting Px-Backup version")
+			//log.Infof("Version response - %s", versionResponse.String())
+
+			log.Infof("In Step")
+
+			log.Infof("Infof In Describe %s %d", "1234", 1234)
+			log.Info("Info In Describe")
+			log.Debugf("Debugf In Describe %s %d", "1234", 1234)
+			log.Debug("Debug In Describe")
+			log.Errorf("Errorf In Describe %s %d", "1234", 1234)
+			log.Error("Error In Describe")
+			log.Warnf("Warnf In Describe %s %d", "1234", 1234)
+			log.Warn("Warn In Describe")
+			log.Fatalf("Fatalf In Describe %s %d", "1234", 1234)
+			log.FailOnError(fmt.Errorf("FailOnError In Describe %s %d", "1234", 1234), "Fail on error desc")
+
+		})
+	})
+	JustAfterEach(func() {
+		log.Infof("In Just after each")
+	})
+})

--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -7407,39 +7407,3 @@ var _ = Describe("{ScheduleBackupCreationAllNS}", func() {
 		DeleteCloudAccounts(backupLocationMap, cloudAccountName, cloudCredUID, ctx)
 	})
 })
-
-var _ = Describe("{DummyTest}", func() {
-	JustBeforeEach(func() {
-		log.Infof("Just before each")
-	})
-	It("Dummy Test Verification", func() {
-		log.Infof("In It block")
-		By("Check the status of backup pods", func() {
-			//ctx, err := backup.GetAdminCtxFromSecret()
-			//log.FailOnError(err, "Fetching px-central-admin ctx")
-			////t := Inst().Dash.TestSet
-			//log.Infof("Version get request - %s", (&api.VersionGetRequest{}).String())
-			//log.Infof("Backup - %s", Inst().Backup.String())
-			//versionResponse, err := Inst().Backup.GetPxBackupVersion(ctx, &api.VersionGetRequest{})
-			//log.FailOnError(err, "Getting Px-Backup version")
-			//log.Infof("Version response - %s", versionResponse.String())
-
-			log.Infof("In Step")
-
-			log.Infof("Infof In Describe %s %d", "1234", 1234)
-			log.Info("Info In Describe")
-			log.Debugf("Debugf In Describe %s %d", "1234", 1234)
-			log.Debug("Debug In Describe")
-			log.Errorf("Errorf In Describe %s %d", "1234", 1234)
-			log.Error("Error In Describe")
-			log.Warnf("Warnf In Describe %s %d", "1234", 1234)
-			log.Warn("Warn In Describe")
-			log.Fatalf("Fatalf In Describe %s %d", "1234", 1234)
-			log.FailOnError(fmt.Errorf("FailOnError In Describe %s %d", "1234", 1234), "Fail on error desc")
-
-		})
-	})
-	JustAfterEach(func() {
-		log.Infof("In Just after each")
-	})
-})


### PR DESCRIPTION
**What this PR does / why we need it**:
All this while we were not adding Px-Backup related info like build version and build date in the Aetos Dashboard tags section. In this PR, we will be extracting version info and adding it to the dashboard which will help us knowing on which version of Px-Backup the corresponding tests have been executed.

**Which issue(s) this PR fixes** (optional)
Closes #[PA-581](https://portworx.atlassian.net/browse/PA-581)

**Special notes for your reviewer**:
Here is a sample run with a dummy test run - [Aetos Link](http://aetos.pwx.purestorage.com/resultSet/testSetID/102075)

Screenshot:

![Screenshot 2023-02-19 at 15 16 28](https://user-images.githubusercontent.com/114994232/219940731-24f5f40d-7c92-4763-b727-8299d2456cac.png)


[PA-581]: https://portworx.atlassian.net/browse/PA-581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ