### PR TITLE
Fix getting keycloak endpoint after px-backup keycloak bump

### DIFF
--- a/drivers/backup/auth.go
+++ b/drivers/backup/auth.go
@@ -225,7 +225,6 @@ func getKeycloakEndPoint(admin bool) (string, error) {
 		return newURL, nil
 	}
 	log.Infof("Keycloak endpoint - %s", url)
-	url = "http://pxcentral-keycloak-http.px-backup.svc.cluster.local/auth/realms/master"
 	return string(url), nil
 
 }

--- a/drivers/backup/auth.go
+++ b/drivers/backup/auth.go
@@ -831,7 +831,6 @@ func GetAdminCtxFromSecret() (context.Context, error) {
 	if token == "" {
 		return nil, fmt.Errorf("admin token is empty")
 	}
-	log.Debugf("Token from Admin secret: %v", token)
 	ctx := GetCtxWithToken(token)
 
 	return ctx, nil
@@ -857,7 +856,6 @@ func GetAdminTokenFromSecret() (string, error) {
 	if token == "" {
 		return "", fmt.Errorf("admin token is empty")
 	}
-	log.Debugf("Token from Admin secret: %v", token)
 
 	return token, nil
 }

--- a/drivers/backup/auth.go
+++ b/drivers/backup/auth.go
@@ -225,6 +225,7 @@ func getKeycloakEndPoint(admin bool) (string, error) {
 		return newURL, nil
 	}
 	log.Infof("Keycloak endpoint - %s", url)
+	url = "http://pxcentral-keycloak-http.px-backup.svc.cluster.local/auth/realms/master"
 	return string(url), nil
 
 }

--- a/drivers/backup/auth.go
+++ b/drivers/backup/auth.go
@@ -202,26 +202,31 @@ func getKeycloakEndPoint(admin bool) (string, error) {
 		}
 	}
 	name := getOidcSecretName()
+	log.Infof("name - %s", name)
 	ns, err := GetPxBackupNamespace()
 	if err != nil {
 		return "", err
 	}
+	log.Infof("ns - %s", ns)
 	// check and validate oidc details
 	secret, err := k8s.Instance().GetSecret(name, ns)
 	if err != nil {
 		return "", err
 	}
 	url := string(secret.Data[Issuer])
+	log.Infof("url - %s", url)
 	// Expand the service name for K8S DNS resolution, for keycloak requests from different ns
 	splitURL := strings.Split(url, ":")
 	splitURL[1] = fmt.Sprintf("%s.%s.svc.cluster.local", splitURL[1], ns)
 	url = strings.Join(splitURL, ":")
+	log.Infof("url after join - %s", url)
 	// url: http://pxcentral-keycloak-http.px-backup.svc.cluster.local:80/auth/realms/master
 	if admin {
 		// admin url: http://pxcentral-keycloak-http.px-backup.svc.cluster.local:80/auth/realms/master
 		// non-adming url: http://pxcentral-keycloak-http.px-backup.svc.cluster.local:80/auth/admin/realms/master
 		split := strings.Split(url, "auth")
 		newURL := fmt.Sprintf("%sauth/admin%s", split[0], split[1])
+		log.Infof("return admin url - %s", newURL)
 		return newURL, nil
 	}
 	log.Infof("Keycloak endpoint - %s", url)

--- a/drivers/backup/auth.go
+++ b/drivers/backup/auth.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -1191,10 +1190,6 @@ func processHTTPRequest(
 		}
 	}()
 	responseBody, err := ioutil.ReadAll(httpResponse.Body)
-	pc, _, line, _ := runtime.Caller(1)
-	callerFuncSlice := strings.Split(runtime.FuncForPC(pc).Name(), "/")
-	callerFunc := fmt.Sprintf("%s:#%d", callerFuncSlice[len(callerFuncSlice)-1], line)
-	log.Infof("Caller - [%s]\n%s", callerFunc, string(responseBody))
 	return responseBody, err
 }
 

--- a/drivers/backup/auth.go
+++ b/drivers/backup/auth.go
@@ -193,9 +193,11 @@ func getKeycloakEndPoint(admin bool) (string, error) {
 			// admin url: http://pxcentral-keycloak-http:80/auth/realms/master
 			// non-adming url: http://pxcentral-keycloak-http:80/auth/admin/realms/master
 			newURL := fmt.Sprintf("%s/auth/admin/realms/master", keycloakEndpoint)
+			log.Infof("Keycloak endpoint - %s", newURL)
 			return newURL, nil
 		} else {
 			newURL := fmt.Sprintf("%s/auth/realms/master", keycloakEndpoint)
+			log.Infof("Keycloak endpoint - %s", newURL)
 			return newURL, nil
 		}
 	}
@@ -222,6 +224,7 @@ func getKeycloakEndPoint(admin bool) (string, error) {
 		newURL := fmt.Sprintf("%sauth/admin%s", split[0], split[1])
 		return newURL, nil
 	}
+	log.Infof("Keycloak endpoint - %s", url)
 	return string(url), nil
 
 }
@@ -1172,6 +1175,7 @@ func processHTTPRequest(
 	headers http.Header,
 	body io.Reader,
 ) ([]byte, error) {
+	log.Infof("HTTP call with method [%s] for url [%s]", method, url)
 	httpRequest, err := http.NewRequest(method, url, body)
 	if err != nil {
 		return nil, err

--- a/tests/backup/backup_basic_test.go
+++ b/tests/backup/backup_basic_test.go
@@ -87,7 +87,6 @@ func BackupInitInstance() {
 		err = Inst().Backup.Init(Inst().S.String(), Inst().N.String(), Inst().V.String(), token)
 		log.FailOnError(err, "Error occurred while Backup Driver Initialization")
 	}
-	log.Infof("Master node address - %s", node.GetMasterNodes()[0])
 
 	SetupTestRail()
 

--- a/tests/backup/backup_basic_test.go
+++ b/tests/backup/backup_basic_test.go
@@ -87,6 +87,7 @@ func BackupInitInstance() {
 		err = Inst().Backup.Init(Inst().S.String(), Inst().N.String(), Inst().V.String(), token)
 		log.FailOnError(err, "Error occurred while Backup Driver Initialization")
 	}
+	log.Infof("Master node address - %s", node.GetMasterNodes()[0])
 
 	SetupTestRail()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We are creating a secret `pxc-backup-secret`  during px-backup installation

In our automation code, we are fetching the keycloak URL from this secret > data > OIDC_ENDPOINT

If you do a base64 decode
In 2.5.0 and older versions
```
http://pxcentral-keycloak-http:80/auth/realms/master
```
In 2.5.1
```
http://pxcentral-keycloak-http/auth/realms/master
```
They have removed the port reference `:80`  but in our code we are looking for the `:`  to split the URL and add the px-backup namespace and join it again so that our URL will look like this
```
http://pxcentral-keycloak-http.px-backup.svc.cluster.local:80/auth/realms/master
```
Since there is no `:`  our URL is ending up looking like this which is wrong
```
http://pxcentral-keycloak-http/auth/realms/master.central.svc.cluster.local
```

**Which issue(s) this PR fixes** (optional)
Closes #PA-1275

**Special notes for your reviewer**:
[Basic jenkins run with 2.5.0](https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/1729/parameters/)
[Basic jenkins run with 2.5.1](https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/1731/consoleFull)
[Full Jenkins run with all tests](https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/basic-system-test/job/px/job/s3/job/px-backup-system-test-vanilla/282/)

