### PR TITLE
Fixed backup deletion issue with ShareBackupWithUsersAndGroups

### DIFF
--- a/tests/backup/backup_share_test.go
+++ b/tests/backup/backup_share_test.go
@@ -865,14 +865,6 @@ var _ = Describe("{ShareBackupWithUsersAndGroups}", func() {
 
 		ctx, err := backup.GetAdminCtxFromSecret()
 		log.FailOnError(err, "Fetching px-central-admin ctx")
-		backupDriver := Inst().Backup
-		for _, backupName := range backupNames {
-			backupUID, err := backupDriver.GetBackupUID(ctx, backupName, orgID)
-			log.FailOnError(err, "Failed while trying to get backup UID for - %s", backupName)
-			log.Infof("About to delete backup - %s", backupName)
-			_, err = DeleteBackup(backupName, backupUID, orgID, ctx)
-			dash.VerifyFatal(err, nil, fmt.Sprintf("Deleting backup - [%s]", backupName))
-		}
 		CleanupCloudSettingsAndClusters(backupLocationMap, credName, cloudCredUID, ctx)
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
The issue was deleting a already deleted backup in justaftereach while cleaning up all backup's created at test level individually.
Removed code for deleting backup individually in JustAfterEach as DeleteBackupLocation call in later step will cleanup all the active backups remaining.

**Which issue(s) this PR fixes** (optional)
Closes #PA-1294

**Special notes for your reviewer**:
S3 run:
https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/1830/console
https://aetos.pwx.purestorage.com/resultSet/testSetID/251750

NFS run in progress.
https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/1832/console

