### PR TITLE
Added check for cluster state to be Online when new cluster is added: PA-876

### DIFF
--- a/tests/common.go
+++ b/tests/common.go
@@ -3321,13 +3321,19 @@ func CreateSourceAndDestClusters(orgID string, cloudName string, uid string, ctx
 		return err
 	}
 	log.Infof("Save cluster %s kubeconfig to %s", SourceClusterName, srcClusterConfigPath)
-
 	sourceClusterStatus := func() (interface{}, bool, error) {
 		err = CreateCluster(SourceClusterName, srcClusterConfigPath, orgID, cloudName, uid, ctx)
 		if err != nil && !strings.Contains(err.Error(), "already exists with status: Online") {
 			return "", true, err
 		}
-		return "", false, nil
+		srcClusterStatus, err := Inst().Backup.GetClusterStatus(orgID, SourceClusterName, ctx)
+		if err != nil {
+			return "", true, err
+		}
+		if srcClusterStatus == api.ClusterInfo_StatusInfo_Online {
+			return "", false, nil
+		}
+		return "", true, fmt.Errorf("the %s cluster state is not Online yet", SourceClusterName)
 	}
 	_, err = task.DoRetryWithTimeout(sourceClusterStatus, clusterCreationTimeout, clusterCreationRetryTime)
 	if err != nil {
@@ -3345,7 +3351,14 @@ func CreateSourceAndDestClusters(orgID string, cloudName string, uid string, ctx
 		if err != nil && !strings.Contains(err.Error(), "already exists with status: Online") {
 			return "", true, err
 		}
-		return "", false, nil
+		destClusterStatus, err := Inst().Backup.GetClusterStatus(orgID, destinationClusterName, ctx)
+		if err != nil {
+			return "", true, err
+		}
+		if destClusterStatus == api.ClusterInfo_StatusInfo_Online {
+			return "", false, nil
+		}
+		return "", true, fmt.Errorf("the %s cluster state is not Online yet", destinationClusterName)
 	}
 	_, err = task.DoRetryWithTimeout(destClusterStatus, clusterCreationTimeout, clusterCreationRetryTime)
 	if err != nil {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
At present, if a new cluster was added , and the state of cluster was not Online,CreateSourceAndDestClusters function would still pass when CreateCluster threw no error.
Added the check using GetClusterStatus which makes sure that the newly added cluster state is also 'Online' before proceeding
**Which issue(s) this PR fixes** (optional)
Closes #https://portworx.atlassian.net/browse/PA-876

**Special notes for your reviewer**:

Aetos: 
https://aetos.pwx.purestorage.com/resultSet/testSetID/170155
https://jenkins.pwx.dev.purestorage.com/job/Users/job/Sumit/job/Custom-Pipelines/job/px-backup-on-demand-system-test-byoc/1171/consoleFull

https://aetos.pwx.purestorage.com/resultSet/testSetID/170103
https://jenkins.pwx.dev.purestorage.com/job/Users/job/Sumit/job/Custom-Pipelines/job/px-backup-on-demand-system-test-byoc/1168/consoleFull

