### PR TITLE
PA-1013: Fix cleanup in RebootNodesWhenBackupsAreInProgress

### DIFF
--- a/tests/backup/backup_resiliency_test.go
+++ b/tests/backup/backup_resiliency_test.go
@@ -1290,6 +1290,10 @@ var _ = Describe("{RebootNodesWhenBackupsAreInProgress}", func() {
 	})
 
 	JustAfterEach(func() {
+		defer func() {
+			err := SetSourceKubeConfig()
+			log.FailOnError(err, "Switching context to source cluster")
+		}()
 		defer EndPxBackupTorpedoTest(contexts)
 		log.InfoD("Check if the rebooted nodes on application cluster are up now")
 		log.Infof("Switching cluster context to destination cluster")
@@ -1312,7 +1316,7 @@ var _ = Describe("{RebootNodesWhenBackupsAreInProgress}", func() {
 		log.Infof("Deleting the deployed applications on application cluster")
 		opts := make(map[string]bool)
 		opts[SkipClusterScopedObjects] = true
-		ValidateAndDestroy(contexts, opts)
+		DestroyApps(contexts, opts)
 		log.Infof("Switching cluster context back to source cluster")
 		err = SetSourceKubeConfig()
 		log.FailOnError(err, "Switching context to source cluster")

--- a/tests/common.go
+++ b/tests/common.go
@@ -1790,6 +1790,16 @@ func ValidateAndDestroy(contexts []*scheduler.Context, opts map[string]bool) {
 	})
 }
 
+// DestroyApps destroy applications without validating them
+func DestroyApps(contexts []*scheduler.Context, opts map[string]bool) {
+	Step("destroy apps", func() {
+		log.InfoD("Destroying apps")
+		for _, ctx := range contexts {
+			TearDownContext(ctx, opts)
+		}
+	})
+}
+
 // AddLabelsOnNode adds labels on the node
 func AddLabelsOnNode(n node.Node, labels map[string]string) error {
 	for labelKey, labelValue := range labels {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Link: https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/px-backup-system-test-rke/100/consoleFull 
Atoes Dashboard: https://aetos.pwx.purestorage.com/resultSet/testSetID/184291

`RebootNodesWhenBackupsAreInProgress` failed on `ValidateAndDestroy` as the postgres pods where not up, post which all the other testcases failed as the subsequent context switch happening [here](https://github.com/portworx/torpedo/blob/master/tests/backup/backup_resiliency_test.go#L1317) wasn't executed.  If I check the current state of the pods in the namespace they are still in `CrashLoopBackOff`:

```
postgres-backup-pxbackuptask-0-05-07-12h53m58s   postgres-646f6f7487-8vfcm                                      0/1     CrashLoopBackOff   258 (105s ago)   15h
```

**Fix done in this PR:**
- [x] Add a func `DestroyApps()` which destroys the apps without validating it. 
- [x] Move the context switch inside `defer func() { }` block. 
- [x] Change the function call from  `ValidateAndDestroy()` to `DestroyApps()` in`RebootNodesWhenBackupsAreInProgress` test. 

Dashboard URL:
https://aetos.pwx.purestorage.com/resultSet/testSetID/185172

Follow up ticket to add validation: https://portworx.atlassian.net/browse/PA-1018

**Which issue(s) this PR fixes** (optional)
Closes # PA-1013

**Special notes for your reviewer**:

