### PR TITLE
[PA-659] Fix old and add new helper methods for scheduling backups

### DIFF
--- a/drivers/backup/backup.go
+++ b/drivers/backup/backup.go
@@ -211,8 +211,11 @@ type Backup interface {
 	GetVolumeBackupIDs(ctx context.Context, backupName string, namespace string,
 		clusterObj *api.ClusterObject, orgID string) ([]string, error)
 
-	// GetBackupUID returns uid of the given backup in an organization
+	// GetBackupUID returns uid of the given backup name in an organization
 	GetBackupUID(ctx context.Context, backupName string, orgID string) (string, error)
+
+	// GetBackupName returns name of the given backup uid in an organization
+	GetBackupName(ctx context.Context, backupUid string, orgID string) (string, error)
 
 	// UpdateBackupShare updates backupshare of existing backup object
 	UpdateBackupShare(ctx context.Context, req *api.BackupShareUpdateRequest) (*api.BackupShareUpdateResponse, error)
@@ -313,26 +316,8 @@ type ScheduleBackup interface {
 	// GetAllScheduleBackupNames returns names of all scheduled backups for the given schedule
 	GetAllScheduleBackupNames(ctx context.Context, scheduleName string, orgID string) ([]string, error)
 
-	// GetOrdinalScheduleBackupName returns the name of the backup at the specified ordinal position for the given schedule
-	GetOrdinalScheduleBackupName(ctx context.Context, scheduleName string, ordinal int, orgID string) (string, error)
-
-	// GetFirstScheduleBackupName returns the name of the first scheduled backup for the given schedule
-	GetFirstScheduleBackupName(ctx context.Context, scheduleName string, orgID string) (string, error)
-
-	// GetLatestScheduleBackupName returns the name of the latest scheduled backup for the given schedule
-	GetLatestScheduleBackupName(ctx context.Context, scheduleName string, orgID string) (string, error)
-
 	// GetAllScheduleBackupUIDs returns uids of all scheduled backups for the given schedule
 	GetAllScheduleBackupUIDs(ctx context.Context, scheduleName string, orgID string) ([]string, error)
-
-	// GetOrdinalScheduleBackupUID returns the uid of the backup at the specified ordinal position for the given schedule
-	GetOrdinalScheduleBackupUID(ctx context.Context, scheduleName string, ordinal int, orgID string) (string, error)
-
-	// GetFirstScheduleBackupUID returns the uid of the first scheduled backup for the given schedule
-	GetFirstScheduleBackupUID(ctx context.Context, scheduleName string, orgID string) (string, error)
-
-	// GetLatestScheduleBackupUID returns the uid of the latest scheduled backup for the given schedule
-	GetLatestScheduleBackupUID(ctx context.Context, scheduleName string, orgID string) (string, error)
 }
 
 // License interface

--- a/tests/backup/backup_basic_test.go
+++ b/tests/backup/backup_basic_test.go
@@ -184,7 +184,7 @@ var _ = AfterSuite(func() {
 	// Cleanup all backups
 	allBackups, err := GetAllBackupsAdmin()
 	for _, backupName := range allBackups {
-		backupUID, err := getBackupUID(backupName, orgID)
+		backupUID, err := Inst().Backup.GetBackupUID(ctx, backupName, orgID)
 		dash.VerifySafely(err, nil, fmt.Sprintf("Getting backuip UID for backup %s", backupName))
 		_, err = DeleteBackup(backupName, backupUID, orgID, ctx)
 		dash.VerifySafely(err, nil, fmt.Sprintf("Verifying backup deletion - %s", backupName))

--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -3,8 +3,6 @@ package tests
 import (
 	"context"
 	"fmt"
-	"github.com/portworx/sched-ops/k8s/apps"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -13,6 +11,9 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/portworx/sched-ops/k8s/apps"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo"
 	api "github.com/portworx/px-backup-api/pkg/apis/v1"
@@ -288,7 +289,7 @@ func CreateBackupWithCustomResourceType(backupName string, clusterName string, b
 	return nil
 }
 
-// CreateScheduleBackup creates a scheduled backup
+// CreateScheduleBackup creates a schedule backup
 func CreateScheduleBackup(scheduleName string, clusterName string, bLocation string, bLocationUID string,
 	namespaces []string, labelSelectors map[string]string, orgID string, preRuleName string,
 	preRuleUid string, postRuleName string, postRuleUid string, schPolicyName string, schPolicyUID string, ctx context.Context) error {
@@ -327,11 +328,11 @@ func CreateScheduleBackup(scheduleName string, clusterName string, bLocation str
 	}
 	time.Sleep(1 * time.Minute)
 	backupSuccessCheck := func() (interface{}, bool, error) {
-		firstScheduleBackupName, err = backupDriver.GetFirstScheduleBackupName(ctx, scheduleName, orgID)
+		firstScheduleBackupName, err = GetFirstScheduleBackupName(ctx, scheduleName, orgID)
 		if err != nil {
 			return "", true, err
 		}
-		firstScheduleBackupUid, err = backupDriver.GetFirstScheduleBackupUID(ctx, scheduleName, orgID)
+		firstScheduleBackupUid, err = GetFirstScheduleBackupUID(ctx, scheduleName, orgID)
 		if err != nil {
 			return "", true, err
 		}
@@ -362,7 +363,7 @@ func CreateScheduleBackup(scheduleName string, clusterName string, bLocation str
 // CreateBackupWithoutCheck creates backup without waiting for success
 func CreateBackupWithoutCheck(backupName string, clusterName string, bLocation string, bLocationUID string,
 	namespaces []string, labelSelectors map[string]string, orgID string, uid string, preRuleName string,
-	preRuleUid string, postRuleName string, postRuleUid string, ctx context.Context) error {
+	preRuleUid string, postRuleName string, postRuleUid string, ctx context.Context) (*api.BackupInspectResponse, error) {
 
 	backupDriver := Inst().Backup
 	bkpCreateRequest := &api.BackupCreateRequest{
@@ -392,9 +393,69 @@ func CreateBackupWithoutCheck(backupName string, clusterName string, bLocation s
 	}
 	_, err := backupDriver.CreateBackup(ctx, bkpCreateRequest)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	backupUid, err := backupDriver.GetBackupUID(ctx, backupName, orgID)
+	if err != nil {
+		return nil, err
+	}
+	backupInspectRequest := &api.BackupInspectRequest{
+		Name:  backupName,
+		Uid:   backupUid,
+		OrgId: orgID,
+	}
+	resp, err := backupDriver.InspectBackup(ctx, backupInspectRequest)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
+}
+
+// CreateScheduleBackupWithoutCheck creates a schedule backup without waiting for success
+func CreateScheduleBackupWithoutCheck(scheduleName string, clusterName string, bLocation string, bLocationUID string,
+	namespaces []string, labelSelectors map[string]string, orgID string, preRuleName string,
+	preRuleUid string, postRuleName string, postRuleUid string, schPolicyName string, schPolicyUID string, ctx context.Context) (*api.BackupScheduleInspectResponse, error) {
+	backupDriver := Inst().Backup
+	bkpSchCreateRequest := &api.BackupScheduleCreateRequest{
+		CreateMetadata: &api.CreateMetadata{
+			Name:  scheduleName,
+			OrgId: orgID,
+		},
+		SchedulePolicyRef: &api.ObjectRef{
+			Name: schPolicyName,
+			Uid:  schPolicyUID,
+		},
+		BackupLocationRef: &api.ObjectRef{
+			Name: bLocation,
+			Uid:  bLocationUID,
+		},
+		SchedulePolicy: schPolicyName,
+		Cluster:        clusterName,
+		Namespaces:     namespaces,
+		LabelSelectors: labelSelectors,
+		PreExecRuleRef: &api.ObjectRef{
+			Name: preRuleName,
+			Uid:  preRuleUid,
+		},
+		PostExecRuleRef: &api.ObjectRef{
+			Name: postRuleName,
+			Uid:  postRuleUid,
+		},
+	}
+	_, err := backupDriver.CreateBackupSchedule(ctx, bkpSchCreateRequest)
+	if err != nil {
+		return nil, err
+	}
+	backupScheduleInspectRequest := &api.BackupScheduleInspectRequest{
+		OrgId: orgID,
+		Name:  scheduleName,
+		Uid:   "",
+	}
+	resp, err := backupDriver.InspectBackupSchedule(ctx, backupScheduleInspectRequest)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
 }
 
 // ShareBackup provides access to the mentioned groups or/add users
@@ -673,7 +734,7 @@ func CreateRestoreWithUID(restoreName string, backupName string, namespaceMappin
 
 // CreateRestoreWithoutCheck creates restore without waiting for completion
 func CreateRestoreWithoutCheck(restoreName string, backupName string,
-	namespaceMapping map[string]string, clusterName string, orgID string, ctx context.Context) error {
+	namespaceMapping map[string]string, clusterName string, orgID string, ctx context.Context) (*api.RestoreInspectResponse, error) {
 
 	var bkp *api.BackupObject
 	var bkpUid string
@@ -704,22 +765,17 @@ func CreateRestoreWithoutCheck(restoreName string, backupName string,
 	}
 	_, err := backupDriver.CreateRestore(ctx, createRestoreReq)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
-}
-
-func getBackupUID(backupName, orgID string) (string, error) {
-	backupDriver := Inst().Backup
-	ctx, err := backup.GetAdminCtxFromSecret()
+	backupScheduleInspectRequest := &api.RestoreInspectRequest{
+		OrgId: orgID,
+		Name:  restoreName,
+	}
+	resp, err := backupDriver.InspectRestore(ctx, backupScheduleInspectRequest)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	backupUID, err := backupDriver.GetBackupUID(ctx, backupName, orgID)
-	if err != nil {
-		return "", err
-	}
-	return backupUID, nil
+	return resp, nil
 }
 
 func getSizeOfMountPoint(podName string, namespace string, kubeConfigFile string) (int, error) {
@@ -1336,4 +1392,88 @@ func CreateCustomRestoreWithPVCs(restoreName string, backupName string, namespac
 		return "", fmt.Errorf("restore status is false with error %v", err)
 	}
 	return deployment.Name, nil
+}
+
+// GetOrdinalScheduleBackupName returns the name of the schedule backup at the specified ordinal position for the given schedule
+func GetOrdinalScheduleBackupName(ctx context.Context, scheduleName string, ordinal int, orgID string) (string, error) {
+	if ordinal < 1 {
+		return "", fmt.Errorf("the provided ordinal value [%d] for schedule backups with schedule name [%s] is invalid. valid values range from 1", ordinal, scheduleName)
+	}
+	allScheduleBackupNames, err := Inst().Backup.GetAllScheduleBackupNames(ctx, scheduleName, orgID)
+	if err != nil {
+		return "", err
+	}
+	if len(allScheduleBackupNames) == 0 {
+		return "", fmt.Errorf("no backups were found for the schedule [%s]", scheduleName)
+	}
+	if ordinal > len(allScheduleBackupNames) {
+		return "", fmt.Errorf("schedule backups with schedule name [%s] have not been created up to the provided ordinal value [%d]", scheduleName, ordinal)
+	}
+	return allScheduleBackupNames[ordinal-1], nil
+}
+
+// GetFirstScheduleBackupName returns the name of the first schedule backup for the given schedule
+func GetFirstScheduleBackupName(ctx context.Context, scheduleName string, orgID string) (string, error) {
+	allScheduleBackupNames, err := Inst().Backup.GetAllScheduleBackupNames(ctx, scheduleName, orgID)
+	if err != nil {
+		return "", err
+	}
+	if len(allScheduleBackupNames) == 0 {
+		return "", fmt.Errorf("no backups found for schedule %s", scheduleName)
+	}
+	return allScheduleBackupNames[0], nil
+}
+
+// GetLatestScheduleBackupName returns the name of the latest schedule backup for the given schedule
+func GetLatestScheduleBackupName(ctx context.Context, scheduleName string, orgID string) (string, error) {
+	allScheduleBackupNames, err := Inst().Backup.GetAllScheduleBackupNames(ctx, scheduleName, orgID)
+	if err != nil {
+		return "", err
+	}
+	if len(allScheduleBackupNames) == 0 {
+		return "", fmt.Errorf("no backups found for schedule %s", scheduleName)
+	}
+	return allScheduleBackupNames[len(allScheduleBackupNames)-1], nil
+}
+
+// GetOrdinalScheduleBackupUID returns the uid of the schedule backup at the specified ordinal position for the given schedule
+func GetOrdinalScheduleBackupUID(ctx context.Context, scheduleName string, ordinal int, orgID string) (string, error) {
+	if ordinal < 1 {
+		return "", fmt.Errorf("the provided ordinal value [%d] for schedule backups with schedule name [%s] is invalid. valid values range from 1", ordinal, scheduleName)
+	}
+	allScheduleBackupUids, err := Inst().Backup.GetAllScheduleBackupUIDs(ctx, scheduleName, orgID)
+	if err != nil {
+		return "", err
+	}
+	if len(allScheduleBackupUids) == 0 {
+		return "", fmt.Errorf("no backups were found for the schedule [%s]", scheduleName)
+	}
+	if ordinal > len(allScheduleBackupUids) {
+		return "", fmt.Errorf("schedule backups with schedule name [%s] have not been created up to the provided ordinal value [%d]", scheduleName, ordinal)
+	}
+	return allScheduleBackupUids[ordinal-1], nil
+}
+
+// GetFirstScheduleBackupUID returns the uid of the first schedule backup for the given schedule
+func GetFirstScheduleBackupUID(ctx context.Context, scheduleName string, orgID string) (string, error) {
+	allScheduleBackupUids, err := Inst().Backup.GetAllScheduleBackupUIDs(ctx, scheduleName, orgID)
+	if err != nil {
+		return "", err
+	}
+	if len(allScheduleBackupUids) == 0 {
+		return "", fmt.Errorf("no backups found for schedule %s", scheduleName)
+	}
+	return allScheduleBackupUids[0], nil
+}
+
+// GetLatestScheduleBackupUID returns the uid of the latest schedule backup for the given schedule
+func GetLatestScheduleBackupUID(ctx context.Context, scheduleName string, orgID string) (string, error) {
+	allScheduleBackupUids, err := Inst().Backup.GetAllScheduleBackupUIDs(ctx, scheduleName, orgID)
+	if err != nil {
+		return "", err
+	}
+	if len(allScheduleBackupUids) == 0 {
+		return "", fmt.Errorf("no backups found for schedule %s", scheduleName)
+	}
+	return allScheduleBackupUids[len(allScheduleBackupUids)-1], nil
 }

--- a/tests/backup/backup_portworx_test.go
+++ b/tests/backup/backup_portworx_test.go
@@ -2,6 +2,8 @@ package tests
 
 import (
 	"fmt"
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	"github.com/pborman/uuid"
 	api "github.com/portworx/px-backup-api/pkg/apis/v1"
@@ -16,7 +18,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	storageApi "k8s.io/api/storage/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"time"
 
 	. "github.com/portworx/torpedo/tests"
 )
@@ -100,7 +101,7 @@ var _ = Describe("{BackupLocationWithEncryptionKey}", func() {
 		log.FailOnError(err, "Fetching px-central-admin ctx")
 		err = DeleteRestore(restoreName, orgID, ctx)
 		dash.VerifyFatal(err, nil, fmt.Sprintf("Deleting Restore %s", restoreName))
-		backupUID, err := getBackupUID(backupName, orgID)
+		backupUID, err := Inst().Backup.GetBackupUID(ctx, backupName, orgID)
 		dash.VerifyFatal(err, nil, fmt.Sprintf("Getting backup UID for backup %s", backupName))
 		_, err = DeleteBackup(backupName, backupUID, orgID, ctx)
 		dash.VerifyFatal(err, nil, fmt.Sprintf("Deleting backup %s", backupName))
@@ -250,7 +251,7 @@ var _ = Describe("{ReplicaChangeWhileRestore}", func() {
 			err := Inst().S.Destroy(contexts[i], opts)
 			dash.VerifySafely(err, nil, fmt.Sprintf("Verify destroying app %s", taskName))
 		}
-		backupUID, err := getBackupUID(backupName, orgID)
+		backupUID, err := Inst().Backup.GetBackupUID(ctx, backupName, orgID)
 		dash.VerifyFatal(err, nil, fmt.Sprintf("Getting backup UID for backup %s", backupName))
 		_, err = DeleteBackup(backupName, backupUID, orgID, ctx)
 		dash.VerifySafely(err, nil, fmt.Sprintf("Deleting backup [%s]", backupName))
@@ -551,7 +552,7 @@ var _ = Describe("{RestoreEncryptedAndNonEncryptedBackups}", func() {
 		ctx, err = backup.GetAdminCtxFromSecret()
 		log.FailOnError(err, "Fetching px-central-admin ctx")
 		for _, backupName := range backupNames {
-			backupUID, err := getBackupUID(backupName, orgID)
+			backupUID, err := Inst().Backup.GetBackupUID(ctx, backupName, orgID)
 			dash.VerifyFatal(err, nil, fmt.Sprintf("Getting backup UID for backup %s", backupName))
 			_, err = DeleteBackup(backupName, backupUID, orgID, ctx)
 			dash.VerifyFatal(err, nil, fmt.Sprintf("Deleting backup %s", backupName))

--- a/tests/backup/backup_resiliency_test.go
+++ b/tests/backup/backup_resiliency_test.go
@@ -3,6 +3,10 @@ package tests
 import (
 	"context"
 	"fmt"
+	"strings"
+	"sync"
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	"github.com/pborman/uuid"
 	api "github.com/portworx/px-backup-api/pkg/apis/v1"
@@ -13,9 +17,6 @@ import (
 	"github.com/portworx/torpedo/drivers/scheduler"
 	"github.com/portworx/torpedo/pkg/log"
 	. "github.com/portworx/torpedo/tests"
-	"strings"
-	"sync"
-	"time"
 )
 
 // This test restarts volume driver (PX) while backup is in progress
@@ -132,7 +133,7 @@ var _ = Describe("{BackupRestartPX}", func() {
 				postRuleUid, _ := Inst().Backup.GetRuleUid(orgID, ctx, postRuleNameList[0])
 				backupName := fmt.Sprintf("%s-%s-%v", BackupNamePrefix, namespace, time.Now().Unix())
 				backupNamespaceMap[namespace] = backupName
-				err = CreateBackupWithoutCheck(backupName, SourceClusterName, backupLocation, backupLocationUID, []string{namespace},
+				_, err = CreateBackupWithoutCheck(backupName, SourceClusterName, backupLocation, backupLocationUID, []string{namespace},
 					labelSelectors, orgID, clusterUid, preRuleNameList[0], preRuleUid, postRuleNameList[0], postRuleUid, ctx)
 				dash.VerifyFatal(err, nil, fmt.Sprintf("Creating backup %s", backupName))
 			}
@@ -296,7 +297,7 @@ var _ = Describe("{KillStorkWithBackupsAndRestoresInProgress}", func() {
 				preRuleUid, _ := Inst().Backup.GetRuleUid(orgID, ctx, preRuleNameList[0])
 				postRuleUid, _ := Inst().Backup.GetRuleUid(orgID, ctx, postRuleNameList[0])
 				backupName := fmt.Sprintf("%s-%s-%v", BackupNamePrefix, namespace, time.Now().Unix())
-				err = CreateBackupWithoutCheck(backupName, SourceClusterName, backupLocation, backupLocationUID, []string{namespace},
+				_, err = CreateBackupWithoutCheck(backupName, SourceClusterName, backupLocation, backupLocationUID, []string{namespace},
 					labelSelectors, orgID, clusterUid, preRuleNameList[0], preRuleUid, postRuleNameList[0], postRuleUid, ctx)
 				dash.VerifyFatal(err, nil, fmt.Sprintf("Creating backup %s", backupName))
 				backupNames = append(backupNames, backupName)
@@ -326,7 +327,7 @@ var _ = Describe("{KillStorkWithBackupsAndRestoresInProgress}", func() {
 			for _, backupName := range backupNames {
 				ctx, err := backup.GetAdminCtxFromSecret()
 				log.FailOnError(err, "Fetching px-central-admin ctx")
-				err = CreateRestoreWithoutCheck(fmt.Sprintf("%s-restore", backupName), backupName, nil, SourceClusterName, orgID, ctx)
+				_, err = CreateRestoreWithoutCheck(fmt.Sprintf("%s-restore", backupName), backupName, nil, SourceClusterName, orgID, ctx)
 				log.FailOnError(err, "Failed while trying to restore [%s] the backup [%s]", fmt.Sprintf("%s-restore", backupName), backupName)
 			}
 		})

--- a/tests/backup/backup_restore_basic_test.go
+++ b/tests/backup/backup_restore_basic_test.go
@@ -2,6 +2,9 @@ package tests
 
 import (
 	"fmt"
+	"strconv"
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	"github.com/pborman/uuid"
 	api "github.com/portworx/px-backup-api/pkg/apis/v1"
@@ -13,8 +16,6 @@ import (
 	"github.com/portworx/torpedo/pkg/log"
 	. "github.com/portworx/torpedo/tests"
 	v1 "k8s.io/api/core/v1"
-	"strconv"
-	"time"
 )
 
 // BasicSelectiveRestore selects random backed-up apps and restores them
@@ -265,7 +266,7 @@ var _ = Describe("{CustomResourceBackupAndRestore}", func() {
 			dash.VerifyFatal(err, nil, fmt.Sprintf("Deleting Restore %s", restore))
 		}
 		for _, backupName := range backupNames {
-			backupUID, err := getBackupUID(backupName, orgID)
+			backupUID, err := Inst().Backup.GetBackupUID(ctx, backupName, orgID)
 			dash.VerifyFatal(err, nil, fmt.Sprintf("Getting backup UID for backup %s", backupName))
 			_, err = DeleteBackup(backupName, backupUID, orgID, ctx)
 			dash.VerifyFatal(err, nil, fmt.Sprintf("Deleting backup - %s", backupName))
@@ -572,7 +573,7 @@ var _ = Describe("{ScheduleBackupCreationSingleNS}", func() {
 				err = CreateScheduleBackup(backupName, SourceClusterName, backupLocationName, backupLocationUID, []string{namespace},
 					labelSelectors, orgID, "", "", "", "", periodicPolicyName, schPolicyUid, ctx)
 				dash.VerifyFatal(err, nil, fmt.Sprintf("Verification of creating schedule backup with schedule name - %s", backupName))
-				schBackupName, err = Inst().Backup.GetFirstScheduleBackupName(ctx, backupName, orgID)
+				schBackupName, err = GetFirstScheduleBackupName(ctx, backupName, orgID)
 				dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching the name of the first schedule backup - %s", schBackupName))
 			}
 		})
@@ -704,7 +705,7 @@ var _ = Describe("{ScheduleBackupCreationAllNS}", func() {
 			err = CreateScheduleBackup(backupName, SourceClusterName, backupLocationName, backupLocationUID, bkpNamespaces,
 				labelSelectors, orgID, "", "", "", "", periodicPolicyName, schPolicyUid, ctx)
 			dash.VerifyFatal(err, nil, fmt.Sprintf("Verification of creating schedule backup with schedule name - %s", backupName))
-			schBackupName, err = Inst().Backup.GetFirstScheduleBackupName(ctx, backupName, orgID)
+			schBackupName, err = GetFirstScheduleBackupName(ctx, backupName, orgID)
 			dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching the name of the first schedule backup - %s", schBackupName))
 		})
 

--- a/tests/backup/backup_share_test.go
+++ b/tests/backup/backup_share_test.go
@@ -3,6 +3,12 @@ package tests
 import (
 	"context"
 	"fmt"
+	"math/rand"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	"github.com/pborman/uuid"
 	api "github.com/portworx/px-backup-api/pkg/apis/v1"
@@ -17,11 +23,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	storageApi "k8s.io/api/storage/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"math/rand"
-	"strconv"
-	"strings"
-	"sync"
-	"time"
 )
 
 // This is to create multiple users and groups
@@ -3793,7 +3794,7 @@ var _ = Describe("{IssueMultipleDeletesForSharedBackup}", func() {
 				restoreName := fmt.Sprintf("%s-%s", RestoreNamePrefix, user)
 				restoreNames = append(restoreNames, restoreName)
 				log.Infof("Creating restore %s for user %s", restoreName, user)
-				err = CreateRestoreWithoutCheck(restoreName, backupName, namespaceMapping, destinationClusterName, orgID, ctxNonAdmin)
+				_, err = CreateRestoreWithoutCheck(restoreName, backupName, namespaceMapping, destinationClusterName, orgID, ctxNonAdmin)
 				log.FailOnError(err, "Failed to create restore %s for user %s", restoreName, user)
 			}
 		})


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

What this PR does / why we need it:
This PR adds additional helper functions that facilitate the creation and removal of scheduled backups. Its purpose is to improve the testing process for scenarios that involve scheduling backups.

Which issue(s) this PR fixes (optional)
Closes #PA-659

Special notes for your reviewer:

Please review the Jenkins build for the "AllNSBackupWithIncludeNewNamespacesOption" test case using the link below

https://jenkins.pwx.dev.purestorage.com/job/Users/job/Sumit/job/Custom-Pipelines/job/px-backup-on-demand-system-test-byoc/214/console

Aetos Dashboard: http://aetos.pwx.purestorage.com/resultSet/testSetID/116086

You can find the "AllNSBackupWithIncludeNewNamespacesOption" in branch "topic/krishna-px/test-PA-659"

If you have reviewed PR #1164, please be aware of the following updates:

Backups are listed in descending chronological order during enumeration, whereas during inspection of a schedule backup, they are listed in ascending chronological order in status object. As a result, the logic to fetch schedule name and UID may fail since it was previously assumed that the list would always be in descending chronological order.

I have moved the GetFirst, GetOrdinal, GetLatest Name and UID functions to the backup_helper file.

I have implemented the GetBackupName and GetCurrentScheduleBackupCount functions, and also added AfterCheck functionality for the GetFirst, GetOrdinal, GetLatest Name and UID functions.