### PR TITLE
Update BackupScheduleCreateRequest

### DIFF
--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -327,8 +327,9 @@ func CreateScheduleBackup(scheduleName string, clusterName string, bLocation str
 			Name: postRuleName,
 			Uid:  postRuleUid,
 		},
-		NsLabelSelectors: nsLabelSelectors,
+		// NsLabelSelectors: nsLabelSelectors,
 	}
+	log.InfoD(bkpSchCreateRequest.String())
 	_, err := backupDriver.CreateBackupSchedule(ctx, bkpSchCreateRequest)
 	if err != nil {
 		return err

--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -298,7 +298,7 @@ func CreateBackupWithCustomResourceType(backupName string, clusterName string, b
 // CreateScheduleBackup creates a schedule backup
 func CreateScheduleBackup(scheduleName string, clusterName string, bLocation string, bLocationUID string,
 	namespaces []string, labelSelectors map[string]string, orgID string, preRuleName string,
-	preRuleUid string, postRuleName string, postRuleUid string, schPolicyName string, schPolicyUID string, ctx context.Context) error {
+	preRuleUid string, postRuleName string, postRuleUid string, schPolicyName string, schPolicyUID string, nsLabelSelectors string, ctx context.Context) error {
 	var firstScheduleBackupName string
 	var firstScheduleBackupUid string
 	backupDriver := Inst().Backup
@@ -327,6 +327,7 @@ func CreateScheduleBackup(scheduleName string, clusterName string, bLocation str
 			Name: postRuleName,
 			Uid:  postRuleUid,
 		},
+		NsLabelSelectors: nsLabelSelectors,
 	}
 	_, err := backupDriver.CreateBackupSchedule(ctx, bkpSchCreateRequest)
 	if err != nil {
@@ -420,7 +421,7 @@ func CreateBackupWithoutCheck(backupName string, clusterName string, bLocation s
 // CreateScheduleBackupWithoutCheck creates a schedule backup without waiting for success
 func CreateScheduleBackupWithoutCheck(scheduleName string, clusterName string, bLocation string, bLocationUID string,
 	namespaces []string, labelSelectors map[string]string, orgID string, preRuleName string,
-	preRuleUid string, postRuleName string, postRuleUid string, schPolicyName string, schPolicyUID string, ctx context.Context) (*api.BackupScheduleInspectResponse, error) {
+	preRuleUid string, postRuleName string, postRuleUid string, schPolicyName string, schPolicyUID string, nsLabelSelectors string, ctx context.Context) (*api.BackupScheduleInspectResponse, error) {
 	backupDriver := Inst().Backup
 	bkpSchCreateRequest := &api.BackupScheduleCreateRequest{
 		CreateMetadata: &api.CreateMetadata{
@@ -447,6 +448,7 @@ func CreateScheduleBackupWithoutCheck(scheduleName string, clusterName string, b
 			Name: postRuleName,
 			Uid:  postRuleUid,
 		},
+		NsLabelSelectors: nsLabelSelectors,
 	}
 	_, err := backupDriver.CreateBackupSchedule(ctx, bkpSchCreateRequest)
 	if err != nil {

--- a/tests/backup/backup_restore_basic_test.go
+++ b/tests/backup/backup_restore_basic_test.go
@@ -954,7 +954,7 @@ var _ = Describe("{AllNSBackupWithIncludeNewNSOption}", func() {
 			dash.VerifyFatal(err, nil, "Fetching px-central-admin ctx")
 			periodicSchedulePolicyName = fmt.Sprintf("%s-%v", "periodic", time.Now().Unix())
 			periodicSchedulePolicyUid = uuid.New()
-			periodicSchedulePolicyInfo := Inst().Backup.CreateIntervalSchedulePolicy(5, 15, 5)
+			periodicSchedulePolicyInfo := Inst().Backup.CreateIntervalSchedulePolicy(5, 5, 5)
 			err = Inst().Backup.BackupSchedulePolicy(periodicSchedulePolicyName, periodicSchedulePolicyUid, orgID, periodicSchedulePolicyInfo)
 			dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation of periodic schedule policy of interval 15 minutes named [%s]", periodicSchedulePolicyName))
 			periodicSchedulePolicyUid, err = Inst().Backup.GetSchedulePolicyUid(orgID, ctx, periodicSchedulePolicyName)
@@ -1012,7 +1012,7 @@ var _ = Describe("{AllNSBackupWithIncludeNewNSOption}", func() {
 				return ordinalScheduleBackupName, false, nil
 			}
 			log.InfoD("Waiting for 15 minutes for the next schedule backup to be triggered")
-			time.Sleep(15 * time.Minute)
+			time.Sleep(5 * time.Minute)
 			nextScheduleBackupName, err = task.DoRetryWithTimeout(checkOrdinalScheduleBackupCreation, maxWaitPeriodForBackupCompletionInMinutes*time.Minute, 30*time.Second)
 			dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching next schedule backup name of ordinal [%v] of schedule named [%s]", nextScheduleBackupOrdinal, scheduleName))
 			log.InfoD("Next schedule backup name [%s]", nextScheduleBackupName.(string))

--- a/tests/backup/backup_restore_basic_test.go
+++ b/tests/backup/backup_restore_basic_test.go
@@ -574,7 +574,7 @@ var _ = Describe("{ScheduleBackupCreationSingleNS}", func() {
 			for _, namespace := range bkpNamespaces {
 				backupName = fmt.Sprintf("%s-%s", BackupNamePrefix, namespace)
 				err = CreateScheduleBackup(backupName, SourceClusterName, backupLocationName, backupLocationUID, []string{namespace},
-					labelSelectors, orgID, "", "", "", "", periodicPolicyName, schPolicyUid, ctx)
+					labelSelectors, orgID, "", "", "", "", periodicPolicyName, schPolicyUid, "", ctx)
 				dash.VerifyFatal(err, nil, fmt.Sprintf("Verification of creating schedule backup with schedule name - %s", backupName))
 				schBackupName, err = GetFirstScheduleBackupName(ctx, backupName, orgID)
 				dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching the name of the first schedule backup - %s", schBackupName))
@@ -706,7 +706,7 @@ var _ = Describe("{ScheduleBackupCreationAllNS}", func() {
 			schPolicyUid, _ = Inst().Backup.GetSchedulePolicyUid(orgID, ctx, periodicPolicyName)
 			backupName = fmt.Sprintf("%s-schedule-%v", BackupNamePrefix, timeStamp)
 			err = CreateScheduleBackup(backupName, SourceClusterName, backupLocationName, backupLocationUID, bkpNamespaces,
-				labelSelectors, orgID, "", "", "", "", periodicPolicyName, schPolicyUid, ctx)
+				labelSelectors, orgID, "", "", "", "", periodicPolicyName, schPolicyUid, "", ctx)
 			dash.VerifyFatal(err, nil, fmt.Sprintf("Verification of creating schedule backup with schedule name - %s", backupName))
 			schBackupName, err = GetFirstScheduleBackupName(ctx, backupName, orgID)
 			dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching the name of the first schedule backup - %s", schBackupName))
@@ -968,7 +968,7 @@ var _ = Describe("{AllNSBackupWithIncludeNewNSOption}", func() {
 			namespaces := []string{"*"}
 			labelSelectors := make(map[string]string)
 			err = CreateScheduleBackup(scheduleName, appClusterName, backupLocationName, backupLocationUID, namespaces,
-				labelSelectors, orgID, "", "", "", "", periodicSchedulePolicyName, periodicSchedulePolicyUid, ctx)
+				labelSelectors, orgID, "", "", "", "", periodicSchedulePolicyName, periodicSchedulePolicyUid, "", ctx)
 			dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation of schedule backup with schedule name [%s]", scheduleName))
 			firstScheduleBackupName, err := GetFirstScheduleBackupName(ctx, scheduleName, orgID)
 			dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching the name of the first schedule backup [%s]", firstScheduleBackupName))

--- a/tests/backup/backup_share_test.go
+++ b/tests/backup/backup_share_test.go
@@ -2257,7 +2257,7 @@ var _ = Describe("{ClusterBackupShareToggle}", func() {
 			scheduleName = fmt.Sprintf("%s-schedule-%v", BackupNamePrefix, time.Now().Unix())
 			labelSelectors := make(map[string]string)
 			err = CreateScheduleBackup(scheduleName, backupClusterName, backupLocationName, backupLocationUID, appNamespaces,
-				labelSelectors, orgID, "", "", "", "", periodicSchedulePolicyName, periodicSchedulePolicyUid, ctx)
+				labelSelectors, orgID, "", "", "", "", periodicSchedulePolicyName, periodicSchedulePolicyUid, "", ctx)
 			dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation of schedule backup with schedule name [%s]", scheduleName))
 			firstScheduleBackupName, err := GetFirstScheduleBackupName(ctx, scheduleName, orgID)
 			dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching the name of the first schedule backup [%s]", firstScheduleBackupName))


### PR DESCRIPTION
[PA-730] Fix AllNSBackupWithIncludeNewNSOption

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
The PR updates the BackupScheduleCreateRequest to align with its corresponding API protobuf of Px-Backup 2.4.0. This PR improves the reliability of the "AllNSBackupWithIncludeNewNSOption" test case.

**Which issue(s) this PR fixes** (optional)
Closes #PA-730

**Special notes for your reviewer**:
Please review the Jenkins build of the refactored "AllNSBackupWithIncludeNewNSOption" test case using the link below

https://jenkins.pwx.dev.purestorage.com/job/Users/job/Sumit/job/Custom-Pipelines/job/px-backup-on-demand-system-test-byoc/493

Aetos Dashboard: http://aetos.pwx.purestorage.com/resultSet/testSetID/126299

By upgrading stork to a compatible version of Px-Backup 2.4.0, the issue with "AllNSBackupWithIncludeNewNSOption" appears to be resolved, which in turn avoids the need for this PR.

[PA-730]: https://portworx.atlassian.net/browse/PA-730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ