### PR TITLE
PA-899: Add libraries for large resource creation

### DIFF
--- a/tests/common.go
+++ b/tests/common.go
@@ -6622,16 +6622,6 @@ func AddMetadataDisk(n node.Node) error {
 
 }
 
-// generateRandomString Creates a random string of length n and returns it
-func generateRandomString(n int) string {
-	var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
-	randomString := make([]rune, n)
-	for i := range randomString {
-		randomString[i] = letters[rand.Intn(len(letters))]
-	}
-	return string(randomString)
-}
-
 // createNamespaces Create N number of namespaces and return namespace list
 func createNamespaces(numberOfNamespaces int) ([]string, error) {
 
@@ -6665,12 +6655,13 @@ func createConfigMaps(namespaces []string, numberOfConfigmap int, numberOfEntrie
 	// Create random data to add in ConfigMap
 	var randomData = make(map[string]string)
 	for i := 0; i < numberOfEntries; i++ {
-		randomString := generateRandomString(80)
+		randomString := RandomString(80)
 		randomStringWithTimeStamp := fmt.Sprintf("%v.%v", randomString, time.Now().Unix())
 		randomData[randomStringWithTimeStamp] = randomString
 	}
 
 	// create the number of configmaps needed
+	k8sCore = core.Instance()
 	for _, namespace := range namespaces {
 		for i := 0; i < numberOfConfigmap; i++ {
 			name := fmt.Sprintf("configmap-%s-%d-%v", namespace, i, time.Now().Unix())
@@ -6684,7 +6675,6 @@ func createConfigMaps(namespaces []string, numberOfConfigmap int, numberOfEntrie
 				Data:       randomData,
 			}
 
-			k8sCore = core.Instance()
 			_, err := k8sCore.CreateConfigMap(obj)
 			if err != nil {
 				return err
@@ -6700,12 +6690,13 @@ func createSecrets(namespaces []string, numberOfSecrets int, numberOfEntries int
 	// Create random data to add in ConfigMap
 	var randomData = make(map[string]string)
 	for i := 0; i < numberOfEntries; i++ {
-		randomString := generateRandomString(80)
+		randomString := RandomString(80)
 		randomStringWithTimeStamp := fmt.Sprintf("%v.%v", randomString, time.Now().Unix())
 		randomData[randomStringWithTimeStamp] = randomString
 	}
 
 	// create the number of configmaps needed
+	k8sCore = core.Instance()
 	for _, namespace := range namespaces {
 		for i := 0; i < numberOfSecrets; i++ {
 			name := fmt.Sprintf("secret-%s-%d-%v", namespace, i, time.Now().Unix())
@@ -6719,7 +6710,6 @@ func createSecrets(namespaces []string, numberOfSecrets int, numberOfEntries int
 				StringData: randomData,
 			}
 
-			k8sCore = core.Instance()
 			_, err := k8sCore.CreateSecret(obj)
 			if err != nil {
 				return err
@@ -6732,8 +6722,8 @@ func createSecrets(namespaces []string, numberOfSecrets int, numberOfEntries int
 // deleteNamespaces Deletes all the namespaces given in a list of namespaces and return error if any
 func deleteNamespaces(namespaces []string) error {
 	// Delete a list of namespaces given
+	k8sCore = core.Instance()
 	for _, namespace := range namespaces {
-		k8sCore = core.Instance()
 		err := k8sCore.DeleteNamespace(namespace)
 		if err != nil {
 			return err

--- a/tests/common.go
+++ b/tests/common.go
@@ -76,6 +76,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	// import aks driver to invoke it's init
 	_ "github.com/portworx/torpedo/drivers/node/aks"
@@ -6619,4 +6620,124 @@ func AddMetadataDisk(n node.Node) error {
 
 	return nil
 
+}
+
+// generateRandomString Creates a random string of length n and returns it
+func generateRandomString(n int) string {
+	var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	randomString := make([]rune, n)
+	for i := range randomString {
+		randomString[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(randomString)
+}
+
+// createNamespaces Create N number of namespaces and return namespace list
+func createNamespaces(numberOfNamespaces int) ([]string, error) {
+
+	// Create multiple namespaces in string
+	var (
+		namespaces []string
+	)
+
+	// Create a good number of namespaces
+	for i := 0; i < numberOfNamespaces; i++ {
+		namespace := fmt.Sprintf("large-resource-%d-%v", i, time.Now().Unix())
+		nsName := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		}
+		log.InfoD("Creating namespace %v", namespace)
+		_, err := k8sCore.CreateNamespace(nsName)
+		if err != nil {
+			return nil, err
+		} else {
+			namespaces = append(namespaces, namespace)
+		}
+	}
+	return namespaces, nil
+}
+
+// createConfigMaps with the given number of entries on specified namespaces
+func createConfigMaps(namespaces []string, numberOfConfigmap int, numberOfEntries int) error {
+
+	// Create random data to add in ConfigMap
+	var randomData = make(map[string]string)
+	for i := 0; i < numberOfEntries; i++ {
+		randomString := generateRandomString(80)
+		randomStringWithTimeStamp := fmt.Sprintf("%v.%v", randomString, time.Now().Unix())
+		randomData[randomStringWithTimeStamp] = randomString
+	}
+
+	// create the number of configmaps needed
+	for _, namespace := range namespaces {
+		for i := 0; i < numberOfConfigmap; i++ {
+			name := fmt.Sprintf("configmap-%s-%d-%v", namespace, i, time.Now().Unix())
+			log.InfoD("Creating Configmap: %v", name)
+			metaObj := metaV1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			}
+			obj := &corev1.ConfigMap{
+				ObjectMeta: metaObj,
+				Data:       randomData,
+			}
+
+			k8sCore = core.Instance()
+			_, err := k8sCore.CreateConfigMap(obj)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// createSecrets with the given number of entries on specified namespaces
+func createSecrets(namespaces []string, numberOfSecrets int, numberOfEntries int) error {
+
+	// Create random data to add in ConfigMap
+	var randomData = make(map[string]string)
+	for i := 0; i < numberOfEntries; i++ {
+		randomString := generateRandomString(80)
+		randomStringWithTimeStamp := fmt.Sprintf("%v.%v", randomString, time.Now().Unix())
+		randomData[randomStringWithTimeStamp] = randomString
+	}
+
+	// create the number of configmaps needed
+	for _, namespace := range namespaces {
+		for i := 0; i < numberOfSecrets; i++ {
+			name := fmt.Sprintf("secret-%s-%d-%v", namespace, i, time.Now().Unix())
+			log.InfoD("Creating secret: %v", name)
+			metaObj := metaV1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			}
+			obj := &corev1.Secret{
+				ObjectMeta: metaObj,
+				StringData: randomData,
+			}
+
+			k8sCore = core.Instance()
+			_, err := k8sCore.CreateSecret(obj)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// deleteNamespaces Deletes all the namespaces given in a list of namespaces and return error if any
+func deleteNamespaces(namespaces []string) error {
+	// Delete a list of namespaces given
+	for _, namespace := range namespaces {
+		k8sCore = core.Instance()
+		err := k8sCore.DeleteNamespace(namespace)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Adding the below functions to create large resource backup and restores: 
- [x]  Add func createNamespaces() to create large number of namespaces as per need. 
- [x]  Add func createConfigMaps() to create large number of Configmaps in a set of namespaces. 
- [x]  Add func createSecrets() to create large number of secrets in a set of namespaces. 
- [x]  Add func deleteNamespaces() to delete a set of namespaces. 


**Things I'll take up in the next PR:**
1. Add func createApp() deployments to deploy a specific app multiple times with volume on a given set of namespaces N number of times. 

**Which issue(s) this PR fixes** (optional)
Closes # PA-899

**Special notes for your reviewer**:

