### PR TITLE
[PA-643] Modify GetBackupUID to throw an error if UID cannot be found

### DIFF
--- a/drivers/backup/portworx/portworx.go
+++ b/drivers/backup/portworx/portworx.go
@@ -1087,7 +1087,6 @@ func (p *portworx) GetPxBackupVersion(ctx context.Context, req *api.VersionGetRe
 }
 
 func (p *portworx) GetBackupUID(ctx context.Context, backupName string, orgID string) (string, error) {
-	var backupUID string
 	var totalBackups int
 	bkpEnumerateReq := &api.BackupEnumerateRequest{OrgId: orgID}
 	bkpEnumerateReq.EnumerateOptions = &api.EnumerateOptions{MaxObjects: uint64(enumerateBatchSize), ObjectIndex: 0}
@@ -1106,7 +1105,8 @@ func (p *portworx) GetBackupUID(ctx context.Context, backupName string, orgID st
 			bkpEnumerateReq.EnumerateOptions.ObjectIndex += uint64(len(enumerateRsp.GetBackups()))
 		}
 	}
-	return backupUID, nil
+
+	return "", fmt.Errorf("backup with name '%s' not found for org '%s'", backupName, orgID)
 }
 
 var (


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR modifies the GetBackupUID function, whereby it will now throw an error if the UID for the specified backupName does not exist. This PR enables accurate verification of the creation or deletion of backups within the test case.

**Which issue(s) this PR fixes** (optional)
Closes #PA-643

**Special notes for your reviewer**:
Please review the Jenkins build for the "BasicSelectiveRestore" test case using the link below

https://jenkins.pwx.dev.purestorage.com/job/Users/job/Sumit/job/Custom-Pipelines/job/px-backup-on-demand-system-test-byoc/44/