### PR TITLE
Bugfix - Adding users to group was not uniform

### DIFF
--- a/drivers/pds/lib/utils.go
+++ b/drivers/pds/lib/utils.go
@@ -2380,7 +2380,7 @@ func GetNodesOfSS(SSName string, namespace string) ([]*corev1.Node, error) {
 	return nodes, nil
 }
 
-//Returns list of Pods from a given Statefulset running on a given Node
+// Returns list of Pods from a given Statefulset running on a given Node
 func GetPodsOfSsByNode(SSName string, nodeName string, namespace string) ([]corev1.Pod, error) {
 	// Get StatefulSet Object of the given Statefulset
 	ss, err := k8sApps.GetStatefulSet(SSName, namespace)

--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -883,10 +883,10 @@ var _ = Describe("{ShareBackupWithUsersAndGroups}", func() {
 				email := fmt.Sprintf("testuser%v_%v@cnbu.com", i, time.Now().Unix())
 				wg.Add(1)
 				go func(userName, firstName, lastName, email string) {
+					defer wg.Done()
 					err := backup.AddUser(userName, firstName, lastName, email, "Password1")
 					log.FailOnError(err, "Failed to create user - %s", userName)
 					users = append(users, userName)
-					wg.Done()
 				}(userName, firstName, lastName, email)
 			}
 			wg.Wait()
@@ -899,10 +899,10 @@ var _ = Describe("{ShareBackupWithUsersAndGroups}", func() {
 				groupName := fmt.Sprintf("testGroup%v", i)
 				wg.Add(1)
 				go func(groupName string) {
+					defer wg.Done()
 					err := backup.AddGroup(groupName)
 					log.FailOnError(err, "Failed to create group - %v", groupName)
 					groups = append(groups, groupName)
-					wg.Done()
 				}(groupName)
 			}
 			wg.Wait()
@@ -915,9 +915,9 @@ var _ = Describe("{ShareBackupWithUsersAndGroups}", func() {
 				groupIndex := i / groupSize
 				wg.Add(1)
 				go func(userName string, groupIndex int) {
+					defer wg.Done()
 					err := backup.AddGroupToUser(userName, groups[groupIndex])
 					log.FailOnError(err, "Failed to assign group to user")
-					wg.Done()
 				}(user, groupIndex)
 			}
 			wg.Wait()
@@ -1366,9 +1366,9 @@ var _ = Describe("{ShareLargeNumberOfBackupsWithLargeNumberOfUsers}", func() {
 				groupIndex := i / groupSize
 				wg.Add(1)
 				go func(userName string, groupIndex int) {
+					defer wg.Done()
 					err := backup.AddGroupToUser(userName, groups[groupIndex])
 					log.FailOnError(err, "Failed to assign group to user")
-					wg.Done()
 				}(user, groupIndex)
 			}
 			wg.Wait()
@@ -1698,10 +1698,10 @@ var _ = Describe("{CancelClusterBackupShare}", func() {
 				time.Sleep(2 * time.Second)
 				wg.Add(1)
 				go func(userName, firstName, lastName, email string) {
+					defer wg.Done()
 					err := backup.AddUser(userName, firstName, lastName, email, "Password1")
 					log.FailOnError(err, "Failed to create user - %s", userName)
 					users = append(users, userName)
-					wg.Done()
 				}(userName, firstName, lastName, email)
 			}
 			wg.Wait()
@@ -1721,10 +1721,10 @@ var _ = Describe("{CancelClusterBackupShare}", func() {
 				groupName := fmt.Sprintf("testGroup%v", i)
 				wg.Add(1)
 				go func(groupName string) {
+					defer wg.Done()
 					err := backup.AddGroup(groupName)
 					log.FailOnError(err, "Failed to create group - %v", groupName)
 					groups = append(groups, groupName)
-					wg.Done()
 				}(groupName)
 			}
 			wg.Wait()
@@ -1738,9 +1738,9 @@ var _ = Describe("{CancelClusterBackupShare}", func() {
 				groupIndex := i / groupSize
 				wg.Add(1)
 				go func(userName string, groupIndex int) {
+					defer wg.Done()
 					err := backup.AddGroupToUser(userName, groups[groupIndex])
 					log.FailOnError(err, "Failed to assign group to user")
-					wg.Done()
 				}(user, groupIndex)
 			}
 			wg.Wait()
@@ -2180,10 +2180,10 @@ var _ = Describe("{ShareBackupAndEdit}", func() {
 				email := fmt.Sprintf("testuser%v@cnbu.com", i)
 				wg.Add(1)
 				go func(userName, firstName, lastName, email string) {
+					defer wg.Done()
 					err := backup.AddUser(userName, firstName, lastName, email, "Password1")
 					log.FailOnError(err, "Failed to create user - %s", userName)
 					users = append(users, userName)
-					wg.Done()
 				}(userName, firstName, lastName, email)
 			}
 			wg.Wait()

--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -911,14 +911,14 @@ var _ = Describe("{ShareBackupWithUsersAndGroups}", func() {
 		Step("Add users to group", func() {
 			log.InfoD("Adding users to groups")
 			var wg sync.WaitGroup
-			for i := 0; i < len(users); i++ {
+			for i, user := range users {
 				groupIndex := i / groupSize
 				wg.Add(1)
-				go func(i, groupIndex int) {
-					err := backup.AddGroupToUser(users[i], groups[groupIndex])
+				go func(userName string, groupIndex int) {
+					err := backup.AddGroupToUser(userName, groups[groupIndex])
 					log.FailOnError(err, "Failed to assign group to user")
 					wg.Done()
-				}(i, groupIndex)
+				}(user, groupIndex)
 			}
 			wg.Wait()
 
@@ -1145,6 +1145,7 @@ var _ = Describe("{ShareBackupWithUsersAndGroups}", func() {
 			// Get user from the restore access group
 			username, err := backup.GetRandomUserFromGroup(groups[1])
 			log.FailOnError(err, "Failed to get a random user from group [%s]", groups[1])
+			log.Infof("Sharing backup with user - %s", username)
 
 			// Get user context
 			ctxNonAdmin, err := backup.GetNonAdminCtx(username, "Password1")
@@ -1188,6 +1189,7 @@ var _ = Describe("{ShareBackupWithUsersAndGroups}", func() {
 			// Get user from the view only access group
 			username, err := backup.GetRandomUserFromGroup(groups[0])
 			log.FailOnError(err, "Failed to get a random user from group [%s]", groups[0])
+			log.Infof("Sharing backup with user - %s", username)
 
 			// Get user context
 			ctxNonAdmin, err := backup.GetNonAdminCtx(username, "Password1")
@@ -1360,14 +1362,14 @@ var _ = Describe("{ShareLargeNumberOfBackupsWithLargeNumberOfUsers}", func() {
 		Step("Add users to group", func() {
 			log.InfoD("Adding users to groups")
 			var wg sync.WaitGroup
-			for i := 0; i < len(users); i++ {
+			for i, user := range users {
 				groupIndex := i / groupSize
 				wg.Add(1)
-				go func(i, groupIndex int) {
-					defer wg.Done()
-					err := backup.AddGroupToUser(users[i], groups[groupIndex])
+				go func(userName string, groupIndex int) {
+					err := backup.AddGroupToUser(userName, groups[groupIndex])
 					log.FailOnError(err, "Failed to assign group to user")
-				}(i, groupIndex)
+					wg.Done()
+				}(user, groupIndex)
 			}
 			wg.Wait()
 
@@ -1731,15 +1733,15 @@ var _ = Describe("{CancelClusterBackupShare}", func() {
 		Step("Add users to group", func() {
 			log.InfoD("Adding users to groups")
 			var wg sync.WaitGroup
-			for i := 0; i < len(users); i++ {
+			for i, user := range users {
 				time.Sleep(2 * time.Second)
 				groupIndex := i / groupSize
 				wg.Add(1)
-				go func(i, groupIndex int) {
-					err := backup.AddGroupToUser(users[i], groups[groupIndex])
+				go func(userName string, groupIndex int) {
+					err := backup.AddGroupToUser(userName, groups[groupIndex])
 					log.FailOnError(err, "Failed to assign group to user")
 					wg.Done()
-				}(i, groupIndex)
+				}(user, groupIndex)
 			}
 			wg.Wait()
 

--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -911,14 +911,14 @@ var _ = Describe("{ShareBackupWithUsersAndGroups}", func() {
 		Step("Add users to group", func() {
 			log.InfoD("Adding users to groups")
 			var wg sync.WaitGroup
-			for i, user := range users {
+			for i, userName := range users {
 				groupIndex := i / groupSize
 				wg.Add(1)
 				go func(userName string, groupIndex int) {
 					defer wg.Done()
 					err := backup.AddGroupToUser(userName, groups[groupIndex])
 					log.FailOnError(err, "Failed to assign group to user")
-				}(user, groupIndex)
+				}(userName, groupIndex)
 			}
 			wg.Wait()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In the tests `CancelClusterBackupShare` and `ShareBackupWithUsersAndGroups` when I created 30 users and wanted to add them in 3 groups equally, it was not happening and few groups had more than 10 users. This was happening because I made the classic error of passing the index of the iterator to the go routine which was adding users to the groups.
Now it is working as expected. Please refer to the jenkins run.

Earlier:

```
16:03:22  2023-03-02 10:33:21 +0000:[INFO] [{ShareBackupWithUsersAndGroups}] [backup.FetchIDOfGroup:#1076] - Fetching ID of group testGroup3 - c4414e04-82aa-4eb6-8dbe-5600363acb73

16:03:22  2023-03-02 10:33:22 +0000:[DEBUG] [{ShareBackupWithUsersAndGroups}] [backup.GetMembersOfGroup:#918] - list of members : [testuser1 testuser10 testuser11 testuser12 testuser13 testuser15 testuser16 testuser17 testuser2 testuser22 testuser3 testuser30 testuser4 testuser5 testuser6 testuser7 testuser8 testuser9]

16:03:22  2023-03-02 10:33:22 +0000:[INFO] [{ShareBackupWithUsersAndGroups}] [backup.glob..func10.2.4:#930] - Group [testGroup3] contains the following users: 

16:03:22  [testuser1 testuser10 testuser11 testuser12 testuser13 testuser15 testuser16 testuser17 testuser2 testuser22 testuser3 testuser30 testuser4 testuser5 testuser6 testuser7 testuser8 testuser9]

16:03:23  2023-03-02 10:33:22 +0000:[INFO] [{ShareBackupWithUsersAndGroups}] [backup.FetchIDOfGroup:#1076] - Fetching ID of group testGroup1 - 14a1df34-80de-4737-b102-8dc77f2a6a24

16:03:23  2023-03-02 10:33:23 +0000:[DEBUG] [{ShareBackupWithUsersAndGroups}] [backup.GetMembersOfGroup:#918] - list of members : [testuser1 testuser10 testuser11 testuser13 testuser14 testuser17 testuser18 testuser19 testuser2 testuser20 testuser23 testuser24 testuser25 testuser26 testuser3 testuser9]

16:03:23  2023-03-02 10:33:23 +0000:[INFO] [{ShareBackupWithUsersAndGroups}] [backup.glob..func10.2.4:#930] - Group [testGroup1] contains the following users: 

16:03:23  [testuser1 testuser10 testuser11 testuser13 testuser14 testuser17 testuser18 testuser19 testuser2 testuser20 testuser23 testuser24 testuser25 testuser26 testuser3 testuser9]

16:03:23  2023-03-02 10:33:23 +0000:[INFO] [{ShareBackupWithUsersAndGroups}] [backup.FetchIDOfGroup:#1076] - Fetching ID of group testGroup2 - 21286dc3-5f6d-43da-b87d-3222a2ce2282

16:03:24  2023-03-02 10:33:23 +0000:[DEBUG] [{ShareBackupWithUsersAndGroups}] [backup.GetMembersOfGroup:#918] - list of members : [testuser12 testuser14 testuser15 testuser16 testuser20 testuser21 testuser22 testuser24 testuser25 testuser27 testuser28 testuser29 testuser30 testuser4 testuser5 testuser6]

16:03:24  2023-03-02 10:33:23 +0000:[INFO] [{ShareBackupWithUsersAndGroups}] [backup.glob..func10.2.4:#930] - Group [testGroup2] contains the following users: 

16:03:24  [testuser12 testuser14 testuser15 testuser16 testuser20 testuser21 testuser22 testuser24 testuser25 testuser27 testuser28 testuser29 testuser30 testuser4 testuser5 testuser6]
```

After the fix:

```
16:14:52  2023-03-03 10:44:52 +0000:[INFO] [{ShareBackupWithUsersAndGroups}] [backup.FetchIDOfGroup:#1111] - Fetching ID of group testGroup3 - 2b2411fc-314f-437e-92f9-f40d5a6d7dba

16:14:52  2023-03-03 10:44:52 +0000:[DEBUG] [{ShareBackupWithUsersAndGroups}] [backup.GetMembersOfGroup:#953] - list of members : [testuser10 testuser11 testuser3 testuser30 testuser4 testuser5 testuser6 testuser7 testuser8 testuser9]

16:14:52  2023-03-03 10:44:52 +0000:[INFO] [{ShareBackupWithUsersAndGroups}] [backup.glob..func10.2.4:#940] - Group [testGroup3] contains the following users: 

16:14:52  [testuser10 testuser11 testuser3 testuser30 testuser4 testuser5 testuser6 testuser7 testuser8 testuser9]

16:14:53  2023-03-03 10:44:53 +0000:[INFO] [{ShareBackupWithUsersAndGroups}] [backup.FetchIDOfGroup:#1111] - Fetching ID of group testGroup1 - 7dc5f3eb-148a-4122-b87c-c2fb0d08e3b3

16:14:54  2023-03-03 10:44:54 +0000:[DEBUG] [{ShareBackupWithUsersAndGroups}] [backup.GetMembersOfGroup:#953] - list of members : [testuser1 testuser12 testuser13 testuser14 testuser15 testuser16 testuser17 testuser2 testuser23 testuser24]

16:14:54  2023-03-03 10:44:54 +0000:[INFO] [{ShareBackupWithUsersAndGroups}] [backup.glob..func10.2.4:#940] - Group [testGroup1] contains the following users: 

16:14:54  [testuser1 testuser12 testuser13 testuser14 testuser15 testuser16 testuser17 testuser2 testuser23 testuser24]

16:14:55  2023-03-03 10:44:55 +0000:[INFO] [{ShareBackupWithUsersAndGroups}] [backup.FetchIDOfGroup:#1111] - Fetching ID of group testGroup2 - 58f19c15-1d90-4990-92ad-6a42bd4cc985

16:14:55  2023-03-03 10:44:55 +0000:[DEBUG] [{ShareBackupWithUsersAndGroups}] [backup.GetMembersOfGroup:#953] - list of members : [testuser18 testuser19 testuser20 testuser21 testuser22 testuser25 testuser26 testuser27 testuser28 testuser29]

16:14:55  2023-03-03 10:44:55 +0000:[INFO] [{ShareBackupWithUsersAndGroups}] [backup.glob..func10.2.4:#940] - Group [testGroup2] contains the following users: 

16:14:55  [testuser18 testuser19 testuser20 testuser21 testuser22 testuser25 testuser26 testuser27 testuser28 testuser29]
```


**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
[Jenkins run](https://jenkins.pwx.dev.purestorage.com/job/Users/job/Sumit/job/Custom-Pipelines/job/px-backup-on-demand-system-test-byoc/169/)

