### PR TITLE
Fix torpedo upgrade issue in Anthos scheduler

### DIFF
--- a/drivers/scheduler/anthos/anthos.go
+++ b/drivers/scheduler/anthos/anthos.go
@@ -257,7 +257,6 @@ func (anth *anthos) UpgradeScheduler(version string) error {
 	if err := anth.invokeUpgradeAdminCluster(version); err != nil {
 		return err
 	}
-	// Update node registry after admin cluster upgrade
 	if err := anth.RefreshNodeRegistry(); err != nil {
 		return err
 	}

--- a/drivers/scheduler/anthos/anthos.go
+++ b/drivers/scheduler/anthos/anthos.go
@@ -22,60 +22,60 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-type gcp struct {
+type Gcp struct {
 	ComponentAccessServiceAccountKeyPath string `yaml:"componentAccessServiceAccountKeyPath"`
 }
 
-type hostConfig struct {
-	ip      string   `yaml:"ip"`
-	gateway string   `yaml:"gateway"`
-	netmask string   `yaml:"netmask"`
-	dns     []string `yaml:"dns"`
+type HostConfig struct {
+	Ip      string   `yaml:"ip"`
+	Gateway string   `yaml:"gateway"`
+	Netmask string   `yaml:"netmask"`
+	Dns     []string `yaml:"dns"`
 }
 
 type Network struct {
-	ipAllocationMode string     `yaml:"ipAllocationMode"`
-	hostConfig       hostConfig `yaml:"hostconfig"`
+	IpAllocationMode string     `yaml:"ipAllocationMode"`
+	HostConfig       HostConfig `yaml:"hostconfig"`
 }
 
 type Workstation struct {
-	cpus         int     `yaml:"cpus"`
-	diskGB       int     `yaml:"diskGB"`
-	dataDiskMB   int     `yaml:"dataDiskMB"`
-	dataDiskName string  `yaml:"dataDiskName"`
-	memoryMB     int     `yaml:"memoryMB"`
-	name         string  `yaml:"name"`
-	network      Network `yaml:"network"`
-	ntpServer    string  `yaml:"ntpServer"`
-	proxyUrl     string  `yaml:"proxyUrl"`
+	Cpus         int     `yaml:"cpus"`
+	DiskGB       int     `yaml:"diskGB"`
+	DataDiskMB   int     `yaml:"dataDiskMB"`
+	DataDiskName string  `yaml:"dataDiskName"`
+	MemoryMB     int     `yaml:"memoryMB"`
+	Name         string  `yaml:"name"`
+	Network      Network `yaml:"network"`
+	NtpServer    string  `yaml:"ntpServer"`
+	ProxyUrl     string  `yaml:"proxyUrl"`
 }
 
 type FileRef struct {
-	entry string `yaml:"entry"`
-	path  string `yaml:"path"`
+	Entry string `yaml:"entry"`
+	Path  string `yaml:"path"`
 }
 
-type credentials struct {
-	address string  `yaml:"address"`
-	fileRef FileRef `yaml:"fileRef"`
+type Credentials struct {
+	Address string  `yaml:"address"`
+	FileRef FileRef `yaml:"fileRef"`
 }
 
-type VCenter struct {
-	caCertPath   string      `yaml:"caCertPath"`
-	cluster      string      `yaml:"cluster"`
-	credentials  credentials `yaml:"credentials"`
-	datacenter   string      `yaml:"datacenter"`
-	datastore    string      `yaml:"datastore"`
-	folder       string      `yaml:"folder"`
-	network      string      `yaml:"network"`
-	resourcePool string      `yaml:"resourcePool"`
+type vCenter struct {
+	CaCertPath   string      `yaml:"caCertPath"`
+	Cluster      string      `yaml:"cluster"`
+	Credentials  Credentials `yaml:"credentials"`
+	Datacenter   string      `yaml:"datacenter"`
+	Datastore    string      `yaml:"datastore"`
+	Folder       string      `yaml:"folder"`
+	Network      string      `yaml:"network"`
+	ResourcePool string      `yaml:"resourcePool"`
 }
 
 type AdminWorkstation struct {
-	adminWorkstation Workstation `yaml:"adminWorkstation"`
-	gcp              gcp         `yaml:"gcp"`
-	proxyUrl         string      `yaml:"proxyUrl"`
-	vCenter          VCenter     `yaml:"vCenter"`
+	AdminWorkstation Workstation `yaml:"adminWorkstation"`
+	Gcp              Gcp         `yaml:"gcp"`
+	ProxyUrl         string      `yaml:"proxyUrl"`
+	VCenter          vCenter     `yaml:"vCenter"`
 }
 
 const (
@@ -254,10 +254,11 @@ func (anth *anthos) UpgradeScheduler(version string) error {
 	}
 	timeTaken := time.Since(startTime)
 	log.Infof("Anthos user cluster took: %v time to complete the upgrade", timeTaken)
-	if err := anth.RefreshNodeRegistry(); err != nil {
+	if err := anth.invokeUpgradeAdminCluster(version); err != nil {
 		return err
 	}
-	if err := anth.invokeUpgradeAdminCluster(version); err != nil {
+	// Update node registry after admin cluster upgrade
+	if err := anth.RefreshNodeRegistry(); err != nil {
 		return err
 	}
 	return nil
@@ -271,7 +272,7 @@ func (anth *anthos) invokeUpgradeAdminCluster(version string) error {
 		return err
 	}
 	timeTaken := time.Since(initTime)
-	log.Infof("Anthos upgrade took: %v time to complete upgrade from % to %s version",
+	log.Infof("Anthos upgrade took: %v time to complete upgrade from %s to %s version",
 		timeTaken, anth.version, version)
 	if err := anth.updateNodeInstance(); err != nil {
 		return err
@@ -491,9 +492,9 @@ func (anth *anthos) updateAdminWorkstationNode() error {
 	if err != nil {
 		return err
 	}
-	admWSObj.gcp.ComponentAccessServiceAccountKeyPath = path.Join(anth.instPath, gcpAccessFile)
-	admWSObj.vCenter.credentials.fileRef.path = path.Join(anth.confPath, vcenterCredFile)
-	admWSObj.vCenter.caCertPath = path.Join(anth.confPath, vcenterCrtFile)
+	admWSObj.Gcp.ComponentAccessServiceAccountKeyPath = path.Join(anth.instPath, gcpAccessFile)
+	admWSObj.VCenter.Credentials.FileRef.Path = path.Join(anth.confPath, vcenterCredFile)
+	admWSObj.VCenter.CaCertPath = path.Join(anth.confPath, vcenterCrtFile)
 	out, err := yaml.Marshal(&admWSObj)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix torpedo upgrade issue in Anthos scheduler because of Struct fields

**Which issue(s) this PR fixes** (optional)
Closes # PTX-17660

**Special notes for your reviewer**:
Minor changes, tested locally 
`
package main

import (
	"fmt"

	"gopkg.in/yaml.v3"
)

type Gcp struct {
	ComponentAccessServiceAccountKeyPath string `yaml:"componentAccessServiceAccountKeyPath"`
}

type HostConfig struct {
	Ip      string   `yaml:"ip"`
	Gateway string   `yaml:"gateway"`
	Netmask string   `yaml:"netmask"`
	dns     []string `yaml:"dns"`
}

type Network struct {
	IpAllocationMode string     `yaml:"ipAllocationMode"`
	HostConfig       HostConfig `yaml:"hostconfig"`
}

type Workstation struct {
	Cpus         int     `yaml:"cpus"`
	DiskGB       int     `yaml:"diskGB"`
	DataDiskMB   int     `yaml:"dataDiskMB"`
	DataDiskName string  `yaml:"dataDiskName"`
	MemoryMB     int     `yaml:"memoryMB"`
	Name         string  `yaml:"name"`
	Network      Network `yaml:"network"`
	NtpServer    string  `yaml:"ntpServer"`
	ProxyUrl     string  `yaml:"proxyUrl"`
}

type FileRef struct {
	Entry string `yaml:"entry"`
	Path  string `yaml:"path"`
}

type Credentials struct {
	Address string  `yaml:"address"`
	FileRef FileRef `yaml:"fileRef"`
}

type VCenter struct {
	CaCertPath   string      `yaml:"caCertPath"`
	Cluster      string      `yaml:"cluster"`
	Credentials  Credentials `yaml:"credentials"`
	Datacenter   string      `yaml:"datacenter"`
	Datastore    string      `yaml:"datastore"`
	Folder       string      `yaml:"folder"`
	Network      string      `yaml:"network"`
	ResourcePool string      `yaml:"resourcePool"`
}

type AdminWorkstation struct {
	AdminWorkstation Workstation `yaml:"adminWorkstation"`
	Gcp              Gcp         `yaml:"gcp"`
	ProxyUrl         string      `yaml:"proxyUrl"`
	VCenter          VCenter     `yaml:"vCenter"`
}

func main() {
	adminWs := `
adminWorkstation:
  cpus: 4
  diskGB: 50
  dataDiskMB: 512
  dataDiskName: gke-on-prem-admin-workstation-data-disk/gke-admin-ws-230508-185720-data-disk.vmdk
  memoryMB: 8192
  name: tp-test-anthos-224-224-admin-ws-node
  network:
    ipAllocationMode: static
    hostconfig:
      ip: 10.13.11.219
      gateway: 10.13.8.1
      netmask: 255.255.240.0
      dns:
      - 10.7.32.53
      - 10.7.32.31
      - 10.13.28.11
      - 10.13.28.12
  ntpServer: ntp.ubuntu.com
  proxyUrl: ""
gcp:
  componentAccessServiceAccountKeyPath: /root/workspace/Users/Smit/tp-test-anthos/spawn/my-px-access.json
proxyUrl: ""
vCenter:
  caCertPath: /root/workspace/Users/Smit/tp-test-anthos/spawn/k8s/clusterGroup0/vcenter.crt
  cluster: FA-FC-39DS3
  credentials:
    address: vcsa.pwx.dev.purestorage.com
    fileRef:
      entry: vCenter
      path: /root/workspace/Users/Smit/tp-test-anthos/spawn/k8s/clusterGroup0/credential.yaml
  datacenter: CNBU
  datastore: ms500-39-DS3-FAFC
  folder: ""
  network: QA-1
  resourcePool: FA-FC-N1-RP
`
	b := []byte(adminWs)
	var admWSObj AdminWorkstation
	err := yaml.Unmarshal(b, &admWSObj)
	if err != nil {
		fmt.Printf("err: %v", err)
	}
	fmt.Println("b=", admWSObj)
	admWSObj.Gcp.ComponentAccessServiceAccountKeyPath = "/root/mytestpath/gcp.json"
	admWSObj.VCenter.Credentials.FileRef.Path = "/root/cred.yaml"
	admWSObj.VCenter.CaCertPath = "/root/vcenter.crt"
	out, err := yaml.Marshal(&admWSObj)
	fmt.Println("output=", string(out))

}


Output
==========
b= {{4 50 512 gke-on-prem-admin-workstation-data-disk/gke-admin-ws-230508-185720-data-disk.vmdk 8192 tp-test-anthos-224-224-admin-ws-node {static {10.13.11.219 10.13.8.1 255.255.240.0 []}} ntp.ubuntu.com } {/root/workspace/Users/Smit/tp-test-anthos/spawn/my-px-access.json}  {/root/workspace/Users/Smit/tp-test-anthos/spawn/k8s/clusterGroup0/vcenter.crt FA-FC-39DS3 {vcsa.pwx.dev.purestorage.com {vCenter /root/workspace/Users/Smit/tp-test-anthos/spawn/k8s/clusterGroup0/credential.yaml}} CNBU ms500-39-DS3-FAFC  QA-1 FA-FC-N1-RP}}


output= adminWorkstation:
    cpus: 4
    diskGB: 50
    dataDiskMB: 512
    dataDiskName: gke-on-prem-admin-workstation-data-disk/gke-admin-ws-230508-185720-data-disk.vmdk
    memoryMB: 8192
    name: tp-test-anthos-224-224-admin-ws-node
    network:
        ipAllocationMode: static
        hostconfig:
            ip: 10.13.11.219
            gateway: 10.13.8.1
            netmask: 255.255.240.0
    ntpServer: ntp.ubuntu.com
    proxyUrl: ""
gcp:
    componentAccessServiceAccountKeyPath: /root/mytestpath/gcp.json
proxyUrl: ""
vCenter:
    caCertPath: /root/vcenter.crt
    cluster: FA-FC-39DS3
    credentials:
        address: vcsa.pwx.dev.purestorage.com
        fileRef:
            entry: vCenter
            path: /root/cred.yaml
    datacenter: CNBU
    datastore: ms500-39-DS3-FAFC
    folder: ""
    network: QA-1
    resourcePool: FA-FC-N1-RP
`

