### PR TITLE
[PA-670] Fix and refactor ScheduleBackupCreationSingleNS

### DIFF
--- a/tests/backup/backup_restore_basic_test.go
+++ b/tests/backup/backup_restore_basic_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -10,6 +11,7 @@ import (
 	api "github.com/portworx/px-backup-api/pkg/apis/v1"
 	"github.com/portworx/sched-ops/k8s/apps"
 	"github.com/portworx/sched-ops/k8s/core"
+	"github.com/portworx/sched-ops/task"
 	"github.com/portworx/torpedo/drivers/backup"
 	"github.com/portworx/torpedo/drivers/backup/portworx"
 	"github.com/portworx/torpedo/drivers/scheduler"
@@ -478,137 +480,166 @@ var _ = Describe("{DeleteAllBackupObjects}", func() {
 	})
 })
 
-// This testcase verifies schedule backup creation with a single namespace.
 var _ = Describe("{ScheduleBackupCreationSingleNS}", func() {
 	var (
-		contexts           []*scheduler.Context
-		appContexts        []*scheduler.Context
-		backupLocationName string
-		backupLocationUID  string
-		cloudCredUID       string
-		bkpNamespaces      []string
-		cloudAccountName   string
-		backupName         string
-		schBackupName      string
-		schPolicyUid       string
-		restoreName        string
-		clusterStatus      api.ClusterInfo_StatusInfo_Status
+		contexts                    []*scheduler.Context
+		cloudCredUID                string
+		cloudCredName               string
+		backupLocationName          string
+		backupLocationUID           string
+		backupLocationMap           map[string]string
+		periodicSchedulePolicyNames []string
+		periodicSchedulePolicyUids  []string
+		appNamespaces               []string
+		backupClusterName           string
+		scheduleNames               []string
+		restoreNames                []string
+		providers                   []string
 	)
-	var testrailID = 58014 // testrailID corresponds to: https://portworx.testrail.net/index.php?/cases/view/58014
-	namespaceMapping := make(map[string]string)
-	labelSelectors := make(map[string]string)
-	cloudCredUIDMap := make(map[string]string)
-	backupLocationMap := make(map[string]string)
-	bkpNamespaces = make([]string, 0)
-	timeStamp := strconv.Itoa(int(time.Now().Unix()))
-	periodicPolicyName := fmt.Sprintf("%s-%s", "periodic", timeStamp)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("ScheduleBackupCreationSingleNS", "Create schedule backup creation with a single namespace", nil, testrailID)
-		log.Info("Application installation")
+		StartTorpedoTest("ScheduleBackupCreationSingleNS", "Verification of schedule backup creation with single namespace", nil, 58014)
+		log.InfoD("Scheduling applications")
 		contexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
 			taskName := fmt.Sprintf("%s-%d", taskNamePrefix, i)
-			appContexts = ScheduleApplications(taskName)
+			appContexts := ScheduleApplications(taskName)
 			contexts = append(contexts, appContexts...)
 			for _, ctx := range appContexts {
 				ctx.ReadinessTimeout = appReadinessTimeout
 				namespace := GetAppNamespace(ctx, taskName)
-				bkpNamespaces = append(bkpNamespaces, namespace)
+				log.InfoD("Scheduled application with namespace [%s]", namespace)
+				appNamespaces = append(appNamespaces, namespace)
 			}
 		}
 	})
 
-	It("Schedule Backup Creation with single namespace", func() {
-		Step("Validate deployed applications", func() {
+	It("Validates schedule backups created with single namespace", func() {
+		Step("Validate applications", func() {
+			log.InfoD("Validating applications")
 			ValidateApplications(contexts)
 		})
-		providers := getProviders()
-		Step("Adding Cloud Account", func() {
-			log.InfoD("Adding cloud account")
+		Step("Add cloud credentials", func() {
+			log.InfoD("Adding cloud credentials")
+			providers = getProviders()
+			backupLocationMap = make(map[string]string)
 			for _, provider := range providers {
-				cloudAccountName = fmt.Sprintf("%s-%v", provider, timeStamp)
 				cloudCredUID = uuid.New()
-				cloudCredUIDMap[cloudCredUID] = cloudAccountName
-				CreateCloudCredential(provider, cloudAccountName, cloudCredUID, orgID)
+				cloudCredName = fmt.Sprintf("%s-%s-%v", "cred", provider, time.Now().Unix())
+				log.InfoD("Adding cloud credential named [%s] and uid [%s] using [%s] as provider", cloudCredUID, cloudCredName, provider)
+				CreateCloudCredential(provider, cloudCredName, cloudCredUID, orgID)
 			}
 		})
-
-		Step("Adding Backup Location", func() {
-			log.InfoD("Adding Backup Location")
+		Step("Add backup locations", func() {
+			log.InfoD("Adding backup locations")
+			backupLocationMap = make(map[string]string)
 			for _, provider := range providers {
-				cloudAccountName = fmt.Sprintf("%s-%v", provider, timeStamp)
-				backupLocationName = fmt.Sprintf("auto-bl-%v", time.Now().Unix())
+				bucketName := getGlobalBucketName(provider)
 				backupLocationUID = uuid.New()
+				backupLocationName = fmt.Sprintf("%s-%s-bl", provider, bucketName)
 				backupLocationMap[backupLocationUID] = backupLocationName
-				err := CreateBackupLocation(provider, backupLocationName, backupLocationUID, cloudAccountName, cloudCredUID,
-					getGlobalBucketName(provider), orgID, "")
-				dash.VerifyFatal(err, nil, fmt.Sprintf("Verification of adding backup location - %s", backupLocationName))
+				err := CreateBackupLocation(provider, backupLocationName, backupLocationUID, cloudCredName, cloudCredUID, bucketName, orgID, "")
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying addition of backup location named [%s] with uid [%s] of [%s] as provider", backupLocationName, backupLocationUID, provider))
 			}
 		})
-
-		Step("Creating Schedule Policies", func() {
-			log.InfoD("Creating Schedule Policies")
-			periodicSchedulePolicyInfo := Inst().Backup.CreateIntervalSchedulePolicy(5, 15, 5)
-			periodicPolicyStatus := Inst().Backup.BackupSchedulePolicy(periodicPolicyName, uuid.New(), orgID, periodicSchedulePolicyInfo)
-			dash.VerifyFatal(periodicPolicyStatus, nil, fmt.Sprintf("Verification of creating periodic schedule policy - %s", periodicPolicyName))
-		})
-
-		Step("Adding Clusters for backup", func() {
-			log.InfoD("Adding application clusters")
-			ctx, _ := backup.GetAdminCtxFromSecret()
-			err := CreateSourceAndDestClusters(orgID, "", "", ctx)
-			dash.VerifyFatal(err, nil, fmt.Sprintf("Verification of creating source - %s and destination - %s clusters", SourceClusterName, destinationClusterName))
-			clusterStatus, _ = Inst().Backup.RegisterBackupCluster(orgID, SourceClusterName, "")
-			dash.VerifyFatal(clusterStatus, api.ClusterInfo_StatusInfo_Online, fmt.Sprintf("Verification of adding application clusters - %s", SourceClusterName))
-		})
-
-		Step("Creating schedule backups", func() {
-			log.InfoD("Creating schedule backups")
+		Step("Add source and destination clusters with px-central-admin ctx", func() {
+			log.InfoD("Adding source and destination clusters with px-central-admin ctx")
 			ctx, err := backup.GetAdminCtxFromSecret()
-			log.FailOnError(err, "Fetching px-central-admin ctx")
-			schPolicyUid, _ = Inst().Backup.GetSchedulePolicyUid(orgID, ctx, periodicPolicyName)
-			for _, namespace := range bkpNamespaces {
-				backupName = fmt.Sprintf("%s-%s", BackupNamePrefix, namespace)
-				err = CreateScheduleBackup(backupName, SourceClusterName, backupLocationName, backupLocationUID, []string{namespace},
-					labelSelectors, orgID, "", "", "", "", periodicPolicyName, schPolicyUid, ctx)
-				dash.VerifyFatal(err, nil, fmt.Sprintf("Verification of creating schedule backup with schedule name - %s", backupName))
-				schBackupName, err = GetFirstScheduleBackupName(ctx, backupName, orgID)
-				dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching the name of the first schedule backup - %s", schBackupName))
+			dash.VerifyFatal(err, nil, "Fetching px-central-admin ctx")
+			err = CreateSourceAndDestClusters(orgID, "", "", ctx)
+			dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying addition of source [%s] and destination [%s] clusters with px-central-admin ctx", SourceClusterName, destinationClusterName))
+			backupClusterName = SourceClusterName
+			clusterStatus, clusterUid := Inst().Backup.RegisterBackupCluster(orgID, backupClusterName, "")
+			dash.VerifyFatal(clusterStatus, api.ClusterInfo_StatusInfo_Online, fmt.Sprintf("Verifying status of cluster named [%s] with uid [%s] as backup cluster", backupClusterName, clusterUid))
+		})
+		Step("Add schedule policy for each app namespace", func() {
+			log.InfoD("Adding a schedule policy for each app namespace")
+			ctx, err := backup.GetAdminCtxFromSecret()
+			dash.VerifyFatal(err, nil, "Fetching px-central-admin ctx")
+			for _, namespace := range appNamespaces {
+				periodicSchedulePolicyName := fmt.Sprintf("%s-%s-%v", namespace, "periodic", time.Now().Unix())
+				periodicSchedulePolicyUid := uuid.New()
+				periodicSchedulePolicyInfo := Inst().Backup.CreateIntervalSchedulePolicy(5, 15, 5)
+				err = Inst().Backup.BackupSchedulePolicy(periodicSchedulePolicyName, periodicSchedulePolicyUid, orgID, periodicSchedulePolicyInfo)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying addition of periodic schedule policy of interval 15 minutes named [%s]", periodicSchedulePolicyName))
+				periodicSchedulePolicyUid, err = Inst().Backup.GetSchedulePolicyUid(orgID, ctx, periodicSchedulePolicyName)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching uid of periodic schedule policy named [%s]", periodicSchedulePolicyName))
+				periodicSchedulePolicyNames = append(periodicSchedulePolicyNames, periodicSchedulePolicyName)
+				periodicSchedulePolicyUids = append(periodicSchedulePolicyUids, periodicSchedulePolicyUid)
 			}
 		})
-
-		Step("Restoring scheduled backups", func() {
-			log.InfoD("Restoring scheduled backups")
+		Step("Create schedule backup for each app namespace", func() {
+			log.InfoD("Creating a schedule backup for each namespace")
 			ctx, err := backup.GetAdminCtxFromSecret()
-			log.FailOnError(err, "Fetching px-central-admin ctx")
-			restoreName = fmt.Sprintf("%s-%s", restoreNamePrefix, schBackupName)
-			err = CreateRestore(restoreName, schBackupName, namespaceMapping, destinationClusterName, orgID, ctx, nil)
-			dash.VerifyFatal(err, nil, fmt.Sprintf("Verification of restoring scheduled backups - %s", restoreName))
+			dash.VerifyFatal(err, nil, "Fetching px-central-admin ctx")
+			for index, namespace := range appNamespaces {
+				scheduleName := fmt.Sprintf("%s-%s-schedule-%v", BackupNamePrefix, namespace, time.Now().Unix())
+				namespaces := []string{namespace}
+				labelSelectors := make(map[string]string)
+				err = CreateScheduleBackup(scheduleName, backupClusterName, backupLocationName, backupLocationUID, namespaces,
+					labelSelectors, orgID, "", "", "", "", periodicSchedulePolicyNames[index], periodicSchedulePolicyUids[index], ctx)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation of schedule backup with schedule name [%s] of the namespace [%s]", scheduleName, namespace))
+				scheduleNames = append(scheduleNames, scheduleName)
+				firstScheduleBackupName, err := GetFirstScheduleBackupName(ctx, scheduleName, orgID)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching the name of the first schedule backup [%s] of the namespace [%s]", firstScheduleBackupName, namespace))
+			}
+		})
+		Step("Restore app namespaces from their second schedule backup", func() {
+			log.InfoD("Restoring app namespace from their second schedule backup")
+			ctx, err := backup.GetAdminCtxFromSecret()
+			dash.VerifyFatal(err, nil, "Fetching px-central-admin ctx")
+			for index, namespace := range appNamespaces {
+				secondScheduleBackupOrdinal := 2
+				log.InfoD("Ordinal of the second schedule backup of the namespace [%s] is [%v]", namespace, secondScheduleBackupOrdinal)
+				checkOrdinalScheduleBackupCreation := func() (interface{}, bool, error) {
+					ordinalScheduleBackupName, err := GetOrdinalScheduleBackupName(ctx, scheduleNames[index], secondScheduleBackupOrdinal, orgID)
+					if err != nil {
+						return "", true, err
+					}
+					return ordinalScheduleBackupName, false, nil
+				}
+				log.InfoD("Waiting for 15 minutes for the second schedule backup to be triggered")
+				time.Sleep(15 * time.Minute)
+				secondScheduleBackupName, err := task.DoRetryWithTimeout(checkOrdinalScheduleBackupCreation, maxWaitPeriodForBackupCompletionInMinutes*time.Minute, 30*time.Second)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching second schedule backup name of ordinal [%v] of schedule named [%s] of the namespace [%s]", secondScheduleBackupName, scheduleNames[index], namespace))
+				log.InfoD("Second schedule backup name [%s]", secondScheduleBackupName.(string))
+				_, err = backupSuccessCheck(secondScheduleBackupName.(string), orgID, 0, 0, ctx)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying success of second schedule backup named [%s] of schedule named [%s] of the namespace [%s]", secondScheduleBackupName.(string), scheduleNames[index], namespace))
+				restoreName := fmt.Sprintf("%s-%s-%s", "test-restore", namespace, RandomString(4))
+				for strings.Contains(strings.Join(restoreNames, ","), restoreName) {
+					restoreName = fmt.Sprintf("%s-%s-%s", "test-restore", namespace, RandomString(4))
+				}
+				log.InfoD("Restoring [%s] namespace from the [%s] backup with restore name [%s]", namespace, secondScheduleBackupName, restoreName)
+				namespaceMapping := make(map[string]string, 0)
+				err = CreateRestore(restoreName, secondScheduleBackupName.(string), namespaceMapping, destinationClusterName, orgID, ctx, make(map[string]string))
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Creating restore [%s] of the namespace [%s]", restoreName, namespace))
+				restoreNames = append(restoreNames, restoreName)
+			}
 		})
 	})
 
 	JustAfterEach(func() {
 		defer EndPxBackupTorpedoTest(contexts)
-		ctx, _ := backup.GetAdminCtxFromSecret()
-		log.InfoD("Clean up objects after test execution")
-		log.Info("Deleting backup schedules")
-		scheduleUid, err := GetScheduleUID(backupName, orgID, ctx)
-		log.FailOnError(err, "Error while getting schedule uid %v", backupName)
-		err = DeleteSchedule(backupName, scheduleUid, periodicPolicyName, schPolicyUid, orgID)
-		dash.VerifyFatal(err, nil, fmt.Sprintf("Verification of deleting backup schedules - %s", backupName))
-		log.Info("Deleting restores")
-		err = DeleteRestore(restoreName, orgID, ctx)
-		dash.VerifyFatal(err, nil, fmt.Sprintf("Verification of deleting restores - %s", restoreName))
-		log.Info("Deleting the deployed apps after test execution")
+		ctx, err := backup.GetAdminCtxFromSecret()
+		dash.VerifySafely(err, nil, "Fetching px-central-admin ctx")
+		for index, namespace := range appNamespaces {
+			scheduleUid, err := GetScheduleUID(scheduleNames[index], orgID, ctx)
+			dash.VerifySafely(err, nil, fmt.Sprintf("Fetching uid of schedule named [%s]", scheduleNames[index]))
+			allScheduleBackupNames, err := Inst().Backup.GetAllScheduleBackupNames(ctx, scheduleNames[index], orgID)
+			dash.VerifySafely(err, nil, fmt.Sprintf("Fetching all schedule backup names of schedule named [%s] of the namespace [%s]", scheduleNames[index], namespace))
+			log.InfoD("Deleting schedule named [%s] along with its backups [%v] and schedule policies [%v] of the namespace [%s]", scheduleNames[index], allScheduleBackupNames, []string{periodicSchedulePolicyNames[index]}, namespace)
+			err = DeleteSchedule(scheduleNames[index], scheduleUid, periodicSchedulePolicyNames[index], periodicSchedulePolicyUids[index], orgID)
+			dash.VerifySafely(err, nil, fmt.Sprintf("Verifying deletion of backup schedule named - %s", scheduleNames[index]))
+		}
+		for index, namespace := range appNamespaces {
+			err = DeleteRestore(restoreNames[index], orgID, ctx)
+			dash.VerifySafely(err, nil, fmt.Sprintf("Deleting restore [%s] of the namespace [%s]", restoreNames[index], namespace))
+		}
 		opts := make(map[string]bool)
 		opts[SkipClusterScopedObjects] = true
-		for i := 0; i < len(contexts); i++ {
-			taskName := fmt.Sprintf("%s-%d", taskNamePrefix, i)
-			err := Inst().S.Destroy(contexts[i], opts)
-			dash.VerifySafely(err, nil, fmt.Sprintf("Verify destroying application %s", taskName))
-		}
-		CleanupCloudSettingsAndClusters(backupLocationMap, cloudAccountName, cloudCredUID, ctx)
+		log.InfoD("Deleting deployed namespaces %v", appNamespaces)
+		ValidateAndDestroy(contexts, opts)
+		CleanupCloudSettingsAndClusters(backupLocationMap, cloudCredName, cloudCredUID, ctx)
 	})
 })
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR refactors the "ScheduleBackupCreationSingleNS" function and fixes an issue with getting the UID of the schedule backup. The namespaces are now restored correctly from the second restore. This PR improves the reliability and functionality of the "ScheduleBackupCreationSingleNS" test case, ensuring that it functions as intended.

**Which issue(s) this PR fixes** (optional)
Closes #PA-670

**Special notes for your reviewer**:
Please review the Jenkins build for the "ScheduleBackupCreationSingleNS " test case using the link below

https://jenkins.pwx.dev.purestorage.com/job/Users/job/Sumit/job/Custom-Pipelines/job/px-backup-on-demand-system-test-byoc/263

Aetos Dashboard: http://aetos.pwx.purestorage.com/resultSet/testSetID/119180