### PR TITLE
New test case submission for PTX-15696

### DIFF
--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -648,7 +648,7 @@ func nodePoolsExpansion(testName string) {
 
 			for _, poolToBeResized := range poolsToBeResized {
 				drvSize, err := getPoolDiskSize(poolToBeResized)
-				log.FailOnError(err, fmt.Sprintf("error getting drive size for pool [%s]", poolToBeResized.Uuid))
+				log.FailOnError(err, "error getting drive size for pool [%s]", poolToBeResized.Uuid)
 				expectedSize = (poolToBeResized.TotalSize / units.GiB) + drvSize
 				poolsExpectedSizeMap[poolToBeResized.Uuid] = expectedSize
 
@@ -664,7 +664,7 @@ func nodePoolsExpansion(testName string) {
 				//this condition is skip error where drive is size is small and resize completes very fast
 				if err != nil {
 					expandedPool, err := GetStoragePoolByUUID(poolToBeResized.Uuid)
-					log.FailOnError(err, fmt.Sprintf("error getting pool using uuid [%s]", poolToBeResized.Uuid))
+					log.FailOnError(err, "error getting pool using uuid [%s]", poolToBeResized.Uuid)
 					if expandedPool.LastOperation.Status == api.SdkStoragePool_OPERATION_SUCCESSFUL {
 						// storage pool resize expansion completed
 						err = nil

--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -648,7 +648,7 @@ func nodePoolsExpansion(testName string) {
 
 			for _, poolToBeResized := range poolsToBeResized {
 				drvSize, err := getPoolDiskSize(poolToBeResized)
-				log.FailOnError(err, "error getting drive size for pool [%s]", poolToBeResized.Uuid)
+				log.FailOnError(err, fmt.Sprintf("error getting drive size for pool [%s]", poolToBeResized.Uuid))
 				expectedSize = (poolToBeResized.TotalSize / units.GiB) + drvSize
 				poolsExpectedSizeMap[poolToBeResized.Uuid] = expectedSize
 
@@ -664,7 +664,7 @@ func nodePoolsExpansion(testName string) {
 				//this condition is skip error where drive is size is small and resize completes very fast
 				if err != nil {
 					expandedPool, err := GetStoragePoolByUUID(poolToBeResized.Uuid)
-					log.FailOnError(err, "error getting pool using uuid [%s]", poolToBeResized.Uuid)
+					log.FailOnError(err, fmt.Sprintf("error getting pool using uuid [%s]", poolToBeResized.Uuid))
 					if expandedPool.LastOperation.Status == api.SdkStoragePool_OPERATION_SUCCESSFUL {
 						// storage pool resize expansion completed
 						err = nil

--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -6232,9 +6232,12 @@ var _ = Describe("{VerifyPoolDeleteInvalidPoolID}", func() {
 		PoolDetail, err := GetPoolsDetailsOnNode(*nodeDetail)
 		log.FailOnError(err, "Fetching all pool details from the node [%v] failed ", nodeDetail.Name)
 
-		// Delete Pool without entering Maintenance Mode [ PTX-15157 ]
-		err = Inst().V.DeletePool(*nodeDetail, "0")
-		dash.VerifyFatal(err == nil, false, fmt.Sprintf("Expected Failure as pool not in maintenance mode : Node Detail [%v]", nodeDetail.Name))
+		if IsLocalCluster(*nodeDetail) == true || IsIksCluster() == true {
+			// Delete Pool without entering Maintenance Mode [ PTX-15157 ]
+			err = Inst().V.DeletePool(*nodeDetail, "0")
+			dash.VerifyFatal(err == nil, false, fmt.Sprintf("Expected Failure as pool not in maintenance mode : Node Detail [%v]", nodeDetail.Name))
+
+		}
 
 		commonText := "service mode delete pool.*unable to delete pool with ID.*[0-9]+.*cause.*"
 		compileText := fmt.Sprintf("[%s]operation is not supported", commonText)

--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -8466,7 +8466,14 @@ var _ = Describe("{ReplResyncOnPoolExpand}", func() {
 		for _, eachVol := range volumes {
 			volumeInspect, err := Inst().V.InspectVolume(eachVol.ID)
 			log.FailOnError(err, fmt.Sprintf("Failed to get details of volume [%v]", eachVol.Name))
-			fmt.Printf("Volume Details [%v] is [%v]", volumeInspect.Status, volumeInspect.State)
+
+			if fmt.Sprintf("[%v]", volumeInspect.Status) != "VOLUME_STATUS_UP" {
+
+				fmt.Printf("Volume Details [%v] is [%v]", volumeInspect.Status, volumeInspect.State)
+				log.FailOnError(fmt.Errorf("Volume status did not match "),
+					fmt.Sprintf("Volume [%v] is not up after pool expand", eachVol.Name))
+			}
+
 		}
 	})
 

--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -8432,10 +8432,7 @@ var _ = Describe("{ReplResyncOnPoolExpand}", func() {
 			if len(getReplicaSets[0].Nodes) != 2 {
 				err := Inst().V.SetReplicationFactor(eachVol, 2, nil, nil, true)
 				if err != nil {
-					re := regexp.MustCompile("Failed to update volume: No change requested")
-					if re.MatchString(fmt.Sprintf("%v", err)) == false {
-						log.FailOnError(err, "failed to set replicaiton value of Volume [%v]", eachVol.Name)
-					}
+					log.FailOnError(err, "failed to set replicaiton for Volume [%v]", eachVol.Name)
 				}
 			}
 		}
@@ -8468,8 +8465,6 @@ var _ = Describe("{ReplResyncOnPoolExpand}", func() {
 			log.FailOnError(err, fmt.Sprintf("Failed to get details of volume [%v]", eachVol.Name))
 
 			if fmt.Sprintf("[%v]", volumeInspect.Status) != "VOLUME_STATUS_UP" {
-
-				fmt.Printf("Volume Details [%v] is [%v]", volumeInspect.Status, volumeInspect.State)
 				log.FailOnError(fmt.Errorf("Volume status did not match "),
 					fmt.Sprintf("Volume [%v] is not up after pool expand", eachVol.Name))
 			}

--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -648,7 +648,7 @@ func nodePoolsExpansion(testName string) {
 
 			for _, poolToBeResized := range poolsToBeResized {
 				drvSize, err := getPoolDiskSize(poolToBeResized)
-				log.FailOnError(err, "error getting drive size for pool [%s]", poolToBeResized.Uuid)
+				log.FailOnError(err, fmt.Sprintf("error getting drive size for pool [%s]", poolToBeResized.Uuid))
 				expectedSize = (poolToBeResized.TotalSize / units.GiB) + drvSize
 				poolsExpectedSizeMap[poolToBeResized.Uuid] = expectedSize
 

--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 
 	"github.com/google/uuid"
+	"github.com/libopenstorage/operator/drivers/storage/portworx/util"
 	"github.com/portworx/torpedo/drivers/node"
 	"github.com/portworx/torpedo/drivers/scheduler/k8s"
 	"github.com/portworx/torpedo/drivers/volume"
@@ -19,12 +20,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/portworx/torpedo/pkg/testrailuttils"
-
 	"github.com/libopenstorage/openstorage/api"
 	. "github.com/onsi/ginkgo"
 	"github.com/portworx/sched-ops/task"
 	"github.com/portworx/torpedo/drivers/scheduler"
+	"github.com/portworx/torpedo/pkg/testrailuttils"
 	"github.com/portworx/torpedo/pkg/units"
 	. "github.com/portworx/torpedo/tests"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -664,7 +664,7 @@ func nodePoolsExpansion(testName string) {
 				//this condition is skip error where drive is size is small and resize completes very fast
 				if err != nil {
 					expandedPool, err := GetStoragePoolByUUID(poolToBeResized.Uuid)
-					log.FailOnError(err, "error getting pool using uuid [%s]", poolToBeResized.Uuid)
+					log.FailOnError(err, fmt.Sprintf("error getting pool using uuid [%s]", poolToBeResized.Uuid))
 					if expandedPool.LastOperation.Status == api.SdkStoragePool_OPERATION_SUCCESSFUL {
 						// storage pool resize expansion completed
 						err = nil
@@ -8361,6 +8361,129 @@ var _ = Describe("{AddDiskAddDriveAndDeleteInstance}", func() {
 		AfterEachTest(contexts)
 	})
 })
+
+var _ = Describe("{DriveAddAsJournal}", func() {
+	/*
+		Add drive when as journal
+		case1:if dmthin journal is not supported so it should fail with  error message
+		case2:if it is btrfs and journal drive exists so it should have failed with error message jounral drive exists
+		case3:if it is btrfs and journal drive does not exists so it add journal drive successfully
+
+	*/
+	var testrailID = 0
+	// Testrail Description : Add drive when as journal
+	var runID int
+
+	JustBeforeEach(func() {
+		StartTorpedoTest("DriveAddAsJournal",
+			"Add drive when as journal",
+			nil, testrailID)
+		runID = testrailuttils.AddRunsToMilestone(testrailID)
+	})
+	var contexts []*scheduler.Context
+	stepLog := "Add drive when as journal"
+	It(stepLog, func() {
+		log.InfoD(stepLog)
+
+		contexts = make([]*scheduler.Context, 0)
+		for i := 0; i < Inst().GlobalScaleFactor; i++ {
+			contexts = append(contexts, ScheduleApplications(fmt.Sprintf("adddriveasjournal-%d", i))...)
+		}
+		ValidateApplications(contexts)
+		defer appsValidateAndDestroy(contexts)
+
+		// Get Pool with running IO on the cluster
+		poolUUID, err := GetPoolIDWithIOs(contexts)
+		log.FailOnError(err, "Failed to get pool running with IO")
+		log.InfoD("Pool UUID on which IO is running [%s]", poolUUID)
+
+		// Get Node Details of the Pool with IO
+		nodeDetail, err := GetNodeWithGivenPoolID(poolUUID)
+		log.FailOnError(err, "Failed to get Node Details from PoolUUID [%v]", poolUUID)
+		log.InfoD("Pool with UUID [%v] present in Node [%v]", poolUUID, nodeDetail.Name)
+		// Get PX StorageCluster
+		var dmthinEnabled bool
+		cluster, err := Inst().V.GetDriver()
+		log.FailOnError(err, "Error getting clusterspecs")
+		argsList, err := util.MiscArgs(cluster)
+		for _, args := range argsList {
+			if strings.Contains(args, "dmthin") {
+				dmthinEnabled = true
+			}
+		}
+
+		// Add cloud drive on the node selected and wait for rebalance to happen
+		driveSpecs, err := GetCloudDriveDeviceSpecs()
+		log.FailOnError(err, "Error getting cloud drive specs")
+
+		deviceSpec := driveSpecs[0]
+		devicespecjournal := deviceSpec + " --journal"
+		if dmthinEnabled {
+			err := Inst().V.AddCloudDrive(nodeDetail, devicespecjournal, -1)
+			dash.VerifyFatal(err != nil, true, "Did not Error out when adding cloud drive as expected")
+			re := regexp.MustCompile(".*Journal/Metadata device add not supported for PX-StoreV2*")
+			dash.VerifyFatal(re.MatchString(fmt.Sprintf("%v", err)),
+				true,
+				fmt.Sprintf("Errored while adding Pool as expected on Node [%v]", nodeDetail.Name))
+		} else {
+			err = Inst().V.EnterPoolMaintenance(*nodeDetail)
+			log.FailOnError(err, "Error Entering Maintenance mode on Node[%v]", nodeDetail.Name)
+			log.InfoD("Enter pool Maintenance mode ")
+			expectedStatus := "In Maintenance"
+
+			log.FailOnError(WaitForPoolStatusToUpdate(*nodeDetail, expectedStatus),
+				fmt.Sprintf("node %s pools are not in status %s", nodeDetail.Name, expectedStatus))
+
+			//Wait for 7 min to bring up the portworx daemon before trying cloud drive add
+			time.Sleep(7 * time.Minute)
+			isjournal, err := isJournalEnabled()
+			log.FailOnError(err, "Error getting journal status")
+			if isjournal {
+				devicespecjournal := deviceSpec + " --journal"
+				err = Inst().V.AddCloudDrive(nodeDetail, devicespecjournal, -1)
+				dash.VerifyFatal(err != nil, true, "Did not Error out when adding cloud drive as expected")
+				re := regexp.MustCompile(".*journal exists*")
+				re1 := regexp.MustCompile(".*is alredy configured*")
+				dash.VerifyFatal(re.MatchString(fmt.Sprintf("%v", err)) || re1.MatchString(fmt.Sprintf("%v", err)),
+					true,
+					fmt.Sprintf("Errored while adding Pool as expected on Node [%v]", nodeDetail.Name))
+			} else {
+				systemOpts := node.SystemctlOpts{
+					ConnectionOpts: node.ConnectionOpts{
+						Timeout:         2 * time.Minute,
+						TimeBeforeRetry: defaultRetryInterval,
+					},
+					Action: "start",
+				}
+				drivesMap, err := Inst().N.GetBlockDrives(*nodeDetail, systemOpts)
+				log.FailOnError(err, "error getting block drives from node %s", nodeDetail.Name)
+				blockDeviceBefore := len(drivesMap)
+				devicespecjournal := deviceSpec + " --journal"
+				err = Inst().V.AddCloudDrive(nodeDetail, devicespecjournal, -1)
+				log.FailOnError(err, "journal add failed")
+				drivesMap, err = Inst().N.GetBlockDrives(*nodeDetail, systemOpts)
+				log.FailOnError(err, "error getting block drives from node %s", nodeDetail.Name)
+				blockDeviceAfter := len(drivesMap)
+				dash.VerifyFatal(blockDeviceBefore+1 == blockDeviceAfter, true, "adding cloud drive as journal successful")
+				isjournal, err := isJournalEnabled()
+				log.FailOnError(err, "Error getting journal status")
+				dash.VerifyFatal(isjournal, true, "journal device added successfully")
+			}
+			err = Inst().V.ExitPoolMaintenance(*nodeDetail)
+			log.FailOnError(err, "Exiting maintenance mode failed")
+			log.InfoD("Exiting pool Maintenance mode successful")
+		}
+	})
+
+	JustAfterEach(func() {
+		defer EndTorpedoTest()
+		log.InfoD("Exit from Maintenance mode if Pool is still in Maintenance")
+		log.FailOnError(ExitNodesFromMaintenanceMode(), "exit from maintenance mode failed?")
+		AfterEachTest(contexts, testrailID, runID)
+	})
+
+})
+
 var _ = Describe("{ReplResyncOnPoolExpand}", func() {
 	/*
 		PTX-15696 -> PWX-26967

--- a/tests/common.go
+++ b/tests/common.go
@@ -5918,6 +5918,7 @@ func AsgKillNode(nodeToKill node.Node) error {
 
 }
 
+// RefreshDriverEndPoints returns nil if refreshing driver endpoint is successful
 func RefreshDriverEndPoints() error {
 	var err error
 	err = Inst().V.RefreshDriverEndpoints()
@@ -5927,6 +5928,7 @@ func RefreshDriverEndPoints() error {
 	return nil
 }
 
+// GetVolumesFromPoolID returns list of volumes from pool uuid
 func GetVolumesFromPoolID(contexts []*scheduler.Context, poolUuid string) ([]*volume.Volume, error) {
 	var volumes []*volume.Volume
 

--- a/tests/common.go
+++ b/tests/common.go
@@ -5931,7 +5931,10 @@ func GetVolumesFromPoolID(contexts []*scheduler.Context, poolUuid string) ([]*vo
 	var volumes []*volume.Volume
 
 	// Refresh driver end points before processing
-	RefreshDriverEndPoints()
+	err := RefreshDriverEndPoints()
+	if err != nil {
+		return nil, err
+	}
 	for _, ctx := range contexts {
 		vols, err := Inst().S.GetVolumes(ctx)
 		if err != nil {


### PR DESCRIPTION
STEP: validate fio-writes app's volume fio-log-fio-5 has been deleted in the volume driver
2023-03-24 17:21:54 +0530:[INFO] [{ReplResyncOnPoolExpand}] validate fio-writes app's volume fio-log-fio-5 has been deleted in the volume driver
INFO[2023-03-24 17:21:54] Verifying : Description : fio-writes's volume fio-log-fio-5 deleted successfully? 
INFO[2023-03-24 17:21:54] Actual:true, Expected: true                  
STEP: destroy the fio-writes app's volumes
2023-03-24 17:21:54 +0530:[INFO] [{ReplResyncOnPoolExpand}] [tests.DeleteVolumes.func1:#1393] - destroy the fio-writes app's volumes
2023-03-24 17:21:55 +0530:[INFO] [{ReplResyncOnPoolExpand}] [k8s.(*K8s).DeleteVolumes:#3114] - [fio-writes] Storage class is not found: fio-sc, skipping deletion
2023-03-24 17:21:55 +0530:[INFO] [{ReplResyncOnPoolExpand}] [k8s.(*K8s).DeleteVolumes:#3114] - [fio-writes] Storage class is not found: fio-log, skipping deletion
2023-03-24 17:21:55 +0530:[INFO] [{ReplResyncOnPoolExpand}] [k8s.(*K8s).DeleteVolumes:#3227] - [fio-writes] Destroyed PVCs for StatefulSet: fio
INFO[2023-03-24 17:21:56] Verifying : Description : Test completed successfully ? 
INFO[2023-03-24 17:21:56] Actual:PASS, Expected: PASS         
INFO[2023-03-24 17:21:56] --------Test End------                       
INFO[2023-03-24 17:21:56] #Test: ReplResyncOnPoolExpand                
INFO[2023-03-24 17:21:56] #Description: Resync failed for a volume after pool came out of rebalance  
INFO[2023-03-24 17:21:56] ------------------------                     

• [SLOW TEST:9479.667 seconds]
{ReplResyncOnPoolExpand}
/Users/vprabhakar/Desktop/work/torpedo/torpedo/tests/basic/storage_pool_test.go:8364
  Resync volume after rebalance
  /Users/vprabhakar/Desktop/work/torpedo/torpedo/tests/basic/storage_pool_test.go:8387
------------------------------
