### PR TITLE
Added Testrail result update capability for Px Backup system tests

### DIFF
--- a/tests/backup/backup_basic_test.go
+++ b/tests/backup/backup_basic_test.go
@@ -85,6 +85,9 @@ func BackupInitInstance() {
 		err = Inst().Backup.Init(Inst().S.String(), Inst().N.String(), Inst().V.String(), token)
 		log.FailOnError(err, "Error occurred while Backup Driver Initialization")
 	}
+
+	SetupTestRail()
+
 	// Getting Px version info
 	pxVersion, err := Inst().V.GetDriverVersion()
 	log.FailOnError(err, "Error occurred while getting PX version")
@@ -101,7 +104,8 @@ func BackupInitInstance() {
 	versionResponse, err := Inst().Backup.GetPxBackupVersion(ctx, &api.VersionGetRequest{})
 	log.FailOnError(err, "Getting Px-Backup version")
 	version := versionResponse.GetVersion()
-	t.Tags["px-backup-version"] = fmt.Sprintf("%s.%s.%s-%s", version.GetMajor(), version.GetMinor(), version.GetPatch(), version.GetGitCommit())
+	PxBackupVersion = fmt.Sprintf("%s.%s.%s-%s", version.GetMajor(), version.GetMinor(), version.GetPatch(), version.GetGitCommit())
+	t.Tags["px-backup-version"] = PxBackupVersion
 	t.Tags["px-backup-build-date"] = fmt.Sprintf("%s", version.GetBuildDate())
 
 }

--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -1162,7 +1162,7 @@ func getAllCloudCredentials(ctx context.Context) (map[string]string, error) {
 		for _, cloudCredential := range response.CloudCredentials {
 			cloudCredentialMap[cloudCredential.Uid] = cloudCredential.Name
 		}
-		log.Infof("The backup locations and their UID are %v", cloudCredentialMap)
+		log.Infof("The cloud credentials and their UID are %v", cloudCredentialMap)
 	} else {
 		log.Info("No cloud credentials found")
 	}

--- a/tests/backup/backup_locked_bucket_test.go
+++ b/tests/backup/backup_locked_bucket_test.go
@@ -166,7 +166,7 @@ var _ = Describe("{BackupAlternatingBetweenLockedAndUnlockedBuckets}", func() {
 		})
 	})
 	JustAfterEach(func() {
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(contexts)
 		log.InfoD("Deleting the deployed apps after the testcase")
 		for i := 0; i < len(contexts); i++ {
 			opts := make(map[string]bool)
@@ -391,7 +391,7 @@ var _ = Describe("{LockedBucketResizeOnRestoredVolume}", func() {
 	})
 
 	JustAfterEach(func() {
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(contexts)
 		log.InfoD("Deleting the deployed apps after the testcase")
 		for i := 0; i < len(contexts); i++ {
 			opts := make(map[string]bool)

--- a/tests/backup/backup_portworx_test.go
+++ b/tests/backup/backup_portworx_test.go
@@ -95,7 +95,7 @@ var _ = Describe("{BackupLocationWithEncryptionKey}", func() {
 		})
 	})
 	JustAfterEach(func() {
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(contexts)
 		log.Infof("Deleting backup, restore and backup location, cloud account")
 		ctx, err := backup.GetAdminCtxFromSecret()
 		log.FailOnError(err, "Fetching px-central-admin ctx")
@@ -241,7 +241,7 @@ var _ = Describe("{ReplicaChangeWhileRestore}", func() {
 		})
 	})
 	JustAfterEach(func() {
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(contexts)
 		ctx, _ := backup.GetAdminCtxFromSecret()
 		log.InfoD("Deleting the deployed apps after the testcase")
 		for i := 0; i < len(contexts); i++ {
@@ -428,7 +428,7 @@ var _ = Describe("{ResizeOnRestoredVolume}", func() {
 	})
 
 	JustAfterEach(func() {
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(contexts)
 		log.InfoD("Deleting the deployed apps after the testcase")
 		for i := 0; i < len(contexts); i++ {
 			opts := make(map[string]bool)
@@ -541,7 +541,7 @@ var _ = Describe("{RestoreEncryptedAndNonEncryptedBackups}", func() {
 		})
 	})
 	JustAfterEach(func() {
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(contexts)
 		log.InfoD("Deleting Restores, Backups and Backup locations, cloud account")
 		ctx, err := backup.GetAdminCtxFromSecret()
 		log.FailOnError(err, "Fetching px-central-admin ctx")

--- a/tests/backup/backup_resiliency_test.go
+++ b/tests/backup/backup_resiliency_test.go
@@ -166,7 +166,7 @@ var _ = Describe("{BackupRestartPX}", func() {
 		})
 	})
 	JustAfterEach(func() {
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(contexts)
 		log.InfoD("Deleting the deployed apps after the testcase")
 		for i := 0; i < len(contexts); i++ {
 			opts := make(map[string]bool)
@@ -352,7 +352,7 @@ var _ = Describe("{KillStorkWithBackupsAndRestoresInProgress}", func() {
 		})
 	})
 	JustAfterEach(func() {
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(contexts)
 		ctx, _ := backup.GetAdminCtxFromSecret()
 		log.InfoD("Deleting the deployed apps after the testcase")
 		for i := 0; i < len(contexts); i++ {
@@ -569,7 +569,7 @@ var _ = Describe("{RestartBackupPodDuringBackupSharing}", func() {
 		})
 	})
 	JustAfterEach(func() {
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(contexts)
 		ctx, _ := backup.GetAdminCtxFromSecret()
 		log.InfoD("Deleting the deployed apps after the testcase")
 		for i := 0; i < len(contexts); i++ {

--- a/tests/backup/backup_restore_basic_test.go
+++ b/tests/backup/backup_restore_basic_test.go
@@ -115,7 +115,7 @@ var _ = Describe("{BasicSelectiveRestore}", func() {
 		})
 	})
 	JustAfterEach(func() {
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(contexts)
 		ctx, err := backup.GetAdminCtxFromSecret()
 		log.FailOnError(err, "Fetching px-central-admin ctx")
 		opts := make(map[string]bool)
@@ -251,7 +251,7 @@ var _ = Describe("{CustomResourceBackupAndRestore}", func() {
 		})
 	})
 	JustAfterEach(func() {
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(contexts)
 		ctx, _ := backup.GetAdminCtxFromSecret()
 		log.InfoD("Deleting the deployed apps after the testcase")
 		for i := 0; i < len(contexts); i++ {
@@ -470,7 +470,7 @@ var _ = Describe("{DeleteAllBackupObjects}", func() {
 		})
 	})
 	JustAfterEach(func() {
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(contexts)
 		opts := make(map[string]bool)
 		opts[SkipClusterScopedObjects] = true
 		log.Info(" Deleting deployed applications")
@@ -589,7 +589,7 @@ var _ = Describe("{ScheduleBackupCreationSingleNS}", func() {
 	})
 
 	JustAfterEach(func() {
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(contexts)
 		ctx, _ := backup.GetAdminCtxFromSecret()
 		log.InfoD("Clean up objects after test execution")
 		log.Info("Deleting backup schedules")
@@ -720,7 +720,7 @@ var _ = Describe("{ScheduleBackupCreationAllNS}", func() {
 	})
 
 	JustAfterEach(func() {
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(contexts)
 		ctx, _ := backup.GetAdminCtxFromSecret()
 		log.InfoD("Clean up objects after test execution")
 		log.Info("Deleting backup schedules")
@@ -859,7 +859,7 @@ var _ = Describe("{CustomResourceRestore}", func() {
 		})
 	})
 	JustAfterEach(func() {
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(contexts)
 		ctx, err := backup.GetAdminCtxFromSecret()
 		log.FailOnError(err, "Fetching px-central-admin ctx failed")
 

--- a/tests/backup/backup_share_test.go
+++ b/tests/backup/backup_share_test.go
@@ -127,7 +127,7 @@ var _ = Describe("{CreateMultipleUsersAndGroups}", func() {
 	})
 
 	JustAfterEach(func() {
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(make([]*scheduler.Context, 0))
 		log.Infof("Cleanup started")
 		err := backup.DeleteMultipleGroups(groups)
 		dash.VerifySafely(err, nil, fmt.Sprintf("Delete Groups %v", groups))
@@ -251,7 +251,7 @@ var _ = Describe("{DuplicateSharedBackup}", func() {
 
 	})
 	JustAfterEach(func() {
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(contexts)
 		log.InfoD("Deleting the deployed apps after the testcase")
 		for i := 0; i < len(contexts); i++ {
 			opts := make(map[string]bool)
@@ -409,7 +409,7 @@ var _ = Describe("{DifferentAccessSameUser}", func() {
 
 	JustAfterEach(func() {
 		// For all the delete methods we need to add return and handle the error here
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(contexts)
 		ctx, err := backup.GetAdminCtxFromSecret()
 		log.FailOnError(err, "Fetching px-central-admin ctx")
 		opts := make(map[string]bool)
@@ -820,7 +820,7 @@ var _ = Describe("{ShareBackupWithUsersAndGroups}", func() {
 		})
 	})
 	JustAfterEach(func() {
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(contexts)
 		log.InfoD("Deleting the deployed apps after the testcase")
 		for i := 0; i < len(contexts); i++ {
 			opts := make(map[string]bool)
@@ -1168,7 +1168,7 @@ var _ = Describe("{ShareLargeNumberOfBackupsWithLargeNumberOfUsers}", func() {
 		})
 	})
 	JustAfterEach(func() {
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(contexts)
 		log.InfoD("Deleting the deployed apps after the testcase")
 		for i := 0; i < len(contexts); i++ {
 			opts := make(map[string]bool)
@@ -1672,7 +1672,7 @@ var _ = Describe("{CancelClusterBackupShare}", func() {
 	})
 
 	JustAfterEach(func() {
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(contexts)
 		log.InfoD("Deleting the deployed apps after the testcase")
 		for i := 0; i < len(contexts); i++ {
 			opts := make(map[string]bool)
@@ -1922,7 +1922,7 @@ var _ = Describe("{ShareBackupAndEdit}", func() {
 		})
 	})
 	JustAfterEach(func() {
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(contexts)
 		log.InfoD("Deleting the deployed apps after the testcase")
 		for i := 0; i < len(contexts); i++ {
 			opts := make(map[string]bool)
@@ -2130,7 +2130,7 @@ var _ = Describe("{SharedBackupDelete}", func() {
 		})
 	})
 	JustAfterEach(func() {
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(contexts)
 		log.InfoD("Deleting the deployed apps after the testcase")
 		for i := 0; i < len(contexts); i++ {
 			opts := make(map[string]bool)
@@ -2330,7 +2330,7 @@ var _ = Describe("{ClusterBackupShareToggle}", func() {
 
 	})
 	JustAfterEach(func() {
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(contexts)
 		ctx, err := backup.GetAdminCtxFromSecret()
 		log.FailOnError(err, "Fetching px-central-admin ctx")
 
@@ -2485,7 +2485,7 @@ var _ = Describe("{ShareBackupsAndClusterWithUser}", func() {
 		})
 	})
 	JustAfterEach(func() {
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(contexts)
 		ctx, err := backup.GetAdminCtxFromSecret()
 		log.FailOnError(err, "Fetching px-central-admin ctx")
 		opts := make(map[string]bool)
@@ -2636,7 +2636,7 @@ var _ = Describe("{ShareBackupWithDifferentRoleUsers}", func() {
 	})
 	JustAfterEach(func() {
 		var wg sync.WaitGroup
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(contexts)
 		ctx, err := backup.GetAdminCtxFromSecret()
 		dash.VerifyFatal(err, nil, "Getting px-central-admin context")
 		opts := make(map[string]bool)
@@ -2853,7 +2853,7 @@ var _ = Describe("{DeleteSharedBackup}", func() {
 
 	})
 	JustAfterEach(func() {
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(contexts)
 		log.InfoD("Deleting the deployed apps after the testcase")
 		for i := 0; i < len(contexts); i++ {
 			opts := make(map[string]bool)
@@ -3058,7 +3058,7 @@ var _ = Describe("{ShareAndRemoveBackupLocation}", func() {
 	})
 	JustAfterEach(func() {
 		var wg sync.WaitGroup
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(contexts)
 		ctx, err := backup.GetAdminCtxFromSecret()
 		log.FailOnError(err, "Fetching px-central-admin ctx")
 		opts := make(map[string]bool)
@@ -3291,7 +3291,7 @@ var _ = Describe("{ViewOnlyFullBackupRestoreIncrementalBackup}", func() {
 	})
 
 	JustAfterEach(func() {
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(contexts)
 		log.InfoD("Deleting the deployed apps after the testcase")
 		for i := 0; i < len(contexts); i++ {
 			opts := make(map[string]bool)
@@ -3554,7 +3554,7 @@ var _ = Describe("{IssueMultipleRestoresWithNamespaceAndStorageClassMapping}", f
 	})
 	JustAfterEach(func() {
 		var wg sync.WaitGroup
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(contexts)
 		ctx, err := backup.GetAdminCtxFromSecret()
 		log.FailOnError(err, "Fetching px-central-admin ctx")
 		opts := make(map[string]bool)
@@ -3675,7 +3675,7 @@ var _ = Describe("{DeleteUsersRole}", func() {
 		})
 	})
 	JustAfterEach(func() {
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(make([]*scheduler.Context, 0))
 	})
 })
 
@@ -3839,7 +3839,7 @@ var _ = Describe("{IssueMultipleDeletesForSharedBackup}", func() {
 		})
 	})
 	JustAfterEach(func() {
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(contexts)
 		log.InfoD("Deleting the deployed apps after the testcase")
 		for i := 0; i < len(contexts); i++ {
 			opts := make(map[string]bool)
@@ -4042,7 +4042,7 @@ var _ = Describe("{SwapShareBackup}", func() {
 		})
 	})
 	JustAfterEach(func() {
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(contexts)
 		log.InfoD("Deleting the deployed apps after the testcase")
 		for i := 0; i < len(contexts); i++ {
 			opts := make(map[string]bool)

--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -30,7 +30,7 @@ var _ = Describe("{BackupClusterVerification}", func() {
 		})
 	})
 	JustAfterEach(func() {
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(make([]*scheduler.Context, 0))
 		log.Infof("No cleanup required for this testcase")
 	})
 })
@@ -76,7 +76,7 @@ var _ = Describe("{UserGroupManagement}", func() {
 		})
 	})
 	JustAfterEach(func() {
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(make([]*scheduler.Context, 0))
 		log.Infof("Cleanup started")
 		err := backup.DeleteUser("testuser1")
 		dash.VerifySafely(err, nil, "Delete user testuser1")
@@ -254,7 +254,7 @@ var _ = Describe("{BasicBackupCreation}", func() {
 		})
 	})
 	JustAfterEach(func() {
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(contexts)
 		policyList := []string{intervalName, dailyName, weeklyName, monthlyName}
 		ctx, err := backup.GetAdminCtxFromSecret()
 		log.FailOnError(err, "Fetching px-central-admin ctx")


### PR DESCRIPTION
**What this PR does / why we need it**:
Px Backup system tests did not include the testrail test result update feature. Used the existing mechanism and modified it to make it relevant for Px Backup.
This PR includes

- Created a common function `SetupTestRail` to setup testrail
- Added `PxBackupVersion` attribute to the testrail object
- Replaced all `EndTorpedoTest()` function with `EndPxBackupTorpedoTest(contexts)` because we did not want to call `AfterEachTest` at the end of every test and it felt logical to be part of `EndPxBackupTorpedoTest`
- Modified `StartTorpedoTest` to add Milestone in testrail if the testrail setup goes through fine. Verified that this will not affect existing Px tests which are calling `AddRunsToMilestone` outside the `StartTorpedoTest` function

**Which issue(s) this PR fixes** (optional)
Closes #PA-651

**Special notes for your reviewer**:
Since our jenkins jobs do not support the testrail paramaters, I tested it locally by running from my laptop. Here is a sample test run - https://portworx.testrail.net/index.php?/runs/view/5660&group_by=cases:custom_automated&group_order=asc&group_id=1
