### PR TITLE
[PA-997] Add support for NFS Backup Location Addition

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -659,6 +659,14 @@ spec:
       value: "${PX_BACKUP_HELM_REPO_BRANCH}"
     - name: BACKUP_TYPE
       value: "${BACKUP_TYPE}"
+    - name: NFS_SERVER_ADDR
+      value: "${NFS_SERVER_ADDR}"
+    - name: NFS_SUB_PATH
+      value: "${NFS_SUB_PATH}"
+    - name: NFS_MOUNT_OPTION
+      value: "${NFS_MOUNT_OPTION}"
+    - name: NFS_PATH
+      value: "${NFS_PATH}"
   volumes: [${VOLUMES}]
   restartPolicy: Never
   serviceAccountName: torpedo-account

--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -9,6 +9,8 @@ const (
 	ProviderGke = "gke"
 	// ProviderPortworx for portworx provider
 	ProviderPortworx = "pxd"
+	// ProviderNfs for nfs provider
+	ProviderNfs = "nfs"
 )
 
 // Driver specifies the most basic methods to be implemented by a Torpedo driver.

--- a/tests/backup/backup_basic_test.go
+++ b/tests/backup/backup_basic_test.go
@@ -36,6 +36,8 @@ func getGlobalBucketName(provider string) string {
 		return globalAzureBucketName
 	case drivers.ProviderGke:
 		return globalGCPBucketName
+	case drivers.ProviderNfs:
+		return globalNFSBucketName
 	default:
 		return globalAWSBucketName
 	}
@@ -147,6 +149,8 @@ var _ = BeforeSuite(func() {
 			globalGCPBucketName = fmt.Sprintf("%s-%s", globalGCPBucketPrefix, bucketNameSuffix)
 			CreateBucket(provider, globalGCPBucketName)
 			log.Infof("Bucket created with name - %s", globalGCPBucketName)
+		case drivers.ProviderNfs:
+			globalNFSBucketName = fmt.Sprintf("%s-%s", globalNFSBucketPrefix, bucketNameSuffix)
 		}
 	}
 	lockedBucketNameSuffix, present := os.LookupEnv("LOCKED_BUCKET_NAME")

--- a/tests/common.go
+++ b/tests/common.go
@@ -3522,6 +3522,8 @@ func CreateBackupLocation(provider, name, uid, credName, credUID, bucketName, or
 		err = CreateS3BackupLocation(name, uid, credName, credUID, bucketName, orgID, encryptionKey)
 	case drivers.ProviderAzure:
 		err = CreateAzureBackupLocation(name, uid, credName, CloudCredUID, bucketName, orgID)
+	case drivers.ProviderNfs:
+		err = CreateNFSBackupLocation(name, uid, orgID, encryptionKey, true)
 	}
 	return err
 }
@@ -3618,6 +3620,9 @@ func CreateCloudCredential(provider, credName string, uid, orgID string, ctx con
 				},
 			},
 		}
+	case drivers.ProviderNfs:
+		log.Warnf("provider [%s] does not require creating cloud credential", provider)
+		return nil
 	default:
 		return fmt.Errorf("provider [%s] not supported for creating cloud credential", provider)
 	}
@@ -3735,6 +3740,82 @@ func CreateAzureBackupLocation(name string, uid string, cloudCred string, cloudC
 	_, err = backupDriver.CreateBackupLocation(ctx, bLocationCreateReq)
 	if err != nil {
 		return fmt.Errorf("failed to create backup location Error: %v", err)
+	}
+	return nil
+}
+
+// WaitForBackupLocationAddition waits for backup location to be added successfully
+// or till timeout is reached. API should poll every `timeBeforeRetry` duration
+func WaitForBackupLocationAddition(
+	ctx context1.Context,
+	backupLocationName,
+	UID,
+	orgID string,
+	timeout time.Duration,
+	timeBeforeRetry time.Duration,
+) error {
+	req := &api.BackupLocationInspectRequest{
+		Name:  backupLocationName,
+		Uid:   UID,
+		OrgId: orgID,
+	}
+	f := func() (interface{}, bool, error) {
+		inspectBlResp, err := Inst().Backup.InspectBackupLocation(ctx, req)
+		if err != nil {
+			return "", true, err
+		}
+		actual := inspectBlResp.GetBackupLocation().GetBackupLocationInfo().GetStatus().GetStatus()
+		if actual == api.BackupLocationInfo_StatusInfo_Valid {
+			return "", false, nil
+		}
+		return "", true, fmt.Errorf("backup location status for [%s] expected was [%s] but got [%s]", backupLocationName, api.BackupLocationInfo_StatusInfo_Valid, actual)
+	}
+	_, err := task.DoRetryWithTimeout(f, timeout, timeBeforeRetry)
+	if err != nil {
+		return fmt.Errorf("failed to wait for backup location addition. Error:[%v]", err)
+	}
+	return nil
+}
+
+// CreateNFSBackupLocation creates backup location for nfs
+func CreateNFSBackupLocation(name string, uid string, orgID string, encryptionKey string, validate bool) error {
+	serverAddr := os.Getenv("NFS_SERVER_ADDR")
+	subPath := os.Getenv("NFS_SUB_PATH")
+	mountOption := os.Getenv("NFS_MOUNT_OPTION")
+	path := os.Getenv("NFS_PATH")
+	backupDriver := Inst().Backup
+	bLocationCreateReq := &api.BackupLocationCreateRequest{
+		CreateMetadata: &api.CreateMetadata{
+			Name:  name,
+			OrgId: orgID,
+			Uid:   uid,
+		},
+		BackupLocation: &api.BackupLocationInfo{
+			Config: &api.BackupLocationInfo_NfsConfig{
+				NfsConfig: &api.NFSConfig{
+					ServerAddr:  serverAddr,
+					SubPath:     subPath,
+					MountOption: mountOption,
+				},
+			},
+			Path:          path,
+			Type:          api.BackupLocationInfo_NFS,
+			EncryptionKey: encryptionKey,
+		},
+	}
+	ctx, err := backup.GetAdminCtxFromSecret()
+	if err != nil {
+		return err
+	}
+	_, err = backupDriver.CreateBackupLocation(ctx, bLocationCreateReq)
+	if err != nil {
+		return fmt.Errorf("failed to create backup location Error: %v", err)
+	}
+	if validate {
+		err = WaitForBackupLocationAddition(ctx, name, uid, orgID, defaultTimeout, defaultRetryInterval)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR makes changes to support NFS Backup Location addition. This will help improve the test coverage.

**Which issue(s) this PR fixes** (optional)
Closes #PA-997,PA-1158

**Special notes for your reviewer**:
~~As of the time of writing, deleting backups in the NFS Backup Location is not supported, making it impossible to run tests involving the deletion of created backups.~~

Please review the Jenkins build for the "BasicBackupCreation" test case using the link below

~~https://jenkins.pwx.dev.purestorage.com/job/Users/job/Sumit/job/Custom-Pipelines/job/px-backup-on-demand-system-test-byoc/1431/ (hard-coded parameters)~~

~~Aetos Dashboard: https://aetos.pwx.purestorage.com/resultSet/testSetID/203298~~

Thanks to the efforts of @ak-px, the "BasicBackupCreation" test case was successfully executed using a dedicated BYOC pipeline for NFS backup location. Please review the following Jenkins builds:

https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/NFS/job/PX-Backup-System-Test-(BYOC)-NFS/7

Aetos Dashboard: https://aetos.pwx.purestorage.com/resultSet/testSetID/208325

https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/NFS/job/PX-Backup-System-Test-(BYOC)-NFS/8 (FB NFS Endpoint)

Aetos Dashboard: https://aetos.pwx.purestorage.com/resultSet/testSetID/208332