### PR TITLE
Deregister Target Cluster from PDS Control Plane

### DIFF
--- a/drivers/pds/lib/utils.go
+++ b/drivers/pds/lib/utils.go
@@ -1375,13 +1375,14 @@ func DeletePDSCRDs(pdsApiGroups []string) error {
 	isCrdsAvailable = false
 	for index := range pdsApiGroups {
 		for _, crd := range crdList.Items {
+			log.Debugf("CRD NAMES %s", crd.Name)
 			if strings.Contains(crd.Name, pdsApiGroups[index]) {
-				crdInfo, err := k8sApiClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), crd.Name, metav1.GetOptions{})
+				crdInfo, err := k8sApiClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), crd.Name, metav1.GetOptions{})
 				if err != nil {
 					return fmt.Errorf("error while getting crd information: %v", err)
 				}
 				log.InfoD("Deleting crd: %s", crdInfo.Name)
-				err = k8sApiClient.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(context.TODO(), crd.Name, metav1.DeleteOptions{})
+				err = k8sApiClient.ApiextensionsV1().CustomResourceDefinitions().Delete(context.TODO(), crd.Name, metav1.DeleteOptions{})
 				if err != nil {
 					return fmt.Errorf("error while deleting crd: %v", err)
 				}

--- a/drivers/pds/lib/utils.go
+++ b/drivers/pds/lib/utils.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"k8s.io/client-go/tools/clientcmd"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -28,7 +27,7 @@ import (
 	tc "github.com/portworx/torpedo/drivers/pds/targetcluster"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -1356,17 +1355,18 @@ func ValidatePDSDeploymentTargetHealthStatus(DeploymentTargetID, healthStatus st
 
 func DeletePDSCRDs(pdsApiGroups []string) error {
 	var isCrdsAvailable bool
-	ctx := GetAndExpectStringEnvVar("TARGET_KUBECONFIG")
-	config, err := clientcmd.BuildConfigFromFlags("", ctx)
-	if err != nil {
-		return err
-	}
+	//ctx := GetAndExpectStringEnvVar("TARGET_KUBECONFIG")
+	//config, err := clientcmd.BuildConfigFromFlags("", ctx)
+	//if err != nil {
+	//	return err
+	//}
+	//
+	//k8sApiClient, err := apiextensionsclient.NewForConfig(config)
+	//if err != nil {
+	//	return err
+	//}
 
-	k8sApiClient, err := apiextensionsclient.NewForConfig(config)
-	if err != nil {
-		return err
-	}
-
+	var k8sApiClient *clientset.Clientset
 	crdList, err := k8sApiClient.ApiextensionsV1().CustomResourceDefinitions().List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("error while listing crds: %v", err)

--- a/drivers/pds/lib/utils.go
+++ b/drivers/pds/lib/utils.go
@@ -1356,18 +1356,19 @@ func ValidatePDSDeploymentTargetHealthStatus(DeploymentTargetID, healthStatus st
 
 func DeletePDSCRDs(pdsApiGroups []string) error {
 	var isCrdsAvailable bool
+	var k8sApiClient *apiextensionsclient.Clientset
+
 	ctx := GetAndExpectStringEnvVar("TARGET_KUBECONFIG")
 	config, err := clientcmd.BuildConfigFromFlags("", ctx)
 	if err != nil {
 		return err
 	}
 
-	k8sApiClient, err := apiextensionsclient.NewForConfig(config)
+	k8sApiClient, err = apiextensionsclient.NewForConfig(config)
 	if err != nil {
 		return err
 	}
 
-	//var k8sApiClient *clientset.Clientset
 	crdList, err := k8sApiClient.ApiextensionsV1().CustomResourceDefinitions().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("error while listing crds: %v", err)

--- a/drivers/pds/lib/utils.go
+++ b/drivers/pds/lib/utils.go
@@ -34,12 +34,6 @@ import (
 
 type PDS_Health_Status string
 
-const (
-	PDS_Health_Status_DOWN     PDS_Health_Status = "Down"
-	PDS_Health_Status_DEGRADED PDS_Health_Status = "Degraded"
-	PDS_Health_Status_HEALTHY  PDS_Health_Status = "Healthy"
-)
-
 type Parameter struct {
 	DataServiceToTest []struct {
 		Name          string `json:"Name"`
@@ -165,6 +159,10 @@ type StorageClassConfig struct {
 
 // PDS const
 const (
+	PDS_Health_Status_DOWN     PDS_Health_Status = "Down"
+	PDS_Health_Status_DEGRADED PDS_Health_Status = "Degraded"
+	PDS_Health_Status_HEALTHY  PDS_Health_Status = "Healthy"
+
 	defaultCommandRetry   = 5 * time.Second
 	defaultCommandTimeout = 1 * time.Minute
 	storageTemplateName   = "QaDefault"
@@ -202,16 +200,23 @@ const (
 	configmapNamespace    = "default"
 )
 
+// K8s/PDS Instances
+var (
+	k8sCore       = core.Instance()
+	k8sApps       = apps.Instance()
+	apiExtentions = apiextensions.Instance()
+	serviceType   = "LoadBalancer"
+)
+
 // PDS vars
 var (
-	k8sCore = core.Instance()
-	k8sApps = apps.Instance()
+	components    *pdsapi.Components
+	deployment    *pds.ModelsDeployment
+	apiClient     *pds.APIClient
+	ns            *corev1.Namespace
+	pdsAgentpod   corev1.Pod
+	ApiComponents *pdsapi.Components
 
-	components                            *pdsapi.Components
-	deployment                            *pds.ModelsDeployment
-	apiClient                             *pds.APIClient
-	ns                                    *corev1.Namespace
-	pdsAgentpod                           corev1.Pod
 	err                                   error
 	isavailable                           bool
 	isTemplateavailable                   bool
@@ -230,7 +235,6 @@ var (
 	istargetclusterAvailable              bool
 	isAccountAvailable                    bool
 	isStorageTemplateAvailable            bool
-	serviceType                           = "LoadBalancer"
 
 	dataServiceDefaultResourceTemplateIDMap = make(map[string]string)
 	dataServiceNameIDMap                    = make(map[string]string)
@@ -241,8 +245,6 @@ var (
 	namespaceNameIDMap                      = make(map[string]string)
 	dataServiceVersionBuildMap              = make(map[string][]string)
 	dataServiceImageMap                     = make(map[string][]string)
-	ApiComponents                           *pdsapi.Components
-	apiExtentions                           = apiextensions.Instance()
 )
 
 // GetAndExpectStringEnvVar parses a string from env variable.

--- a/drivers/pds/targetcluster/targetcluster.go
+++ b/drivers/pds/targetcluster/targetcluster.go
@@ -88,7 +88,7 @@ func (targetCluster *TargetCluster) DeRegisterFromControlPlane() error {
 		}
 		log.InfoD("helm list output: %v", output)
 	}
-	//TODO: Add a method to remove CRD's
+
 	log.Infof("wait till all the pds-system pods are deleted")
 	err = wait.Poll(10*time.Second, 5*time.Minute, func() (bool, error) {
 		pods, err := k8sCore.GetPods(PDSNamespace, nil)

--- a/tests/pds/common.go
+++ b/tests/pds/common.go
@@ -44,6 +44,8 @@ const (
 	timeInterval                     = 1 * time.Second
 	ActiveNodeRebootDuringDeployment = "active-node-reboot-during-deployment"
 	KillDeploymentControllerPod      = "kill-deployment-controller-pod-during-deployment"
+	BackUpCRD                        = "backups.pds.io"
+	DeploymentCRD                    = "deployments.pds.io"
 )
 
 var (


### PR DESCRIPTION
1. Deploy Data service
2. Delete Data service
3. Delete CRDs
4. Uninstall PDS helm chart
5. Validate the Deployment Target health status
6. Register back the Target Cluster

reference doc - https://pds.docs.portworx.com/admin-guide/remove-cluster/remove-cluster-wipe-data/

Jenlkins run:
https://jenkins.pwx.dev.purestorage.com/job/PDS/job/pds-branch-build-test/181/console

aetos dashboard:
http://aetos.pwx.purestorage.com/resultSet/testSetID/142633/testCaseID/726956