### PR TITLE
[PA-637] Modify GetPxBackupNamespace to detect PxBackup namespace

### DIFF
--- a/drivers/backup/auth.go
+++ b/drivers/backup/auth.go
@@ -18,6 +18,11 @@ import (
 	"github.com/portworx/sched-ops/task"
 	"github.com/portworx/torpedo/pkg/log"
 	"google.golang.org/grpc/metadata"
+
+	"github.com/portworx/sched-ops/k8s/core"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // PxCentralAdminPwd password of PxCentralAdminUser
@@ -52,12 +57,19 @@ const (
 
 	defaultWaitTimeout  time.Duration = 30 * time.Second
 	defaultWaitInterval time.Duration = 5 * time.Second
-	// pxBackupNamespace where px backup is running
-	pxBackupNamespace = "PX_BACKUP_NAMESPACE"
 	// OidcSecretName where secrets for OIDC auth cred info resides
 	oidcSecretName = "SECRET_NAME"
 	// PxCentralUI URL Eg: http://<IP>:<Port>
 	PxCentralUIURL = "PX_CENTRAL_UI_URL"
+)
+
+const (
+	// PxBackupServiceName is the name of the PxBackup service in kubernetes
+	PxBackupServiceName = "px-backup"
+)
+
+var (
+	k8sCore = core.Instance()
 )
 
 type tokenResponse struct {
@@ -189,7 +201,8 @@ func getKeycloakEndPoint(admin bool) (string, error) {
 		}
 	}
 	name := getOidcSecretName()
-	ns := GetPxBackupNamespace()
+	ns, err := GetPxBackupNamespace()
+	log.FailOnError(err, "Unable to get PxBackup namespace")
 	// check and validate oidc details
 	secret, err := k8s.Instance().GetSecret(name, ns)
 	if err != nil {
@@ -213,12 +226,18 @@ func getKeycloakEndPoint(admin bool) (string, error) {
 }
 
 // GetPxBackupNamespace returns namespace of px-backup deployment.
-func GetPxBackupNamespace() string {
-	ns, present := os.LookupEnv(pxBackupNamespace)
-	if !(present) {
-		return AdminTokenSecretNamespace
+func GetPxBackupNamespace() (string, error) {
+	var allServices *corev1.ServiceList
+	var err error
+	if allServices, err = k8sCore.ListServices("", metav1.ListOptions{}); err != nil {
+		return "", fmt.Errorf("failed to get list of services. Err: %v", err)
 	}
-	return ns
+	for _, svc := range allServices.Items {
+		if svc.Name == PxBackupServiceName {
+			return svc.Namespace, nil
+		}
+	}
+	return "", fmt.Errorf("can't find PxBackup service [%s] from list of services", PxBackupServiceName)
 }
 
 // GetToken fetches JWT token for given user credentials
@@ -270,7 +289,9 @@ func GetCommonHTTPHeaders(userName, password string) (http.Header, error) {
 // GetPxCentralAdminPwd fetches password from PxCentralAdminUser from secret
 func GetPxCentralAdminPwd() (string, error) {
 
-	secret, err := k8s.Instance().GetSecret(PxCentralAdminSecretName, GetPxBackupNamespace())
+	pxBackupNamespace, err := GetPxBackupNamespace()
+	log.FailOnError(err, "Unable to get PxBackup namespace")
+	secret, err := k8s.Instance().GetSecret(PxCentralAdminSecretName, pxBackupNamespace)
 	if err != nil {
 		return "", err
 	}
@@ -768,7 +789,9 @@ func UpdatePxBackupAdminSecret() error {
 		return err
 	}
 
-	secret, err := k8s.Instance().GetSecret(AdminTokenSecretName, GetPxBackupNamespace())
+	pxBackupNamespace, err := GetPxBackupNamespace()
+	log.FailOnError(err, "Unable to get PxBackup namespace")
+	secret, err := k8s.Instance().GetSecret(AdminTokenSecretName, pxBackupNamespace)
 	if err != nil {
 		return err
 	}
@@ -789,7 +812,9 @@ func GetAdminCtxFromSecret() (context.Context, error) {
 		return nil, err
 	}
 
-	secret, err := k8s.Instance().GetSecret(AdminTokenSecretName, GetPxBackupNamespace())
+	pxBackuupNamespace, err := GetPxBackupNamespace()
+	log.FailOnError(err, "Unable to get PxBackup namespace")
+	secret, err := k8s.Instance().GetSecret(AdminTokenSecretName, pxBackuupNamespace)
 	if err != nil {
 		return nil, err
 	}
@@ -811,7 +836,9 @@ func GetAdminTokenFromSecret() (string, error) {
 		return "", err
 	}
 
-	secret, err := k8s.Instance().GetSecret(AdminTokenSecretName, GetPxBackupNamespace())
+	pxBackuupNamespace, err := GetPxBackupNamespace()
+	log.FailOnError(err, "Unable to get PxBackup namespace")
+	secret, err := k8s.Instance().GetSecret(AdminTokenSecretName, pxBackuupNamespace)
 	if err != nil {
 		return "", err
 	}

--- a/drivers/backup/portworx/portworx.go
+++ b/drivers/backup/portworx/portworx.go
@@ -135,7 +135,8 @@ func (p *portworx) Init(schedulerDriverName string, nodeDriverName string, volum
 		return fmt.Errorf("Error getting volume driver %v: %v", volumeDriverName, err)
 	}
 
-	if err = p.setDriver(pxbServiceName, backup.GetPxBackupNamespace()); err != nil {
+	pxBackupNamespace, _ := backup.GetPxBackupNamespace()
+	if err = p.setDriver(pxbServiceName, pxBackupNamespace); err != nil {
 		return fmt.Errorf("Error setting px-backup endpoint: %v", err)
 	}
 
@@ -1442,7 +1443,7 @@ func (p *portworx) DeleteBackupSchedulePolicy(orgID string, policyList []string)
 func (p *portworx) ValidateBackupCluster() error {
 	flag := false
 	labelSelectors := map[string]string{"job-name": post_install_hook_pod}
-	ns := backup.GetPxBackupNamespace()
+	ns, _ := backup.GetPxBackupNamespace()
 	pods, err := core.Instance().GetPods(ns, labelSelectors)
 	if err != nil {
 		err = fmt.Errorf("Unable to fetch pxcentral-post-install-hook pod from backup namespace\n Error : [%v]\n",

--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -6917,7 +6917,8 @@ var _ = Describe("{RestartBackupPodDuringBackupSharing}", func() {
 			log.InfoD("Restart backup pod when backup sharing is in-progress")
 			backupPodLabel := make(map[string]string)
 			backupPodLabel["app"] = "px-backup"
-			err := DeletePodWithLabelInNamespace(backup.GetPxBackupNamespace(), backupPodLabel)
+			pxBackupNamespace, _ := backup.GetPxBackupNamespace()
+			err := DeletePodWithLabelInNamespace(pxBackupNamespace, backupPodLabel)
 			dash.VerifyFatal(err, nil, "Restart backup pod when backup sharing is in-progress")
 			pods, err := core.Instance().GetPods("px-backup", backupPodLabel)
 			dash.VerifyFatal(err, nil, "Getting px-backup pod")
@@ -6973,7 +6974,8 @@ var _ = Describe("{RestartBackupPodDuringBackupSharing}", func() {
 			log.InfoD("Restart mongo pod when backup sharing is in-progress")
 			backupPodLabel := make(map[string]string)
 			backupPodLabel["app.kubernetes.io/component"] = "pxc-backup-mongodb"
-			err := DeletePodWithLabelInNamespace(backup.GetPxBackupNamespace(), backupPodLabel)
+			pxBackupNamespace, _ := backup.GetPxBackupNamespace()
+			err := DeletePodWithLabelInNamespace(pxBackupNamespace, backupPodLabel)
 			dash.VerifyFatal(err, nil, "Restart mongo pod when backup sharing is in-progress")
 			pods, err := core.Instance().GetPods("px-backup", backupPodLabel)
 			dash.VerifyFatal(err, nil, "Getting mongo pods")


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR fixes an issue in the Px-Backup automation where it was previously limited to working only in the "px-backup" namespace. With this PR, the automation can now be executed in any namespace, making it more flexible and adaptable to different deployment scenarios.

**Which issue(s) this PR fixes** (optional)
Closes #PA-637

**Special notes for your reviewer**:
Please review the Jenkins build for the "BasicBackupCreation" test case using the link below

https://jenkins.pwx.dev.purestorage.com/job/Users/job/Sumit/job/Custom-Pipelines/job/px-backup-on-demand-system-test-byoc/37/
