### PR TITLE
Add anthos upgrade code in Torpedo

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -201,6 +201,15 @@ if [ -z "$TORPEDO_JOB_NAME"]; then
     TORPEDO_JOB_NAME="torpedo-daily-job"
 fi
 
+ANTHOS_ADMIN_WS_NODE=""
+if [ -n "$ANTHOS_ADMIN_WS_NODE" ]; then
+    ANTHOS_ADMIN_WS_NODE="${ANTHOS_ADMIN_WS_NODE}"
+fi
+ANTHOS_INST_PATH=""
+if [ -n "$ANTHOS_INST_PATH" ]; then
+    ANTHOS_INST_PATH="${ANTHOS_INST_PATH}"
+fi
+
 for i in $@
 do
 case $i in
@@ -482,6 +491,8 @@ spec:
             "--vault-addr=$VAULT_ADDR",
             "--vault-token=$VAULT_TOKEN",
             "--px-runtime-opts=$PX_RUNTIME_OPTS",
+            "--anthos-ws-node-ip=$ANTHOS_ADMIN_WS_NODE",
+            "--anthos-inst-path=$ANTHOS_INST_PATH",
             "--autopilot-upgrade-version=$AUTOPILOT_UPGRADE_VERSION",
             "--csi-generic-driver-config-map=$CSI_GENERIC_CONFIGMAP",
             "--sched-upgrade-hops=$SCHEDULER_UPGRADE_HOPS",

--- a/drivers/node/ssh/ssh.go
+++ b/drivers/node/ssh/ssh.go
@@ -742,6 +742,25 @@ func (s *SSH) SystemCheck(n node.Node, options node.ConnectionOpts) (string, err
 	return file, nil
 }
 
+// UpdateNodeCreds update username and ssh key path
+func (s *SSH) UpdateNodeCreds(username string, keyPath string) error {
+	s.username = username
+	s.keyPath = keyPath
+	pubkey, err := getKeyFile(s.keyPath)
+	if err != nil {
+		return fmt.Errorf("error getting public keyPath from keyfile")
+	}
+	s.sshConfig = &ssh_pkg.ClientConfig{
+		User: username,
+		Auth: []ssh_pkg.AuthMethod{
+			ssh_pkg.PublicKeys(pubkey),
+		},
+		HostKeyCallback: ssh_pkg.InsecureIgnoreHostKey(),
+		Timeout:         time.Second * 5,
+	}
+	return nil
+}
+
 // GetBlockDrives returns the block drives on the node
 func (s *SSH) GetBlockDrives(n node.Node, options node.SystemctlOpts) (map[string]*node.BlockDrive, error) {
 	drives := make(map[string]*node.BlockDrive)

--- a/drivers/scheduler/anthos/anthos.go
+++ b/drivers/scheduler/anthos/anthos.go
@@ -1,0 +1,563 @@
+package anthos
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-version"
+	"github.com/portworx/sched-ops/k8s/core"
+	"github.com/portworx/torpedo/drivers/node"
+	"github.com/portworx/torpedo/drivers/node/ssh"
+	"github.com/portworx/torpedo/drivers/scheduler"
+	kube "github.com/portworx/torpedo/drivers/scheduler/k8s"
+	"github.com/portworx/torpedo/pkg/log"
+	"gopkg.in/yaml.v2"
+)
+
+type gcp struct {
+	ComponentAccessServiceAccountKeyPath string `yaml:"componentAccessServiceAccountKeyPath"`
+}
+
+type hostConfig struct {
+	ip      string   `yaml:"ip"`
+	gateway string   `yaml:"gateway"`
+	netmask string   `yaml:"netmask"`
+	dns     []string `yaml:"dns"`
+}
+
+type Network struct {
+	ipAllocationMode string     `yaml:"ipAllocationMode"`
+	hostConfig       hostConfig `yaml:"hostconfig"`
+}
+
+type Workstation struct {
+	cpus         int     `yaml:"cpus"`
+	diskGB       int     `yaml:"diskGB"`
+	dataDiskMB   int     `yaml:"dataDiskMB"`
+	dataDiskName string  `yaml:"dataDiskName"`
+	memoryMB     int     `yaml:"memoryMB"`
+	name         string  `yaml:"name"`
+	network      Network `yaml:"network"`
+	ntpServer    string  `yaml:"ntpServer"`
+	proxyUrl     string  `yaml:"proxyUrl"`
+}
+
+type FileRef struct {
+	entry string `yaml:"entry"`
+	path  string `yaml:"path"`
+}
+
+type credentials struct {
+	address string  `yaml:"address"`
+	fileRef FileRef `yaml:"fileRef"`
+}
+
+type VCenter struct {
+	caCertPath   string      `yaml:"caCertPath"`
+	cluster      string      `yaml:"cluster"`
+	credentials  credentials `yaml:"credentials"`
+	datacenter   string      `yaml:"datacenter"`
+	datastore    string      `yaml:"datastore"`
+	folder       string      `yaml:"folder"`
+	network      string      `yaml:"network"`
+	resourcePool string      `yaml:"resourcePool"`
+}
+
+type AdminWorkstation struct {
+	adminWorkstation Workstation `yaml:"adminWorkstation"`
+	gcp              gcp         `yaml:"gcp"`
+	proxyUrl         string      `yaml:"proxyUrl"`
+	vCenter          VCenter     `yaml:"vCenter"`
+}
+
+const (
+	// SchedName is the name of the kubernetes scheduler driver implementation
+	SchedName                    = "anthos"
+	adminUserName                = "ubuntu"
+	adminWsConfFile              = "admin-ws-config.yaml"
+	gcpAccessFile                = "my-px-access.json"
+	vcenterCrtFile               = "vcenter.crt"
+	vcenterCredFile              = "credential.yaml"
+	googleDownloadUrl            = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads"
+	googleCloudCliPkg            = "google-cloud-cli-428.0.0-linux-x86_64.tar.gz"
+	upgradeAdminWsCmd            = "gkeadm upgrade admin-workstation"
+	upgradePrepareCmd            = "gkectl prepare  --bundle-path /var/lib/gke/bundles/gke-onprem-vsphere-"
+	upgradeUserClusterCmd        = "gkectl upgrade cluster"
+	upgradeAdminClusterCmd       = "gkectl upgrade admin"
+	adminWsIdRsa                 = "id_rsa"
+	kubeConfig                   = "kubeconfig"
+	clusterGrpPath               = "k8s/clusterGroup0"
+	gsUtilCmd                    = "./google-cloud-sdk/bin/gsutil"
+	jsonInstances                = "/instances.json"
+	errorTimeDuration            = 0 * time.Minute
+	defaultTestConnectionTimeout = 15 * time.Minute
+	defaultWaitUpgradeRetry      = 10 * time.Second
+)
+
+var (
+	versionReg = regexp.MustCompile(`\w.\w+.\w+-gke.\w+`)
+)
+
+type AnthosInstance struct {
+	Name             string
+	HostName         string
+	User             string
+	PublicIpAddress  string
+	PrivateIpAddress string
+	IpV6IpAddress    string
+	Passwd           string
+	Key              string
+	Port             string
+	OS               string
+	KernelVersion    string
+	OSVersion        string
+	Version          string
+	ESXiHost         string
+	PxClusterId      string
+	Disks            []string
+	Interfaces       []string
+	IsJsonEmpty      bool
+	IsWindows        bool
+	VMSpec           any `json:"VMspec"`
+
+	Datacenter string
+
+	VcenterName                         string `json:",omitempty"`
+	VcenterDatacenter                   string `json:",omitempty"`
+	VcenterCluster                      string `json:",omitempty"`
+	VcenterDatastore                    string `json:",omitempty"`
+	VcenterResourcePool                 string `json:",omitempty"`
+	VcenterHost                         string `json:",omitempty"`
+	VcenterPCIPassthroughAllowedDevices string `json:",omitempty"`
+	VcenterPCIPassthroughDeviceCount    int    `json:",omitempty"`
+
+	DockerDisk   string
+	JournalDisk  string
+	MetadataDisk string
+	CacheDisk    string
+	Owner        string
+	Lease        int
+}
+
+type anthos struct {
+	version string
+	kube.K8s
+	adminWsSSHInstance *ssh.SSH
+	instances          []AnthosInstance
+	adminWsNode        *node.Node
+	adminWsKeyPath     string
+	instPath           string
+	confPath           string
+}
+
+// Init Initialize the driver
+func (anth *anthos) Init(schedOpts scheduler.InitOptions) error {
+	if schedOpts.AnthosAdminWorkStationNodeIP == "" {
+		return fmt.Errorf("anthos admin workstation node is must for anthos scheduler")
+	}
+	if schedOpts.AnthosInstancePath == "" {
+		return fmt.Errorf("anthos conf path is needed for anthos scheduler")
+	}
+	anth.adminWsSSHInstance = &ssh.SSH{}
+	anth.adminWsNode = &node.Node{}
+	anth.instPath = schedOpts.AnthosInstancePath
+	anth.confPath = path.Join(anth.instPath, clusterGrpPath)
+	anth.adminWsKeyPath = path.Join(anth.confPath, adminWsIdRsa)
+	anth.adminWsNode.Name = schedOpts.AnthosAdminWorkStationNodeIP
+	anth.adminWsNode.Addresses = append(anth.adminWsNode.Addresses, schedOpts.AnthosAdminWorkStationNodeIP)
+	anth.adminWsNode.UsableAddr = schedOpts.AnthosAdminWorkStationNodeIP
+	if err := anth.K8s.Init(schedOpts); err != nil {
+		return err
+	}
+	if err := anth.adminWsSSHInstance.Init(node.InitOptions{SpecDir: schedOpts.SpecDir}); err != nil {
+		return err
+	}
+	if err := anth.adminWsSSHInstance.UpdateNodeCreds(adminUserName, anth.adminWsKeyPath); err != nil {
+		return err
+	}
+	if err := anth.getVersion(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// execOnAdminWSNode execute command on admin workstation node
+func (anth *anthos) execOnAdminWSNode(cmd string) (string, error) {
+	if err := os.Setenv("TORPEDO_SSH_KEY", anth.adminWsKeyPath); err != nil {
+		return "", err
+	}
+	if err := os.Setenv("TORPEDO_SSH_USER", adminUserName); err != nil {
+		return "", err
+	}
+	var connectOpts = node.ConnectionOpts{
+		Timeout:         kube.DefaultTimeout,
+		TimeBeforeRetry: kube.DefaultRetryInterval,
+		Sudo:            true,
+	}
+	out, err := anth.adminWsSSHInstance.RunCommand(*anth.adminWsNode, cmd, connectOpts)
+	if err != nil {
+		return out, err
+	}
+	if err := os.Unsetenv("TORPEDO_SSH_KEY"); err != nil {
+		return "", err
+	}
+	if err := os.Unsetenv("TORPEDO_SSH_USER"); err != nil {
+		return "", err
+	}
+	return out, err
+}
+
+// getVersion get anthos current version
+func (anth *anthos) getVersion() error {
+	cmd := "gkectl version"
+	out, err := anth.execOnAdminWSNode(cmd)
+	if err != nil {
+		return err
+	}
+	matches := versionReg.FindAllString(out, -1)
+	if len(matches) == 0 {
+		return fmt.Errorf("unable to parse version from output: %s", out)
+	}
+	anth.version = matches[0]
+	return nil
+}
+
+// UpgradeScheduler upgrade anthos scheduler and return time taken by user-cluster to upgrade
+func (anth *anthos) UpgradeScheduler(version string) error {
+	log.Info("Upgrading Anthos user cluster")
+	if !versionReg.MatchString(version) {
+		return fmt.Errorf("incorrect upgrade version: [%s] is provided", version)
+	}
+	if err := anth.VerifyUpgradeVersion(version); err != nil {
+		return err
+	}
+	if err := anth.loadInstances(); err != nil {
+		return err
+	}
+	if err := downloadAndInstallGsutils(); err != nil {
+		return err
+	}
+	if err := anth.upgradeAdminWorkstation(version); err != nil {
+		return err
+	}
+	startTime := time.Now()
+	if err := anth.upgradeUserCluster(version); err != nil {
+		return err
+	}
+	timeTaken := time.Since(startTime)
+	log.Infof("Anthos user cluster took: %v time to complete the upgrade", timeTaken)
+	if err := anth.RefreshNodeRegistry(); err != nil {
+		return err
+	}
+	if err := anth.invokeUpgradeAdminCluster(version); err != nil {
+		return err
+	}
+	return nil
+}
+
+// invokeUpgradeAdminCluster start admin cluster upgrade
+func (anth *anthos) invokeUpgradeAdminCluster(version string) error {
+	log.Info("Upgrading admin cluster")
+	initTime := time.Now()
+	if err := anth.upgradeAdminCluster(version); err != nil {
+		return err
+	}
+	timeTaken := time.Since(initTime)
+	log.Infof("Anthos upgrade took: %v time to complete upgrade from % to %s version",
+		timeTaken, anth.version, version)
+	if err := anth.updateNodeInstance(); err != nil {
+		return err
+	}
+	if err := anth.saveInstance(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// updateNodeInstance will update the host info after upgrade
+func (anth *anthos) updateNodeInstance() error {
+	log.Info("Updating node Instance")
+	var startAdminNodeIndex int = 2
+	var lastAdminNodeIndex int = 4
+	k8sOps, err := core.NewInstanceFromConfigFile(path.Join(anth.confPath, kubeConfig))
+	if err != nil {
+		return err
+	}
+	adminNodeList, err := k8sOps.GetNodes()
+	if err != nil {
+		return err
+	}
+	adminIndex := startAdminNodeIndex
+	for _, adminNode := range adminNodeList.Items {
+		if adminIndex > lastAdminNodeIndex {
+			break
+		}
+		anth.instances[adminIndex].HostName = adminNode.Name
+		anth.instances[adminIndex].PublicIpAddress = adminNode.Status.Addresses[0].Address
+		anth.instances[adminIndex].PrivateIpAddress = adminNode.Status.Addresses[0].Address
+		adminIndex += 1
+	}
+	return nil
+}
+
+// saveInstance save the instances.json after upgrade
+func (anth *anthos) saveInstance() error {
+	log.Debug("Saving instances.json")
+	b, err := json.MarshalIndent(anth.instances, "", "  ")
+	if err != nil {
+		return fmt.Errorf("cannot marshall Instances, %v", err)
+	}
+	if os.WriteFile(path.Join(anth.instPath, jsonInstances), b, 0644); err != nil {
+		return fmt.Errorf("couldn't write to %s/%s: %v", anth.instPath, jsonInstances, err)
+	}
+	return nil
+}
+
+// verifyUpgradeVersion validates that correct version is provided for upgrade or not
+func (anth *anthos) VerifyUpgradeVersion(upgradeVersion string) error {
+	log.Infof("Checking the upgrade from version: [%s] to version: [%s]",
+		anth.version, upgradeVersion)
+	var vReg = regexp.MustCompile(`(^\w).(\w+).(\w+)`)
+	parseV1 := strings.Split(anth.version, "-")
+	parseV2 := strings.Split(upgradeVersion, "-")
+	v1 := strings.TrimSpace(parseV1[0])
+	v2 := strings.TrimSpace(parseV2[0])
+	version1, err := version.NewVersion(v1)
+	if err != nil {
+		return err
+	}
+	version2, err := version.NewVersion(v2)
+	if err != nil {
+		return err
+	}
+	if version1.GreaterThanOrEqual(version2) {
+		return fmt.Errorf("incorrect upgrade version:%s is provided."+
+			"Upgrade version should be higher", upgradeVersion)
+	}
+	toVersion := vReg.FindAllStringSubmatch(v1, -1)
+	fromVersion := vReg.FindAllStringSubmatch(v2, -1)
+	val1, err := strconv.Atoi(toVersion[0][2])
+	if err != nil {
+		return err
+	}
+	val2, err := strconv.Atoi(fromVersion[0][2])
+	if err != nil {
+		return fmt.Errorf("failed to parse version: %s. Error: %v", fromVersion, err)
+	}
+	if (len(toVersion) > 0 && len(fromVersion) > 0) &&
+		(toVersion[0][1] != fromVersion[0][1] || (val2-val1) > 1) {
+		return fmt.Errorf("incorrect upgrade version:%s is provided."+
+			"One major version upgrade support at a time", upgradeVersion)
+	}
+	log.Debugf("Successfully verified the version:[%]", upgradeVersion)
+	return nil
+}
+
+// updateGkeadmUtil update gkeadm version to given version
+func (anth *anthos) updateGkeadmUtil(version string) error {
+	log.Infof("Updating gkeadm to version: [%s]", version)
+	src := fmt.Sprintf("gs://gke-on-prem-release/gkeadm/%s/linux/gkeadm", version)
+	if out, err := exec.Command(gsUtilCmd, "cp", src, anth.confPath).CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to download gkeadm : [%s], Err:(%v)", out, err)
+	}
+	gkeAdmCLI := fmt.Sprintf("%s/gkeadm", anth.confPath)
+	if err := os.Chmod(gkeAdmCLI, 0755); err != nil {
+		return err
+	}
+	return nil
+}
+
+// upgradeAdminWorkstation upgrade admin work-station node
+func (anth *anthos) upgradeAdminWorkstation(version string) error {
+	log.Infof("upgrading admin workstation node to version: %s", version)
+	var re = regexp.MustCompile(`(?m)ubuntu\@([\d.]+)`)
+	if err := anth.updateGkeadmUtil(version); err != nil {
+		return err
+	}
+	if err := anth.updateAdminWorkstationNode(); err != nil {
+		return err
+	}
+	gkeExecPath, err := getExecPath()
+	if err != nil {
+		return err
+	}
+	log.Debugf("Using path: [%s] for executing commands", gkeExecPath)
+	gkeadmCmd := fmt.Sprintf("%s/gkeadm", anth.confPath)
+	adminWsConfPath := path.Join(anth.confPath, adminWsConfFile)
+	execCmd := exec.Command(gkeadmCmd,
+		"upgrade", "admin-workstation", "--config", adminWsConfPath)
+	execCmd.Dir = anth.confPath
+	execCmd.Env = append(execCmd.Environ(), gkeExecPath)
+	log.Debugf("Executing command: %v", execCmd)
+
+	out, err := execCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to upgrade admin workstation: [%s]. Err: (%v)", out, err)
+	}
+	adminWsNewIp := re.FindAllStringSubmatch(string(out), -1)
+	if len(adminWsNewIp) > 0 {
+		anth.adminWsNode.Name = adminWsNewIp[0][1]
+		anth.adminWsNode.Addresses = []string{adminWsNewIp[0][1]}
+		anth.adminWsNode.UsableAddr = adminWsNewIp[0][1]
+		anth.instances[0].PublicIpAddress = adminWsNewIp[0][1]
+	}
+	if err := os.Setenv("TORPEDO_SSH_KEY", anth.adminWsKeyPath); err != nil {
+		return err
+	}
+	err = anth.adminWsSSHInstance.TestConnection(*anth.adminWsNode, node.ConnectionOpts{
+		Timeout:         defaultTestConnectionTimeout,
+		TimeBeforeRetry: defaultWaitUpgradeRetry,
+	})
+	if err := os.Unsetenv("TORPEDO_SSH_KEY"); err != nil {
+		return err
+	}
+	if err != nil {
+		return fmt.Errorf("admin work station node failed to come up after upgrade. Error: %v", err)
+	}
+
+	log.Debugf("Successfully upgraded the admin work-station node: %s", adminWsNewIp)
+	return nil
+}
+
+// upgradeUserCluster upgrade user cluster to newer version
+func (anth *anthos) upgradeUserCluster(version string) error {
+	log.Infof("Upgrading user cluster to a newer version: %s", version)
+	var cmd = fmt.Sprintf("%s%s.tgz  --kubeconfig /home/ubuntu/kubeconfig", upgradePrepareCmd, version)
+	if out, err := anth.execOnAdminWSNode(cmd); err != nil {
+		return fmt.Errorf("preparing user cluster for upgrade is failing: [%s]. Err: (%v)", out, err)
+	}
+	cmd = fmt.Sprintf("%s --kubeconfig /home/ubuntu/kubeconfig --config /home/ubuntu/user-cluster.yaml",
+		upgradeUserClusterCmd)
+	if out, err := anth.execOnAdminWSNode(cmd); err != nil {
+		return fmt.Errorf("upgrading user cluster is failing: [%s]. Err: (%v)", out, err)
+	}
+	log.Debug("Successfully upgraded the user cluster")
+	return nil
+}
+
+// upgradeAdminCluster upgrades admin cluster
+func (anth *anthos) upgradeAdminCluster(version string) error {
+	log.Infof("Upgrading admin cluster to a newer version: %s", version)
+	var cmd = fmt.Sprintf("cp /home/ubuntu/%s ~/", vcenterCrtFile)
+	if _, err := anth.execOnAdminWSNode(cmd); err != nil {
+		return fmt.Errorf("failed to copy vcenter certificate: %s. Err: %v", vcenterCrtFile, err)
+	}
+	cmd = fmt.Sprintf("%s --kubeconfig  /home/ubuntu/kubeconfig --config  /home/ubuntu/admin-cluster.yaml",
+		upgradeAdminClusterCmd)
+	if out, err := anth.execOnAdminWSNode(cmd); err != nil {
+		return fmt.Errorf("upgrading admin cluster is failing: [%s]. Err: (%v)", out, err)
+	}
+	return nil
+}
+
+// loadInstance load the instances.json file
+func (anth *anthos) loadInstances() error {
+	log.Info("Loading the anthos admin instance")
+	var instances []AnthosInstance
+	b, err := ioutil.ReadFile(anth.instPath + "/instances.json")
+	if err != nil {
+		return fmt.Errorf("unable to read instances.json: %v", err)
+	}
+	if err := json.Unmarshal(b, &instances); err != nil {
+		return fmt.Errorf("unable to unmarshal instances.json: %v", err)
+	}
+	anth.instances = instances
+	return nil
+}
+
+// updateAdminWorkstationNode update container paths in admin-ws-config
+func (anth *anthos) updateAdminWorkstationNode() error {
+	log.Info("Updating admin workstation configs")
+	adminWsConfigPath := path.Join(anth.confPath, adminWsConfFile)
+	adminWsConfigYaml, err := os.Open(adminWsConfigPath)
+	if err != nil {
+		return err
+	}
+	defer adminWsConfigYaml.Close()
+	adminWsConfigYamlContent, err := ioutil.ReadAll(adminWsConfigYaml)
+	if err != nil {
+		return err
+	}
+	var admWSObj AdminWorkstation
+	err = yaml.Unmarshal(adminWsConfigYamlContent, &admWSObj)
+	if err != nil {
+		return err
+	}
+	admWSObj.gcp.ComponentAccessServiceAccountKeyPath = path.Join(anth.instPath, gcpAccessFile)
+	admWSObj.vCenter.credentials.fileRef.path = path.Join(anth.confPath, vcenterCredFile)
+	admWSObj.vCenter.caCertPath = path.Join(anth.confPath, vcenterCrtFile)
+	out, err := yaml.Marshal(&admWSObj)
+	if err != nil {
+		return err
+	}
+	if err = ioutil.WriteFile(adminWsConfigPath, out, 0744); err != nil {
+		return err
+	}
+	log.Debugf("[%s] file path successfully updated", adminWsConfigPath)
+	return nil
+}
+
+// downloadAndInstallGsutils download and install gsutil for google cloud
+func downloadAndInstallGsutils() error {
+	log.Info("Downloading gcloud sdk")
+	var pkgName = "google-cloud-cli-linux.tar.gz"
+	googleCliUrl := fmt.Sprintf("%s/%s", googleDownloadUrl, googleCloudCliPkg)
+	out, err := exec.Command("curl", "-o", pkgName, googleCliUrl).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("[%s] downloading google cloud sdk failing: [%s]. Err: %v",
+			googleCloudCliPkg, out, err)
+	}
+	out, err = exec.Command("tar", "-xvf", pkgName).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("[%s] pkag extracting is failing: [%s]. Err: %v",
+			pkgName, out, err)
+	}
+	log.Infof("Extracted %s successfully.", pkgName)
+	out, err = exec.Command("apk", "add", "--update", "--no-cache", "python3").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("install python in container failing: [%s]. Err: %v", out, err)
+	}
+	out, err = exec.Command("ln", "-sf", "python3", "/usr/bin/python").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("linking python is failing: [%s]. Err: %v", out, err)
+	}
+	out, err = exec.Command("apk", "add", "--update", "--no-cache", "openssh").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("installing openssh is failing: [%s]. Err: %v", out, err)
+	}
+
+	return nil
+}
+
+// getExecPath return binaries exec path
+func getExecPath() (string, error) {
+	cmd := exec.Command("pwd")
+	curWkDir, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	curDir := strings.TrimSpace(string(curWkDir))
+	gcloudExecPath := path.Join(string(curDir), "google-cloud-sdk/bin")
+	cmd = exec.Command("echo", os.Getenv("PATH"))
+	execPath, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+	envPath := strings.TrimSpace(string(execPath))
+	return fmt.Sprintf("PATH=%s:%s:%s", curWkDir, envPath, gcloudExecPath), nil
+
+}
+
+// init registering anthos sheduler
+func init() {
+	anthos := &anthos{}
+	scheduler.Register(SchedName, anthos)
+}

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -113,6 +113,10 @@ type InitOptions struct {
 	RunCSISnapshotAndRestoreManyTest bool
 	//SecureApps identifies apps to be deployed with secure annotation in storage class
 	SecureApps []string
+	// AnthosAdminWorkStationNodeIP needed for anthos scheduler
+	AnthosAdminWorkStationNodeIP string
+	// AnthosInstancePath needed for anthos scheduler
+	AnthosInstancePath string
 }
 
 // ScheduleOptions are options that callers to pass to influence the apps that get schduled

--- a/tests/common.go
+++ b/tests/common.go
@@ -9,11 +9,12 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/portworx/sched-ops/k8s/apps"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"math/rand"
 	"net/http"
 	"regexp"
+
+	"github.com/portworx/sched-ops/k8s/apps"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/portworx/torpedo/pkg/aetosutil"
 	"github.com/portworx/torpedo/pkg/log"
@@ -125,6 +126,9 @@ import (
 	// import driver to invoke it's init
 	_ "github.com/portworx/torpedo/drivers/monitor/prometheus"
 
+	// import scheduler drivers to invoke it's init
+	_ "github.com/portworx/torpedo/drivers/scheduler/anthos"
+
 	context1 "context"
 
 	"github.com/libopenstorage/operator/drivers/storage/portworx/util"
@@ -208,6 +212,10 @@ const (
 	torpedoJobTypeFlag       = "torpedo-job-type"
 	clusterCreationTimeout   = 5 * time.Minute
 	clusterCreationRetryTime = 10 * time.Second
+
+	// Anthos
+	anthosWsNodeIpCliFlag = "anthos-ws-node-ip"
+	anthosInstPathCliFlag = "anthos-inst-path"
 )
 
 // Dashboard params
@@ -399,6 +407,8 @@ func InitInstance() {
 		RunCSISnapshotAndRestoreManyTest: Inst().RunCSISnapshotAndRestoreManyTest,
 		HelmValuesConfigMapName:          Inst().HelmValuesConfigMap,
 		SecureApps:                       Inst().SecureAppList,
+		AnthosAdminWorkStationNodeIP:     Inst().AnthosAdminWorkStationNodeIP,
+		AnthosInstancePath:               Inst().AnthosInstPath,
 	})
 
 	log.FailOnError(err, "Error occured while Scheduler Driver Initialization")
@@ -4453,6 +4463,8 @@ type Torpedo struct {
 	JobName                             string
 	JobType                             string
 	PortworxPodRestartCheck             bool
+	AnthosAdminWorkStationNodeIP        string
+	AnthosInstPath                      string
 }
 
 // ParseFlags parses command line flags
@@ -4503,6 +4515,8 @@ func ParseFlags() {
 	var testsetID int
 	var torpedoJobName string
 	var torpedoJobType string
+	var anthosWsNodeIp string
+	var anthosInstPath string
 
 	flag.StringVar(&s, schedulerCliFlag, defaultScheduler, "Name of the scheduler to use")
 	flag.StringVar(&n, nodeDriverCliFlag, defaultNodeDriver, "Name of the node driver to use")
@@ -4567,6 +4581,8 @@ func ParseFlags() {
 	flag.StringVar(&testProduct, testProductFlag, "PxEnp", "Portworx product under test")
 	flag.StringVar(&pxRuntimeOpts, "px-runtime-opts", "", "comma separated list of run time options for cluster update")
 	flag.BoolVar(&pxPodRestartCheck, failOnPxPodRestartCount, false, "Set it true for px pods restart check during test")
+	flag.StringVar(&anthosWsNodeIp, anthosWsNodeIpCliFlag, "", "Anthos admin work station node IP")
+	flag.StringVar(&anthosInstPath, anthosInstPathCliFlag, "", "Anthos config path where all conf files present")
 	flag.Parse()
 
 	log.SetLoglevel(logLevel)
@@ -4772,6 +4788,8 @@ func ParseFlags() {
 				JobName:                             torpedoJobName,
 				JobType:                             torpedoJobType,
 				PortworxPodRestartCheck:             pxPodRestartCheck,
+				AnthosAdminWorkStationNodeIP:        anthosWsNodeIp,
+				AnthosInstPath:                      anthosInstPath,
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Added Anthos scheduler to support Anthos upgrade from torpedo so that application deployments can be done and validated after anthos upgrade.

**Which issue(s) this PR fixes** (optional)
Closes # PTX-16072

**Special notes for your reviewer**:
------------
[90m------------------------------[0m
[0m{UpgradeCluster}[0m 
  [1mupgrade scheduler and ensure everything is running fine[0m
  [37m/go/src/github.com/portworx/torpedo/tests/basic/upgrade_cluster_test.go:23[0m
2023-05-06 00:38:18 +0000:[INFO] [{UpgradeCluster}] Log Dir: /testresults//UpgradeCluster.log
[36mINFO[0m[2023-05-06 00:38:18] --------Test Start------                     
[36mINFO[0m[2023-05-06 00:38:18] #Test: UpgradeCluster                        
[36mINFO[0m[2023-05-06 00:38:18] #Description: Upgrade cluster test           
[36mINFO[0m[2023-05-06 00:38:18] ------------------------                     
[36mINFO[0m[2023-05-06 00:38:18] Running test from file torpedo/tests/common.go, module: UpgradeCluster 
[1mSTEP[0m: schedule applications
2023-05-06 00:38:18 +0000:[INFO] [{UpgradeCluster}] [tests.CreateScheduleOptions:#1533] - Creating ScheduleOptions
2023-05-06 00:38:18 +0000:[INFO] [{UpgradeCluster}] [tests.CreateScheduleOptions:#1570] - ScheduleOptions: Scheduling Apps with hyper-converged
2023-05-06 00:38:18 +0000:[INFO] [{UpgradeCluster}] [k8s.(*K8s).createStorageObject:#1417] - Setting provisioner of px-nginx-sc-v4 to kubernetes.io/portworx-volume
2023-05-06 00:38:18 +0000:[INFO] [{UpgradeCluster}] [k8s.(*K8s).createStorageObject:#1436] - [nginx-sharedv4] Found existing storage class: px-nginx-sc-v4
2023-05-06 00:38:18 +0000:[INFO] [{UpgradeCluster}] [k8s.(*K8s).createStorageObject:#1504] - [nginx-sharedv4] Created PVC: px-nginx-pvc-sharedv4
2023-05-06 00:38:18 +0000:[INFO] [{UpgradeCluster}] [k8s.(*K8s).createStorageObject:#1504] - [nginx-sharedv4] Created PVC: px-nginx-pvc-enc-sharedv4
2023-05-06 00:38:19 +0000:[INFO] [{UpgradeCluster}] [k8s.(*K8s).createCoreObject:#1924] - [nginx-sharedv4] Created Service: nginx-service
{Volumes:[{Name:nginx-persistent-storage VolumeSource:{HostPath:nil EmptyDir:nil GCEPersistentDisk:nil AWSElasticBlockStore:nil GitRepo:nil Secret:nil NFS:nil ISCSI:nil Glusterfs:nil PersistentVolumeClaim:&PersistentVolumeClaimVolumeSource{ClaimName:px-nginx-pvc-sharedv4,ReadOnly:false,} RBD:nil FlexVolume:nil Cinder:nil CephFS:nil Flocker:nil DownwardAPI:nil FC:nil AzureFile:nil ConfigMap:nil VsphereVolume:nil Quobyte:nil AzureDisk:nil PhotonPersistentDisk:nil Projected:nil PortworxVolume:nil ScaleIO:nil StorageOS:nil CSI:nil Ephemeral:nil}} {Name:nginx-persistent-storage-enc VolumeSource:{HostPath:nil EmptyDir:nil GCEPersistentDisk:nil AWSElasticBlockStore:nil GitRepo:nil Secret:nil NFS:nil ISCSI:nil Glusterfs:nil PersistentVolumeClaim:&PersistentVolumeClaimVolumeSource{ClaimName:px-nginx-pvc-enc-sharedv4,ReadOnly:false,} RBD:nil FlexVolume:nil Cinder:nil CephFS:nil Flocker:nil DownwardAPI:nil FC:nil AzureFile:nil ConfigMap:nil VsphereVolume:nil Quobyte:nil AzureDisk:nil PhotonPersistentDisk:nil Projected:nil PortworxVolume:nil ScaleIO:nil StorageOS:nil CSI:nil Ephemeral:nil}}] InitContainers:[] Containers:[{Name:nginx Image:bitnami/nginx Command:[] Args:[] WorkingDir: Ports:[{Name: HostPort:0 ContainerPort:80 Protocol: HostIP:}] EnvFrom:[] Env:[] Resources:{Limits:map[] Requests:map[]} VolumeMounts:[{Name:nginx-persistent-storage ReadOnly:false MountPath:/usr/share/nginx/html SubPath: MountPropagation:<nil> SubPathExpr:} {Name:nginx-persistent-storage-enc ReadOnly:false MountPath:/usr/share/nginx/html-enc SubPath: MountPropagation:<nil> SubPathExpr:}] VolumeDevices:[] LivenessProbe:nil ReadinessProbe:nil StartupProbe:nil Lifecycle:nil TerminationMessagePath: TerminationMessagePolicy: ImagePullPolicy:IfNotPresent SecurityContext:nil Stdin:false StdinOnce:false TTY:false}] EphemeralContainers:[] RestartPolicy: TerminationGracePeriodSeconds:<nil> ActiveDeadlineSeconds:<nil> DNSPolicy: NodeSelector:map[] ServiceAccountName: DeprecatedServiceAccount: AutomountServiceAccountToken:<nil> NodeName: HostNetwork:false HostPID:false HostIPC:false ShareProcessNamespace:<nil> SecurityContext:nil ImagePullSecrets:[] Hostname: Subdomain: Affinity:nil SchedulerName: Tolerations:[] HostAliases:[] PriorityClassName: Priority:<nil> DNSConfig:nil ReadinessGates:[] RuntimeClassName:<nil> EnableServiceLinks:<nil> PreemptionPolicy:<nil> Overhead:map[] TopologySpreadConstraints:[] SetHostnameAsFQDN:<nil> OS:nil HostUsers:<nil>}
2023-05-06 00:38:19 +0000:[INFO] [{UpgradeCluster}] [k8s.(*K8s).createCoreObject:#1834] - [nginx-sharedv4] Created deployment: nginx
2023-05-06 00:38:19 +0000:[INFO] [{UpgradeCluster}] [k8s.(*K8s).createCoreObject:#1948] - [nginx-sharedv4] Created Secret: volume-secrets
[1mSTEP[0m: validate applications
2023-05-06 00:38:19 +0000:[INFO] [{UpgradeCluster}] Validate applications
2023-05-06 00:38:19 +0000:[INFO] [{UpgradeCluster}] Validating nginx-sharedv4 app
[1mSTEP[0m: validate nginx-sharedv4 app's volumes
2023-05-06 00:38:19 +0000:[INFO] [{UpgradeCluster}] Validating nginx-sharedv4 app's volumes
[1mSTEP[0m: inspect nginx-sharedv4 app's volumes
2023/05/06 00:38:19 PVC px-nginx-pvc-sharedv4 is not ready yet. Cause: PVC expected status: Bound PVC actual status: Pending Next retry in: 10s
2023-05-06 00:38:29 +0000:[INFO] [{UpgradeCluster}] [k8s.(*K8s).ValidateVolumes:#3144] - [nginx-sharedv4] Validated PVC: px-nginx-pvc-sharedv4, Namespace: nginx-sharedv4-upgradecluster-0-05-06-00h36m03s
2023-05-06 00:38:29 +0000:[INFO] [{UpgradeCluster}] [k8s.(*K8s).ValidateVolumes:#3144] - [nginx-sharedv4] Validated PVC: px-nginx-pvc-enc-sharedv4, Namespace: nginx-sharedv4-upgradecluster-0-05-06-00h36m03s
[1mSTEP[0m: get nginx-sharedv4 app's volume's custom parameters
[1mSTEP[0m: get nginx-sharedv4 app's volume: pvc-ee5adad8-2d0d-411b-9f24-97dc8c6c2ec5 inspected by the volume driver
2023-05-06 00:38:50 +0000:[WARNING] [{UpgradeCluster}] [portworx.(*portworx).setDriver:#2656] - testAndSetEndpoint failed for 10.96.7.10: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 10.96.7.10:9020: i/o timeout"
2023-05-06 00:38:50 +0000:[INFO] [{UpgradeCluster}] [portworx.(*portworx).setDriver:#2667] - Getting new driver.
2023-05-06 00:38:50 +0000:[INFO] [{UpgradeCluster}] [portworx.(*portworx).testAndSetEndpoint:#2740] - Using 10.13.11.223:9020 as endpoint for portworx volume driver
2023-05-06 00:39:10 +0000:[WARNING] [{UpgradeCluster}] [portworx.(*portworx).setDriver:#2656] - testAndSetEndpoint failed for 10.96.7.10: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 10.96.7.10:9020: i/o timeout"
2023-05-06 00:39:10 +0000:[INFO] [{UpgradeCluster}] [portworx.(*portworx).setDriver:#2667] - Getting new driver.
2023-05-06 00:39:10 +0000:[INFO] [{UpgradeCluster}] [portworx.(*portworx).testAndSetEndpoint:#2740] - Using 10.13.11.223:9020 as endpoint for portworx volume driver
2023-05-06 00:39:30 +0000:[WARNING] [{UpgradeCluster}] [portworx.(*portworx).setDriver:#2656] - testAndSetEndpoint failed for 10.96.7.10: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 10.96.7.10:9020: i/o timeout"
2023-05-06 00:39:30 +0000:[INFO] [{UpgradeCluster}] [portworx.(*portworx).setDriver:#2667] - Getting new driver.
2023-05-06 00:39:30 +0000:[WARNING] [{UpgradeCluster}] [portworx.(*portworx).setDriver:#2671] - testAndSetEndpoint failed for 10.13.11.221: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 10.13.11.221:9020: connect: connection refused"
2023-05-06 00:39:30 +0000:[WARNING] [{UpgradeCluster}] [portworx.(*portworx).setDriver:#2671] - testAndSetEndpoint failed for 10.13.11.221: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 10.13.11.221:9020: connect: connection refused"
2023-05-06 00:39:30 +0000:[INFO] [{UpgradeCluster}] [portworx.(*portworx).testAndSetEndpoint:#2740] - Using 10.13.11.222:9020 as endpoint for portworx volume driver
2023-05-06 00:39:50 +0000:[WARNING] [{UpgradeCluster}] [portworx.(*portworx).setDriver:#2656] - testAndSetEndpoint failed for 10.96.7.10: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 10.96.7.10:9020: i/o timeout"
2023-05-06 00:39:50 +0000:[INFO] [{UpgradeCluster}] [portworx.(*portworx).setDriver:#2667] - Getting new driver.
2023-05-06 00:39:50 +0000:[INFO] [{UpgradeCluster}] [portworx.(*portworx).testAndSetEndpoint:#2740] - Using 10.13.11.224:9020 as endpoint for portworx volume driver
2023-05-06 00:39:50 +0000:[INFO] [{UpgradeCluster}] [portworx.(*portworx).ValidateCreateVolume:#1384] - Successfully inspected volume [pvc-ee5adad8-2d0d-411b-9f24-97dc8c6c2ec5] (976090148438928896)
[1mSTEP[0m: get nginx-sharedv4 app's volume: pvc-bddf05bf-8ca1-4e1a-bc9c-b2e2e995e97e inspected by the volume driver
2023-05-06 00:40:10 +0000:[WARNING] [{UpgradeCluster}] [portworx.(*portworx).setDriver:#2656] - testAndSetEndpoint failed for 10.96.7.10: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 10.96.7.10:9020: i/o timeout"
2023-05-06 00:40:10 +0000:[INFO] [{UpgradeCluster}] [portworx.(*portworx).setDriver:#2667] - Getting new driver.
2023-05-06 00:40:10 +0000:[WARNING] [{UpgradeCluster}] [portworx.(*portworx).setDriver:#2671] - testAndSetEndpoint failed for 10.13.11.221: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 10.13.11.221:9020: connect: connection refused"
2023-05-06 00:40:10 +0000:[WARNING] [{UpgradeCluster}] [portworx.(*portworx).setDriver:#2671] - testAndSetEndpoint failed for 10.13.11.221: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 10.13.11.221:9020: connect: connection refused"
2023-05-06 00:40:10 +0000:[INFO] [{UpgradeCluster}] [portworx.(*portworx).testAndSetEndpoint:#2740] - Using 10.13.11.222:9020 as endpoint for portworx volume driver
2023-05-06 00:40:30 +0000:[WARNING] [{UpgradeCluster}] [portworx.(*portworx).setDriver:#2656] - testAndSetEndpoint failed for 10.96.7.10: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 10.96.7.10:9020: i/o timeout"
2023-05-06 00:40:30 +0000:[INFO] [{UpgradeCluster}] [portworx.(*portworx).setDriver:#2667] - Getting new driver.
2023-05-06 00:40:30 +0000:[WARNING] [{UpgradeCluster}] [portworx.(*portworx).setDriver:#2671] - testAndSetEndpoint failed for 10.13.11.221: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 10.13.11.221:9020: connect: connection refused"
2023-05-06 00:40:30 +0000:[WARNING] [{UpgradeCluster}] [portworx.(*portworx).setDriver:#2671] - testAndSetEndpoint failed for 10.13.11.221: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 10.13.11.221:9020: connect: connection refused"
2023-05-06 00:40:30 +0000:[INFO] [{UpgradeCluster}] [portworx.(*portworx).testAndSetEndpoint:#2740] - Using 10.13.11.222:9020 as endpoint for portworx volume driver
2023-05-06 00:40:50 +0000:[WARNING] [{UpgradeCluster}] [portworx.(*portworx).setDriver:#2656] - testAndSetEndpoint failed for 10.96.7.10: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 10.96.7.10:9020: i/o timeout"
2023-05-06 00:40:50 +0000:[INFO] [{UpgradeCluster}] [portworx.(*portworx).setDriver:#2667] - Getting new driver.
2023-05-06 00:40:50 +0000:[INFO] [{UpgradeCluster}] [portworx.(*portworx).testAndSetEndpoint:#2740] - Using 10.13.11.222:9020 as endpoint for portworx volume driver
2023-05-06 00:41:10 +0000:[WARNING] [{UpgradeCluster}] [portworx.(*portworx).setDriver:#2656] - testAndSetEndpoint failed for 10.96.7.10: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 10.96.7.10:9020: i/o timeout"
2023-05-06 00:41:10 +0000:[INFO] [{UpgradeCluster}] [portworx.(*portworx).setDriver:#2667] - Getting new driver.
2023-05-06 00:41:10 +0000:[WARNING] [{UpgradeCluster}] [portworx.(*portworx).setDriver:#2671] - testAndSetEndpoint failed for 10.13.11.221: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 10.13.11.221:9020: connect: connection refused"
2023-05-06 00:41:10 +0000:[WARNING] [{UpgradeCluster}] [portworx.(*portworx).setDriver:#2671] - testAndSetEndpoint failed for 10.13.11.221: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 10.13.11.221:9020: connect: connection refused"
2023-05-06 00:41:10 +0000:[INFO] [{UpgradeCluster}] [portworx.(*portworx).testAndSetEndpoint:#2740] - Using 10.13.11.222:9020 as endpoint for portworx volume driver
2023-05-06 00:41:10 +0000:[INFO] [{UpgradeCluster}] [portworx.(*portworx).ValidateCreateVolume:#1384] - Successfully inspected volume [pvc-bddf05bf-8ca1-4e1a-bc9c-b2e2e995e97e] (808045700810247798)
[1mSTEP[0m: wait for nginx-sharedv4 app to start running
2023-05-06 00:41:10 +0000:[INFO] [{UpgradeCluster}] wait for nginx-sharedv4 app to start running
2023-05-06 00:41:10 +0000:[INFO] [{UpgradeCluster}] [k8s.(*K8s).WaitForRunning:#2376] - [nginx-sharedv4] Validated Service: nginx-service
2023-05-06 00:41:10 +0000:[INFO] [{UpgradeCluster}] [k8s.(*K8s).WaitForRunning:#2357] - [nginx-sharedv4] Validated deployment: nginx
[1mSTEP[0m: validate if nginx-sharedv4 app's volumes are setup
2023-05-06 00:41:10 +0000:[INFO] [{UpgradeCluster}] validate if nginx-sharedv4 app's volumes are setup
[1mSTEP[0m: validate if nginx-sharedv4 app's volume: px-nginx-pvc-sharedv4 is setup
2023-05-06 00:41:10 +0000:[INFO] [{UpgradeCluster}] [tests.ValidateContext.func2.4.1:#564] - validate if nginx-sharedv4 app's volume: px-nginx-pvc-sharedv4 is setup
2023-05-06 00:41:10 +0000:[INFO] [{UpgradeCluster}] [schedops.printStatus:#926] - Pod [nginx-sharedv4-upgradecluster-0-05-06-00h36m03s] nginx-578db87f68-42jtq ready on node tp-test-anthos-2 - Initialized: True Ready: True Scheduled: True 
2023-05-06 00:41:10 +0000:[INFO] [{UpgradeCluster}] [schedops.printStatus:#926] - Pod [nginx-sharedv4-upgradecluster-0-05-06-00h36m03s] nginx-578db87f68-rqzjz ready on node tp-test-anthos-2 - Initialized: True Ready: True Scheduled: True 
2023-05-06 00:41:10 +0000:[INFO] [{UpgradeCluster}] [schedops.printStatus:#926] - Pod [nginx-sharedv4-upgradecluster-0-05-06-00h36m03s] nginx-578db87f68-wcbqs ready on node tp-test-anthos-2 - Initialized: True Ready: True Scheduled: True 
2023-05-06 00:41:10 +0000:[DEBUG] [{UpgradeCluster}] [schedops.(*k8sSchedOps).validateMountsInPods:#313] - validating the mounts in pod nginx-sharedv4-upgradecluster-0-05-06-00h36m03s/nginx-578db87f68-42jtq
2023-05-06 00:41:10 +0000:[DEBUG] [{UpgradeCluster}] [schedops.(*k8sSchedOps).validateMountsInPods:#333] - pod: [nginx-sharedv4-upgradecluster-0-05-06-00h36m03s] nginx-578db87f68-42jtq has PX mount: [/dev/pxd/pxd976090148438928896 /usr/share/nginx/html /dev/pxd/pxd976090148438928896 ]
2023-05-06 00:41:10 +0000:[DEBUG] [{UpgradeCluster}] [schedops.(*k8sSchedOps).validateMountsInPods:#333] - pod: [nginx-sharedv4-upgradecluster-0-05-06-00h36m03s] nginx-578db87f68-42jtq has PX mount: [/dev/mapper/pxd-enc808045700810247798 /usr/share/nginx/html-enc /dev/mapper/pxd-enc808045700810247798 ]
2023-05-06 00:41:10 +0000:[DEBUG] [{UpgradeCluster}] [ssh.(*SSH).doCmdUsingPod.func1:#606] - Finding the debug pod to run command on node tp-test-anthos-2
2023-05-06 00:41:11 +0000:[DEBUG] [{UpgradeCluster}] [ssh.(*SSH).doCmdUsingPod.func1:#626] - Running command on pod debug-7b6b4 [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-ee5adad8-2d0d-411b-9f24-97dc8c6c2ec5]]
2023-05-06 00:41:11 +0000:[DEBUG] [{UpgradeCluster}] [schedops.(*k8sSchedOps).validateMountsInPods:#313] - validating the mounts in pod nginx-sharedv4-upgradecluster-0-05-06-00h36m03s/nginx-578db87f68-rqzjz
2023-05-06 00:41:11 +0000:[DEBUG] [{UpgradeCluster}] [schedops.(*k8sSchedOps).validateMountsInPods:#333] - pod: [nginx-sharedv4-upgradecluster-0-05-06-00h36m03s] nginx-578db87f68-rqzjz has PX mount: [/dev/pxd/pxd976090148438928896 /usr/share/nginx/html /dev/pxd/pxd976090148438928896 ]
2023-05-06 00:41:11 +0000:[DEBUG] [{UpgradeCluster}] [schedops.(*k8sSchedOps).validateMountsInPods:#333] - pod: [nginx-sharedv4-upgradecluster-0-05-06-00h36m03s] nginx-578db87f68-rqzjz has PX mount: [/dev/mapper/pxd-enc808045700810247798 /usr/share/nginx/html-enc /dev/mapper/pxd-enc808045700810247798 ]
2023-05-06 00:41:11 +0000:[DEBUG] [{UpgradeCluster}] [ssh.(*SSH).doCmdUsingPod.func1:#606] - Finding the debug pod to run command on node tp-test-anthos-2
2023-05-06 00:41:11 +0000:[DEBUG] [{UpgradeCluster}] [ssh.(*SSH).doCmdUsingPod.func1:#626] - Running command on pod debug-7b6b4 [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-ee5adad8-2d0d-411b-9f24-97dc8c6c2ec5]]
2023-05-06 00:41:12 +0000:[DEBUG] [{UpgradeCluster}] [schedops.(*k8sSchedOps).validateMountsInPods:#313] - validating the mounts in pod nginx-sharedv4-upgradecluster-0-05-06-00h36m03s/nginx-578db87f68-wcbqs
2023-05-06 00:41:12 +0000:[DEBUG] [{UpgradeCluster}] [schedops.(*k8sSchedOps).validateMountsInPods:#333] - pod: [nginx-sharedv4-upgradecluster-0-05-06-00h36m03s] nginx-578db87f68-wcbqs has PX mount: [/dev/pxd/pxd976090148438928896 /usr/share/nginx/html /dev/pxd/pxd976090148438928896 ]
2023-05-06 00:41:12 +0000:[DEBUG] [{UpgradeCluster}] [schedops.(*k8sSchedOps).validateMountsInPods:#333] - pod: [nginx-sharedv4-upgradecluster-0-05-06-00h36m03s] nginx-578db87f68-wcbqs has PX mount: [/dev/mapper/pxd-enc808045700810247798 /usr/share/nginx/html-enc /dev/mapper/pxd-enc808045700810247798 ]
2023-05-06 00:41:12 +0000:[DEBUG] [{UpgradeCluster}] [ssh.(*SSH).doCmdUsingPod.func1:#606] - Finding the debug pod to run command on node tp-test-anthos-2
2023-05-06 00:41:12 +0000:[DEBUG] [{UpgradeCluster}] [ssh.(*SSH).doCmdUsingPod.func1:#626] - Running command on pod debug-7b6b4 [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-ee5adad8-2d0d-411b-9f24-97dc8c6c2ec5]]
[1mSTEP[0m: validate if nginx-sharedv4 app's volume: px-nginx-pvc-enc-sharedv4 is setup
2023-05-06 00:41:12 +0000:[INFO] [{UpgradeCluster}] [tests.ValidateContext.func2.4.1:#564] - validate if nginx-sharedv4 app's volume: px-nginx-pvc-enc-sharedv4 is setup
2023-05-06 00:41:12 +0000:[INFO] [{UpgradeCluster}] [schedops.printStatus:#926] - Pod [nginx-sharedv4-upgradecluster-0-05-06-00h36m03s] nginx-578db87f68-42jtq ready on node tp-test-anthos-2 - Initialized: True Ready: True Scheduled: True 
2023-05-06 00:41:12 +0000:[INFO] [{UpgradeCluster}] [schedops.printStatus:#926] - Pod [nginx-sharedv4-upgradecluster-0-05-06-00h36m03s] nginx-578db87f68-rqzjz ready on node tp-test-anthos-2 - Initialized: True Ready: True Scheduled: True 
2023-05-06 00:41:12 +0000:[INFO] [{UpgradeCluster}] [schedops.printStatus:#926] - Pod [nginx-sharedv4-upgradecluster-0-05-06-00h36m03s] nginx-578db87f68-wcbqs ready on node tp-test-anthos-2 - Initialized: True Ready: True Scheduled: True 
2023-05-06 00:41:13 +0000:[DEBUG] [{UpgradeCluster}] [schedops.(*k8sSchedOps).validateMountsInPods:#313] - validating the mounts in pod nginx-sharedv4-upgradecluster-0-05-06-00h36m03s/nginx-578db87f68-42jtq
2023-05-06 00:41:13 +0000:[DEBUG] [{UpgradeCluster}] [schedops.(*k8sSchedOps).validateMountsInPods:#333] - pod: [nginx-sharedv4-upgradecluster-0-05-06-00h36m03s] nginx-578db87f68-42jtq has PX mount: [/dev/pxd/pxd976090148438928896 /usr/share/nginx/html /dev/pxd/pxd976090148438928896 ]
2023-05-06 00:41:13 +0000:[DEBUG] [{UpgradeCluster}] [schedops.(*k8sSchedOps).validateMountsInPods:#333] - pod: [nginx-sharedv4-upgradecluster-0-05-06-00h36m03s] nginx-578db87f68-42jtq has PX mount: [/dev/mapper/pxd-enc808045700810247798 /usr/share/nginx/html-enc /dev/mapper/pxd-enc808045700810247798 ]
2023-05-06 00:41:13 +0000:[DEBUG] [{UpgradeCluster}] [ssh.(*SSH).doCmdUsingPod.func1:#606] - Finding the debug pod to run command on node tp-test-anthos-2
2023-05-06 00:41:13 +0000:[DEBUG] [{UpgradeCluster}] [ssh.(*SSH).doCmdUsingPod.func1:#626] - Running command on pod debug-7b6b4 [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-bddf05bf-8ca1-4e1a-bc9c-b2e2e995e97e]]
2023-05-06 00:41:13 +0000:[DEBUG] [{UpgradeCluster}] [schedops.(*k8sSchedOps).validateMountsInPods:#313] - validating the mounts in pod nginx-sharedv4-upgradecluster-0-05-06-00h36m03s/nginx-578db87f68-rqzjz
2023-05-06 00:41:13 +0000:[DEBUG] [{UpgradeCluster}] [schedops.(*k8sSchedOps).validateMountsInPods:#333] - pod: [nginx-sharedv4-upgradecluster-0-05-06-00h36m03s] nginx-578db87f68-rqzjz has PX mount: [/dev/pxd/pxd976090148438928896 /usr/share/nginx/html /dev/pxd/pxd976090148438928896 ]
2023-05-06 00:41:13 +0000:[DEBUG] [{UpgradeCluster}] [schedops.(*k8sSchedOps).validateMountsInPods:#333] - pod: [nginx-sharedv4-upgradecluster-0-05-06-00h36m03s] nginx-578db87f68-rqzjz has PX mount: [/dev/mapper/pxd-enc808045700810247798 /usr/share/nginx/html-enc /dev/mapper/pxd-enc808045700810247798 ]
2023-05-06 00:41:13 +0000:[DEBUG] [{UpgradeCluster}] [ssh.(*SSH).doCmdUsingPod.func1:#606] - Finding the debug pod to run command on node tp-test-anthos-2
2023-05-06 00:41:13 +0000:[DEBUG] [{UpgradeCluster}] [ssh.(*SSH).doCmdUsingPod.func1:#626] - Running command on pod debug-7b6b4 [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-bddf05bf-8ca1-4e1a-bc9c-b2e2e995e97e]]
2023-05-06 00:41:14 +0000:[DEBUG] [{UpgradeCluster}] [schedops.(*k8sSchedOps).validateMountsInPods:#313] - validating the mounts in pod nginx-sharedv4-upgradecluster-0-05-06-00h36m03s/nginx-578db87f68-wcbqs
2023-05-06 00:41:14 +0000:[DEBUG] [{UpgradeCluster}] [schedops.(*k8sSchedOps).validateMountsInPods:#333] - pod: [nginx-sharedv4-upgradecluster-0-05-06-00h36m03s] nginx-578db87f68-wcbqs has PX mount: [/dev/pxd/pxd976090148438928896 /usr/share/nginx/html /dev/pxd/pxd976090148438928896 ]
2023-05-06 00:41:14 +0000:[DEBUG] [{UpgradeCluster}] [schedops.(*k8sSchedOps).validateMountsInPods:#333] - pod: [nginx-sharedv4-upgradecluster-0-05-06-00h36m03s] nginx-578db87f68-wcbqs has PX mount: [/dev/mapper/pxd-enc808045700810247798 /usr/share/nginx/html-enc /dev/mapper/pxd-enc808045700810247798 ]
2023-05-06 00:41:14 +0000:[DEBUG] [{UpgradeCluster}] [ssh.(*SSH).doCmdUsingPod.func1:#606] - Finding the debug pod to run command on node tp-test-anthos-2
2023-05-06 00:41:14 +0000:[DEBUG] [{UpgradeCluster}] [ssh.(*SSH).doCmdUsingPod.func1:#626] - Running command on pod debug-7b6b4 [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c cat /proc/mounts | grep -E '(pxd|pxfs|pxns|pxd-enc|loop|px_)' | grep pvc-bddf05bf-8ca1-4e1a-bc9c-b2e2e995e97e]]
[1mSTEP[0m: Validate Px pod restart count
[1mSTEP[0m: Getting current restart counts for portworx pods and matching
[1mSTEP[0m: start scheduler upgrade
2023-05-06 00:41:15 +0000:[INFO] [{UpgradeCluster}] [anthos.(*anthos).UpgradeScheduler:#235] - Upgrading Anthos user cluster
2023-05-06 00:41:15 +0000:[INFO] [{UpgradeCluster}] [anthos.(*anthos).verifyUpgradeVersion:#326] - Checking the upgrade from version: [1.11.0-gke.543] to version: [1.12.5-gke.34]
2023-05-06 00:41:15 +0000:[DEBUG] [{UpgradeCluster}] [anthos.(*anthos).verifyUpgradeVersion:#361] - Successfully verified the version:[%!](string=1.12.5-gke.34)
2023-05-06 00:41:15 +0000:[INFO] [{UpgradeCluster}] [anthos.(*anthos).loadInstances:#472] - Loading the anthos admin instance
2023-05-06 00:41:15 +0000:[INFO] [{UpgradeCluster}] [anthos.downloadAndInstallGsutils:#519] - Downloading gcloud sdk
2023-05-06 00:41:28 +0000:[INFO] [{UpgradeCluster}] [anthos.downloadAndInstallGsutils:#533] - Extracted google-cloud-cli-linux.tar.gz successfully.
2023-05-06 00:41:31 +0000:[INFO] [{UpgradeCluster}] [anthos.(*anthos).upgradeAdminWorkstation:#382] - upgrading admin workstation node to version: 1.12.5-gke.34
2023-05-06 00:41:31 +0000:[INFO] [{UpgradeCluster}] [anthos.(*anthos).updateGkeadmUtil:#367] - Updating gkeadm to version: [1.12.5-gke.34]
2023-05-06 00:41:37 +0000:[INFO] [{UpgradeCluster}] [anthos.(*anthos).updateAdminWorkstationNode:#487] - Updating admin workstation configs
2023-05-06 00:41:37 +0000:[DEBUG] [{UpgradeCluster}] [anthos.(*anthos).updateAdminWorkstationNode:#513] - [/root/workspace/Users/Smit/tp-test-anthos/spawn/k8s/clusterGroup0/admin-ws-config.yaml] file path successfully updated
2023-05-06 00:41:37 +0000:[DEBUG] [{UpgradeCluster}] [anthos.(*anthos).upgradeAdminWorkstation:#394] - Using path: [PATH=/go/src/github.com/portworx/torpedo/bin
:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/go/src/github.com/portworx/torpedo/bin/google-cloud-sdk/bin] for executing commands
2023-05-06 00:41:37 +0000:[DEBUG] [{UpgradeCluster}] [anthos.(*anthos).upgradeAdminWorkstation:#401] - Executing command: /root/workspace/Users/Smit/tp-test-anthos/spawn/k8s/clusterGroup0/gkeadm upgrade admin-workstation --config /root/workspace/Users/Smit/tp-test-anthos/spawn/k8s/clusterGroup0/admin-ws-config.yaml
[36mINFO[0m[2023-05-06 00:46:03] sched stats: workers: current=10, started=10, exited=0 
[36mINFO[0m[2023-05-06 00:46:03] sched stats: tick interval: 600 < 1.2s (100%) 
[36mINFO[0m[2023-05-06 00:46:03] sched stats: tick process durations: 599 < 500ms (100%) 
2023-05-06 00:47:15 +0000:[DEBUG] [{UpgradeCluster}] [anthos.(*anthos).upgradeAdminWorkstation:#431] - Successfully upgraded the admin work-station node: [[ubuntu@10.13.11.220 10.13.11.220]]
2023-05-06 00:47:15 +0000:[INFO] [{UpgradeCluster}] [anthos.(*anthos).upgradeUserCluster:#437] - Upgrading user cluster to a newer version: 1.12.5-gke.34
[36mINFO[0m[2023-05-06 00:56:04] sched stats: workers: current=10, started=10, exited=0 
[36mINFO[0m[2023-05-06 00:56:04] sched stats: tick interval: 1201 < 1.2s (100%) 
[36mINFO[0m[2023-05-06 00:56:04] sched stats: tick process durations: 1200 < 500ms (100%) 
[36mINFO[0m[2023-05-06 01:06:05] sched stats: workers: current=10, started=10, exited=0 
[36mINFO[0m[2023-05-06 01:06:05] sched stats: tick interval: 1802 < 1.2s (100%) 
[36mINFO[0m[2023-05-06 01:06:05] sched stats: tick process durations: 1801 < 500ms (100%) 
[36mINFO[0m[2023-05-06 01:16:06] sched stats: workers: current=10, started=10, exited=0 
[36mINFO[0m[2023-05-06 01:16:06] sched stats: tick interval: 2403 < 1.2s (100%) 
[36mINFO[0m[2023-05-06 01:16:06] sched stats: tick process durations: 2402 < 500ms (100%) 
[36mINFO[0m[2023-05-06 01:26:07] sched stats: workers: current=10, started=10, exited=0 
[36mINFO[0m[2023-05-06 01:26:07] sched stats: tick interval: 3004 < 1.2s (100%) 
[36mINFO[0m[2023-05-06 01:26:07] sched stats: tick process durations: 3003 < 500ms (100%) 
[36mINFO[0m[2023-05-06 01:36:08] sched stats: workers: current=10, started=10, exited=0 
[36mINFO[0m[2023-05-06 01:36:08] sched stats: tick interval: 3605 < 1.2s (100%) 
[36mINFO[0m[2023-05-06 01:36:08] sched stats: tick process durations: 3604 < 500ms (100%) 
[36mINFO[0m[2023-05-06 01:46:09] sched stats: workers: current=10, started=10, exited=0 
[36mINFO[0m[2023-05-06 01:46:09] sched stats: tick interval: 4206 < 1.2s (100%) 
[36mINFO[0m[2023-05-06 01:46:09] sched stats: tick process durations: 4205 < 500ms (100%) 
2023-05-06 01:51:12 +0000:[DEBUG] [{UpgradeCluster}] [anthos.(*anthos).upgradeUserCluster:#449] - Successfully upgraded the user cluster%!(EXTRA string=Successfully upgraded the user cluster)
2023-05-06 01:51:12 +0000:[INFO] [{UpgradeCluster}] [anthos.(*anthos).UpgradeScheduler:#256] - Anthos user cluster took: 1h3m56.584410302s time to complete the upgrade
2023-05-06 01:51:12 +0000:[INFO] [{UpgradeCluster}] [k8s.(*K8s).parseK8SNode:#803] - Parsed node [tp-test-anthos-0] as Type: Worker, Zone: , Region 
2023-05-06 01:51:12 +0000:[INFO] [{UpgradeCluster}] [k8s.(*K8s).parseK8SNode:#803] - Parsed node [tp-test-anthos-1] as Type: Worker, Zone: , Region 
2023-05-06 01:51:12 +0000:[INFO] [{UpgradeCluster}] [k8s.(*K8s).parseK8SNode:#803] - Parsed node [tp-test-anthos-3] as Type: Worker, Zone: , Region 
2023-05-06 01:51:12 +0000:[INFO] [{UpgradeCluster}] [k8s.(*K8s).parseK8SNode:#803] - Parsed node [tp-test-anthos-4] as Type: Worker, Zone: , Region 
2023-05-06 01:51:12 +0000:[INFO] [{UpgradeCluster}] [anthos.(*anthos).UpgradeAdminCluster:#268] - Upgrading admin cluster
2023-05-06 01:51:12 +0000:[INFO] [{UpgradeCluster}] [anthos.(*anthos).upgradeAdminCluster:#455] - Upgrading admin cluster to a newer version: 1.12.5-gke.34
[36mINFO[0m[2023-05-06 01:56:10] sched stats: workers: current=10, started=10, exited=0 
[36mINFO[0m[2023-05-06 01:56:10] sched stats: tick interval: 4807 < 1.2s (100%) 
[36mINFO[0m[2023-05-06 01:56:10] sched stats: tick process durations: 4806 < 500ms (100%) 
[36mINFO[0m[2023-05-06 02:06:11] sched stats: workers: current=10, started=10, exited=0 
[36mINFO[0m[2023-05-06 02:06:11] sched stats: tick interval: 5408 < 1.2s (100%) 
[36mINFO[0m[2023-05-06 02:06:11] sched stats: tick process durations: 5407 < 500ms (100%) 
[36mINFO[0m[2023-05-06 02:16:11] sched stats: workers: current=10, started=10, exited=0 
[36mINFO[0m[2023-05-06 02:16:11] sched stats: tick interval: 6008 < 1.2s (100%) 
[36mINFO[0m[2023-05-06 02:16:11] sched stats: tick process durations: 6007 < 500ms (100%) 
[36mINFO[0m[2023-05-06 02:26:12] sched stats: workers: current=10, started=10, exited=0 
[36mINFO[0m[2023-05-06 02:26:12] sched stats: tick interval: 6609 < 1.2s (100%) 
[36mINFO[0m[2023-05-06 02:26:12] sched stats: tick process durations: 6608 < 500ms (100%) 
[36mINFO[0m[2023-05-06 02:36:13] sched stats: workers: current=10, started=10, exited=0 
[36mINFO[0m[2023-05-06 02:36:13] sched stats: tick interval: 7210 < 1.2s (100%) 
[36mINFO[0m[2023-05-06 02:36:13] sched stats: tick process durations: 7209 < 500ms (100%) 
[36mINFO[0m[2023-05-06 02:46:14] sched stats: workers: current=10, started=10, exited=0 
[36mINFO[0m[2023-05-06 02:46:14] sched stats: tick interval: 7811 < 1.2s (100%) 
[36mINFO[0m[2023-05-06 02:46:14] sched stats: tick process durations: 7810 < 500ms (100%) 
[36mINFO[0m[2023-05-06 02:56:15] sched stats: workers: current=10, started=10, exited=0 
[36mINFO[0m[2023-05-06 02:56:15] sched stats: tick interval: 8412 < 1.2s (100%) 
[36mINFO[0m[2023-05-06 02:56:15] sched stats: tick process durations: 8411 < 500ms (100%) 
[36mINFO[0m[2023-05-06 03:06:16] sched stats: workers: current=10, started=10, exited=0 
[36mINFO[0m[2023-05-06 03:06:16] sched stats: tick interval: 9013 < 1.2s (100%) 
[36mINFO[0m[2023-05-06 03:06:16] sched stats: tick process durations: 9012 < 500ms (100%) 
[36mINFO[0m[2023-05-06 03:16:17] sched stats: workers: current=10, started=10, exited=0 
[36mINFO[0m[2023-05-06 03:16:17] sched stats: tick interval: 9614 < 1.2s (100%) 
[36mINFO[0m[2023-05-06 03:16:17] sched stats: tick process durations: 9613 < 500ms (100%) 
2023-05-06 03:22:04 +0000:[INFO] [{UpgradeCluster}] [anthos.(*anthos).UpgradeAdminCluster:#274] - Anthos upgrade took: 1h30m51.822667166s time to complete upgrade from %!t(string=1.11.0-gke.543)o 1.12.5-gke.34 version
2023-05-06 03:22:04 +0000:[INFO] [{UpgradeCluster}] [anthos.(*anthos).updateNodeInstance:#287] - Updating node Instance
2023-05-06 03:22:04 +0000:[DEBUG] [{UpgradeCluster}] [anthos.(*anthos).saveInstance:#313] - Saving instances.json%!(EXTRA string=Saving instances.json)
[1mSTEP[0m: validate storage components

