### PR TITLE
PTX-18603 bug fix: all tests get run if "verbose" is not set for ginkgo

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -463,7 +463,7 @@ spec:
             "--timeout", "${TIMEOUT}",
             "$FAIL_FAST",
             "--slowSpecThreshold", "600",
-            "$VERBOSE",
+            $VERBOSE,
             "$FOCUS_ARG",
             "$SKIP_ARG",
             $TEST_SUITE,

--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -x
 
-if [ -n "${VERBOSE}" ]; then
-    VERBOSE="--v"
-fi
-
 if [ -z "${ENABLE_DASH}" ]; then
     ENABLE_DASH=true
 fi
@@ -463,7 +459,6 @@ spec:
             "--timeout", "${TIMEOUT}",
             "$FAIL_FAST",
             "--slowSpecThreshold", "600",
-            $VERBOSE,
             "$FOCUS_ARG",
             "$SKIP_ARG",
             $TEST_SUITE,


### PR DESCRIPTION
Removed the VERBOSE parameter. 
Tested at https://jenkins.pwx.dev.purestorage.com/job/Users/job/alyu/job/pool-expansion-dmthin-vsphere/24/
The build succeeded, and fucus_test parameter was correctly parsed (see console log).