### PR TITLE
PWX-28724 : Update OKE automation to use disk encryption

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -624,6 +624,8 @@ spec:
       value: "${PX_ORACLE_fingerprint}"
     - name: PX_ORACLE_private_key_path
       value: "${ORACLE_API_KEY}"
+    - name: INSTANCE_GROUP
+      value: "${INSTANCE_GROUP}"
   volumes: [${VOLUMES}]
   restartPolicy: Never
   serviceAccountName: torpedo-account


### PR DESCRIPTION
Add missing env variable "INSTANCE_GROUP" required for torpedo automation.

Tested with the change done, value is being set on torpedo pod and jenkins build passed.