### PR TITLE
PTX-18480 fix SKIP_PX_OPERATOR_UPGRADE flag and not ignore

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -83,6 +83,10 @@ if [ -z "${UPGRADE_STORAGE_DRIVER_ENDPOINT_LIST}" ]; then
     UPGRADE_STORAGE_DRIVER_ENDPOINT_LIST=""
 fi
 
+if [ -z "${SKIP_PX_OPERATOR_UPGRADE}" ]; then
+    SKIP_PX_OPERATOR_UPGRADE=false
+fi
+
 if [ -z "${ENABLE_STORK_UPGRADE}" ]; then
     ENABLE_STORK_UPGRADE=false
 fi
@@ -668,6 +672,8 @@ spec:
       value: "${NFS_MOUNT_OPTION}"
     - name: NFS_PATH
       value: "${NFS_PATH}"
+    - name: SKIP_PX_OPERATOR_UPGRADE
+      value: "${SKIP_PX_OPERATOR_UPGRADE}"
   volumes: [${VOLUMES}]
   restartPolicy: Never
   serviceAccountName: torpedo-account


### PR DESCRIPTION
flag SKIP_PX_OPERATOR_UPGRADE was not propagated to the actual `torpedo` container and was always set to false by default, we will now honor it and pass it to `torpedo` container

