### PR TITLE
Fixed ViewOnlyFullBackupRestoreIncrementalBackup cleanup

### DIFF
--- a/drivers/pds/lib/resiliency_utils.go
+++ b/drivers/pds/lib/resiliency_utils.go
@@ -85,7 +85,6 @@ func CloseResiliencyChannel() {
 	}
 }
 
-//
 func InduceFailureAfterWaitingForCondition(deployment *pds.ModelsDeployment, namespace string, CheckTillReplica int32) error {
 	switch FailureType.Type {
 	// Case when we want to reboot a node onto which a deployment pod is coming up

--- a/drivers/pds/lib/utils.go
+++ b/drivers/pds/lib/utils.go
@@ -1329,7 +1329,7 @@ func SetupPDSTest(ControlPlaneURL, ClusterType, AccountName, TenantName, Project
 }
 
 // RegisterClusterToControlPlane checks and registers the given target cluster to the controlplane
-//func RegisterClusterToControlPlane(controlPlaneUrl, tenantId, clusterType string, installOldVersion bool) error {
+// func RegisterClusterToControlPlane(controlPlaneUrl, tenantId, clusterType string, installOldVersion bool) error {
 func RegisterClusterToControlPlane(infraParams *Parameter, tenantId string, installOldVersion bool) error {
 	log.InfoD("Test control plane url connectivity.")
 	var helmChartversion string

--- a/tests/backup/backup_share_test.go
+++ b/tests/backup/backup_share_test.go
@@ -3322,14 +3322,6 @@ var _ = Describe("{ViewOnlyFullBackupRestoreIncrementalBackup}", func() {
 		err = backup.DeleteUser(individualUser)
 		log.FailOnError(err, "Error deleting user %v", individualUser)
 
-		backupDriver := Inst().Backup
-		for _, backupName := range backupNames {
-			backupUID, err := backupDriver.GetBackupUID(ctx, backupName, orgID)
-			log.FailOnError(err, "Failed while trying to get backup UID for - %s", backupName)
-			log.Infof("About to delete backup - %s", backupName)
-			_, err = DeleteBackup(backupName, backupUID, orgID, ctx)
-			dash.VerifyFatal(err, nil, fmt.Sprintf("Deleting backup - [%s]", backupName))
-		}
 		CleanupCloudSettingsAndClusters(backupLocationMap, credName, cloudCredUID, ctx)
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
`ViewOnlyFullBackupRestoreIncrementalBackup` was failing in [nightly run](https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/px-backup-system-test-vanilla/112/display/redirect) because it was trying to delete a backup which was already deleted and hence clean up was failing. Have removed the backup deletion part from cleanup as it is taken care while deleting backup location

**Which issue(s) this PR fixes** (optional)
Closes #PA-798

**Special notes for your reviewer**:
[Jenkins Run](https://jenkins.pwx.dev.purestorage.com/job/Users/job/Sumit/job/Custom-Pipelines/job/px-backup-on-demand-system-test-byoc/742/)

