### PR TITLE
Added EndPxBackupTorpedoTest in JustAfterEach

### DIFF
--- a/tests/backup/backup_license_test.go
+++ b/tests/backup/backup_license_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/portworx/sched-ops/k8s/core"
 	"github.com/portworx/torpedo/drivers/backup"
 	"github.com/portworx/torpedo/drivers/node"
+	"github.com/portworx/torpedo/drivers/scheduler"
 	"github.com/portworx/torpedo/pkg/log"
 	. "github.com/portworx/torpedo/tests"
 )
@@ -19,6 +20,7 @@ var _ = Describe("{NodeCountForLicensing}", func() {
 		totalNumberOfWorkerNodes      []node.Node
 		srcClusterStatus              api.ClusterInfo_StatusInfo_Status
 		destClusterStatus             api.ClusterInfo_StatusInfo_Status
+		contexts                      []*scheduler.Context
 	)
 	JustBeforeEach(func() {
 		StartTorpedoTest("NodeCountForLicensing",
@@ -101,9 +103,11 @@ var _ = Describe("{NodeCountForLicensing}", func() {
 		})
 	})
 	JustAfterEach(func() {
+		defer EndPxBackupTorpedoTest(contexts)
 		ctx, err := backup.GetAdminCtxFromSecret()
 		log.FailOnError(err, "Fetching px-central-admin ctx")
-		SetDestinationKubeConfig()
+		err = SetDestinationKubeConfig()
+		log.FailOnError(err, "Switching context to destination cluster failed")
 		nodeLabels, err := core.Instance().GetLabelsOnNode(destinationClusterWorkerNodes[0].Name)
 		if err != nil {
 			dash.VerifySafely(err, nil, fmt.Sprintf("Getting label from worker node %v", destinationClusterWorkerNodes[0].Name))

--- a/tests/backup/backup_resiliency_test.go
+++ b/tests/backup/backup_resiliency_test.go
@@ -1016,7 +1016,7 @@ var _ = Describe("{ScaleMongoDBWhileBackupAndRestore}", func() {
 
 	JustAfterEach(func() {
 		var wg sync.WaitGroup
-		EndPxBackupTorpedoTest(contexts)
+		defer EndPxBackupTorpedoTest(contexts)
 		log.InfoD("Updating the mongodb statefulset replica count as it was at the start of this testcase")
 		statefulSet, err = apps.Instance().GetStatefulSet(mongodbStatefulset, pxBackupNS)
 		if *statefulSet.Spec.Replicas != originalReplicaCount {
@@ -1542,7 +1542,7 @@ var _ = Describe("{ScaleDownPxBackupPodWhileBackupAndRestoreIsInProgress}", func
 
 	JustAfterEach(func() {
 		var wg sync.WaitGroup
-		EndPxBackupTorpedoTest(contexts)
+		defer EndPxBackupTorpedoTest(contexts)
 		log.InfoD("Updating the px_backup deployment replica count as it was at the start of this testcase")
 		backupDeployment, err = apps.Instance().GetDeployment(pxBackupDeployment, pxBackupNS)
 		log.FailOnError(err, "Getting px-backup deployment")

--- a/tests/common.go
+++ b/tests/common.go
@@ -6425,7 +6425,6 @@ func DoRetryWithTimeoutWithGinkgoRecover(taskFunc func() (interface{}, bool, err
 	return task.DoRetryWithTimeout(taskFuncWithGinkgoRecover, timeout, timeBeforeRetry)
 }
 
-
 // GetVolumesInDegradedState Get the list of volumes in degraded state
 func GetVolumesInDegradedState(contexts []*scheduler.Context) ([]*volume.Volume, error) {
 	var volumes []*volume.Volume

--- a/tests/common.go
+++ b/tests/common.go
@@ -6425,6 +6425,7 @@ func DoRetryWithTimeoutWithGinkgoRecover(taskFunc func() (interface{}, bool, err
 	return task.DoRetryWithTimeout(taskFuncWithGinkgoRecover, timeout, timeBeforeRetry)
 }
 
+
 // GetVolumesInDegradedState Get the list of volumes in degraded state
 func GetVolumesInDegradedState(contexts []*scheduler.Context) ([]*volume.Volume, error) {
 	var volumes []*volume.Volume


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Added EndPxBackupTorpedoTest in JustAfterEach
Added keyword defer in JustAfterEach
**Which issue(s) this PR fixes** (optional)
Closes #https://portworx.atlassian.net/browse/PA-870,https://portworx.atlassian.net/browse/PA-856

**Special notes for your reviewer**:

