### PR TITLE
PA: 212, PA: 1155 - Get Data service PVC to full condition and resize

### DIFF
--- a/drivers/pds/controlplane/controlplane.go
+++ b/drivers/pds/controlplane/controlplane.go
@@ -2,14 +2,15 @@ package controlplane
 
 import (
 	"fmt"
+	"net/url"
+	"strings"
+
 	pds "github.com/portworx/pds-api-go-client/pds/v1alpha1"
 	"github.com/portworx/sched-ops/k8s/apps"
 	"github.com/portworx/sched-ops/k8s/core"
 	"github.com/portworx/torpedo/drivers/pds/api"
 	pdsapi "github.com/portworx/torpedo/drivers/pds/api"
 	"github.com/portworx/torpedo/pkg/log"
-	"net/url"
-	"strings"
 )
 
 // ControlPlane PDS
@@ -23,13 +24,13 @@ var (
 	isTemplateavailable        bool
 	isStorageTemplateAvailable bool
 
-	resourceTemplateID  string
-	appConfigTemplateID string
-	storageTemplateID   string
+	resourceTemplateID   string
+	appConfigTemplateID  string
+	storageTemplateID    string
+	resourceTemplateName = "Small"
 )
 
 const (
-	resourceTemplateName  = "Small"
 	appConfigTemplateName = "QaDefault"
 	storageTemplateName   = "QaDefault"
 )
@@ -193,6 +194,13 @@ func (cp *ControlPlane) GetAppConfTemplate(tenantID string, ds string) (string, 
 		log.Errorf("App Config Template with name %v does not exist", appConfigTemplateName)
 	}
 	return appConfigTemplateID, nil
+}
+
+// update template name with custom name
+func (cp *ControlPlane) UpdateResourceTemplateName(TemplateName string) string {
+	log.Infof("Updating the resource template name with : %v", TemplateName)
+	resourceTemplateName = TemplateName
+	return resourceTemplateName
 }
 
 // GetResourceTemplate get the resource template id

--- a/tests/pds/common.go
+++ b/tests/pds/common.go
@@ -1,16 +1,21 @@
 package tests
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/portworx/torpedo/drivers/pds/parameters"
+	"github.com/portworx/torpedo/drivers/scheduler"
+	"github.com/portworx/torpedo/tests"
 
 	pds "github.com/portworx/pds-api-go-client/pds/v1alpha1"
 
 	"github.com/portworx/sched-ops/k8s/core"
+	"github.com/portworx/sched-ops/task"
 	pdslib "github.com/portworx/torpedo/drivers/pds/lib"
 	"github.com/portworx/torpedo/pkg/aetosutil"
 	"github.com/portworx/torpedo/pkg/log"
+	"github.com/portworx/torpedo/pkg/units"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -161,4 +166,82 @@ func RunWorkloads(params pdslib.WorkloadGenerationParams, ds PDSDataService, dep
 
 	return pod, dep, err
 
+}
+
+// Check the DS related PV usage and resize in case of 90% full
+func CheckPVCtoFullCondition(context []*scheduler.Context) error {
+	log.Infof("Check PVC Usage")
+	f := func() (interface{}, bool, error) {
+		for _, ctx := range context {
+			vols, err := tests.Inst().S.GetVolumes(ctx)
+			if err != nil {
+				return nil, true, err
+			}
+			for _, vol := range vols {
+				appVol, err := tests.Inst().V.InspectVolume(vol.ID)
+				if err != nil {
+					return nil, true, err
+				}
+				pvcCapacity := appVol.Spec.Size / units.GiB
+				usedGiB := appVol.GetUsage() / units.GiB
+				threshold := pvcCapacity - 1
+				if usedGiB >= threshold {
+					log.Infof("The PVC capacity was %vGB , the consumed PVC is %vGB", pvcCapacity, usedGiB)
+					return nil, false, nil
+				}
+			}
+		}
+		return nil, true, fmt.Errorf("threshold not achieved for the PVC, ")
+	}
+	_, err := task.DoRetryWithTimeout(f, 30*time.Minute, 15*time.Second)
+
+	return err
+}
+
+// Increase PVC by 1 gb
+func IncreasePVCby1Gig(context []*scheduler.Context) error {
+	log.Info("Resizing of the PVC begins")
+	initialCapacity, err := GetVolumeCapacityInGB(context)
+	log.Debugf("Initial volume storage size is : %v", initialCapacity)
+	if err != nil {
+		return err
+	}
+	for _, ctx := range context {
+		appVolumes, err := tests.Inst().S.ResizeVolume(ctx, "")
+		log.FailOnError(err, "Volume resize successful ?")
+		log.InfoD(fmt.Sprintf("validating successful volume size increase on app %s's volumes: %v",
+			ctx.App.Key, appVolumes))
+	}
+	// wait for the resize to take effect
+	time.Sleep(30 * time.Second)
+	newcapacity, err := GetVolumeCapacityInGB(context)
+	log.Infof("Resized volume storage size is : %v", newcapacity)
+	if err != nil {
+		return err
+	}
+
+	if newcapacity > initialCapacity {
+		log.InfoD("Successfully resized the pvc by 1gb")
+		return nil
+	}
+	return nil
+}
+
+// Get volume capacity
+func GetVolumeCapacityInGB(context []*scheduler.Context) (uint64, error) {
+	var pvcCapacity uint64
+	for _, ctx := range context {
+		vols, err := tests.Inst().S.GetVolumes(ctx)
+		if err != nil {
+			return 0, err
+		}
+		for _, vol := range vols {
+			appVol, err := tests.Inst().V.InspectVolume(vol.ID)
+			if err != nil {
+				return 0, err
+			}
+			pvcCapacity = appVol.Spec.Size / units.GiB
+		}
+	}
+	return pvcCapacity, err
 }

--- a/tests/pds/common.go
+++ b/tests/pds/common.go
@@ -4,18 +4,16 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/portworx/torpedo/drivers/pds/parameters"
-	"github.com/portworx/torpedo/drivers/scheduler"
-	"github.com/portworx/torpedo/tests"
-
 	pds "github.com/portworx/pds-api-go-client/pds/v1alpha1"
-
 	"github.com/portworx/sched-ops/k8s/core"
 	"github.com/portworx/sched-ops/task"
 	pdslib "github.com/portworx/torpedo/drivers/pds/lib"
+	"github.com/portworx/torpedo/drivers/pds/parameters"
+	"github.com/portworx/torpedo/drivers/scheduler"
 	"github.com/portworx/torpedo/pkg/aetosutil"
 	"github.com/portworx/torpedo/pkg/log"
 	"github.com/portworx/torpedo/pkg/units"
+	. "github.com/portworx/torpedo/tests"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -173,12 +171,12 @@ func CheckPVCtoFullCondition(context []*scheduler.Context) error {
 	log.Infof("Check PVC Usage")
 	f := func() (interface{}, bool, error) {
 		for _, ctx := range context {
-			vols, err := tests.Inst().S.GetVolumes(ctx)
+			vols, err := Inst().S.GetVolumes(ctx)
 			if err != nil {
 				return nil, true, err
 			}
 			for _, vol := range vols {
-				appVol, err := tests.Inst().V.InspectVolume(vol.ID)
+				appVol, err := Inst().V.InspectVolume(vol.ID)
 				if err != nil {
 					return nil, true, err
 				}
@@ -207,7 +205,7 @@ func IncreasePVCby1Gig(context []*scheduler.Context) error {
 		return err
 	}
 	for _, ctx := range context {
-		appVolumes, err := tests.Inst().S.ResizeVolume(ctx, "")
+		appVolumes, err := Inst().S.ResizeVolume(ctx, "")
 		log.FailOnError(err, "Volume resize successful ?")
 		log.InfoD(fmt.Sprintf("validating successful volume size increase on app %s's volumes: %v",
 			ctx.App.Key, appVolumes))
@@ -231,12 +229,12 @@ func IncreasePVCby1Gig(context []*scheduler.Context) error {
 func GetVolumeCapacityInGB(context []*scheduler.Context) (uint64, error) {
 	var pvcCapacity uint64
 	for _, ctx := range context {
-		vols, err := tests.Inst().S.GetVolumes(ctx)
+		vols, err := Inst().S.GetVolumes(ctx)
 		if err != nil {
 			return 0, err
 		}
 		for _, vol := range vols {
-			appVol, err := tests.Inst().V.InspectVolume(vol.ID)
+			appVol, err := Inst().V.InspectVolume(vol.ID)
 			if err != nil {
 				return 0, err
 			}

--- a/tests/pds/dataservice_test.go
+++ b/tests/pds/dataservice_test.go
@@ -1683,8 +1683,8 @@ var _ = Describe("{GetPvcToFullCondition}", func() {
 
 		Step("Deploy Data Services", func() {
 			for _, ds := range params.DataServiceToTest {
-				Step("Deploy and validate data service", func() {
-					if dsName == "PostgreSQL" {
+				if ds.Name == postgresql {
+					Step("Deploy and validate data service", func() {
 						isDeploymentsDeleted = false
 						controlPlane.UpdateResourceTemplateName("pds-auto-pvcFullCondition")
 						deployment, _, dataServiceVersionBuildMap, err = DeployandValidateDataServices(ds, params.InfraToTest.Namespace, tenantID, projectID)
@@ -1693,8 +1693,9 @@ var _ = Describe("{GetPvcToFullCondition}", func() {
 						dsVersions[ds.Name] = dataServiceVersionBuildMap
 						depList = append(depList, deployment)
 						dsName = ds.Name
-					}
-				})
+
+					})
+				}
 			}
 			defer func() {
 				for _, newDeployment := range deployments {

--- a/tests/pds/dataservice_test.go
+++ b/tests/pds/dataservice_test.go
@@ -1684,7 +1684,7 @@ var _ = Describe("{GetPvcToFullCondition}", func() {
 		Step("Deploy Data Services", func() {
 			for _, ds := range params.DataServiceToTest {
 				Step("Deploy and validate data service", func() {
-					if dsName == postgresql {
+					if dsName == "PostgreSQL" {
 						isDeploymentsDeleted = false
 						controlPlane.UpdateResourceTemplateName("pds-auto-pvcFullCondition")
 						deployment, _, dataServiceVersionBuildMap, err = DeployandValidateDataServices(ds, params.InfraToTest.Namespace, tenantID, projectID)

--- a/tests/pds/dataservice_test.go
+++ b/tests/pds/dataservice_test.go
@@ -1671,7 +1671,6 @@ var _ = Describe("{AddAndValidateUserRoles}", func() {
 var _ = Describe("{GetPvcToFullCondition}", func() {
 
 	JustBeforeEach(func() {
-		InitInstance()
 		StartTorpedoTest("GetPvcToFullCondition", "Deploys and increases the pvc size of DS once trhreshold is met", pdsLabels, 0)
 	})
 
@@ -1684,17 +1683,19 @@ var _ = Describe("{GetPvcToFullCondition}", func() {
 
 		Step("Deploy Data Services", func() {
 			for _, ds := range params.DataServiceToTest {
-				Step("Deploy and validate data service", func() {
-					isDeploymentsDeleted = false
-					controlPlane.UpdateResourceTemplateName("pds-auto-pvcFullCondition")
-					deployment, _, dataServiceVersionBuildMap, err = DeployandValidateDataServices(ds, params.InfraToTest.Namespace, tenantID, projectID)
-					log.FailOnError(err, "Error while deploying data services")
-					deployments[ds] = deployment
-					dsVersions[ds.Name] = dataServiceVersionBuildMap
-					depList = append(depList, deployment)
-					dsName = ds.Name
+				if dsName == postgresql {
+					Step("Deploy and validate data service", func() {
+						isDeploymentsDeleted = false
+						controlPlane.UpdateResourceTemplateName("pds-auto-pvcFullCondition")
+						deployment, _, dataServiceVersionBuildMap, err = DeployandValidateDataServices(ds, params.InfraToTest.Namespace, tenantID, projectID)
+						log.FailOnError(err, "Error while deploying data services")
+						deployments[ds] = deployment
+						dsVersions[ds.Name] = dataServiceVersionBuildMap
+						depList = append(depList, deployment)
+						dsName = ds.Name
 
-				})
+					})
+				}
 			}
 			defer func() {
 				for _, newDeployment := range deployments {

--- a/tests/pds/dataservice_test.go
+++ b/tests/pds/dataservice_test.go
@@ -3,7 +3,6 @@ package tests
 import (
 	"errors"
 	"fmt"
-	"github.com/portworx/torpedo/drivers/pds/dataservice"
 	"math/rand"
 	"net/http"
 	"os"
@@ -11,6 +10,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/portworx/torpedo/drivers/pds/dataservice"
 
 	tc "github.com/portworx/torpedo/drivers/pds/targetcluster"
 
@@ -1664,5 +1665,99 @@ var _ = Describe("{AddAndValidateUserRoles}", func() {
 
 	JustAfterEach(func() {
 		EndTorpedoTest()
+	})
+})
+
+var _ = Describe("{GetPvcToFullCondition}", func() {
+
+	JustBeforeEach(func() {
+		InitInstance()
+		StartTorpedoTest("GetPvcToFullCondition", "Deploys and increases the pvc size of DS once trhreshold is met", pdsLabels, 0)
+	})
+
+	It("Deploy Dataservices", func() {
+		var generateWorkloads = make(map[string]string)
+		var deployments = make(map[PDSDataService]*pds.ModelsDeployment)
+		var dsVersions = make(map[string]map[string][]string)
+		var depList []*pds.ModelsDeployment
+		var dsName string
+
+		Step("Deploy Data Services", func() {
+			for _, ds := range params.DataServiceToTest {
+				Step("Deploy and validate data service", func() {
+					isDeploymentsDeleted = false
+					controlPlane.UpdateResourceTemplateName("pds-auto-pvcFullCondition")
+					deployment, _, dataServiceVersionBuildMap, err = DeployandValidateDataServices(ds, params.InfraToTest.Namespace, tenantID, projectID)
+					log.FailOnError(err, "Error while deploying data services")
+					deployments[ds] = deployment
+					dsVersions[ds.Name] = dataServiceVersionBuildMap
+					depList = append(depList, deployment)
+					dsName = ds.Name
+
+				})
+			}
+			defer func() {
+				for _, newDeployment := range deployments {
+					Step("Delete created deployments")
+					resp, err := pdslib.DeleteDeployment(newDeployment.GetId())
+					log.FailOnError(err, "Error while deleting data services")
+					dash.VerifyFatal(resp.StatusCode, http.StatusAccepted, "validating the status response")
+				}
+			}()
+
+			// This testcase is currently applicable only for postgresql ds deployments
+			if dsName == postgresql {
+				Step("Running Workloads before scaling up PVC ", func() {
+					for ds, deployment := range deployments {
+						if Contains(dataServicePodWorkloads, ds.Name) || Contains(dataServiceDeploymentWorkloads, ds.Name) {
+							log.InfoD("Running Workloads on DataService %v ", ds.Name)
+							var params pdslib.WorkloadGenerationParams
+							pod, dep, err = RunWorkloads(params, ds, deployment, namespace)
+							log.FailOnError(err, fmt.Sprintf("Error while genearating workloads for dataservice [%s]", ds.Name))
+							generateWorkloads[ds.Name] = dep.Name
+							for dsName, workloadContainer := range generateWorkloads {
+								log.Debugf("dsName %s, workloadContainer %s", dsName, workloadContainer)
+							}
+						}
+					}
+				})
+
+				defer func() {
+					for dsName, workloadContainer := range generateWorkloads {
+						Step("Delete the workload generating deployments", func() {
+							if Contains(dataServiceDeploymentWorkloads, dsName) {
+								log.InfoD("Deleting Workload Generating deployment %v ", workloadContainer)
+								err = pdslib.DeleteK8sDeployments(workloadContainer, namespace)
+							} else if Contains(dataServicePodWorkloads, dsName) {
+								log.InfoD("Deleting Workload Generating pod %v ", workloadContainer)
+								err = pdslib.DeleteK8sPods(workloadContainer, namespace)
+							}
+							log.FailOnError(err, "error deleting workload generating pods")
+						})
+					}
+				}()
+
+				Step("Checking the PVC usage", func() {
+					ctx, err := dsTest.CreateSchedulerContextForPDSApps(depList)
+					log.FailOnError(err, "Unable to create scheduler context")
+					err = CheckPVCtoFullCondition(ctx)
+					log.FailOnError(err, "Failing while filling the PVC to 90 percentage of its capacity due to ...")
+					err = IncreasePVCby1Gig(ctx)
+					log.FailOnError(err, "Failing while Increasing the PVC name...")
+				})
+
+				Step("Validate Deployments after PVC Resize", func() {
+					for ds, deployment := range deployments {
+						err = dsTest.ValidateDataServiceDeployment(deployment, namespace)
+						log.FailOnError(err, "Error while validating dataservices")
+						log.InfoD("Data-service: %v is up and healthy", ds.Name)
+					}
+				})
+			}
+
+		})
+	})
+	JustAfterEach(func() {
+		defer EndTorpedoTest()
 	})
 })

--- a/tests/pds/dataservice_test.go
+++ b/tests/pds/dataservice_test.go
@@ -1683,6 +1683,7 @@ var _ = Describe("{GetPvcToFullCondition}", func() {
 
 		Step("Deploy Data Services", func() {
 			for _, ds := range params.DataServiceToTest {
+				log.Debugf("DS NAME IS : %v", ds.Name)
 				if dsName == postgresql {
 					Step("Deploy and validate data service", func() {
 						isDeploymentsDeleted = false

--- a/tests/pds/dataservice_test.go
+++ b/tests/pds/dataservice_test.go
@@ -1683,9 +1683,8 @@ var _ = Describe("{GetPvcToFullCondition}", func() {
 
 		Step("Deploy Data Services", func() {
 			for _, ds := range params.DataServiceToTest {
-				log.Debugf("DS NAME IS : %v", ds.Name)
-				if dsName == postgresql {
-					Step("Deploy and validate data service", func() {
+				Step("Deploy and validate data service", func() {
+					if dsName == postgresql {
 						isDeploymentsDeleted = false
 						controlPlane.UpdateResourceTemplateName("pds-auto-pvcFullCondition")
 						deployment, _, dataServiceVersionBuildMap, err = DeployandValidateDataServices(ds, params.InfraToTest.Namespace, tenantID, projectID)
@@ -1694,9 +1693,8 @@ var _ = Describe("{GetPvcToFullCondition}", func() {
 						dsVersions[ds.Name] = dataServiceVersionBuildMap
 						depList = append(depList, deployment)
 						dsName = ds.Name
-
-					})
-				}
+					}
+				})
 			}
 			defer func() {
 				for _, newDeployment := range deployments {

--- a/tests/pds/pds_basic_test.go
+++ b/tests/pds/pds_basic_test.go
@@ -1,6 +1,9 @@
 package tests
 
 import (
+	"os"
+	"testing"
+
 	pdsdriver "github.com/portworx/torpedo/drivers/pds"
 	"github.com/portworx/torpedo/drivers/pds/api"
 	"github.com/portworx/torpedo/drivers/pds/controlplane"
@@ -8,8 +11,6 @@ import (
 	pdslib "github.com/portworx/torpedo/drivers/pds/lib"
 	"github.com/portworx/torpedo/drivers/pds/parameters"
 	"github.com/portworx/torpedo/drivers/pds/targetcluster"
-	"os"
-	"testing"
 
 	"github.com/portworx/torpedo/pkg/log"
 
@@ -43,6 +44,7 @@ var _ = BeforeSuite(func() {
 	log.InfoD(steplog)
 	Step(steplog, func() {
 		log.InfoD(steplog)
+		InitInstance()
 		dash = Inst().Dash
 		dash.TestSet.Product = "pds"
 		dash.TestSetBegin(dash.TestSet)


### PR DESCRIPTION
This PR is with respect to two JIRA tickets -

https://portworx.atlassian.net/browse/PA-1155 (Create a function to poll for PVC usage and resize after full usage)
https://portworx.atlassian.net/browse/PA-212 (testcase - Get Data service PVC to full condition and resize the pvc)
Enhancements made ->

Used portworx libraries to get the volumes and inspect the usage of the pvc.
After reaching a threshold, resizing the pvc by 1 gb.
To fill the pvc, pds workload scripts are executed.
Introduced a new function to pass custom resource templates from the testcase.
PS: 1.This testcase currently runs only for Postgres as I need to pass a custom resource template with a small size storage for faster test execution.

Jenkins Run -

https://jenkins.pwx.dev.purestorage.com/job/PDS/job/pds-branch-build-test/375/console
