### PR TITLE
Added cluster and ctx parameter support for DeleteSchedule utility

### DIFF
--- a/tests/backup/backup_delete_test.go
+++ b/tests/backup/backup_delete_test.go
@@ -653,9 +653,7 @@ var _ = Describe("{DeleteBucketVerifyCloudBackupMissing}", func() {
 		opts[SkipClusterScopedObjects] = true
 		ValidateAndDestroy(contexts, opts)
 		for _, scheduleName := range scheduleNames {
-			scheduleUid, err := GetScheduleUID(scheduleName, orgID, ctx)
-			log.FailOnError(err, "Error while getting schedule uid %v", scheduleName)
-			err = DeleteSchedule(scheduleName, scheduleUid, orgID)
+			err = DeleteSchedule(scheduleName, SourceClusterName, orgID, ctx)
 			dash.VerifySafely(err, nil, fmt.Sprintf("Verification of deleting backup schedule - %s", scheduleName))
 		}
 		log.Infof("Deleting backup schedule policy")

--- a/tests/backup/backup_locked_bucket_test.go
+++ b/tests/backup/backup_locked_bucket_test.go
@@ -629,9 +629,7 @@ var _ = Describe("{LockedBucketResizeVolumeOnScheduleBackup}", func() {
 		ctx, err := backup.GetAdminCtxFromSecret()
 		log.FailOnError(err, "Unable to px-central-admin ctx")
 		for _, scheduleName := range scheduleNames {
-			scheduleUid, err := GetScheduleUID(scheduleName, orgID, ctx)
-			log.FailOnError(err, "Error while getting schedule uid %s", scheduleName)
-			err = DeleteSchedule(scheduleName, scheduleUid, orgID)
+			err = DeleteSchedule(scheduleName, SourceClusterName, orgID, ctx)
 			dash.VerifySafely(err, nil, fmt.Sprintf("Verification of deleting backup schedule - %s", scheduleName))
 		}
 		err = Inst().Backup.DeleteBackupSchedulePolicy(orgID, []string{periodicSchedulePolicyName})

--- a/tests/backup/backup_portworx_test.go
+++ b/tests/backup/backup_portworx_test.go
@@ -839,9 +839,7 @@ var _ = Describe("{ResizeVolumeOnScheduleBackup}", func() {
 		ctx, err := backup.GetAdminCtxFromSecret()
 		dash.VerifySafely(err, nil, "Fetching px-central-admin ctx")
 		for i := 0; i < len(scheduleNames); i++ {
-			scheduleUid, err := GetScheduleUID(scheduleNames[i], orgID, ctx)
-			dash.VerifySafely(err, nil, fmt.Sprintf("Fetching uid of schedule named [%s]", scheduleNames[i]))
-			err = DeleteSchedule(scheduleName, scheduleUid, orgID)
+			err = DeleteSchedule(scheduleNames[i], SourceClusterName, orgID, ctx)
 			dash.VerifySafely(err, nil, fmt.Sprintf("Verifying deletion of schedule named [%s] and schedule policies [%v]", scheduleNames[i], periodicSchedulePolicyNames[i]))
 		}
 		log.InfoD("Deleting created restores")

--- a/tests/backup/backup_restore_basic_test.go
+++ b/tests/backup/backup_restore_basic_test.go
@@ -2,11 +2,12 @@ package tests
 
 import (
 	"fmt"
-	"github.com/blang/semver"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/blang/semver"
 
 	"github.com/portworx/sched-ops/k8s/storage"
 	"github.com/portworx/torpedo/drivers/scheduler/k8s"
@@ -623,9 +624,7 @@ var _ = Describe("{ScheduleBackupCreationSingleNS}", func() {
 		log.InfoD("Clean up objects after test execution")
 		log.Infof("Deleting backup schedules")
 		for _, scheduleName := range scheduleNames {
-			scheduleUid, err := GetScheduleUID(scheduleName, orgID, ctx)
-			log.FailOnError(err, "Error while getting schedule uid %v", scheduleName)
-			err = DeleteSchedule(scheduleName, scheduleUid, orgID)
+			err = DeleteSchedule(scheduleName, SourceClusterName, orgID, ctx)
 			dash.VerifySafely(err, nil, fmt.Sprintf("Verification of deleting backup schedule - %s", scheduleName))
 		}
 		log.Infof("Deleting backup schedule policy")
@@ -765,9 +764,7 @@ var _ = Describe("{ScheduleBackupCreationAllNS}", func() {
 		log.InfoD("Clean up objects after test execution")
 		log.Infof("Deleting backup schedules")
 		for _, scheduleName := range scheduleNames {
-			scheduleUid, err := GetScheduleUID(scheduleName, orgID, ctx)
-			log.FailOnError(err, "Error while getting schedule uid %v", scheduleName)
-			err = DeleteSchedule(scheduleName, scheduleUid, orgID)
+			err = DeleteSchedule(scheduleName, SourceClusterName, orgID, ctx)
 			dash.VerifySafely(err, nil, fmt.Sprintf("Verification of deleting backup schedule - %s", scheduleName))
 		}
 		log.Infof("Deleting backup schedule policy")
@@ -1119,9 +1116,7 @@ var _ = Describe("{AllNSBackupWithIncludeNewNSOption}", func() {
 		defer EndPxBackupTorpedoTest(allContexts)
 		ctx, err := backup.GetAdminCtxFromSecret()
 		log.FailOnError(err, "Fetching px-central-admin ctx")
-		scheduleUid, err := GetScheduleUID(scheduleName, orgID, ctx)
-		dash.VerifySafely(err, nil, fmt.Sprintf("Getting schedule [%s] uid", scheduleName))
-		err = DeleteSchedule(scheduleName, scheduleUid, orgID)
+		err = DeleteSchedule(scheduleName, destinationClusterName, orgID, ctx)
 		dash.VerifySafely(err, nil, fmt.Sprintf("Verification of deleting backup schedule - %s", scheduleName))
 		log.Infof("Deleting backup schedule policy")
 		policyList := []string{schedulePolicyName}
@@ -1796,9 +1791,7 @@ var _ = Describe("{AddMultipleNamespaceLabels}", func() {
 		defer EndPxBackupTorpedoTest(contexts)
 		ctx, err := backup.GetAdminCtxFromSecret()
 		log.FailOnError(err, "Unable to px-central-admin ctx")
-		scheduleUid, err := GetScheduleUID(scheduleName, orgID, ctx)
-		log.FailOnError(err, "Error while getting schedule uid %s", scheduleName)
-		err = DeleteSchedule(scheduleName, scheduleUid, orgID)
+		err = DeleteSchedule(scheduleName, SourceClusterName, orgID, ctx)
 		dash.VerifySafely(err, nil, fmt.Sprintf("Verification of deleting backup schedule - %s", scheduleName))
 		err = Inst().Backup.DeleteBackupSchedulePolicy(orgID, []string{periodicSchedulePolicyName})
 		dash.VerifySafely(err, nil, fmt.Sprintf("Deleting backup schedule policies %s ", []string{periodicSchedulePolicyName}))
@@ -2082,9 +2075,7 @@ var _ = Describe("{ManualAndScheduleBackupUsingNamespaceLabel}", func() {
 		ctx, err := backup.GetAdminCtxFromSecret()
 		log.FailOnError(err, "Fetching px-central-admin ctx")
 		for _, scheduleName := range scheduleNames {
-			scheduleUid, err := GetScheduleUID(scheduleName, orgID, ctx)
-			log.FailOnError(err, "Error while getting schedule uid %s", scheduleName)
-			err = DeleteSchedule(scheduleName, scheduleUid, orgID)
+			err = DeleteSchedule(scheduleName, SourceClusterName, orgID, ctx)
 			dash.VerifySafely(err, nil, fmt.Sprintf("Verification of deleting backup schedule - %s", scheduleName))
 		}
 		err = Inst().Backup.DeleteBackupSchedulePolicy(orgID, []string{periodicSchedulePolicyName})
@@ -2628,10 +2619,8 @@ var _ = Describe("{SetUnsetNSLabelDuringScheduleBackup}", func() {
 		defer EndPxBackupTorpedoTest(contexts)
 		ctx, err := backup.GetAdminCtxFromSecret()
 		log.FailOnError(err, "Unable to fetch px-central-admin ctx")
-		scheduleUid, err := GetScheduleUID(scheduleName, orgID, ctx)
-		dash.VerifySafely(err, nil, fmt.Sprintf("Fetching uid of schedule named [%s]", scheduleName))
 		log.InfoD("Deleting schedule named [%s] along with its backups [%v] and schedule policies [%v]", scheduleName, allScheduleBackupNames, []string{periodicSchedulePolicyName})
-		err = DeleteSchedule(scheduleName, scheduleUid, orgID)
+		err = DeleteSchedule(scheduleName, SourceClusterName, orgID, ctx)
 		dash.VerifySafely(err, nil, fmt.Sprintf("Verification of deleting backup schedule - %s", scheduleName))
 		err = Inst().Backup.DeleteBackupSchedulePolicy(orgID, []string{periodicSchedulePolicyName})
 		dash.VerifySafely(err, nil, fmt.Sprintf("Deleting backup schedule policies %s ", []string{periodicSchedulePolicyName}))

--- a/tests/backup/backup_share_test.go
+++ b/tests/backup/backup_share_test.go
@@ -2394,9 +2394,7 @@ var _ = Describe("{ClusterBackupShareToggle}", func() {
 		//Delete Schedule Backup-
 		log.Infof("Deleting backup schedule")
 		for _, scheduleName := range scheduleNames {
-			scheduleUid, err := GetScheduleUID(scheduleName, orgID, ctx)
-			log.FailOnError(err, "Error while getting schedule uid %v", scheduleName)
-			err = DeleteSchedule(scheduleName, scheduleUid, orgID)
+			err = DeleteSchedule(scheduleName, backupClusterName, orgID, ctx)
 			dash.VerifySafely(err, nil, fmt.Sprintf("Verification of deleting backup schedule - %s", scheduleName))
 		}
 		log.Infof("Deleting backup schedule policy")

--- a/tests/backup/backup_upgrade_test.go
+++ b/tests/backup/backup_upgrade_test.go
@@ -188,9 +188,7 @@ var _ = Describe("{StorkUpgradeWithBackup}", func() {
 		log.InfoD("Clean up objects after test execution")
 		log.Infof("Deleting backup schedule")
 		for _, scheduleName := range scheduleNames {
-			scheduleUid, err := GetScheduleUID(scheduleName, orgID, ctx)
-			log.FailOnError(err, "Error while getting schedule uid %v", scheduleName)
-			err = DeleteSchedule(scheduleName, scheduleUid, orgID)
+			err = DeleteSchedule(scheduleName, SourceClusterName, orgID, ctx)
 			dash.VerifySafely(err, nil, fmt.Sprintf("Verification of deleting backup schedule - %s", scheduleName))
 		}
 		log.Infof("Deleting backup schedule policy")


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently DeleteSchedule which delete the backup schedules doesnt take any cluster parameter and by default delete schedules only on source cluster, with this PR added support to pass clusterName as parameter and will be able to delete schedules on any cluster..

Also made the code to fetch schedule uid within `DeleteSchedule` Function.

**Which issue(s) this PR fixes** (optional)
Closes #PA-814

**Special notes for your reviewer**:
https://jenkins.pwx.dev.purestorage.com/job/Users/job/Sumit/job/Custom-Pipelines/job/px-backup-on-demand-system-test-byoc/1252/consoleFull
