### PR TITLE
Adding Backuplocation status to logs while cleaning up

### DIFF
--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -958,7 +958,7 @@ func CleanupCloudSettingsAndClusters(backupLocationMap map[string]string, credNa
 						return "", true, fmt.Errorf("inspect backup location - backup location %s still present with error %v", bkpLocationName, err)
 					}
 					backupLocationStatus := backupLocationObject.BackupLocation.BackupLocationInfo.GetStatus()
-					return "", true, fmt.Errorf("backup location %s is not deleted yet. Status - [%s]", backupLocationStatus)
+					return "", true, fmt.Errorf("backup location %s is not deleted yet. Status - [%s]", bkpLocationName, backupLocationStatus)
 				}
 				return "", false, nil
 			}

--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -948,7 +948,17 @@ func CleanupCloudSettingsAndClusters(backupLocationMap map[string]string, credNa
 					return "", true, fmt.Errorf("backup location %s still present with error %v", bkpLocationName, err)
 				}
 				if status {
-					return "", true, fmt.Errorf("backup location %s is not deleted yet", bkpLocationName)
+					backupLocationInspectRequest := api.BackupLocationInspectRequest{
+						Name:  bkpLocationName,
+						Uid:   backupLocationUID,
+						OrgId: orgID,
+					}
+					backupLocationObject, err := Inst().Backup.InspectBackupLocation(ctx, &backupLocationInspectRequest)
+					if err != nil {
+						return "", true, fmt.Errorf("inspect backup location - backup location %s still present with error %v", bkpLocationName, err)
+					}
+					backupLocationStatus := backupLocationObject.BackupLocation.BackupLocationInfo.GetStatus()
+					return "", true, fmt.Errorf("backup location %s is not deleted yet. Status - [%s]", backupLocationStatus)
 				}
 				return "", false, nil
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding Backup location status to logs while cleaning up
Currently, we are not printing the status of backup location after we send the delete request. Found in NFS tests that the backup location deletion is not happening

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

