### PR TITLE
Resiliency Test to kill teleport pod during deployment

### DIFF
--- a/drivers/pds/lib/resiliency_utils.go
+++ b/drivers/pds/lib/resiliency_utils.go
@@ -23,6 +23,7 @@ import (
 const (
 	PdsDeploymentControllerManagerPod = "pds-deployment-controller-manager"
 	PdsAgentPod                       = "pds-agent"
+	PdsTeleportPod                    = "pds-teleport"
 	ActiveNodeRebootDuringDeployment  = "active-node-reboot-during-deployment"
 	KillDeploymentControllerPod       = "kill-deployment-controller-pod-during-deployment"
 	RestartPxDuringDSScaleUp          = "restart-portworx-during-ds-scaleup"
@@ -31,6 +32,7 @@ const (
 	RestartAppDuringResourceUpdate    = "restart-app-during-resource-update"
 	UpdateTemplate                    = "medium"
 	RebootNodeDuringAppVersionUpdate  = "reboot-node-during-app-version-update"
+	KillTeleportPodDuringDeployment   = "kill-teleport-pod-during-deployment"
 )
 
 // PDS vars
@@ -163,6 +165,16 @@ func InduceFailureAfterWaitingForCondition(deployment *pds.ModelsDeployment, nam
 		}
 		ExecuteInParallel(func1, func2)
 	case KillAgentPodDuringDeployment:
+		checkTillReplica = CheckTillReplica
+		log.InfoD("Entering to check if Data service has %v active pods. Once it does, we will kill the Agent Pod.", checkTillReplica)
+		func1 := func() {
+			GetPdsSs(deployment.GetClusterResourceName(), namespace, checkTillReplica)
+		}
+		func2 := func() {
+			InduceFailure(FailureType.Type, namespace)
+		}
+		ExecuteInParallel(func1, func2)
+	case KillTeleportPodDuringDeployment:
 		checkTillReplica = CheckTillReplica
 		log.InfoD("Entering to check if Data service has %v active pods. Once it does, we will kill the Agent Pod.", checkTillReplica)
 		func1 := func() {
@@ -443,14 +455,14 @@ func KillPodsInNamespace(ns string, podName string) error {
 		CapturedErrors <- testError
 		return testError
 	}
-	// Get List of All Pods matching with the name : deployment controller manager pod
+	// Get List of All Pods matching with the name : podName
 	for _, pod := range podList.Items {
 		if strings.Contains(pod.Name, podName) {
 			log.Infof("Pod Name is : %v", pod.Name)
 			Pods = append(Pods, pod)
 		}
 	}
-	// Kill All Deployment Controller Pods
+	// Kill All Pods matching with podName
 	for _, pod := range Pods {
 		log.InfoD("Deleting Pod: %s", pod.Name)
 		testError = DeleteK8sPods(pod.Name, ns)

--- a/tests/pds/common.go
+++ b/tests/pds/common.go
@@ -53,6 +53,7 @@ const (
 	DeploymentCRD                    = "deployments.pds.io"
 	RebootNodesDuringDeployment      = "reboot-multiple-nodes-during-deployment"
 	KillAgentPodDuringDeployment     = "kill-agent-pod-during-deployment"
+	KillTeleportPodDuringDeployment  = "kill-teleport-pod-during-deployment"
 )
 
 var (

--- a/tests/pds/resiliency_test.go
+++ b/tests/pds/resiliency_test.go
@@ -530,9 +530,6 @@ var _ = Describe("{KillTeleportDuringDeployment}", func() {
 		Step("Deploy Data Services", func() {
 			var dsVersionBuildMap = make(map[string][]string)
 			for _, ds := range params.DataServiceToTest {
-				if ds.Name != postgresql {
-					continue
-				}
 				Step("Start deployment, Kill Teleport Pod while deployment is ongoing and validate data service", func() {
 					isDeploymentsDeleted = false
 					// Global Resiliency TC marker

--- a/tests/pds/resiliency_test.go
+++ b/tests/pds/resiliency_test.go
@@ -530,7 +530,7 @@ var _ = Describe("{KillTeleportDuringDeployment}", func() {
 		Step("Deploy Data Services", func() {
 			var dsVersionBuildMap = make(map[string][]string)
 			for _, ds := range params.DataServiceToTest {
-				Step("Start deployment, Kill Teleport Pod while deployment is ongoing and validate data service", func() {
+				Step("Start deployment, Kill Agent Pod while deployment is ongoing and validate data service", func() {
 					isDeploymentsDeleted = false
 					// Global Resiliency TC marker
 					pdslib.MarkResiliencyTC(true, false)
@@ -546,9 +546,11 @@ var _ = Describe("{KillTeleportDuringDeployment}", func() {
 					deployment, _, dsVersionBuildMap, err = dsTest.TriggerDeployDataService(ds, params.InfraToTest.Namespace, tenantID, projectID, false,
 						dss.TestParams{NamespaceId: namespaceID, StorageTemplateId: storageTemplateID, DeploymentTargetId: deploymentTargetID, DnsZone: dnsZone, ServiceType: serviceType})
 					log.FailOnError(err, "Error while deploying data services")
+
 					err = pdslib.InduceFailureAfterWaitingForCondition(deployment, namespace, params.ResiliencyTest.CheckTillReplica)
 					log.FailOnError(err, fmt.Sprintf("Error happened while executing Kill Teleport Pod test for data service %v", *deployment.ClusterResourceName))
-					dataServiceDefaultResourceTemplateID, err = pdslib.GetResourceTemplate(tenantID, ds.Name)
+
+					dataServiceDefaultResourceTemplateID, err = controlPlane.GetResourceTemplate(tenantID, ds.Name)
 					log.FailOnError(err, "Error while getting resource template")
 					log.InfoD("dataServiceDefaultResourceTemplateID %v ", dataServiceDefaultResourceTemplateID)
 

--- a/tests/pds/resiliency_test.go
+++ b/tests/pds/resiliency_test.go
@@ -520,3 +520,57 @@ var _ = Describe("{RestartAppDuringResourceUpdate}", func() {
 		EndTorpedoTest()
 	})
 })
+
+var _ = Describe("{KillTeleportDuringDeployment}", func() {
+	JustBeforeEach(func() {
+		StartTorpedoTest("KillTeleportDuringDeployment", "Kill Teleport Pod when a DS Deployment is happening", pdsLabels, 0)
+	})
+
+	It("Deploy Dataservices", func() {
+		Step("Deploy Data Services", func() {
+			var dsVersionBuildMap = make(map[string][]string)
+			for _, ds := range params.DataServiceToTest {
+				if ds.Name != postgresql {
+					continue
+				}
+				Step("Start deployment, Kill Teleport Pod while deployment is ongoing and validate data service", func() {
+					isDeploymentsDeleted = false
+					// Global Resiliency TC marker
+					pdslib.MarkResiliencyTC(true, false)
+					// Type of failure that this TC needs to cover
+					failuretype := pdslib.TypeOfFailure{
+						Type: KillTeleportPodDuringDeployment,
+						Method: func() error {
+							return pdslib.KillPodsInNamespace(params.InfraToTest.PDSNamespace, pdslib.PdsTeleportPod)
+						},
+					}
+					pdslib.DefineFailureType(failuretype)
+					// Deploy and Validate this Data service after injecting the type of failure we want to catch
+					deployment, _, dsVersionBuildMap, err = dsTest.TriggerDeployDataService(ds, params.InfraToTest.Namespace, tenantID, projectID, false,
+						dss.TestParams{NamespaceId: namespaceID, StorageTemplateId: storageTemplateID, DeploymentTargetId: deploymentTargetID, DnsZone: dnsZone, ServiceType: serviceType})
+					log.FailOnError(err, "Error while deploying data services")
+					err = pdslib.InduceFailureAfterWaitingForCondition(deployment, namespace, params.ResiliencyTest.CheckTillReplica)
+					log.FailOnError(err, fmt.Sprintf("Error happened while executing Kill Teleport Pod test for data service %v", *deployment.ClusterResourceName))
+					dataServiceDefaultResourceTemplateID, err = pdslib.GetResourceTemplate(tenantID, ds.Name)
+					log.FailOnError(err, "Error while getting resource template")
+					log.InfoD("dataServiceDefaultResourceTemplateID %v ", dataServiceDefaultResourceTemplateID)
+
+					resourceTemp, storageOp, config, err := pdslib.ValidateDataServiceVolumes(deployment, ds.Name, dataServiceDefaultResourceTemplateID, storageTemplateID, namespace)
+					log.FailOnError(err, "error on ValidateDataServiceVolumes method")
+
+					ValidateDeployments(resourceTemp, storageOp, config, int(ds.Replicas), dsVersionBuildMap)
+				})
+			}
+		})
+	})
+	JustAfterEach(func() {
+		defer EndTorpedoTest()
+
+		if !isDeploymentsDeleted {
+			Step("Delete created deployments")
+			resp, err := pdslib.DeleteDeployment(deployment.GetId())
+			log.FailOnError(err, "Error while deleting data services")
+			dash.VerifyFatal(resp.StatusCode, http.StatusAccepted, "validating the status response")
+		}
+	})
+})


### PR DESCRIPTION
Test does the following:
1. Starts deploying a Data service
2. While deployment is ongoing, kill all teleport pods one by one
3. Wait for deployment to come up
4. Validate deployment 

Jenkins Run: https://jenkins.pwx.dev.purestorage.com/job/PDS/job/pds-branch-build-test/286/
https://jenkins.pwx.dev.purestorage.com/job/PDS/job/pds-branch-build-test/288/