### PR TITLE
[PA-662] Modify GetPxBackupNamespace to detect PxBackup namespace

### DIFF
--- a/drivers/backup/portworx/portworx.go
+++ b/drivers/backup/portworx/portworx.go
@@ -135,7 +135,11 @@ func (p *portworx) Init(schedulerDriverName string, nodeDriverName string, volum
 		return fmt.Errorf("Error getting volume driver %v: %v", volumeDriverName, err)
 	}
 
-	if err = p.setDriver(pxbServiceName, backup.GetPxBackupNamespace()); err != nil {
+	pxbNamespace, err := backup.GetPxBackupNamespace()
+	if err != nil {
+		return err
+	}
+	if err = p.setDriver(pxbServiceName, pxbNamespace); err != nil {
 		return fmt.Errorf("Error setting px-backup endpoint: %v", err)
 	}
 
@@ -1442,7 +1446,10 @@ func (p *portworx) DeleteBackupSchedulePolicy(orgID string, policyList []string)
 func (p *portworx) ValidateBackupCluster() error {
 	flag := false
 	labelSelectors := map[string]string{"job-name": post_install_hook_pod}
-	ns := backup.GetPxBackupNamespace()
+	ns, err := backup.GetPxBackupNamespace()
+	if err != nil {
+		return err
+	}
 	pods, err := core.Instance().GetPods(ns, labelSelectors)
 	if err != nil {
 		err = fmt.Errorf("Unable to fetch pxcentral-post-install-hook pod from backup namespace\n Error : [%v]\n",

--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -6308,7 +6308,9 @@ var _ = Describe("{RestartBackupPodDuringBackupSharing}", func() {
 			log.InfoD("Restart backup pod when backup sharing is in-progress")
 			backupPodLabel := make(map[string]string)
 			backupPodLabel["app"] = "px-backup"
-			err := DeletePodWithLabelInNamespace(backup.GetPxBackupNamespace(), backupPodLabel)
+			pxbNamespace, err := backup.GetPxBackupNamespace()
+			dash.VerifyFatal(err, nil, "Getting px-backup namespace")
+			err = DeletePodWithLabelInNamespace(pxbNamespace, backupPodLabel)
 			dash.VerifyFatal(err, nil, "Restart backup pod when backup sharing is in-progress")
 			pods, err := core.Instance().GetPods("px-backup", backupPodLabel)
 			dash.VerifyFatal(err, nil, "Getting px-backup pod")
@@ -6364,7 +6366,9 @@ var _ = Describe("{RestartBackupPodDuringBackupSharing}", func() {
 			log.InfoD("Restart mongo pod when backup sharing is in-progress")
 			backupPodLabel := make(map[string]string)
 			backupPodLabel["app.kubernetes.io/component"] = "pxc-backup-mongodb"
-			err := DeletePodWithLabelInNamespace(backup.GetPxBackupNamespace(), backupPodLabel)
+			pxbNamespace, err := backup.GetPxBackupNamespace()
+			dash.VerifyFatal(err, nil, "Getting px-backup namespace")
+			err = DeletePodWithLabelInNamespace(pxbNamespace, backupPodLabel)
 			dash.VerifyFatal(err, nil, "Restart mongo pod when backup sharing is in-progress")
 			pods, err := core.Instance().GetPods("px-backup", backupPodLabel)
 			dash.VerifyFatal(err, nil, "Getting mongo pods")


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR fixes an issue in the Px-Backup automation where it was previously limited to working only in the "px-backup" namespace. With this PR, the automation can now be executed in any namespace, making it more flexible and adaptable to different deployment scenarios.

**Which issue(s) this PR fixes** (optional)
Closes #PA-662

**Special notes for your reviewer**:
Please review the Jenkins build for the "BasicBackupCreation" test case with px-backup namespace "px-backup" using the link below [PASSED]

https://jenkins.pwx.dev.purestorage.com/job/Users/job/Sumit/job/Custom-Pipelines/job/px-backup-on-demand-system-test-byoc/105/

Please review the Jenkins build for the "BasicBackupCreation" test case with px-backup namespace "central" using the link below [PASSED]

https://jenkins.pwx.dev.purestorage.com/job/Users/job/Sumit/job/Custom-Pipelines/job/px-backup-on-demand-system-test-byoc/108/

Please review the Jenkins build for the "BasicBackupCreation" test case with no px-backup using the link below [FAILED]

https://jenkins.pwx.dev.purestorage.com/job/Users/job/Sumit/job/Custom-Pipelines/job/px-backup-on-demand-system-test-byoc/107