### PR TITLE
[PA-597, 598, 599] TC Automation - PXBackup End-To-End Backup and Restore with Upgrade

### DIFF
--- a/tests/backup/backup_upgrade_test.go
+++ b/tests/backup/backup_upgrade_test.go
@@ -2,7 +2,9 @@ package tests
 
 import (
 	"fmt"
+	"os"
 	"strconv"
+	"sync"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -108,7 +110,7 @@ var _ = Describe("{StorkUpgradeWithBackup}", func() {
 			}
 		})
 
-		Step("Creating Schedule Policiy", func() {
+		Step("Creating Schedule Policy", func() {
 			log.InfoD("Creating Schedule Policy")
 			periodicSchedulePolicyInfo := Inst().Backup.CreateIntervalSchedulePolicy(5, 15, 5)
 			periodicPolicyStatus := Inst().Backup.BackupSchedulePolicy(periodicPolicyName, uuid.New(), orgID, periodicSchedulePolicyInfo)
@@ -200,5 +202,503 @@ var _ = Describe("{StorkUpgradeWithBackup}", func() {
 		opts[SkipClusterScopedObjects] = true
 		ValidateAndDestroy(contexts, opts)
 		CleanupCloudSettingsAndClusters(backupLocationMap, cloudAccountName, cloudCredUID, ctx)
+	})
+})
+
+// This testcase executes and validates end-to-end backup and restore operations with PX-Backup upgrade
+var _ = Describe("{PXBackupEndToEndBackupAndRestoreWithUpgrade}", func() {
+	var (
+		numDeployments                     int
+		srcClusterContexts                 []*scheduler.Context
+		srcClusterAppNamespaces            map[string][]string
+		destClusterContexts                []*scheduler.Context
+		destClusterAppNamespaces           map[string][]string
+		cloudAccountUid                    string
+		cloudAccountName                   string
+		backupLocationName                 string
+		backupLocationUid                  string
+		backupLocationMap                  map[string]string
+		srcClusterUid                      string
+		destClusterUid                     string
+		preRuleNames                       map[string]string
+		preRuleUids                        map[string]string
+		postRuleNames                      map[string]string
+		postRuleUids                       map[string]string
+		backupWithoutRuleNames             []string
+		backupWithRuleNames                []string
+		schedulePolicyName                 string
+		schedulePolicyUid                  string
+		intervalInMins                     int
+		singleNSNamespaces                 []string
+		singleNSScheduleNames              []string
+		allNamespaces                      []string
+		allNSScheduleName                  string
+		backupAfterUpgradeWithoutRuleNames []string
+		backupAfterUpgradeWithRuleNames    []string
+		restoreNames                       []string
+		mutex                              sync.Mutex
+	)
+
+	JustBeforeEach(func() {
+		StartTorpedoTest("PXBackupEndToEndBackupAndRestoreWithUpgrade", "Validates end-to-end backup and restore operations with PX-Backup upgrade", nil, 0)
+		log.Infof("Scheduling applications")
+		numDeployments = Inst().GlobalScaleFactor
+		if len(Inst().AppList) == 1 && numDeployments < 2 {
+			numDeployments = 2
+		}
+		destClusterContexts = make([]*scheduler.Context, 0)
+		destClusterAppNamespaces = make(map[string][]string, 0)
+		log.InfoD("Scheduling applications in destination cluster")
+		err := SetDestinationKubeConfig()
+		log.FailOnError(err, "Switching context to destination cluster failed")
+		for i := 0; i < numDeployments; i++ {
+			taskName := fmt.Sprintf("dst-%s-%d", taskNamePrefix, i)
+			appContexts := ScheduleApplications(taskName)
+			destClusterContexts = append(destClusterContexts, appContexts...)
+			for index, ctx := range appContexts {
+				appName := Inst().AppList[index]
+				ctx.ReadinessTimeout = appReadinessTimeout
+				namespace := GetAppNamespace(ctx, taskName)
+				log.InfoD("Scheduled application [%s] in destination cluster in namespace [%s]", appName, namespace)
+				destClusterAppNamespaces[appName] = append(destClusterAppNamespaces[appName], namespace)
+			}
+		}
+		srcClusterContexts = make([]*scheduler.Context, 0)
+		srcClusterAppNamespaces = make(map[string][]string, 0)
+		log.InfoD("Scheduling applications in source cluster")
+		err = SetSourceKubeConfig()
+		log.FailOnError(err, "Switching context to source cluster failed")
+		for i := 0; i < numDeployments; i++ {
+			taskName := fmt.Sprintf("src-%s-%d", taskNamePrefix, i)
+			appContexts := ScheduleApplications(taskName)
+			srcClusterContexts = append(srcClusterContexts, appContexts...)
+			for index, ctx := range appContexts {
+				appName := Inst().AppList[index]
+				ctx.ReadinessTimeout = appReadinessTimeout
+				namespace := GetAppNamespace(ctx, taskName)
+				log.InfoD("Scheduled application [%s] in source cluster in namespace [%s]", appName, namespace)
+				srcClusterAppNamespaces[appName] = append(srcClusterAppNamespaces[appName], namespace)
+			}
+		}
+	})
+	It("PX-Backup End-to-End Backup and Restore with Upgrade", func() {
+		Step("Validate app namespaces in destination cluster", func() {
+			log.InfoD("Validating app namespaces in destination cluster")
+			err := SetDestinationKubeConfig()
+			log.FailOnError(err, "Switching context to destination cluster failed")
+			ValidateApplications(destClusterContexts)
+		})
+		Step("Validate app namespaces in source cluster", func() {
+			log.InfoD("Validating app namespaces in source cluster")
+			err := SetSourceKubeConfig()
+			log.FailOnError(err, "Switching context to source cluster failed")
+			ValidateApplications(srcClusterContexts)
+		})
+		Step("Create cloud credentials and backup locations", func() {
+			log.InfoD("Creating cloud credentials and backup locations")
+			providers := getProviders()
+			backupLocationMap = make(map[string]string, 0)
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			for _, provider := range providers {
+				cloudAccountUid = uuid.New()
+				cloudAccountName = fmt.Sprintf("%s-%s-%v", "cred", provider, time.Now().Unix())
+				log.Infof("Creating a cloud credential [%s] with UID [%s] using [%s] as the provider", cloudAccountUid, cloudAccountName, provider)
+				err := CreateCloudCredential(provider, cloudAccountName, cloudAccountUid, orgID, ctx)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation of cloud credential [%s] with UID [%s] using [%s] as the provider", cloudAccountName, orgID, provider))
+				backupLocationName = fmt.Sprintf("%s-bl-%v", getGlobalBucketName(provider), time.Now().Unix())
+				backupLocationUid = uuid.New()
+				backupLocationMap[backupLocationUid] = backupLocationName
+				bucketName := getGlobalBucketName(provider)
+				log.Infof("Creating a backup location [%s] with UID [%s] using the [%s] bucket", backupLocationName, backupLocationUid, bucketName)
+				err = CreateBackupLocation(provider, backupLocationName, backupLocationUid, cloudAccountName, cloudAccountUid, bucketName, orgID, "")
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation of backup location [%s] with UID [%s] using the bucket [%s]", backupLocationName, backupLocationUid, bucketName))
+			}
+		})
+		Step("Create source and destination clusters", func() {
+			log.InfoD("Creating source and destination clusters")
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			log.Infof("Creating source [%s] and destination [%s] clusters", SourceClusterName, destinationClusterName)
+			err = CreateSourceAndDestClusters(orgID, "", "", ctx)
+			dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation of source [%s] and destination [%s] clusters with px-central-admin ctx", SourceClusterName, destinationClusterName))
+			srcClusterStatus, err := Inst().Backup.GetClusterStatus(orgID, SourceClusterName, ctx)
+			log.FailOnError(err, fmt.Sprintf("Fetching [%s] cluster status", SourceClusterName))
+			dash.VerifyFatal(srcClusterStatus, api.ClusterInfo_StatusInfo_Online, fmt.Sprintf("Verifying if [%s] cluster is online", SourceClusterName))
+			srcClusterUid, err = Inst().Backup.GetClusterUID(ctx, orgID, SourceClusterName)
+			log.FailOnError(err, fmt.Sprintf("Fetching [%s] cluster uid", SourceClusterName))
+			log.Infof("Cluster [%s] uid: [%s]", SourceClusterName, srcClusterUid)
+			dstClusterStatus, err := Inst().Backup.GetClusterStatus(orgID, destinationClusterName, ctx)
+			log.FailOnError(err, fmt.Sprintf("Fetching [%s] cluster status", destinationClusterName))
+			dash.VerifyFatal(dstClusterStatus, api.ClusterInfo_StatusInfo_Online, fmt.Sprintf("Verifying if [%s] cluster is online", destinationClusterName))
+			destClusterUid, err = Inst().Backup.GetClusterUID(ctx, orgID, destinationClusterName)
+			log.FailOnError(err, fmt.Sprintf("Fetching [%s] cluster uid", destinationClusterName))
+			log.Infof("Cluster [%s] uid: [%s]", destinationClusterName, destClusterUid)
+		})
+		Step("Create pre and post exec rules for applications", func() {
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			preRuleNames = make(map[string]string, 0)
+			preRuleUids = make(map[string]string, 0)
+			log.InfoD("Creating pre exec rules for applications %v", Inst().AppList)
+			for _, appName := range Inst().AppList {
+				log.Infof("Creating pre backup rule for application [%s]", appName)
+				_, preRuleName, err := Inst().Backup.CreateRuleForBackup(appName, orgID, "pre")
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation of pre backup rule for application [%s]", appName))
+				preRuleUid := ""
+				if preRuleName != "" {
+					preRuleUid, err = Inst().Backup.GetRuleUid(orgID, ctx, preRuleName)
+					log.FailOnError(err, "Fetching pre backup rule [%s] uid", preRuleName)
+					log.Infof("Pre backup rule [%s] uid: [%s]", preRuleName, preRuleUid)
+				}
+				for i := 0; i < len(srcClusterAppNamespaces[appName]); i++ {
+					preRuleNames[appName] = preRuleName
+					preRuleUids[appName] = preRuleUid
+				}
+			}
+			postRuleNames = make(map[string]string, 0)
+			postRuleUids = make(map[string]string, 0)
+			log.InfoD("Creating post exec rules for applications %v", Inst().AppList)
+			for _, appName := range Inst().AppList {
+				log.Infof("Creating post backup rule for application [%s]", appName)
+				_, postRuleName, err := Inst().Backup.CreateRuleForBackup(appName, orgID, "post")
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation of post-backup rule for application [%s]", appName))
+				postRuleUid := ""
+				if postRuleName != "" {
+					postRuleUid, err = Inst().Backup.GetRuleUid(orgID, ctx, postRuleName)
+					log.FailOnError(err, "Fetching post backup rule [%s] uid", postRuleName)
+					log.Infof("Post backup rule [%s] uid: [%s]", postRuleName, postRuleUid)
+				}
+				for i := 0; i < len(srcClusterAppNamespaces[appName]); i++ {
+					postRuleNames[appName] = postRuleName
+					postRuleUids[appName] = postRuleUid
+				}
+			}
+		})
+		Step("Create backups with and without pre and post exec rules", func() {
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			createBackupWithRulesTask := func(appName string) {
+				namespace := srcClusterAppNamespaces[appName][0]
+				backupName := fmt.Sprintf("%s-%s-%v-with-rules", BackupNamePrefix, namespace, time.Now().Unix())
+				labelSelectors := make(map[string]string, 0)
+				log.InfoD("Creating a backup of namespace [%s] with pre and post exec rules", namespace)
+				err := CreateBackup(backupName, SourceClusterName, backupLocationName, backupLocationUid, []string{namespace},
+					labelSelectors, orgID, srcClusterUid, preRuleNames[appName], preRuleUids[appName], postRuleNames[appName], postRuleUids[appName], ctx)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation of backup [%s]", backupName))
+				err = IsFullBackup(backupName, orgID, ctx)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying if backup [%s] is a full backup", backupName))
+				backupWithRuleNames = SafeAppend(&mutex, backupWithRuleNames, backupName).([]string)
+			}
+			_ = TaskHandler(Inst().AppList, createBackupWithRulesTask, Parallel)
+			createBackupWithoutRulesTask := func(appName string) {
+				namespace := srcClusterAppNamespaces[appName][0]
+				backupName := fmt.Sprintf("%s-%s-%v-without-rules", BackupNamePrefix, namespace, time.Now().Unix())
+				labelSelectors := make(map[string]string, 0)
+				log.InfoD("Creating a backup of namespace [%s] without pre and post exec rules", namespace)
+				err := CreateBackup(backupName, SourceClusterName, backupLocationName, backupLocationUid, []string{namespace},
+					labelSelectors, orgID, srcClusterUid, "", "", "", "", ctx)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation of backup [%s]", backupName))
+				backupWithoutRuleNames = SafeAppend(&mutex, backupWithoutRuleNames, backupName).([]string)
+			}
+			_ = TaskHandler(Inst().AppList, createBackupWithoutRulesTask, Parallel)
+		})
+		Step("Create a schedule policy", func() {
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			intervalInMins = 15
+			log.InfoD("Creating a schedule policy with interval [%v] mins", intervalInMins)
+			schedulePolicyName = fmt.Sprintf("interval-%v-%v", intervalInMins, time.Now().Unix())
+			schedulePolicyInfo := Inst().Backup.CreateIntervalSchedulePolicy(5, int64(intervalInMins), 5)
+			err = Inst().Backup.BackupSchedulePolicy(schedulePolicyName, uuid.New(), orgID, schedulePolicyInfo)
+			dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation of schedule policy [%s] with interval [%v] mins", schedulePolicyName, intervalInMins))
+			schedulePolicyUid, err = Inst().Backup.GetSchedulePolicyUid(orgID, ctx, schedulePolicyName)
+			log.FailOnError(err, "Fetching uid of schedule policy [%s]", schedulePolicyName)
+			log.Infof("Schedule policy [%s] uid: [%s]", schedulePolicyName, schedulePolicyUid)
+		})
+		Step("Create schedule backup for each namespace", func() {
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			createSingleNSBackupTask := func(appName string) {
+				namespace := srcClusterAppNamespaces[appName][0]
+				labelSelectors := make(map[string]string, 0)
+				singleNSScheduleName := fmt.Sprintf("%s-single-namespace-schedule-%v", namespace, time.Now().Unix())
+				log.InfoD("Creating schedule backup with schedule [%s] of source cluster namespace [%s]", singleNSScheduleName, namespace)
+				err = CreateScheduleBackup(singleNSScheduleName, SourceClusterName, backupLocationName, backupLocationUid, []string{namespace},
+					labelSelectors, orgID, preRuleNames[appName], preRuleUids[appName], postRuleNames[appName], postRuleUids[appName], schedulePolicyName, schedulePolicyUid, ctx)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation of schedule backup with schedule [%s]", singleNSScheduleName))
+				firstScheduleBackupName, err := GetFirstScheduleBackupName(ctx, singleNSScheduleName, orgID)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching name of the first schedule backup with schedule [%s]", singleNSScheduleName))
+				log.Infof("First schedule backup name: [%s]", firstScheduleBackupName)
+				singleNSNamespaces = SafeAppend(&mutex, singleNSNamespaces, namespace).([]string)
+				singleNSScheduleNames = SafeAppend(&mutex, singleNSScheduleNames, singleNSScheduleName).([]string)
+			}
+			_ = TaskHandler(Inst().AppList, createSingleNSBackupTask, Parallel)
+		})
+		Step("Create schedule backup of all namespaces", func() {
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			for _, appName := range Inst().AppList {
+				allNamespaces = append(allNamespaces, destClusterAppNamespaces[appName]...)
+			}
+			allNSScheduleName = fmt.Sprintf("%s-all-namespaces-schedule-%v", BackupNamePrefix, time.Now().Unix())
+			labelSelectors := make(map[string]string, 0)
+			log.InfoD("Creating schedule backup with schedule [%s] of all namespaces of destination cluster [%s]", allNSScheduleName, allNamespaces)
+			err = CreateScheduleBackup(allNSScheduleName, destinationClusterName, backupLocationName, backupLocationUid, allNamespaces,
+				labelSelectors, orgID, "", "", "", "", schedulePolicyName, schedulePolicyUid, ctx)
+			dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation of schedule backup with schedule [%s]", allNSScheduleName))
+			firstScheduleBackupName, err := GetFirstScheduleBackupName(ctx, allNSScheduleName, orgID)
+			dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching name of the first schedule backup with schedule [%s]", allNSScheduleName))
+			log.Infof("First schedule backup name: [%s]", firstScheduleBackupName)
+		})
+		Step("Upgrading px-backup", func() {
+			latestPxBackupVersionFromEnv := os.Getenv("LATEST_PXBACKUP_VERSION")
+			if latestPxBackupVersionFromEnv == "" {
+				latestPxBackupVersionFromEnv = latestPxBackupVersion
+			}
+			log.InfoD("Upgrading px-backup to latest version [%s]", latestPxBackupVersionFromEnv)
+			err := UpgradePxBackup(latestPxBackupVersionFromEnv)
+			dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying completion of px-backup upgrade to latest version [%s]", latestPxBackupVersionFromEnv))
+		})
+		Step("Create backups after px-backup upgrade with and without pre and post exec rules", func() {
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			createBackupWithRulesTask := func(appName string) {
+				namespace := srcClusterAppNamespaces[appName][0]
+				backupName := fmt.Sprintf("%s-%s-%v-with-rules", BackupNamePrefix, namespace, time.Now().Unix())
+				labelSelectors := make(map[string]string, 0)
+				log.InfoD("Creating a backup of namespace [%s] after px-backup upgrade with pre and post exec rules", namespace)
+				err := CreateBackup(backupName, SourceClusterName, backupLocationName, backupLocationUid, []string{namespace},
+					labelSelectors, orgID, srcClusterUid, preRuleNames[appName], preRuleUids[appName], postRuleNames[appName], postRuleUids[appName], ctx)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation of backup [%s]", backupName))
+				backupAfterUpgradeWithRuleNames = SafeAppend(&mutex, backupAfterUpgradeWithRuleNames, backupName).([]string)
+			}
+			_ = TaskHandler(Inst().AppList, createBackupWithRulesTask, Parallel)
+			createBackupWithoutRulesTask := func(appName string) {
+				namespace := srcClusterAppNamespaces[appName][0]
+				backupName := fmt.Sprintf("%s-%s-%v-without-rules", BackupNamePrefix, namespace, time.Now().Unix())
+				labelSelectors := make(map[string]string, 0)
+				log.InfoD("Creating a backup of namespace [%s] after px-backup upgrade without pre and post exec rules", namespace)
+				err := CreateBackup(backupName, SourceClusterName, backupLocationName, backupLocationUid, []string{namespace},
+					labelSelectors, orgID, srcClusterUid, "", "", "", "", ctx)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation of backup [%s]", backupName))
+				backupAfterUpgradeWithoutRuleNames = SafeAppend(&mutex, backupAfterUpgradeWithoutRuleNames, backupName).([]string)
+			}
+			_ = TaskHandler(Inst().AppList, createBackupWithoutRulesTask, Parallel)
+		})
+		Step("Restore backups created before px-backup upgrade with and without pre and post exec rules", func() {
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			log.InfoD("Restoring backups [%s] created before px-backup upgrade with rules", backupWithRuleNames)
+			for _, backupName := range backupWithRuleNames {
+				namespaceMapping := make(map[string]string, 0)
+				storageClassMapping := make(map[string]string, 0)
+				restoreName := fmt.Sprintf("%s-%s-%v", "test-restore", backupName, time.Now().Unix())
+				log.InfoD("Restoring backup [%s] in cluster [%s] with restore [%s]", backupName, destinationClusterName, restoreName)
+				err = CreateRestore(restoreName, backupName, namespaceMapping, destinationClusterName, orgID, ctx, storageClassMapping)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying restoration [%s] of backup [%s] in cluster [%s]", restoreName, backupName, destinationClusterName))
+				restoreNames = append(restoreNames, restoreName)
+			}
+			log.InfoD("Restoring backups [%s] created before px-backup upgrade without rules", backupWithoutRuleNames)
+			for _, backupName := range backupWithoutRuleNames {
+				namespaceMapping := make(map[string]string, 0)
+				storageClassMapping := make(map[string]string, 0)
+				restoreName := fmt.Sprintf("%s-%s-%v", "test-restore", backupName, time.Now().Unix())
+				log.InfoD("Restoring backup [%s] in cluster [%s] with restore [%s]", backupName, destinationClusterName, restoreName)
+				err = CreateRestore(restoreName, backupName, namespaceMapping, destinationClusterName, orgID, ctx, storageClassMapping)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying restoration [%s] of backup [%s] in cluster [%s]", restoreName, backupName, restoreName))
+				restoreNames = append(restoreNames, restoreName)
+			}
+		})
+		Step("Restore backups created after px-backup upgrade with and without pre and post exec rules", func() {
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			log.InfoD("Restoring backups [%s] created after px-backup upgrade with rules", backupWithRuleNames)
+			for _, backupName := range backupAfterUpgradeWithRuleNames {
+				namespaceMapping := make(map[string]string, 0)
+				storageClassMapping := make(map[string]string, 0)
+				restoreName := fmt.Sprintf("%s-%s-%v", "test-restore", backupName, time.Now().Unix())
+				log.InfoD("Restoring backup [%s] in cluster [%s] with restore [%s]", backupName, destinationClusterName, restoreName)
+				err = CreateRestore(restoreName, backupName, namespaceMapping, destinationClusterName, orgID, ctx, storageClassMapping)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying restoration [%s] of backup [%s] in cluster [%s]", restoreName, backupName, destinationClusterName))
+				restoreNames = append(restoreNames, restoreName)
+			}
+			log.InfoD("Restoring backups [%s] created after px-backup upgrade without rules", backupWithoutRuleNames)
+			for _, backupName := range backupAfterUpgradeWithoutRuleNames {
+				namespaceMapping := make(map[string]string, 0)
+				storageClassMapping := make(map[string]string, 0)
+				restoreName := fmt.Sprintf("%s-%s-%v", "test-restore", backupName, time.Now().Unix())
+				log.InfoD("Restoring backup [%s] in cluster [%s] with restore [%s]", backupName, destinationClusterName, restoreName)
+				err = CreateRestore(restoreName, backupName, namespaceMapping, destinationClusterName, orgID, ctx, storageClassMapping)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying restoration [%s] of backup [%s] in cluster [%s]", restoreName, backupName, restoreName))
+				restoreNames = append(restoreNames, restoreName)
+			}
+		})
+		// First single namespace schedule backups are taken before px-backup upgrade
+		Step("Restore first single namespace schedule backups", func() {
+			ctx, err := backup.GetAdminCtxFromSecret()
+			dash.VerifyFatal(err, nil, "Fetching px-central-admin ctx")
+			restoreSingleNSBackupInVariousWaysTask := func(index int, namespace string) {
+				firstSingleNSScheduleBackupName, err := GetFirstScheduleBackupName(ctx, singleNSScheduleNames[index], orgID)
+				log.FailOnError(err, "Getting first backup name of schedule [%s] failed", singleNSScheduleNames[index])
+				restoreConfigs := []struct {
+					namePrefix          string
+					namespaceMapping    map[string]string
+					storageClassMapping map[string]string
+					replacePolicy       ReplacePolicy_Type
+				}{
+					{
+						"test-restore-single-ns",
+						make(map[string]string, 0),
+						make(map[string]string, 0),
+						ReplacePolicy_Retain,
+					},
+					{
+						"test-custom-restore-single-ns",
+						map[string]string{namespace: "custom-" + namespace},
+						make(map[string]string, 0),
+						ReplacePolicy_Retain,
+					},
+					{
+						"test-replace-restore-single-ns",
+						make(map[string]string, 0),
+						make(map[string]string, 0),
+						ReplacePolicy_Delete,
+					},
+				}
+				for _, config := range restoreConfigs {
+					restoreName := fmt.Sprintf("%s-%s", config.namePrefix, RandomString(4))
+					log.InfoD("Restoring first single namespace schedule backup [%s] in cluster [%s] with restore [%s] and namespace mapping %v", firstSingleNSScheduleBackupName, destinationClusterName, restoreName, config.namespaceMapping)
+					if config.replacePolicy == ReplacePolicy_Retain {
+						err = CreateRestore(restoreName, firstSingleNSScheduleBackupName, config.namespaceMapping, destinationClusterName, orgID, ctx, config.storageClassMapping)
+					} else if config.replacePolicy == ReplacePolicy_Delete {
+						err = CreateRestoreWithReplacePolicy(restoreName, firstSingleNSScheduleBackupName, config.namespaceMapping, destinationClusterName, orgID, ctx, config.storageClassMapping, config.replacePolicy)
+					}
+					dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying restoration [%s] of first single namespace schedule backup [%s] in cluster [%s]", restoreName, firstSingleNSScheduleBackupName, restoreName))
+					restoreNames = SafeAppend(&mutex, restoreNames, restoreName).([]string)
+				}
+			}
+			_ = TaskHandler(singleNSNamespaces, restoreSingleNSBackupInVariousWaysTask, Parallel)
+		})
+		// By the time the next single namespace schedule backups are taken, the px-backup upgrade would have been completed
+		Step("Restore next single namespace schedule backups", func() {
+			ctx, err := backup.GetAdminCtxFromSecret()
+			dash.VerifyFatal(err, nil, "Fetching px-central-admin ctx")
+			restoreSingleNSBackupInVariousWaysTask := func(index int, namespace string) {
+				nextScheduleBackupName, err := GetNextScheduleBackupName(singleNSScheduleNames[index], time.Duration(intervalInMins), ctx)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching next schedule backup name of schedule named [%s]", singleNSScheduleNames[index]))
+				log.InfoD("Next schedule backup name [%s]", nextScheduleBackupName)
+				restoreConfigs := []struct {
+					namePrefix          string
+					namespaceMapping    map[string]string
+					storageClassMapping map[string]string
+					replacePolicy       ReplacePolicy_Type
+				}{
+					{
+						"test-restore-single-ns",
+						make(map[string]string, 0),
+						make(map[string]string, 0),
+						ReplacePolicy_Retain,
+					},
+					{
+						"test-custom-restore-single-ns",
+						map[string]string{namespace: "custom" + namespace},
+						make(map[string]string, 0),
+						ReplacePolicy_Retain,
+					},
+					{
+						"test-replace-restore-single-ns",
+						make(map[string]string, 0),
+						make(map[string]string, 0),
+						ReplacePolicy_Delete,
+					},
+				}
+				for _, config := range restoreConfigs {
+					restoreName := fmt.Sprintf("%s-%s", config.namePrefix, RandomString(4))
+					log.InfoD("Restoring next single namespace schedule backup [%s] in cluster [%s] with restore [%s] and namespace mapping %v", nextScheduleBackupName, destinationClusterName, restoreName, config.namespaceMapping)
+					if config.replacePolicy == ReplacePolicy_Retain {
+						err = CreateRestore(restoreName, nextScheduleBackupName, config.namespaceMapping, destinationClusterName, orgID, ctx, config.storageClassMapping)
+					} else if config.replacePolicy == ReplacePolicy_Delete {
+						err = CreateRestoreWithReplacePolicy(restoreName, nextScheduleBackupName, config.namespaceMapping, destinationClusterName, orgID, ctx, config.storageClassMapping, config.replacePolicy)
+					}
+					dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying restoration [%s] of next single namespace schedule backup [%s] in cluster [%s]", restoreName, nextScheduleBackupName, restoreName))
+					restoreNames = SafeAppend(&mutex, restoreNames, restoreName).([]string)
+				}
+			}
+			_ = TaskHandler(singleNSNamespaces, restoreSingleNSBackupInVariousWaysTask, Parallel)
+		})
+		// First all namespaces schedule backup is taken before px-backup upgrade
+		Step("Restore first all namespaces schedule backup", func() {
+			ctx, err := backup.GetAdminCtxFromSecret()
+			dash.VerifyFatal(err, nil, "Fetching px-central-admin ctx")
+			firstAllNSScheduleBackupName, err := GetFirstScheduleBackupName(ctx, allNSScheduleName, orgID)
+			log.FailOnError(err, "Getting first backup name of schedule [%s] failed", allNSScheduleName)
+			restoreName := fmt.Sprintf("%s-%s", "test-restore-all-ns", RandomString(4))
+			log.InfoD("Restoring first all namespaces schedule backup [%s] in cluster [%s] with restore [%s]", firstAllNSScheduleBackupName, SourceClusterName, restoreName)
+			namespaceMapping := make(map[string]string, 0)
+			err = CreateRestore(restoreName, firstAllNSScheduleBackupName, namespaceMapping, SourceClusterName, orgID, ctx, make(map[string]string, 0))
+			dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying restoration [%s] of first all namespaces schedule backup [%s] in cluster [%s]", restoreName, firstAllNSScheduleBackupName, restoreName))
+			restoreNames = append(restoreNames, restoreName)
+		})
+		// By the time the next all namespaces schedule backups are taken, the px-backup upgrade would have been completed
+		Step("Restore next all namespaces schedule backup", func() {
+			ctx, err := backup.GetAdminCtxFromSecret()
+			dash.VerifyFatal(err, nil, "Fetching px-central-admin ctx")
+			nextScheduleBackupName, err := GetNextScheduleBackupName(allNSScheduleName, time.Duration(intervalInMins), ctx)
+			dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching next schedule backup name of schedule named [%s]", allNSScheduleName))
+			log.InfoD("Next schedule backup name [%s]", nextScheduleBackupName)
+			restoreName := fmt.Sprintf("%s-%s", "test-restore-all-ns", RandomString(4))
+			log.InfoD("Restoring next all namespaces schedule backup [%s] in cluster [%s] with restore [%s]", nextScheduleBackupName, SourceClusterName, restoreName)
+			namespaceMapping := make(map[string]string, 0)
+			err = CreateRestore(restoreName, nextScheduleBackupName, namespaceMapping, SourceClusterName, orgID, ctx, make(map[string]string, 0))
+			dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying restoration [%s] of next all namespaces schedule backup [%s] in cluster [%s]", restoreName, nextScheduleBackupName, restoreName))
+			restoreNames = append(restoreNames, restoreName)
+		})
+	})
+	JustAfterEach(func() {
+		allContexts := append(srcClusterContexts, destClusterContexts...)
+		defer EndPxBackupTorpedoTest(allContexts)
+		ctx, err := backup.GetAdminCtxFromSecret()
+		log.FailOnError(err, "Fetching px-central-admin ctx")
+		deleteSingleNSScheduleTask := func(scheduleName string) {
+			log.InfoD("Deleting single namespace backup schedule [%s]", scheduleName)
+			err = DeleteSchedule(scheduleName, SourceClusterName, orgID, ctx)
+			dash.VerifySafely(err, nil, fmt.Sprintf("Verifying deletion of backup schedule [%s]", scheduleName))
+		}
+		_ = TaskHandler(singleNSScheduleNames, deleteSingleNSScheduleTask, Parallel)
+		log.InfoD("Deleting all namespaces backup schedule [%s]", allNSScheduleName)
+		err = DeleteSchedule(allNSScheduleName, SourceClusterName, orgID, ctx)
+		dash.VerifySafely(err, nil, fmt.Sprintf("Verifying deletion of backup schedule [%s]", allNSScheduleName))
+		log.InfoD("Deleting pre exec rules %s", preRuleNames)
+		for _, preRuleName := range preRuleNames {
+			if preRuleName != "" {
+				err := DeleteRule(preRuleName, orgID, ctx)
+				dash.VerifySafely(err, nil, fmt.Sprintf("Verifying deletion of pre backup rule [%s]", preRuleName))
+			}
+		}
+		log.InfoD("Deleting post exec rules %s", postRuleNames)
+		for _, postRuleName := range postRuleNames {
+			if postRuleName != "" {
+				err := DeleteRule(postRuleName, orgID, ctx)
+				dash.VerifySafely(err, nil, fmt.Sprintf("Verifying deletion of post-backup rule [%s]", postRuleName))
+			}
+		}
+		log.InfoD("Deleting schedule policy [%s]", schedulePolicyName)
+		err = Inst().Backup.DeleteBackupSchedulePolicy(orgID, []string{schedulePolicyName})
+		dash.VerifySafely(err, nil, fmt.Sprintf("Verifying deletion of schedule policy [%s]", schedulePolicyName))
+		log.InfoD("Deleting restores %s in cluster [%s]", restoreNames, destinationClusterName)
+		for _, restoreName := range restoreNames {
+			err = DeleteRestore(restoreName, orgID, ctx)
+			dash.VerifySafely(err, nil, fmt.Sprintf("Verifying deletion of restore [%s]", restoreName))
+		}
+		opts := make(map[string]bool)
+		opts[SkipClusterScopedObjects] = true
+		err = SetDestinationKubeConfig()
+		log.FailOnError(err, "Switching context to destination cluster failed")
+		ValidateAndDestroy(destClusterContexts, opts)
+		err = SetSourceKubeConfig()
+		log.FailOnError(err, "Switching context to source cluster failed")
+		ValidateAndDestroy(srcClusterContexts, opts)
+		CleanupCloudSettingsAndClusters(backupLocationMap, cloudAccountName, cloudAccountUid, ctx)
 	})
 })


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR adds Upgrade Scenario - Mega Testcase.

1. TC Automation - Upgrade scenario - Take manual backups before preceding to upgrade
> Manual Backups with and without Rules
> Upgrade
> Restore only from full backup taken pre and post upgrade
> Restore only from incremental backup taken pre and post upgrade

2. TC Automation - Upgrade scenario - Create schedules for each namespace
> Single namespace Schedule backup with Rules
> Upgrade
> Custom Restore from first schedule backup (Mysql1 -> Mysql2)
> Default Restore with retain from first schedule backup (Mysql1 -> Mysql1)
> Default Restore with replace from first schedule backup (Mysql1 -> Mysql1)
> Custom Restore from incremental backup (Mysql1 -> Mysql2)
> Default Restore with retain from incremental backup (Mysql1 -> Mysql1)
> Default Restore with replace from incremental backup (Mysql1 -> Mysql1)

3. TC Automation - Upgrade scenario - Create a schedule for all namespaces
> All Namespaces schedule backup
> Upgrade
> Default Restore first schedule backup (All -> All)
> Default Restore incremental schedule backup (All -> All)

**Which issue(s) this PR fixes** (optional)
Closes #PA-597, #PA-598, #PA-599

**Special notes for your reviewer**:
Please review the Jenkins build for the "PXBackupEndToEndBackupAndRestoreWithUpgrade" (2.3.3 -> 2.4.0) test case using the link below

~~https://jenkins.pwx.dev.purestorage.com/job/Users/job/Sumit/job/Custom-Pipelines/job/px-backup-on-demand-system-test-byoc/1116~~

~~Aetos Dashboard: https://aetos.pwx.purestorage.com/resultSet/testSetID/157198~~

~~https://jenkins.pwx.dev.purestorage.com/job/Users/job/Sumit/job/Custom-Pipelines/job/px-backup-on-demand-system-test-byoc/1122~~

~~Aetos Dashboard: https://aetos.pwx.purestorage.com/resultSet/testSetID/157693~~

~~https://jenkins.pwx.dev.purestorage.com/job/Users/job/Sumit/job/Custom-Pipelines/job/px-backup-on-demand-system-test-byoc/1146~~

~~Aetos Dashboard: https://aetos.pwx.purestorage.com/resultSet/testSetID/162497/testCaseID/838516~~

https://jenkins.pwx.dev.purestorage.com/job/Users/job/Sumit/job/Custom-Pipelines/job/px-backup-on-demand-system-test-byoc/1270

Aetos Dashboard: https://aetos.pwx.purestorage.com/resultSet/testSetID/178857

[No Upgrade Runs]

~~https://jenkins.pwx.dev.purestorage.com/job/Users/job/Sumit/job/Custom-Pipelines/job/px-backup-on-demand-system-test-byoc/1267~~

~~Aetos Dashboard: https://aetos.pwx.purestorage.com/resultSet/testSetID/178757~~

https://jenkins.pwx.dev.purestorage.com/job/Users/job/Sumit/job/Custom-Pipelines/job/px-backup-on-demand-system-test-byoc/1284

Aetos Dashboard: https://aetos.pwx.purestorage.com/resultSet/testSetID/180023

Currently, the test case is failing while attempting to backup the Postgres application with rules. By default, only one out of the two pods is in Running state, while the other remains in a ContainerCreating state, impeding the ability to execute rules on the latter pod. Thanks to @snigdha-px for pointing out this issue and suggesting a workaround to reduce the replica count to 1 in the Postgres application YAML.