### PR TITLE
PA-1127: Collect MongoDB logs in `UpgradePxBackup()`

### DIFF
--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -2092,6 +2092,10 @@ func ValidateAllPodsInPxBackupNamespace() error {
 		log.Infof("Checking status for pod - %s", pod.GetName())
 		err = core.Instance().ValidatePod(&pod, 5*time.Minute, 30*time.Second)
 		if err != nil {
+			// Collect mongoDB logs right after the command
+			ginkgoTest := CurrentGinkgoTestDescription()
+			testCaseName := fmt.Sprintf("%s-error", ginkgoTest.FullTestText)
+			CollectMongoDBLogs(testCaseName)
 			return err
 		}
 	}

--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -2004,6 +2004,11 @@ func UpgradePxBackup(versionToUpgrade string) error {
 	}
 	log.Infof("Terminal output: %s", output)
 
+	// Collect mongoDB logs right after the command
+	ginkgoTest := CurrentGinkgoTestDescription()
+	testCaseName := fmt.Sprintf("%s-start", ginkgoTest.FullTestText)
+	CollectMongoDBLogs(testCaseName)
+
 	// Wait for post install hook job to be completed
 	postInstallHookJobCompletedCheck := func() (interface{}, bool, error) {
 		job, err := batch.Instance().GetJob(pxCentralPostInstallHookJobName, pxBackupNamespace)
@@ -2026,6 +2031,11 @@ func UpgradePxBackup(versionToUpgrade string) error {
 	if err != nil {
 		return err
 	}
+
+	// Collect mongoDB logs once the postInstallHook is completed
+	ginkgoTest = CurrentGinkgoTestDescription()
+	testCaseName = fmt.Sprintf("%s-end", ginkgoTest.FullTestText)
+	CollectMongoDBLogs(testCaseName)
 
 	pxBackupUpgradeEndTime := time.Now()
 	pxBackupUpgradeDuration := pxBackupUpgradeEndTime.Sub(pxBackupUpgradeStartTime)

--- a/tests/common.go
+++ b/tests/common.go
@@ -5062,7 +5062,7 @@ func collectStorkLogs(testCaseName string) {
 	collectLogsFromPods(testCaseName, storkLabel, pxNamespace, "stork")
 }
 
-// collectMongoDBLogs collects MongoDB logs and stores them using the collectLogsFromPods function
+// CollectMongoDBLogs collects MongoDB logs and stores them using the collectLogsFromPods function
 func CollectMongoDBLogs(testCaseName string) {
 	pxbLabel := make(map[string]string)
 	pxbLabel["app.kubernetes.io/component"] = "pxc-backup-mongodb"

--- a/tests/common.go
+++ b/tests/common.go
@@ -255,6 +255,7 @@ const (
 	SchedulePolicyAllName             = "schedule-policy-all"
 	SchedulePolicyScaleName           = "schedule-policy-scale"
 	BucketNamePrefix                  = "tp-backup-bucket"
+	mongodbStatefulset                = "pxc-backup-mongodb"
 )
 
 const (
@@ -5065,7 +5066,7 @@ func collectStorkLogs(testCaseName string) {
 // CollectMongoDBLogs collects MongoDB logs and stores them using the collectLogsFromPods function
 func CollectMongoDBLogs(testCaseName string) {
 	pxbLabel := make(map[string]string)
-	pxbLabel["app.kubernetes.io/component"] = "pxc-backup-mongodb"
+	pxbLabel["app.kubernetes.io/component"] = mongodbStatefulset
 	pxbNamespace, err := backup.GetPxBackupNamespace()
 	if err != nil {
 		log.Errorf("Error in getting px-backup namespace. Err: %v", err.Error())

--- a/tests/common.go
+++ b/tests/common.go
@@ -5062,6 +5062,18 @@ func collectStorkLogs(testCaseName string) {
 	collectLogsFromPods(testCaseName, storkLabel, pxNamespace, "stork")
 }
 
+// collectMongoDBLogs collects MongoDB logs and stores them using the collectLogsFromPods function
+func CollectMongoDBLogs(testCaseName string) {
+	pxbLabel := make(map[string]string)
+	pxbLabel["app.kubernetes.io/component"] = "pxc-backup-mongodb"
+	pxbNamespace, err := backup.GetPxBackupNamespace()
+	if err != nil {
+		log.Errorf("Error in getting px-backup namespace. Err: %v", err.Error())
+		return
+	}
+	collectLogsFromPods(testCaseName, pxbLabel, pxbNamespace, "mongodb")
+}
+
 // collectPxBackupLogs collects Px-Backup logs and stores them using the collectLogsFromPods function
 func collectPxBackupLogs(testCaseName string) {
 	pxbLabel := make(map[string]string)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
- [x] Add `CollectMongoDBLogs()` in common.go
- [x] Add calls to `CollectMongoDBLogs()` in `UpgradePxBackup()` right after helm command and once post install hook is done. 

Dashboard URL : https://aetos.pwx.purestorage.com/resultSet/testSetID/198113
```
[root@ip-10-13-205-221 px-backup-test-logs]# ls *
{PXBackupEndToEndBackupAndRestoreWithUpgrade}PX-BackupEnd-to-EndBackupandRestorewithUpgrade-end-logs:
pxc-backup-mongodb-0.log  pxc-backup-mongodb-1.log  pxc-backup-mongodb-2.log

{PXBackupEndToEndBackupAndRestoreWithUpgrade}PX-BackupEnd-to-EndBackupandRestorewithUpgrade-start-logs:
pxc-backup-mongodb-0.log  pxc-backup-mongodb-1.log  pxc-backup-mongodb-2.log
[root@ip-10-13-205-221 px-backup-test-logs]# ls 
{PXBackupEndToEndBackupAndRestoreWithUpgrade}PX-BackupEnd-to-EndBackupandRestorewithUpgrade-end-logs
{PXBackupEndToEndBackupAndRestoreWithUpgrade}PX-BackupEnd-to-EndBackupandRestorewithUpgrade-start-logs
[root@ip-10-13-205-221 px-backup-test-logs]# 

```


**Which issue(s) this PR fixes** (optional)
Closes #PA-1127 

**Special notes for your reviewer**:

