### PR TITLE
Add the ability to add namespace labels to namespaces created for backup

### DIFF
--- a/drivers/scheduler/dcos/dcos.go
+++ b/drivers/scheduler/dcos/dcos.go
@@ -965,6 +965,31 @@ func (d *dcos) GetPodsRestartCount(namespace string, label map[string]string) (m
 		Operation: "GetPodsRestartCoun()",
 	}
 }
+
+func (d *dcos) AddNamespaceLabel(namespace string, labelMap map[string]string) error {
+	// AddNamespaceLabel is not supported
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "AddNamespaceLabel()",
+	}
+}
+
+func (d *dcos) RemoveNamespaceLabel(namespace string, labelMap map[string]string) error {
+	// RemoveNamespaceLabel is not supported
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "RemoveNamespaceLabel()",
+	}
+}
+
+func (d *dcos) GetNamespaceLabel(namespace string) (map[string]string, error) {
+	// GetNamespaceLabel is not supported
+	return nil, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "GetNamespaceLabel()",
+	}
+}
+
 func init() {
 	d := &dcos{}
 	scheduler.Register(SchedName, d)

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -6346,6 +6346,43 @@ func getLabelsFromNodeAffinity(nodeAffSpec *v1.NodeAffinity) map[string]string {
 	return label
 }
 
+// AddNamespaceLabel adds a label key=value on the given namespace
+func (k *K8s) AddNamespaceLabel(namespace string, labelMap map[string]string) error {
+	ns, err := k8sCore.GetNamespace(namespace)
+	if err != nil {
+		return err
+	}
+	ns.SetLabels(labelMap)
+	if _, err := k8sCore.UpdateNamespace(ns); err == nil {
+		return nil
+	}
+	return err
+}
+
+// RemoveNamespaceLabel removes the label with key on given namespace
+func (k *K8s) RemoveNamespaceLabel(namespace string, labelMap map[string]string) error {
+	ns, err := k8sCore.GetNamespace(namespace)
+	if err != nil {
+		return err
+	}
+	for key := range labelMap {
+		delete(ns.Labels, key)
+	}
+	if _, err = k8sCore.UpdateNamespace(ns); err == nil {
+		return nil
+	}
+	return err
+}
+
+// GetNamespaceLabel gets the labels on given namespace
+func (k *K8s) GetNamespaceLabel(namespace string) (map[string]string, error) {
+	ns, err := k8sCore.GetNamespace(namespace)
+	if err != nil {
+		return nil, err
+	}
+	return ns.Labels, nil
+}
+
 // rotateTopologyArray Rotates topology arrays by one
 func rotateTopologyArray(options *scheduler.ScheduleOptions) {
 	if len(options.TopologyLabels) > 1 {

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -388,6 +388,15 @@ type Driver interface {
 
 	// GetPodsRestartCount gets restart count maps for pods in given namespace
 	GetPodsRestartCount(namespace string, label map[string]string) (map[*corev1.Pod]int32, error)
+
+	// AddNamespaceLabel adds a label key=value on the given namespace
+	AddNamespaceLabel(namespace string, labelMap map[string]string) error
+
+	// RemoveNamespaceLabel removes the label with key on given namespace
+	RemoveNamespaceLabel(namespace string, labelMap map[string]string) error
+
+	// GetNamespaceLabel gets the labels on given namespace
+	GetNamespaceLabel(namespace string) (map[string]string, error)
 }
 
 var (


### PR DESCRIPTION

**What this PR does / why we need it**:
Px backup 2.4.0 release supports, namespace label feature. This PR will handle to add, remove & get labels on given namespace.

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PA-685

**Special notes for your reviewer**:
http://aetos.pwx.purestorage.com/resultSet/testSetID/126549/testCaseID/633241

```
vpinisetti--MacBookPro18:~/gitspace/torpedo$ make clean build-backup
Makefile:45: DOCKER_HUB_REPO not defined, using 'vpinisettipx' instead
Makefile:49: DOCKER_HUB_TAG not defined, using 'latest' instead
sudo rm -rf bin
sudo find . -type f -name "*.test" -delete
Deleting basic image
docker rmi -f vpinisettipx/torpedo:latest
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
make: [clean] Error 1 (ignored)
Deleting pds image
docker rmi -f vpinisettipx/torpedo-pds:latest
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
make: [clean] Error 1 (ignored)
Deleting backup image
docker rmi -f vpinisettipx/torpedo-backup:latest
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
make: [clean] Error 1 (ignored)
go clean -i github.com/portworx/torpedo/drivers github.com/portworx/torpedo/drivers/api github.com/portworx/torpedo/drivers/backup github.com/portworx/torpedo/drivers/backup/portworx github.com/portworx/torpedo/drivers/monitor github.com/portworx/torpedo/drivers/monitor/prometheus github.com/portworx/torpedo/drivers/node github.com/portworx/torpedo/drivers/node/aks github.com/portworx/torpedo/drivers/node/aws github.com/portworx/torpedo/drivers/node/gke github.com/portworx/torpedo/drivers/node/ibm github.com/portworx/torpedo/drivers/node/oracle github.com/portworx/torpedo/drivers/node/ssh github.com/portworx/torpedo/drivers/node/vsphere github.com/portworx/torpedo/drivers/objectstore github.com/portworx/torpedo/drivers/pds/api github.com/portworx/torpedo/drivers/pds/controlplane github.com/portworx/torpedo/drivers/pds/lib github.com/portworx/torpedo/drivers/pds/pdsutils github.com/portworx/torpedo/drivers/pds/targetcluster github.com/portworx/torpedo/drivers/scheduler github.com/portworx/torpedo/drivers/scheduler/dcos github.com/portworx/torpedo/drivers/scheduler/k8s github.com/portworx/torpedo/drivers/scheduler/openshift github.com/portworx/torpedo/drivers/scheduler/rke github.com/portworx/torpedo/drivers/scheduler/spec github.com/portworx/torpedo/drivers/volume github.com/portworx/torpedo/drivers/volume/aws github.com/portworx/torpedo/drivers/volume/azure github.com/portworx/torpedo/drivers/volume/gce github.com/portworx/torpedo/drivers/volume/generic_csi github.com/portworx/torpedo/drivers/volume/linstor github.com/portworx/torpedo/drivers/volume/portworx github.com/portworx/torpedo/drivers/volume/portworx/schedops github.com/portworx/torpedo/pkg/aetosutil github.com/portworx/torpedo/pkg/applicationbackup github.com/portworx/torpedo/pkg/asyncdr github.com/portworx/torpedo/pkg/aututils github.com/portworx/torpedo/pkg/email github.com/portworx/torpedo/pkg/errors github.com/portworx/torpedo/pkg/ipv6util github.com/portworx/torpedo/pkg/jirautils github.com/portworx/torpedo/pkg/kvdbutils github.com/portworx/torpedo/pkg/log github.com/portworx/torpedo/pkg/netutil github.com/portworx/torpedo/pkg/osutils github.com/portworx/torpedo/pkg/pureutils github.com/portworx/torpedo/pkg/restutil github.com/portworx/torpedo/pkg/s3utils github.com/portworx/torpedo/pkg/snapshotutils github.com/portworx/torpedo/pkg/testrailuttils github.com/portworx/torpedo/pkg/units github.com/portworx/torpedo/porx/px/api
Add the ability to add namespace labels to namespaces created for backup
mkdir -p /Users/vpinisetti/gitspace/torpedo/bin
go build -tags "daemon"  github.com/portworx/torpedo/drivers github.com/portworx/torpedo/drivers/api github.com/portworx/torpedo/drivers/backup github.com/portworx/torpedo/drivers/backup/portworx github.com/portworx/torpedo/drivers/monitor github.com/portworx/torpedo/drivers/monitor/prometheus github.com/portworx/torpedo/drivers/node github.com/portworx/torpedo/drivers/node/aks github.com/portworx/torpedo/drivers/node/aws github.com/portworx/torpedo/drivers/node/gke github.com/portworx/torpedo/drivers/node/ibm github.com/portworx/torpedo/drivers/node/oracle github.com/portworx/torpedo/drivers/node/ssh github.com/portworx/torpedo/drivers/node/vsphere github.com/portworx/torpedo/drivers/objectstore github.com/portworx/torpedo/drivers/pds/api github.com/portworx/torpedo/drivers/pds/controlplane github.com/portworx/torpedo/drivers/pds/lib github.com/portworx/torpedo/drivers/pds/pdsutils github.com/portworx/torpedo/drivers/pds/targetcluster github.com/portworx/torpedo/drivers/scheduler github.com/portworx/torpedo/drivers/scheduler/dcos github.com/portworx/torpedo/drivers/scheduler/k8s github.com/portworx/torpedo/drivers/scheduler/openshift github.com/portworx/torpedo/drivers/scheduler/rke github.com/portworx/torpedo/drivers/scheduler/spec github.com/portworx/torpedo/drivers/volume github.com/portworx/torpedo/drivers/volume/aws github.com/portworx/torpedo/drivers/volume/azure github.com/portworx/torpedo/drivers/volume/gce github.com/portworx/torpedo/drivers/volume/generic_csi github.com/portworx/torpedo/drivers/volume/linstor github.com/portworx/torpedo/drivers/volume/portworx github.com/portworx/torpedo/drivers/volume/portworx/schedops github.com/portworx/torpedo/pkg/aetosutil github.com/portworx/torpedo/pkg/applicationbackup github.com/portworx/torpedo/pkg/asyncdr github.com/portworx/torpedo/pkg/aututils github.com/portworx/torpedo/pkg/email github.com/portworx/torpedo/pkg/errors github.com/portworx/torpedo/pkg/ipv6util github.com/portworx/torpedo/pkg/jirautils github.com/portworx/torpedo/pkg/kvdbutils github.com/portworx/torpedo/pkg/log github.com/portworx/torpedo/pkg/netutil github.com/portworx/torpedo/pkg/osutils github.com/portworx/torpedo/pkg/pureutils github.com/portworx/torpedo/pkg/restutil github.com/portworx/torpedo/pkg/s3utils github.com/portworx/torpedo/pkg/snapshotutils github.com/portworx/torpedo/pkg/testrailuttils github.com/portworx/torpedo/pkg/units github.com/portworx/torpedo/porx/px/api
ginkgo build -r ./tests/backup
Compiling backup...
    compiled backup.test
find ./tests/backup -name '*.test' | awk '{cmd="cp  "$1"  /Users/vpinisetti/gitspace/torpedo/bin"; system(cmd)}'
chmod -R 755 bin/*
vpinisetti--MacBookPro18:~/gitspace/torpedo$
````
