### PR TITLE
PWX-30979: Reduces pool resize timeout from 6 hours to 1

### DIFF
--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	replicationUpdateTimeout = 4 * time.Hour
-	poolResizeTimeout        = time.Minute * 360
+	poolResizeTimeout        = time.Minute * 60
 	retryTimeout             = time.Minute * 2
 	addDriveUpTimeOut        = time.Minute * 15
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Pool resizes should not take 6 hours to complete: if they do, something is very wrong. Reduced this to a still long, but more reasonable 1 hour.


