### PR TITLE
Replacing ValidateBackupCluster function

### DIFF
--- a/drivers/backup/backup.go
+++ b/drivers/backup/backup.go
@@ -132,9 +132,6 @@ type Cluster interface {
 		timeBeforeRetry time.Duration,
 	) error
 
-	// ValidateBackupCluster validates if backup pods are up or not
-	ValidateBackupCluster() error
-
 	// GetClusterUID returns uid of the given cluster name in an organization
 	GetClusterUID(ctx context.Context, orgID string, clusterName string) (string, error)
 

--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -24,7 +24,7 @@ var _ = Describe("{BackupClusterVerification}", func() {
 	It("Backup Cluster Verification", func() {
 		Step("Check the status of backup pods", func() {
 			log.InfoD("Check the status of backup pods")
-			err := Inst().Backup.ValidateBackupCluster()
+			err := ValidateAllPodsInPxBackupNamespace()
 			dash.VerifyFatal(err, nil, "Backup Cluster Verification successful")
 		})
 	})

--- a/tests/common.go
+++ b/tests/common.go
@@ -14,8 +14,6 @@ import (
 	"net/http"
 	"regexp"
 
-
-
 	"github.com/portworx/sched-ops/k8s/apps"
 	"github.com/portworx/torpedo/drivers/pds"
 	"github.com/portworx/torpedo/pkg/aetosutil"


### PR DESCRIPTION
**What this PR does / why we need it**:
The function `ValidateBackupCluster` was written during the early days of backup automation when we dint not have a separate `backup_helper.go`. During the creation of upgrade test case we wrote a function `ValidateAllPodsInPxBackupNamespace` which does the exact same thing, so we are finally retiring `ValidateBackupCluster`

**Which issue(s) this PR fixes** (optional)
Closes #PA-777

**Special notes for your reviewer**:
[Jenkins Run](https://jenkins.pwx.dev.purestorage.com/job/Users/job/Sumit/job/Custom-Pipelines/job/px-backup-on-demand-system-test-byoc/1413/)

