### PR TITLE
Add caller and test name info in log entry

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -212,6 +212,10 @@ func (mf *MyFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	if subIndex != -1 {
 		funcName = funcName[subIndex+1:]
 	}
+
+	// TODO: Once we migrate to ginkgo v2, we can extract test name as follows:
+	// report := CurrentSpecReport()
+	// testName := report.ContainerHierarchyTexts[0]
 	report := CurrentGinkgoTestDescription()
 	testName := strings.Split(report.FullTestText, " ")[0]
 	if testName != "" {

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -3,14 +3,16 @@ package log
 import (
 	"bytes"
 	"fmt"
-	"io"
-	"os"
-	"strings"
-	"sync"
-
+	"github.com/google/gnostic/compiler"
+	. "github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	"github.com/portworx/torpedo/pkg/aetosutil"
 	"gopkg.in/natefinch/lumberjack.v2"
+	"io"
+	"os"
+	"runtime"
+	"strings"
+	"sync"
 
 	"github.com/fatih/color"
 	"github.com/sirupsen/logrus"
@@ -197,44 +199,68 @@ type MyFormatter struct{}
 
 func (mf *MyFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	var b *bytes.Buffer
+	var writeString string
 	if entry.Buffer != nil {
 		b = entry.Buffer
 	} else {
 		b = &bytes.Buffer{}
 	}
 	level := strings.ToUpper(entry.Level.String())
-	strList := strings.Split(entry.Caller.File, "/")
-	fileName := strList[len(strList)-1]
 	funcList := strings.Split(entry.Caller.Function, "/")
 	funcName := funcList[len(funcList)-1]
 	subIndex := strings.Index(funcName, ".")
 	if subIndex != -1 {
 		funcName = funcName[subIndex+1:]
 	}
+	report := CurrentGinkgoTestDescription()
+	testName := strings.Split(report.FullTestText, " ")[0]
+	if testName != "" {
+		writeString = fmt.Sprintf("%s:[%s] [%s] %s\n",
+			entry.Time.Format("2006-01-02 15:04:05 -0700"), level, testName,
+			entry.Message)
+	} else {
+		writeString = fmt.Sprintf("%s:[%s] %s\n",
+			entry.Time.Format("2006-01-02 15:04:05 -0700"), level,
+			entry.Message)
+	}
 
-	b.WriteString(fmt.Sprintf("%s:[%s %s:#%d]  %s\n",
-		entry.Time.Format("2006-01-02 15:04:05 -0700"), level, fileName, entry.Caller.Line,
-		entry.Message))
+	b.WriteString(writeString)
 	return b.Bytes(), nil
 }
 
 func Fatalf(format string, args ...interface{}) {
-	dash.Fatal(format, args...)
-	tpLog.Errorf(format, args...)
+	pc, _, line, _ := runtime.Caller(1)
+	callerFuncSlice := strings.Split(runtime.FuncForPC(pc).Name(), "/")
+	callerFunc := fmt.Sprintf("%s:#%d", callerFuncSlice[len(callerFuncSlice)-1], line)
+	extendedFormat := fmt.Sprintf("[%s] - %s", callerFunc, format)
+	dash.Fatal(extendedFormat, args...)
+	tpLog.Errorf(extendedFormat, args...)
 }
 
 func Errorf(format string, args ...interface{}) {
-	dash.Errorf(format, args...)
-	tpLog.Errorf(format, args...)
+	pc, _, line, _ := runtime.Caller(1)
+	callerFuncSlice := strings.Split(runtime.FuncForPC(pc).Name(), "/")
+	callerFunc := fmt.Sprintf("%s:#%d", callerFuncSlice[len(callerFuncSlice)-1], line)
+	extendedFormat := fmt.Sprintf("[%s] - %s", callerFunc, format)
+	dash.Errorf(extendedFormat, args...)
+	tpLog.Errorf(extendedFormat, args...)
 }
 
 func Warnf(format string, args ...interface{}) {
-	dash.Warnf(format, args...)
-	tpLog.Warningf(format, args...)
+	pc, _, line, _ := runtime.Caller(1)
+	callerFuncSlice := strings.Split(runtime.FuncForPC(pc).Name(), "/")
+	callerFunc := fmt.Sprintf("%s:#%d", callerFuncSlice[len(callerFuncSlice)-1], line)
+	extendedFormat := fmt.Sprintf("[%s] - %s", callerFunc, format)
+	dash.Warnf(extendedFormat, args...)
+	tpLog.Warningf(extendedFormat, args...)
 }
 
 func Infof(format string, args ...interface{}) {
-	tpLog.Infof(format, args...)
+	pc, _, line, _ := runtime.Caller(1)
+	callerFuncSlice := strings.Split(runtime.FuncForPC(pc).Name(), "/")
+	callerFunc := fmt.Sprintf("%s:#%d", callerFuncSlice[len(callerFuncSlice)-1], line)
+	extendedFormat := fmt.Sprintf("[%s] - %s", callerFunc, format)
+	tpLog.Infof(extendedFormat, args...)
 }
 
 func InfoD(format string, args ...interface{}) {
@@ -243,34 +269,64 @@ func InfoD(format string, args ...interface{}) {
 }
 
 func Debugf(format string, args ...interface{}) {
-	tpLog.Debugf(format, args...)
+	pc, _, line, _ := runtime.Caller(1)
+	callerFuncSlice := strings.Split(runtime.FuncForPC(pc).Name(), "/")
+	callerFunc := fmt.Sprintf("%s:#%d", callerFuncSlice[len(callerFuncSlice)-1], line)
+	extendedFormat := fmt.Sprintf("[%s] - %s", callerFunc, format)
+	tpLog.Debugf(extendedFormat, args...)
 }
 
 func Error(args ...interface{}) {
+	pc, _, line, _ := runtime.Caller(1)
+	callerFuncSlice := strings.Split(runtime.FuncForPC(pc).Name(), "/")
+	callerFunc := fmt.Sprintf("%s:#%d", callerFuncSlice[len(callerFuncSlice)-1], line)
+	extendedFormat := fmt.Sprintf("[%s] - %s", callerFunc, strings.Join(compiler.ConvertInterfaceArrayToStringArray(args), " "))
 	dash.Error(fmt.Sprint(args...))
-	tpLog.Error(args...)
+	tpLog.Error(extendedFormat)
 }
 
 func Warn(args ...interface{}) {
+	pc, _, line, _ := runtime.Caller(1)
+	callerFuncSlice := strings.Split(runtime.FuncForPC(pc).Name(), "/")
+	callerFunc := fmt.Sprintf("%s:#%d", callerFuncSlice[len(callerFuncSlice)-1], line)
+	extendedFormat := fmt.Sprintf("[%s] - %s", callerFunc, strings.Join(compiler.ConvertInterfaceArrayToStringArray(args), " "))
 	dash.Warn(fmt.Sprint(args...))
-	tpLog.Warn(args...)
+	tpLog.Warn(extendedFormat)
 }
 
 func Info(args ...interface{}) {
-	tpLog.Info(args...)
+	pc, _, line, _ := runtime.Caller(1)
+	callerFuncSlice := strings.Split(runtime.FuncForPC(pc).Name(), "/")
+	callerFunc := fmt.Sprintf("%s:#%d", callerFuncSlice[len(callerFuncSlice)-1], line)
+	extendedFormat := fmt.Sprintf("[%s] - %s", callerFunc, strings.Join(compiler.ConvertInterfaceArrayToStringArray(args), " "))
+	tpLog.Info(extendedFormat)
 }
 
 func Debug(args ...interface{}) {
-	tpLog.Debug(args...)
+	pc, _, line, _ := runtime.Caller(1)
+	callerFuncSlice := strings.Split(runtime.FuncForPC(pc).Name(), "/")
+	callerFunc := fmt.Sprintf("%s:#%d", callerFuncSlice[len(callerFuncSlice)-1], line)
+	extendedFormat := fmt.Sprintf("[%s] - %s", callerFunc, strings.Join(compiler.ConvertInterfaceArrayToStringArray(args), " "))
+	tpLog.Debugf(extendedFormat, args...)
 }
 
 func Panicf(format string, args ...interface{}) {
-	tpLog.Panicf(format, args...)
+	pc, _, line, _ := runtime.Caller(1)
+	callerFuncSlice := strings.Split(runtime.FuncForPC(pc).Name(), "/")
+	callerFunc := fmt.Sprintf("%s:#%d", callerFuncSlice[len(callerFuncSlice)-1], line)
+	extendedFormat := fmt.Sprintf("[%s] - %s", callerFunc, format)
+	tpLog.Panicf(extendedFormat, args...)
 }
 
 func FailOnError(err error, description string, args ...interface{}) {
 	if err != nil {
-		Fatalf("%v. Err: %v", fmt.Sprintf(description, args...), err)
+		errorString := fmt.Sprintf("%v. Err: %v", fmt.Sprintf(description, args...), err)
+		pc, _, line, _ := runtime.Caller(1)
+		callerFuncSlice := strings.Split(runtime.FuncForPC(pc).Name(), "/")
+		callerFunc := fmt.Sprintf("%s:#%d", callerFuncSlice[len(callerFuncSlice)-1], line)
+		extendedFormat := fmt.Sprintf("[%s] - %s", callerFunc, errorString)
+		dash.Fatal(extendedFormat)
+		tpLog.Errorf(extendedFormat)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The log wrapper for logrus written in `pkg/log/log.go` did not provide us the information regarding the current test case which is being executed and also the caller function with the line number. This is sometimes cumbersome to debug issues and zero upon the block of code causing the failure.
This PR fixes the problem by adding the test case name as part of the log formatter and also provides the caller function information along with the line from which the log function is being called.

Before this PR logs looked like this:

```
2023-02-19 11:04:31 +0000:[INFO log.go:#237]  dump kubeconfigs to file system
2023-02-19 11:04:31 +0000:[INFO log.go:#237]  Get over kubeconfig list [source-config destination-config]
2023-02-19 11:04:31 +0000:[INFO log.go:#237]  Save kubeconfig to /tmp/source-config
2023-02-19 11:04:31 +0000:[INFO log.go:#237]  Save kubeconfig to /tmp/destination-config
2023-02-19 11:04:31 +0000:[INFO log.go:#242]  Create cluster [source-cluster] in org [default]
2023-02-19 11:04:31 +0000:[INFO log.go:#237]  Source config path: /tmp/source-config
2023-02-19 11:04:31 +0000:[INFO log.go:#237]  Save cluster source-cluster kubeconfig to /tmp/source-config
2023-02-19 11:04:31 +0000:[INFO log.go:#242]  Create cluster [source-cluster] in org [default]
2023-02-19 11:04:32 +0000:[INFO log.go:#242]  Create cluster [destination-cluster] in org [default]
2023-02-19 11:04:32 +0000:[INFO log.go:#237]  Destination config path: /tmp/destination-config
2023-02-19 11:04:32 +0000:[INFO log.go:#237]  Save cluster destination-cluster kubeconfig to /tmp/destination-config
2023-02-19 11:04:32 +0000:[INFO log.go:#242]  Create cluster [destination-cluster] in org [default]
```

As we can see there is no information regarding the caller function and the line number

Now it would look like this:

```
2023-02-18 23:15:41 +0000:[INFO] [{CancelClusterBackupShare}] [tests.dumpKubeConfigs:#3890] - dump kubeconfigs to file system
2023-02-18 23:15:41 +0000:[INFO] [{CancelClusterBackupShare}] [tests.dumpKubeConfigs:#3896] - Get over kubeconfig list [source-config destination-config]
2023-02-18 23:15:41 +0000:[INFO] [{CancelClusterBackupShare}] [tests.dumpKubeConfigs:#3905] - Save kubeconfig to /tmp/source-config
2023-02-18 23:15:41 +0000:[INFO] [{CancelClusterBackupShare}] [tests.dumpKubeConfigs:#3905] - Save kubeconfig to /tmp/destination-config
2023-02-18 23:15:41 +0000:[INFO] [{CancelClusterBackupShare}] Create cluster [source-cluster] in org [default]
2023-02-18 23:15:41 +0000:[INFO] [{CancelClusterBackupShare}] [tests.GetSourceClusterConfigPath:#3332] - Source config path: /tmp/source-config
2023-02-18 23:15:41 +0000:[INFO] [{CancelClusterBackupShare}] [tests.CreateSourceAndDestClusters:#2833] - Save cluster source-cluster kubeconfig to /tmp/source-config
2023-02-18 23:15:41 +0000:[INFO] [{CancelClusterBackupShare}] Create cluster [source-cluster] in org [default]
2023-02-18 23:15:41 +0000:[INFO] [{CancelClusterBackupShare}] Create cluster [destination-cluster] in org [default]
2023-02-18 23:15:41 +0000:[INFO] [{CancelClusterBackupShare}] [tests.GetDestinationClusterConfigPath:#3349] - Destination config path: /tmp/destination-config
2023-02-18 23:15:41 +0000:[INFO] [{CancelClusterBackupShare}] [tests.CreateSourceAndDestClusters:#2844] - Save cluster destination-cluster kubeconfig to /tmp/destination-config
2023-02-18 23:15:41 +0000:[INFO] [{CancelClusterBackupShare}] Create cluster [destination-cluster] in org [default]
```

Here we know that the test name is `{CancelClusterBackupShare}` and the line number is appended after the function name - `tests.GetDestinationClusterConfigPath:#3349` which will ease the debugging process.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
Here is a full [jenkins run](https://jenkins.pwx.dev.purestorage.com/job/Users/job/Sumit/job/PX-Backup/job/system-tests/job/px-backup-system-test/120/consoleFull) where I have executed all the Px-Backup system tests

Please feel free to use this branch and test out your code/test cases to see if everything works as expected.
