### PR TITLE
Fix kubectl exec arguments 

### DIFF
--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -707,7 +707,7 @@ func CreateRestoreWithoutCheck(restoreName string, backupName string,
 
 func getSizeOfMountPoint(podName string, namespace string, kubeConfigFile string) (int, error) {
 	var number int
-	ret, err := kubectlExec([]string{podName, "-n", namespace, "--kubeconfig=", kubeConfigFile, " -- /bin/df"})
+	ret, err := kubectlExec([]string{fmt.Sprintf("--kubeconfig=%v", kubeConfigFile), "exec", "-it", podName, "-n", namespace, "--", "/bin/df"})
 	if err != nil {
 		return 0, err
 	}
@@ -727,7 +727,7 @@ func kubectlExec(arguments []string) (string, error) {
 	if len(arguments) == 0 {
 		return "", fmt.Errorf("no arguments supplied for kubectl command")
 	}
-	cmd := exec.Command("kubectl exec -it", arguments...)
+	cmd := exec.Command("kubectl", arguments...)
 	output, err := cmd.Output()
 	log.Debugf("command output for '%s': %s", cmd.String(), string(output))
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Raising this fix to unblock @sn-px 
In `getSizeOfMountPoint` changed the helper function format for passing kubeconfig

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

