### PR TITLE
Fixed confluent kafka asyncdr test

### DIFF
--- a/tests/basic/longevity_test.go
+++ b/tests/basic/longevity_test.go
@@ -91,6 +91,7 @@ var _ = Describe("{Longevity}", func() {
 		ValidateDeviceMapper:   TriggerValidateDeviceMapperCleanup,
 		MetroDR:                TriggerMetroDR,
 		AsyncDR:                TriggerAsyncDR,
+		ConfluentAsyncDR:       TriggerConfluentAsyncDR,
 		AsyncDRVolumeOnly:      TriggerAsyncDRVolumeOnly,
 		StorkApplicationBackup: TriggerStorkApplicationBackup,
 		StorkAppBkpVolResize:   TriggerStorkAppBkpVolResize,

--- a/tests/testTriggers.go
+++ b/tests/testTriggers.go
@@ -388,9 +388,8 @@ const (
 	// AsyncDR runs Async DR between two clusters
 	AsyncDR = "asyncdr"
 	// ConfluentAsyncDR runs Async DR between two clusters for Confluent kafka CRD
-	ConfluentAsyncDR = "ConfluentAsyncDR"
+	ConfluentAsyncDR = "confluentasyncdr"
 	// AsyncDR Volume Only runs Async DR volume only migration between two clusters
-
 	AsyncDRVolumeOnly = "asyncdrvolumeonly"
 	// stork application backup runs stork backups for applications
 	StorkApplicationBackup = "storkapplicationbackup"


### PR DESCRIPTION
Added a small fix for confluent kafka asyncdr test (Longevity trigger)

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #https://portworx.atlassian.net/browse/PTX-17272

**Special notes for your reviewer**:
https://aetos.pwx.purestorage.com/resultSet/testSetID/170322/testCaseID/871102

