### PR TITLE
PTX-15161 -cloud drive add of same size/types should not create seperate pools

### DIFF
--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -1140,6 +1140,8 @@ var _ = Describe("{AddDriveWithPXRestart}", func() {
 	//2) Create a volume on that pool and write some data on the volume.
 	//3) Expand pool by adding cloud drives.
 	//4) Restart px service where the pool expansion is in-progress
+	//5) Verify total pool count after addition of cloud drive of same spec with PX restart
+
 	var testrailID = 50632
 	// testrailID corresponds to: https://portworx.testrail.net/index.php?/cases/view/50632
 	var runID int
@@ -1161,11 +1163,13 @@ var _ = Describe("{AddDriveWithPXRestart}", func() {
 		ValidateApplications(contexts)
 		defer appsValidateAndDestroy(contexts)
 
+		var initialPoolCount int
 		stNode, err := GetRandomNodeWithPoolIOs(contexts)
 		log.FailOnError(err, "error identifying node to run test")
 		pools, err := Inst().V.ListStoragePools(metav1.LabelSelector{})
 		log.FailOnError(err, "error getting pools list")
 		dash.VerifyFatal(len(pools) > 0, true, "Verify pools exist")
+		initialPoolCount = len(pools)
 
 		var currentTotalPoolSize uint64
 		var specSize uint64
@@ -1203,6 +1207,7 @@ var _ = Describe("{AddDriveWithPXRestart}", func() {
 			log.FailOnError(err, "Pool re-balance failed")
 			dash.VerifyFatal(err == nil, true, "PX is up after add drive with vol driver restart")
 
+			var finalPoolCount int
 			var newTotalPoolSize uint64
 			pools, err := Inst().V.ListStoragePools(metav1.LabelSelector{})
 			log.FailOnError(err, "error getting pools list")
@@ -1210,7 +1215,9 @@ var _ = Describe("{AddDriveWithPXRestart}", func() {
 			for _, pool := range pools {
 				newTotalPoolSize += pool.GetTotalSize() / units.GiB
 			}
+			finalPoolCount = len(pools)
 			dash.VerifyFatal(newTotalPoolSize, expectedTotalPoolSize, fmt.Sprintf("Validate total pool size after add cloud drive on node %s", stNode.Name))
+			dash.VerifyFatal(initialPoolCount == finalPoolCount, true, fmt.Sprintf("Total pool count after cloud drive add with PX restart Expected:[%d] Got:[%d]", initialPoolCount, finalPoolCount))
 		})
 
 	})
@@ -6111,7 +6118,7 @@ var _ = Describe("{ChangedIOPriorityPersistPoolExpand}", func() {
 		ioPriorityAfter, err := Inst().V.GetPoolLabelValue(poolUUID, "iopriority")
 		log.FailOnError(err, "Failed to get IO Priority for Pool with UUID [%v]", poolUUID)
 
-                log.InfoD(fmt.Sprintf("Priority Before [%s] was set to [%s] and Priority after Pool Expansion [%s]", ioPriorityBefore, setIOPriority, ioPriorityAfter))
+		log.InfoD(fmt.Sprintf("Priority Before [%s] was set to [%s] and Priority after Pool Expansion [%s]", ioPriorityBefore, setIOPriority, ioPriorityAfter))
 		dash.VerifyFatal(strings.ToLower(setIOPriority) == strings.ToLower(ioPriorityAfter), true, "IO Priority mismatch after pool expansion")
 
 	})


### PR DESCRIPTION


<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

During addition of cloud drive (of same size and type) to the existing pools with PX restart - no new pool should get created.

Added a check to verify total pool count after addition of cloud drive 

**Which issue(s) this PR fixes** (optional)
Closes #
PTX-16216

**Special notes for your reviewer**:

