### PR TITLE
PA-600:Added test for StorkUpgradeWithBackup

### DIFF
--- a/tests/backup/backup_restore_basic_test.go
+++ b/tests/backup/backup_restore_basic_test.go
@@ -131,20 +131,16 @@ var _ = Describe("{BasicSelectiveRestore}", func() {
 		opts[SkipClusterScopedObjects] = true
 		log.InfoD("Deleting deployed applications")
 		ValidateAndDestroy(contexts, opts)
-
 		backupDriver := Inst().Backup
 		backupUID, err := backupDriver.GetBackupUID(ctx, backupName, orgID)
 		log.FailOnError(err, "Failed while trying to get backup UID for - [%s]", backupName)
-
 		log.InfoD("Deleting backup")
 		_, err = DeleteBackup(backupName, backupUID, orgID, ctx)
 		dash.VerifyFatal(err, nil, fmt.Sprintf("Deleting backup [%s]", backupName))
-
 		log.InfoD("Deleting restore")
 		log.InfoD(fmt.Sprintf("Backup name [%s]", restoreName))
 		err = DeleteRestore(restoreName, orgID, ctx)
 		dash.VerifyFatal(err, nil, fmt.Sprintf("Deleting restore [%s]", restoreName))
-
 		CleanupCloudSettingsAndClusters(backupLocationMap, cloudCredName, cloudCredUID, ctx)
 	})
 })
@@ -631,7 +627,6 @@ var _ = Describe("{ScheduleBackupCreationSingleNS}", func() {
 		policyList := []string{periodicPolicyName}
 		err = Inst().Backup.DeleteBackupSchedulePolicy(orgID, policyList)
 		dash.VerifySafely(err, nil, fmt.Sprintf("Deleting backup schedule policies %s ", policyList))
-
 		log.Infof("Deleting restores")
 		err = DeleteRestore(restoreName, orgID, ctx)
 		dash.VerifyFatal(err, nil, fmt.Sprintf("Verification of deleting restores - %s", restoreName))
@@ -909,7 +904,6 @@ var _ = Describe("{CustomResourceRestore}", func() {
 		defer EndPxBackupTorpedoTest(contexts)
 		ctx, err := backup.GetAdminCtxFromSecret()
 		log.FailOnError(err, "Fetching px-central-admin ctx")
-
 		//Delete Backup
 		log.InfoD("Deleting backup")
 		backupDriver := Inst().Backup
@@ -920,14 +914,12 @@ var _ = Describe("{CustomResourceRestore}", func() {
 			_, err = DeleteBackup(backupName, backupUID, orgID, ctx)
 			dash.VerifySafely(err, nil, fmt.Sprintf("Verifying backup %s deletion is successful", backupName))
 		}
-
 		//Delete Restore
 		log.InfoD("Deleting restore")
 		for _, restoreName := range restoreNames {
 			err = DeleteRestore(restoreName, orgID, ctx)
 			dash.VerifySafely(err, nil, fmt.Sprintf("Deleting user restore %s", restoreName))
 		}
-
 		log.Infof("Deleting the deployed apps after the testcase")
 		opts := make(map[string]bool)
 		opts[SkipClusterScopedObjects] = true

--- a/tests/backup/backup_share_test.go
+++ b/tests/backup/backup_share_test.go
@@ -272,7 +272,6 @@ var _ = Describe("{DuplicateSharedBackup}", func() {
 		backupUID, err := backupDriver.GetBackupUID(ctx, backupName, orgID)
 		backupDeleteResponse, err := DeleteBackup(backupName, backupUID, orgID, ctx)
 		log.FailOnError(err, "Backup [%s] could not be deleted with delete response %s", backupName, backupDeleteResponse)
-
 		CleanupCloudSettingsAndClusters(backupLocationMap, credName, cloudCredUID, ctx)
 	})
 
@@ -870,7 +869,6 @@ var _ = Describe("{ShareBackupWithUsersAndGroups}", func() {
 			_, err = DeleteBackup(backupName, backupUID, orgID, ctx)
 			dash.VerifyFatal(err, nil, fmt.Sprintf("Deleting backup - [%s]", backupName))
 		}
-
 		CleanupCloudSettingsAndClusters(backupLocationMap, credName, cloudCredUID, ctx)
 	})
 })
@@ -2492,9 +2490,7 @@ var _ = Describe("{ShareBackupsAndClusterWithUser}", func() {
 		dash.VerifySafely(err, nil, fmt.Sprintf("Getting backup UID for backup %s", backupName))
 		_, err = DeleteBackup(backupName, backupUID, orgID, ctx)
 		dash.VerifyFatal(err, nil, fmt.Sprintf("Deleting backup - [%s]", backupName))
-
 		CleanupCloudSettingsAndClusters(backupLocationMap, cloudCredName, cloudCredUID, ctx)
-
 		log.Infof("Cleaning up users")
 		for _, user := range userNames {
 			err = backup.DeleteUser(user)
@@ -3334,7 +3330,6 @@ var _ = Describe("{ViewOnlyFullBackupRestoreIncrementalBackup}", func() {
 			_, err = DeleteBackup(backupName, backupUID, orgID, ctx)
 			dash.VerifyFatal(err, nil, fmt.Sprintf("Deleting backup - [%s]", backupName))
 		}
-
 		CleanupCloudSettingsAndClusters(backupLocationMap, credName, cloudCredUID, ctx)
 	})
 })

--- a/tests/backup/backup_upgrade_test.go
+++ b/tests/backup/backup_upgrade_test.go
@@ -1,7 +1,14 @@
 package tests
 
 import (
+	"fmt"
+	"strconv"
+	"time"
+
 	. "github.com/onsi/ginkgo"
+	"github.com/pborman/uuid"
+	api "github.com/portworx/px-backup-api/pkg/apis/v1"
+	"github.com/portworx/torpedo/drivers/backup"
 	"github.com/portworx/torpedo/drivers/scheduler"
 	"github.com/portworx/torpedo/pkg/log"
 	. "github.com/portworx/torpedo/tests"
@@ -23,5 +30,177 @@ var _ = Describe("{UpgradePxBackup}", func() {
 	JustAfterEach(func() {
 		defer EndPxBackupTorpedoTest(make([]*scheduler.Context, 0))
 		log.Infof("No cleanup required for this testcase")
+
+	})
+})
+
+// StorkUpgradeWithBackup validates backups with stork upgrade
+var _ = Describe("{StorkUpgradeWithBackup}", func() {
+	var (
+		contexts             []*scheduler.Context
+		appContexts          []*scheduler.Context
+		backupLocationName   string
+		backupLocationUID    string
+		cloudCredUID         string
+		bkpNamespaces        []string
+		scheduleNames        []string
+		cloudAccountName     string
+		backupName           string
+		scheduleName         string
+		schBackupName        string
+		schPolicyUid         string
+		upgradeStorkImageStr string
+		clusterUid           string
+		clusterStatus        api.ClusterInfo_StatusInfo_Status
+	)
+	var testrailID = 58023 // testrailID corresponds to: https://portworx.testrail.net/index.php?/cases/view/58023
+	labelSelectors := make(map[string]string)
+	cloudCredUIDMap := make(map[string]string)
+	backupLocationMap := make(map[string]string)
+	bkpNamespaces = make([]string, 0)
+	timeStamp := strconv.Itoa(int(time.Now().Unix()))
+	periodicPolicyName := fmt.Sprintf("%s-%s", "periodic", timeStamp)
+
+	JustBeforeEach(func() {
+		StartTorpedoTest("StorkUpgradeWithBackup", "Validates the scheduled backups and creation of new backup after stork upgrade", nil, testrailID)
+		log.Infof("Application installation")
+		contexts = make([]*scheduler.Context, 0)
+		for i := 0; i < Inst().GlobalScaleFactor; i++ {
+			taskName := fmt.Sprintf("%s-%d", taskNamePrefix, i)
+			appContexts = ScheduleApplications(taskName)
+			contexts = append(contexts, appContexts...)
+			for _, ctx := range appContexts {
+				ctx.ReadinessTimeout = appReadinessTimeout
+				namespace := GetAppNamespace(ctx, taskName)
+				bkpNamespaces = append(bkpNamespaces, namespace)
+			}
+		}
+	})
+
+	It("StorkUpgradeWithBackup", func() {
+		Step("Validate deployed applications", func() {
+			ValidateApplications(contexts)
+		})
+		providers := getProviders()
+		Step("Adding Cloud Account", func() {
+			log.InfoD("Adding cloud account")
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			for _, provider := range providers {
+				cloudAccountName = fmt.Sprintf("%s-%v", provider, timeStamp)
+				cloudCredUID = uuid.New()
+				cloudCredUIDMap[cloudCredUID] = cloudAccountName
+				err := CreateCloudCredential(provider, cloudAccountName, cloudCredUID, orgID, ctx)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation of cloud credential named [%s] for org [%s] with [%s] as provider", cloudAccountName, orgID, provider))
+			}
+		})
+
+		Step("Adding Backup Location", func() {
+			log.InfoD("Adding Backup Location")
+			for _, provider := range providers {
+				cloudAccountName = fmt.Sprintf("%s-%v", provider, timeStamp)
+				backupLocationName = fmt.Sprintf("auto-bl-%v", time.Now().Unix())
+				backupLocationUID = uuid.New()
+				backupLocationMap[backupLocationUID] = backupLocationName
+				err := CreateBackupLocation(provider, backupLocationName, backupLocationUID, cloudAccountName, cloudCredUID,
+					getGlobalBucketName(provider), orgID, "")
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Verification of adding backup location - %s", backupLocationName))
+			}
+		})
+
+		Step("Creating Schedule Policiy", func() {
+			log.InfoD("Creating Schedule Policy")
+			periodicSchedulePolicyInfo := Inst().Backup.CreateIntervalSchedulePolicy(5, 15, 5)
+			periodicPolicyStatus := Inst().Backup.BackupSchedulePolicy(periodicPolicyName, uuid.New(), orgID, periodicSchedulePolicyInfo)
+			dash.VerifyFatal(periodicPolicyStatus, nil, fmt.Sprintf("Verification of creating periodic schedule policy - %s", periodicPolicyName))
+		})
+
+		Step("Adding Clusters for backup", func() {
+			log.InfoD("Adding application clusters")
+			ctx, err := backup.GetAdminCtxFromSecret()
+			dash.VerifySafely(err, nil, "Fetching px-central-admin ctx")
+			err = CreateSourceAndDestClusters(orgID, "", "", ctx)
+			dash.VerifyFatal(err, nil, fmt.Sprintf("Verification of creating source - %s and destination - %s clusters", SourceClusterName, destinationClusterName))
+			clusterStatus, err = Inst().Backup.GetClusterStatus(orgID, SourceClusterName, ctx)
+			log.FailOnError(err, fmt.Sprintf("Fetching [%s] cluster status", SourceClusterName))
+			dash.VerifyFatal(clusterStatus, api.ClusterInfo_StatusInfo_Online, fmt.Sprintf("Verifying if [%s] cluster is online", SourceClusterName))
+			clusterUid, err = Inst().Backup.GetClusterUID(ctx, orgID, SourceClusterName)
+			dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching [%s] cluster uid", SourceClusterName))
+		})
+
+		Step("Creating schedule backups", func() {
+			log.InfoD("Creating schedule backups")
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			schPolicyUid, err = Inst().Backup.GetSchedulePolicyUid(orgID, ctx, periodicPolicyName)
+			dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching uid of periodic schedule policy named [%s]", periodicPolicyName))
+			for _, namespace := range bkpNamespaces {
+				scheduleName = fmt.Sprintf("%s-%s-%v", BackupNamePrefix, namespace, time.Now().Unix())
+				err = CreateScheduleBackup(scheduleName, SourceClusterName, backupLocationName, backupLocationUID, []string{namespace},
+					labelSelectors, orgID, "", "", "", "", periodicPolicyName, schPolicyUid, ctx)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Verification of creating schedule backup with schedule name - %s", scheduleName))
+				scheduleNames = append(scheduleNames, scheduleName)
+			}
+		})
+
+		Step("Upgrade the stork version", func() {
+			log.InfoD("Upgrade the stork version")
+			upgradeStorkImageStr = getEnv(upgradeStorkImage, latestStorkImage)
+			err := upgradeStorkVersion(upgradeStorkImageStr)
+			dash.VerifyFatal(err, nil, fmt.Sprintf("Verification of stork version upgrade to - %s", upgradeStorkImageStr))
+		})
+
+		Step("Verifying scheduled backup after stork version upgrade", func() {
+			log.InfoD("Verifying scheduled backup after stork version upgrade")
+			log.Infof("waiting 15 minutes for another backup schedule to trigger")
+			time.Sleep(15 * time.Minute)
+			for _, scheduleName := range scheduleNames {
+				ctx, err := backup.GetAdminCtxFromSecret()
+				log.FailOnError(err, "Fetching px-central-admin ctx")
+				allScheduleBackupNames, err := Inst().Backup.GetAllScheduleBackupNames(ctx, scheduleName, orgID)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Verification of all schedule backups with schedule name - %s", scheduleName))
+				dash.VerifyFatal(len(allScheduleBackupNames) > 1, true, fmt.Sprintf("Verfiying the backup count is increased for backups with schedule name - %s", scheduleName))
+				//Get the status of latest backup
+				schBackupName, err = GetLatestScheduleBackupName(ctx, scheduleName, orgID)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Verification of latest schedule backup with schedule name - %s", scheduleName))
+				err = backupSuccessCheck(schBackupName, orgID, maxWaitPeriodForBackupCompletionInMinutes*time.Minute, 30*time.Second, ctx)
+				dash.VerifyFatal(err, nil, "Inspecting the backup success for - "+schBackupName)
+			}
+		})
+
+		Step("Verify creating new backups after upgrade", func() {
+			log.InfoD("Verify creating new backups after upgrade")
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			for _, namespace := range bkpNamespaces {
+				backupName = fmt.Sprintf("%s-%s-%v", BackupNamePrefix, namespace, time.Now().Unix())
+				err = CreateBackup(backupName, SourceClusterName, backupLocationName, backupLocationUID, []string{namespace},
+					labelSelectors, orgID, clusterUid, "", "", "", "", ctx)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying backup [%s] creation", backupName))
+			}
+		})
+	})
+
+	JustAfterEach(func() {
+		defer EndPxBackupTorpedoTest(contexts)
+		ctx, err := backup.GetAdminCtxFromSecret()
+		log.FailOnError(err, "Fetching px-central-admin ctx")
+		log.InfoD("Clean up objects after test execution")
+		log.Infof("Deleting backup schedule")
+		for _, scheduleName := range scheduleNames {
+			scheduleUid, err := GetScheduleUID(scheduleName, orgID, ctx)
+			log.FailOnError(err, "Error while getting schedule uid %v", scheduleName)
+			err = DeleteSchedule(scheduleName, scheduleUid, orgID)
+			dash.VerifySafely(err, nil, fmt.Sprintf("Verification of deleting backup schedule - %s", scheduleName))
+		}
+		log.Infof("Deleting backup schedule policy")
+		policyList := []string{periodicPolicyName}
+		err = Inst().Backup.DeleteBackupSchedulePolicy(orgID, policyList)
+		dash.VerifySafely(err, nil, fmt.Sprintf("Deleting backup schedule policies %s ", policyList))
+		log.Infof("Deleting the deployed apps after test execution")
+		opts := make(map[string]bool)
+		opts[SkipClusterScopedObjects] = true
+		ValidateAndDestroy(contexts, opts)
+		CleanupCloudSettingsAndClusters(backupLocationMap, cloudAccountName, cloudCredUID, ctx)
 	})
 })

--- a/tests/common.go
+++ b/tests/common.go
@@ -2811,7 +2811,7 @@ func DeleteBackupLocation(name string, backupLocationUID string, orgID string, D
 }
 
 // DeleteSchedule deletes backup schedule
-func DeleteSchedule(backupScheduleName, backupScheduleUID, schedulePolicyName, schedulePolicyUID, OrgID string) error {
+func DeleteSchedule(backupScheduleName, backupScheduleUID, OrgID string) error {
 	backupDriver := Inst().Backup
 	bkpScheduleDeleteRequest := &api.BackupScheduleDeleteRequest{
 		OrgId: OrgID,
@@ -2840,19 +2840,6 @@ func DeleteSchedule(backupScheduleName, backupScheduleUID, schedulePolicyName, s
 		clusterObj,
 		BackupRestoreCompletionTimeoutMin*time.Minute,
 		RetrySeconds*time.Second)
-	if err != nil {
-		return err
-	}
-	schedulePolicyDeleteRequest := &api.SchedulePolicyDeleteRequest{
-		OrgId: OrgID,
-		Name:  schedulePolicyName,
-		Uid:   schedulePolicyUID,
-	}
-	ctx, err = backup.GetPxCentralAdminCtx()
-	if err != nil {
-		return err
-	}
-	_, err = backupDriver.DeleteSchedulePolicy(ctx, schedulePolicyDeleteRequest)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Automate testcase :https://portworx.testrail.net/index.php?/cases/view/58023

- Added test StorkUpgradeWithBackup
- Added helper functions - upgradeStorkVersion , getStorkImage
- Made changes to DeleteSchedule - The function was deleting the schedule policy pointing to mutiple schedules,causing delete schedule to fail when mutiple apps/schedule are there.
- Made changes to testcases wherever  DeleteSchedule is called.



**Which issue(s) this PR fixes** (optional)
Closes #PA-600
Closes #PA-723

**Special notes for your reviewer**:

https://jenkins.pwx.dev.purestorage.com/job/Users/job/Sumit/job/Custom-Pipelines/job/px-backup-on-demand-system-test-byoc/353/

The test is expected to fail when current stork version is greater than or equal to upgrade version.

latest logs after including operator case.

https://jenkins.pwx.dev.purestorage.com/job/Users/job/Sumit/job/Custom-Pipelines/job/px-backup-on-demand-system-test-byoc/452/
