### PR TITLE
Added px-backup upgrade related env variables

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -634,6 +634,10 @@ spec:
       value: "${LOGGLY_API_TOKEN}"
     - name: PODMETRIC_METERING_INTERVAL_MINUTES
       value: "${PODMETRIC_METERING_INTERVAL_MINUTES}"
+    - name: TARGET_PXBACKUP_VERSION
+      value: "${TARGET_PXBACKUP_VERSION}"
+    - name: TARGET_STORK_VERSION
+      value: "${TARGET_STORK_VERSION}"
   volumes: [${VOLUMES}]
   restartPolicy: Never
   serviceAccountName: torpedo-account

--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -42,7 +42,7 @@ const (
 	cloudAccountDeleteRetryTime               = 30 * time.Second
 	storkDeploymentName                       = "stork"
 	defaultStorkDeploymentNamespace           = "kube-system"
-	upgradeStorkImage                         = "UPGRADE_STORK_IMAGE"
+	upgradeStorkImage                         = "TARGET_STORK_VERSION"
 	latestStorkImage                          = "openstorage/stork:23.2.0"
 	restoreNamePrefix                         = "tp-restore"
 	destinationClusterName                    = "destination-cluster"

--- a/tests/backup/backup_upgrade_test.go
+++ b/tests/backup/backup_upgrade_test.go
@@ -452,7 +452,7 @@ var _ = Describe("{PXBackupEndToEndBackupAndRestoreWithUpgrade}", func() {
 			log.Infof("First schedule backup name: [%s]", firstScheduleBackupName)
 		})
 		Step("Upgrading px-backup", func() {
-			latestPxBackupVersionFromEnv := os.Getenv("LATEST_PXBACKUP_VERSION")
+			latestPxBackupVersionFromEnv := os.Getenv("TARGET_PXBACKUP_VERSION")
 			if latestPxBackupVersionFromEnv == "" {
 				latestPxBackupVersionFromEnv = latestPxBackupVersion
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
Added px-backup upgrade related env varibales LATEST_PXBACKUP_VERSION & UPGRADE_STORK_IMAGE which is required for upgrade pipelines
**Which issue(s) this PR fixes** (optional)
Closes #PA-1002

