### PR TITLE
Remove InitInstance From Resiliency TCs

### DIFF
--- a/drivers/pds/lib/resiliency_utils.go
+++ b/drivers/pds/lib/resiliency_utils.go
@@ -76,7 +76,7 @@ func ExecuteInParallel(functions ...func()) {
 func MarkResiliencyTC(resiliency bool, node_ops bool) {
 	ResiliencyFlag = resiliency
 	if node_ops && !isInitDone {
-		tests.InitInstance()
+		// tests.InitInstance()
 		isInitDone = true
 	}
 }

--- a/drivers/pds/lib/resiliency_utils.go
+++ b/drivers/pds/lib/resiliency_utils.go
@@ -46,7 +46,6 @@ var (
 	CapturedErrors            = make(chan error, 10)
 	checkTillReplica          int32
 	ResiliencyCondition       = make(chan bool)
-	isInitDone                = false
 )
 
 // Struct Definition for kind of Failure the framework needs to trigger
@@ -73,12 +72,8 @@ func ExecuteInParallel(functions ...func()) {
 }
 
 // Function to enable Resiliency Test
-func MarkResiliencyTC(resiliency bool, node_ops bool) {
+func MarkResiliencyTC(resiliency bool) {
 	ResiliencyFlag = resiliency
-	if node_ops && !isInitDone {
-		// tests.InitInstance()
-		isInitDone = true
-	}
 }
 
 // Function to wait for event to induce failure

--- a/tests/pds/resiliency_test.go
+++ b/tests/pds/resiliency_test.go
@@ -14,7 +14,7 @@ import (
 var _ = Describe("{RestartPXDuringAppScaleUp}", func() {
 	JustBeforeEach(func() {
 		StartTorpedoTest("RestartPXDuringAppScaleUp", "Restart PX on a node during application is scaled up", pdsLabels, 0)
-		pdslib.MarkResiliencyTC(true, true)
+		pdslib.MarkResiliencyTC(true)
 	})
 
 	It("Deploy Dataservices and Restart PX During App scaleup", func() {
@@ -142,7 +142,7 @@ var _ = Describe("{RebootActiveNodeDuringDeployment}", func() {
 				Step("Start deployment, Reboot a node on which deployment is coming up and validate data service", func() {
 					isDeploymentsDeleted = false
 					// Global Resiliency TC marker
-					pdslib.MarkResiliencyTC(true, true)
+					pdslib.MarkResiliencyTC(true)
 
 					// Deploy and Validate this Data service after injecting the type of failure we want to catch
 					deployment, _, dsVersionBuildMap, err = dsTest.TriggerDeployDataService(ds, params.InfraToTest.Namespace, tenantID, projectID, false,
@@ -188,7 +188,7 @@ var _ = Describe("{RebootNodeDuringAppVersionUpdate}", func() {
 	JustBeforeEach(func() {
 		StartTorpedoTest("RebootNodeDuringAppVersionUpdate", "Reboot node while app version update is going on", pdsLabels, 0)
 		// Global Resiliency TC marker
-		pdslib.MarkResiliencyTC(true, true)
+		pdslib.MarkResiliencyTC(true)
 	})
 
 	It("Reboot Node While App Version update is going on", func() {
@@ -324,7 +324,7 @@ var _ = Describe("{KillDeploymentControllerDuringDeployment}", func() {
 				Step("Start deployment, Kill Deployment Controller Pod while deployment is ongoing and validate data service", func() {
 					isDeploymentsDeleted = false
 					// Global Resiliency TC marker
-					pdslib.MarkResiliencyTC(true, false)
+					pdslib.MarkResiliencyTC(true)
 					// Type of failure that this TC needs to cover
 					failuretype := pdslib.TypeOfFailure{
 						Type: KillDeploymentControllerPod,
@@ -376,7 +376,7 @@ var _ = Describe("{RebootAllWorkerNodesDuringDeployment}", func() {
 				Step("Start deployment, Reboot multiple nodes on which deployment is coming up and validate data service", func() {
 					isDeploymentsDeleted = false
 					// Global Resiliency TC marker
-					pdslib.MarkResiliencyTC(true, false)
+					pdslib.MarkResiliencyTC(true)
 
 					// Deploy and Validate this Data service after injecting the type of failure we want to catch
 					deployment, _, dsVersionBuildMap, err = dsTest.TriggerDeployDataService(ds, params.InfraToTest.Namespace, tenantID, projectID, false,
@@ -430,7 +430,7 @@ var _ = Describe("{KillAgentDuringDeployment}", func() {
 				Step("Start deployment, Kill Agent Pod while deployment is ongoing and validate data service", func() {
 					isDeploymentsDeleted = false
 					// Global Resiliency TC marker
-					pdslib.MarkResiliencyTC(true, false)
+					pdslib.MarkResiliencyTC(true)
 					// Type of failure that this TC needs to cover
 					failuretype := pdslib.TypeOfFailure{
 						Type: KillAgentPodDuringDeployment,
@@ -474,7 +474,7 @@ var _ = Describe("{KillAgentDuringDeployment}", func() {
 var _ = Describe("{RestartAppDuringResourceUpdate}", func() {
 	JustBeforeEach(func() {
 		StartTorpedoTest("RestartAppDuringResourceUpdate", "Restart application pod during resource update", pdsLabels, 0)
-		pdslib.MarkResiliencyTC(true, false)
+		pdslib.MarkResiliencyTC(true)
 	})
 
 	It("Deploy Data Services", func() {
@@ -535,7 +535,7 @@ var _ = Describe("{KillTeleportDuringDeployment}", func() {
 				Step("Start deployment, Kill Agent Pod while deployment is ongoing and validate data service", func() {
 					isDeploymentsDeleted = false
 					// Global Resiliency TC marker
-					pdslib.MarkResiliencyTC(true, false)
+					pdslib.MarkResiliencyTC(true)
 					// Type of failure that this TC needs to cover
 					failuretype := pdslib.TypeOfFailure{
 						Type: KillTeleportPodDuringDeployment,
@@ -590,7 +590,7 @@ var _ = Describe("{RebootActiveNodeMultipleTimesDuringDeployment}", func() {
 				Step("Start deployment, Reboot a node on which deployment is coming up and validate data service", func() {
 					isDeploymentsDeleted = false
 					// Global Resiliency TC marker
-					pdslib.MarkResiliencyTC(true, true)
+					pdslib.MarkResiliencyTC(true)
 
 					// Deploy and Validate this Data service after injecting the type of failure we want to catch
 					deployment, _, dsVersionBuildMap, err = dsTest.TriggerDeployDataService(ds, params.InfraToTest.Namespace, tenantID, projectID, false,


### PR DESCRIPTION
Removing InitInstance from Resiliency Utils as we have now mandated it in the PDS Suite. 

Jenkins Run: https://jenkins.pwx.dev.purestorage.com/job/PDS/job/pds-branch-build-test/406