### PR TITLE
Fix: Torpedo Container not Privileged to generate testresults for OCP

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -16,6 +16,10 @@ if [ -z "${DASH_UID}" ]; then
     fi
 fi
 
+SECURITY_CONTEXT=false
+if [ "${IS_OCP}" == true ]; then
+    SECURITY_CONTEXT=true
+fi
 
 if [ -z "${SCALE_FACTOR}" ]; then
     SCALE_FACTOR="10"
@@ -435,6 +439,8 @@ spec:
   - name: torpedo
     image: ${TORPEDO_IMG}
     imagePullPolicy: Always
+    securityContext:
+      privileged: ${SECURITY_CONTEXT}
     command: [ "ginkgo" ]
     args: [ "--trace",
             "--timeout", "${TIMEOUT}",


### PR DESCRIPTION
**What this PR does / why we need it**:
Exporting the Junit XML Report post Torpedo Run works fine for AKS, EKS, GCP, Vanilla, RKE, but for OCP I am getting `Permission Denied` error while the reports are generated.
Found that the `torpedo` container has to be privileged to write to `HostPath`, hence, proposing the changes.

<img width="1449" alt="Screenshot 2023-02-21 at 8 33 24 PM" src="https://user-images.githubusercontent.com/109576118/220554218-8119f605-9f8d-4104-ba45-0b8d22222634.png">

**Failure Jenkins Run Console URL for OCP**
[URL](https://jenkins.pwx.dev.purestorage.com/blue/rest/organizations/jenkins/pipelines/Users/pipelines/Sumit/pipelines/PX-Backup/pipelines/system-tests/pipelines/px-backup-system-test-ocp/runs/41/nodes/262/steps/265/log/?start=0)

**Success Jenkins Run Console for OCP with proposed changes**
[URL](https://jenkins.pwx.dev.purestorage.com/blue/organizations/jenkins/Users%2FSumit%2FPX-Backup%2Fsystem-tests%2Fpx-backup-system-test-ocp/detail/px-backup-system-test-ocp/45/pipeline)

**Success Jenkins Run Console for Vanilla K8s with proposed changes**
[URL](https://jenkins.pwx.dev.purestorage.com/blue/rest/organizations/jenkins/pipelines/Users/pipelines/Sumit/pipelines/Custom-Pipelines/pipelines/px-backup-on-demand-system-test-byoc/runs/22/nodes/144/steps/147/log/?start=0)
*Does not affect other provisioners like Vanilla, RKE, AKS, EKS, GCP*

**Special notes for your reviewer**:
- Added a new ENV var named `IS_OCP`, when set to `true`, it makes the `torpedo` container priviledged.

