### PR TITLE
[PA-1112] Add ScheduleWithCustomAppSpecs

### DIFF
--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -868,6 +868,50 @@ func (k *K8s) Schedule(instanceID string, options scheduler.ScheduleOptions) ([]
 	return contexts, nil
 }
 
+// ScheduleWithCustomAppSpecs Schedules the application with custom app specs
+func (k *K8s) ScheduleWithCustomAppSpecs(apps []*spec.AppSpec, instanceID string, options scheduler.ScheduleOptions) ([]*scheduler.Context, error) {
+	var contexts []*scheduler.Context
+	oldOptionsNamespace := options.Namespace
+	for _, app := range apps {
+
+		appNamespace := app.GetID(instanceID)
+		if options.Namespace != "" {
+			appNamespace = options.Namespace
+		} else {
+			options.Namespace = appNamespace
+		}
+		if len(options.TopologyLabels) > 1 {
+			rotateTopologyArray(&options)
+		}
+
+		specObjects, err := k.CreateSpecObjects(app, appNamespace, options)
+		if err != nil {
+			return nil, err
+		}
+
+		helmSpecObjects, err := k.HelmSchedule(app, appNamespace, options)
+		if err != nil {
+			return nil, err
+		}
+
+		specObjects = append(specObjects, helmSpecObjects...)
+		ctx := &scheduler.Context{
+			UID: instanceID,
+			App: &spec.AppSpec{
+				Key:      app.Key,
+				SpecList: specObjects,
+				Enabled:  app.Enabled,
+			},
+			ScheduleOptions: options,
+		}
+
+		contexts = append(contexts, ctx)
+		options.Namespace = oldOptionsNamespace
+	}
+
+	return contexts, nil
+}
+
 // CreateSpecObjects Create application
 func (k *K8s) CreateSpecObjects(app *spec.AppSpec, namespace string, options scheduler.ScheduleOptions) ([]interface{}, error) {
 	var specObjects []interface{}

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -166,6 +166,9 @@ type Driver interface {
 	// Schedule starts applications and returns a context for each one of them
 	Schedule(instanceID string, opts ScheduleOptions) ([]*Context, error)
 
+	// ScheduleWithCustomAppSpecs starts applications with custom app specs and returns a context for each one of them
+	ScheduleWithCustomAppSpecs(apps []*spec.AppSpec, instanceID string, options ScheduleOptions) ([]*Context, error)
+
 	// WaitForRunning waits for application to start running.
 	WaitForRunning(cc *Context, timeout, retryInterval time.Duration) error
 

--- a/tests/common.go
+++ b/tests/common.go
@@ -1522,8 +1522,11 @@ func DeleteVolumesAndWait(ctx *scheduler.Context, options *scheduler.VolumeOptio
 }
 
 // GetAppNamespace returns namespace in which context is created
-func GetAppNamespace(ctx *scheduler.Context, taskname string) string {
-	return ctx.App.GetID(fmt.Sprintf("%s-%s", taskname, Inst().InstanceID))
+func GetAppNamespace(ctx *scheduler.Context, taskName string) string {
+	if ctx.ScheduleOptions.Namespace == "" {
+		return ctx.App.GetID(fmt.Sprintf("%s-%s", taskName, Inst().InstanceID))
+	}
+	return ctx.ScheduleOptions.Namespace
 }
 
 // GetAppStorageClasses gets the storage classes belonging to an app's PVCs


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR implments a new ScheduleWithCustomAppSpecs function based on Schedule function to allow the use of custom app specifications. It makes it possible to deploy applications multiple times in the same namespace without needing to manually modify YAML files.

**Which issue(s) this PR fixes** (optional)
Closes #PA-1112

**Special notes for your reviewer**:
Please review the Jenkins build of the "BasicBackupCreation" test case using the link below

https://jenkins.pwx.dev.purestorage.com/job/Users/job/Sumit/job/Custom-Pipelines/job/px-backup-on-demand-system-test-byoc/1343

Aetos Dashboard: https://aetos.pwx.purestorage.com/resultSet/testSetID/189178