### PR TITLE
[PA-650] Modify backup and restore success checks to stop on failure

### DIFF
--- a/tests/backup/backup_resiliency_test.go
+++ b/tests/backup/backup_resiliency_test.go
@@ -41,8 +41,6 @@ var _ = Describe("{BackupRestartPX}", func() {
 	var clusterUid string
 	var cloudCredName string
 	var clusterStatus api.ClusterInfo_StatusInfo_Status
-	var retryDuration int
-	var retryInterval int
 	bkpNamespaces = make([]string, 0)
 	backupNamespaceMap := make(map[string]string)
 
@@ -161,9 +159,8 @@ var _ = Describe("{BackupRestartPX}", func() {
 			for _, namespace := range bkpNamespaces {
 				backupName := backupNamespaceMap[namespace]
 
-				backupStatus, err := backupSuccessCheck(backupName, orgID, retryDuration, retryInterval, ctx)
-				log.FailOnError(err, "Failed while Inspecting Backup for - %s", backupName)
-				dash.VerifyFatal(backupStatus, true, "Inspecting the backup success for - "+backupName)
+				err := backupSuccessCheck(backupName, orgID, maxWaitPeriodForBackupCompletionInMinutes*time.Minute, 30*time.Second, ctx)
+				dash.VerifyFatal(err, nil, "Inspecting the backup success for - "+backupName)
 
 			}
 		})
@@ -208,8 +205,6 @@ var _ = Describe("{KillStorkWithBackupsAndRestoresInProgress}", func() {
 	var clusterStatus api.ClusterInfo_StatusInfo_Status
 	bkpNamespaces := make([]string, 0)
 	var backupNames []string
-	var retryDuration int
-	var retryInterval int
 
 	JustBeforeEach(func() {
 		StartTorpedoTest("KillStorkWithBackupsAndRestoresInProgress", "Kill Stork when backups and restores in progress", nil, 55819)
@@ -318,9 +313,8 @@ var _ = Describe("{KillStorkWithBackupsAndRestoresInProgress}", func() {
 			ctx, err := backup.GetAdminCtxFromSecret()
 			log.FailOnError(err, "Fetching px-central-admin ctx")
 			for _, backupName := range backupNames {
-				backupStatus, err := backupSuccessCheck(backupName, orgID, retryDuration, retryInterval, ctx)
-				log.FailOnError(err, "Failed while Inspecting Backup for - %s", backupName)
-				dash.VerifyFatal(backupStatus, true, "Inspecting the backup success for - "+backupName)
+				err = backupSuccessCheck(backupName, orgID, maxWaitPeriodForBackupCompletionInMinutes*time.Minute, 30*time.Second, ctx)
+				dash.VerifyFatal(err, nil, "Inspecting the backup success for - "+backupName)
 			}
 		})
 		Step("Validate applications", func() {
@@ -345,9 +339,8 @@ var _ = Describe("{KillStorkWithBackupsAndRestoresInProgress}", func() {
 			log.FailOnError(err, "Fetching px-central-admin ctx")
 			for _, backupName := range backupNames {
 				restoreName := fmt.Sprintf("%s-restore", backupName)
-				restoreStatus, err := restoreSuccessCheck(restoreName, orgID, retryDuration, retryInterval, ctx)
-				log.FailOnError(err, "Failed while restoring Backup for - %s", backupName)
-				dash.VerifyFatal(restoreStatus, true, "Inspecting the Restore success for - "+restoreName)
+				err = restoreSuccessCheck(restoreName, orgID, maxWaitPeriodForRestoreCompletionInMinute*time.Minute, 30*time.Second, ctx)
+				dash.VerifyFatal(err, nil, "Inspecting the restore success for - "+restoreName)
 			}
 		})
 		Step("Validate applications", func() {
@@ -923,9 +916,8 @@ var _ = Describe("{ScaleMongoDBWhileBackupAndRestore}", func() {
 			ctx, err = backup.GetAdminCtxFromSecret()
 			log.FailOnError(err, "Fetching px-central-admin ctx")
 			for _, backupName := range backupNames {
-				backupStatus, err := backupSuccessCheck(backupName, orgID, 0, 0, ctx)
-				dash.VerifyFatal(err, nil, "Getting the status for backup- "+backupName)
-				dash.VerifyFatal(backupStatus, true, "Verifying the backup status for backup - "+backupName)
+				err = backupSuccessCheck(backupName, orgID, maxWaitPeriodForBackupCompletionInMinutes*time.Minute, 30*time.Second, ctx)
+				dash.VerifyFatal(err, nil, "Verifying the backup status for backup - "+backupName)
 			}
 		})
 		Step("Restoring the backups taken", func() {
@@ -984,9 +976,8 @@ var _ = Describe("{ScaleMongoDBWhileBackupAndRestore}", func() {
 			ctx, err = backup.GetAdminCtxFromSecret()
 			log.FailOnError(err, "Fetching px-central-admin ctx")
 			for _, restoreName := range restoreNames {
-				restoreStatus, err := restoreSuccessCheck(restoreName, orgID, 0, 0, ctx)
-				dash.VerifyFatal(err, nil, "Getting the status for restore-"+restoreName)
-				dash.VerifyFatal(restoreStatus, true, "Verifying the restore status for restore-"+restoreName)
+				err = restoreSuccessCheck(restoreName, orgID, maxWaitPeriodForRestoreCompletionInMinute*time.Minute, 30*time.Second, ctx)
+				dash.VerifyFatal(err, nil, "Verifying the restore status for restore-"+restoreName)
 			}
 		})
 	})

--- a/tests/backup/backup_restore_basic_test.go
+++ b/tests/backup/backup_restore_basic_test.go
@@ -1016,7 +1016,7 @@ var _ = Describe("{AllNSBackupWithIncludeNewNSOption}", func() {
 			nextScheduleBackupName, err = task.DoRetryWithTimeout(checkOrdinalScheduleBackupCreation, maxWaitPeriodForBackupCompletionInMinutes*time.Minute, 30*time.Second)
 			dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching next schedule backup name of ordinal [%v] of schedule named [%s]", nextScheduleBackupOrdinal, scheduleName))
 			log.InfoD("Next schedule backup name [%s]", nextScheduleBackupName.(string))
-			_, err = backupSuccessCheck(nextScheduleBackupName.(string), orgID, 0, 0, ctx)
+			err = backupSuccessCheck(nextScheduleBackupName.(string), orgID, maxWaitPeriodForBackupCompletionInMinutes*time.Minute, 30*time.Second, ctx)
 			dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying success of next schedule backup named [%s] of schedule named [%s]", nextScheduleBackupName.(string), scheduleName))
 			nextScheduleBackupUid, err := Inst().Backup.GetBackupUID(ctx, nextScheduleBackupName.(string), orgID)
 			dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching uid of of next schedule backup named [%s] of schedule named [%s]", nextScheduleBackupName, scheduleName))

--- a/tests/backup/backup_share_test.go
+++ b/tests/backup/backup_share_test.go
@@ -2298,7 +2298,7 @@ var _ = Describe("{ClusterBackupShareToggle}", func() {
 				log.InfoD("All the backups for user [%s] - %v", username, fetchedUserBackups)
 				recentBackupName := fetchedUserBackups[len(fetchedUserBackups)-1]
 				log.InfoD("Recent backup name [%s] ", recentBackupName)
-				_, err = backupSuccessCheck(recentBackupName, orgID, 0, 0, ctx)
+				err = backupSuccessCheck(recentBackupName, orgID, maxWaitPeriodForBackupCompletionInMinutes*time.Minute, 30*time.Second, ctx)
 				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying the success of recent backup named [%s]", recentBackupName))
 			}
 		})
@@ -3647,8 +3647,6 @@ var _ = Describe("{IssueMultipleDeletesForSharedBackup}", func() {
 	var clusterUid string
 	var clusterStatus api.ClusterInfo_StatusInfo_Status
 	var credName string
-	var retryDuration int
-	var retryInterval int
 	bkpNamespaces = make([]string, 0)
 	JustBeforeEach(func() {
 		StartTorpedoTest("IssueMultipleDeletesForSharedBackup",
@@ -3779,9 +3777,8 @@ var _ = Describe("{IssueMultipleDeletesForSharedBackup}", func() {
 				for _, restore := range restoreNames {
 					log.Infof("Validating Restore %s for user %s", restore, user)
 					if strings.Contains(restore, user) {
-						restoreStatus, err := restoreSuccessCheck(restore, orgID, retryDuration, retryInterval, ctxNonAdmin)
-						log.FailOnError(err, "Failed while restoring Backup for - %s", restore)
-						dash.VerifyFatal(restoreStatus, true, "Inspecting the Restore success for - "+restore)
+						err = restoreSuccessCheck(restore, orgID, maxWaitPeriodForRestoreCompletionInMinute*time.Minute, 30*time.Second, ctxNonAdmin)
+						dash.VerifyFatal(err, nil, "Inspecting the Restore success for - "+restore)
 					}
 				}
 			}


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR aims to enhance the backup and restore checks by implementing a fail-fast mechanism for unexpected errors and eliminating redundant success checks. As a result, the number of retries required is expected to decrease.

**Which issue(s) this PR fixes** (optional)
Closes #PA-650

**Special notes for your reviewer**:
Some testing has been done, but backup resiliency tests still need to be run. You can view the Jenkins build for IssueMultipleDeletesForSharedBackup, ClusterBackupShareToggle, and AllNSBackupWithIncludeNewNSOption using the link below

https://jenkins.pwx.dev.purestorage.com/job/Users/job/Sumit/job/Custom-Pipelines/job/px-backup-on-demand-system-test-byoc/463

Aetos Dashboard: http://aetos.pwx.purestorage.com/resultSet/testSetID/125299