### PR TITLE
PA-626: Fix BackupRestartPX testcase failure in system test runs

### DIFF
--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -3528,9 +3528,10 @@ var _ = Describe("{BackupRestartPX}", func() {
 			storageNodes := node.GetWorkerNodes()
 			for index := range storageNodes {
 				// Just restart storage driver on one of the node where volume backup is in progress
-				Inst().V.RestartDriver(storageNodes[index], nil)
-				err := Inst().V.WaitDriverUpOnNode(storageNodes[index], time.Minute*5)
-				dash.VerifyFatal(err, nil, "Validate volume is driver up")
+				err := Inst().V.RestartDriver(storageNodes[index], nil)
+				log.FailOnError(err, "Failed to Restart driver")
+				err = Inst().V.WaitDriverUpOnNode(storageNodes[index], time.Minute*5)
+				dash.VerifyFatal(err, nil, "Validate volume is up")
 			}
 		})
 

--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -3529,6 +3529,8 @@ var _ = Describe("{BackupRestartPX}", func() {
 			for index := range storageNodes {
 				// Just restart storage driver on one of the node where volume backup is in progress
 				Inst().V.RestartDriver(storageNodes[index], nil)
+				err := Inst().V.WaitDriverUpOnNode(storageNodes[index], time.Minute*5)
+				dash.VerifyFatal(err, nil, "Validate volume is driver up")
 			}
 		})
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
We were seeing that the torpedo system test runs for px-backup was failing with the below trace:
```
19:23:56  ERRO[2023-02-20 13:53:48] Actual:TEST-ERROR, Expected: PASS   
19:23:56  INFO[2023-02-20 13:53:48] --------Test End------                       
19:23:56  INFO[2023-02-20 13:53:48] #Test: BackupRestartPX                       
19:23:56  INFO[2023-02-20 13:53:48] #Description: Restart PX when backup in progress  
19:23:56  INFO[2023-02-20 13:53:48] ------------------------                     
19:23:56  
19:23:56  • Failure [887.057 seconds]
19:23:56  {BackupRestartPX}
19:23:56  /go/src/github.com/portworx/torpedo/tests/backup/backup_test.go:3409
19:23:56    Restart PX when backup in progress [It]
19:23:56    /go/src/github.com/portworx/torpedo/tests/backup/backup_test.go:3458
19:23:56  
19:23:56    Unexpected error:
19:23:56        <*task.ErrTimedOut | 0xc00085eb60>: {
19:23:56            Reason: "context deadline exceeded",
19:23:56        }
19:23:56        timed out performing task., Error was: context deadline exceeded
19:23:56    occurred
19:23:56  
19:23:56    /go/src/github.com/portworx/torpedo/pkg/log/log.go:334
19:23:56  
19:23:56    Full Stack Trace
19:23:56    github.com/portworx/torpedo/pkg/log.FailOnError({0x739b9e0, 0xc00085eb60}, {0x6c8e6c0?, 0x35?}, {0xc0014f30b8?, 0xc0012c9078?, 0x219651e?})
19:23:56    	/go/src/github.com/portworx/torpedo/pkg/log/log.go:334 +0x290
19:23:56    github.com/portworx/torpedo/tests/backup.glob..func19.2.8()
19:23:56    	/go/src/github.com/portworx/torpedo/tests/backup/backup_test.go:3560 +0x2f2
19:23:56    github.com/portworx/torpedo/tests/backup.glob..func19.2()
19:23:56    	/go/src/github.com/portworx/torpedo/tests/backup/backup_test.go:3535 +0x713
19:23:56    github.com/portworx/torpedo/tests/backup.TestBasic(0x0?)
19:23:56    	/go/src/github.com/portworx/torpedo/tests/backup/backup_basic_test.go:59 +0xb9
19:23:56    testing.tRunner(0xc0004d8b60, 0x6d9cf20)
19:23:56    	/usr/local/go/src/testing/testing.go:1446 +0x10b
19:23:56    created by testing.(*T).Run
19:23:56    	/usr/local/go/src/testing/testing.go:1493 +0x35f
19:23:56  ------------------------------
```

The torpedo run output isn’t very clear, so tried running the test and logged in to the machine with central admin user. I was able to see that the backup is failing with the below error which is mostly due to the backup not being able to get status from the api server:
![Screenshot 2023-02-21 at 10 36 55 AM](https://user-images.githubusercontent.com/81960124/220317915-bcd1b84a-f5a2-41e6-b7cf-c86ec69748af.png)

I was suspecting that the portworx-api restart is happening too quickly hence tried out with some sleep. 
1. With Sleep of 2 mins, Dashboard URL : http://aetos.pwx.purestorage.com/resultSet/testSetID/103489 
2. With Sleep of 30 sec, Dashboard URL : http://aetos.pwx.purestorage.com/resultSet/testSetID/103505
3. With Sleep of 20 sec, Dashboard URL : http://aetos.pwx.purestorage.com/resultSet/testSetID/103510
4. With Sleep of 10 sec, Dashboard URL : http://aetos.pwx.purestorage.com/resultSet/testSetID/103571
5. With Sleep of 5 sec,  Dashboard URL : http://aetos.pwx.purestorage.com/resultSet/testSetID/103595

Now for the above experiment was using `time.Sleep()` calls for the patch will be using `WaitDriverUpOnNode()` and do run the case multiple times and will open a PR. 

**Testing Data**
Ran the testcase 5 times and haven't seen the failure even once. Below is the dashboard links for all five runs:
1. Dashboard URL : http://aetos.pwx.purestorage.com/resultSet/testSetID/103663 
2. Dashboard URL : http://aetos.pwx.purestorage.com/resultSet/testSetID/103674
3. Dashboard URL : http://aetos.pwx.purestorage.com/resultSet/testSetID/103718
4. Dashboard URL : http://aetos.pwx.purestorage.com/resultSet/testSetID/103729
5. Dashboard URL : http://aetos.pwx.purestorage.com/resultSet/testSetID/103741 


**Which issue(s) this PR fixes** (optional)
Closes # PA-626

**Special notes for your reviewer**:

