### PR TITLE
Get volumemounts independent of application volume type, and select pods based on label from deployment spec

### DIFF
--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/portworx/torpedo/drivers"
+	appsapi "k8s.io/api/apps/v1"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -890,14 +891,14 @@ func CreateRestoreWithValidation(ctx context.Context, restoreName, backupName st
 	return
 }
 
-func getSizeOfMountPoint(podName string, namespace string, kubeConfigFile string) (int, error) {
+func getSizeOfMountPoint(podName string, namespace string, kubeConfigFile string, volumeMount string) (int, error) {
 	var number int
 	ret, err := kubectlExec([]string{fmt.Sprintf("--kubeconfig=%v", kubeConfigFile), "exec", "-it", podName, "-n", namespace, "--", "/bin/df"})
 	if err != nil {
 		return 0, err
 	}
 	for _, line := range strings.SplitAfter(ret, "\n") {
-		if strings.Contains(line, "pxd") {
+		if strings.Contains(line, volumeMount) {
 			ret = strings.Fields(line)[3]
 		}
 	}
@@ -3420,4 +3421,29 @@ func ValidateBackupLocation(ctx context.Context, orgID string, backupLocationNam
 	}
 	_, err := Inst().Backup.ValidateBackupLocation(ctx, backupLocationValidateRequest)
 	return err
+}
+
+// GetAppLabelFromSpec gets the label of the pod from the spec
+func GetAppLabelFromSpec(AppContextsMapping *scheduler.Context) (map[string]string, error) {
+	for _, specObj := range AppContextsMapping.App.SpecList {
+		if obj, ok := specObj.(*appsapi.Deployment); ok {
+			return obj.Spec.Selector.MatchLabels, nil
+		}
+	}
+	return nil, fmt.Errorf("unable to find the label for %s", AppContextsMapping.App.Key)
+}
+
+// GetVolumeMounts gets the volume mounts from the spec
+func GetVolumeMounts(AppContextsMapping *scheduler.Context) ([]string, error) {
+	var volumeMounts []string
+	for _, specObj := range AppContextsMapping.App.SpecList {
+		if obj, ok := specObj.(*appsapi.Deployment); ok {
+			mountPoints := obj.Spec.Template.Spec.Containers[0].VolumeMounts
+			for index := range mountPoints {
+				volumeMounts = append(volumeMounts, mountPoints[index].MountPath)
+			}
+			return volumeMounts, nil
+		}
+	}
+	return nil, fmt.Errorf("unable to find the mount point for %s", AppContextsMapping.App.Key)
 }

--- a/tests/backup/backup_portworx_test.go
+++ b/tests/backup/backup_portworx_test.go
@@ -663,12 +663,15 @@ var _ = Describe("{ResizeVolumeOnScheduleBackup}", func() {
 		nextScheduleBackupNameRef   interface{}
 		restoreNames                []string
 		nextScheduleBackupName      string
+		volumeMounts                []string
+		podList                     []string
 	)
 	labelSelectors := make(map[string]string)
 	cloudCredUIDMap := make(map[string]string)
 	backupLocationMap := make(map[string]string)
-	podListBeforeSizeMap := make(map[string]int)
-	podListAfterSizeMap := make(map[string]int)
+	AppContextsMapping := make(map[string]*scheduler.Context)
+	volListBeforeSizeMap := make(map[string]int)
+	volListAfterSizeMap := make(map[string]int)
 
 	var backupLocation string
 	scheduledAppContexts = make([]*scheduler.Context, 0)
@@ -698,6 +701,7 @@ var _ = Describe("{ResizeVolumeOnScheduleBackup}", func() {
 				namespace := GetAppNamespace(ctx, taskName)
 				appNamespaces = append(appNamespaces, namespace)
 				scheduledAppContexts = append(scheduledAppContexts, ctx)
+				AppContextsMapping[namespace] = ctx
 			}
 		}
 	})
@@ -758,14 +762,23 @@ var _ = Describe("{ResizeVolumeOnScheduleBackup}", func() {
 			for backupLocationUID, backupLocationName := range backupLocationMap {
 				Step("Getting size of volume before resizing", func() {
 					log.InfoD("Getting size of volume before resizing")
+					label, err := GetAppLabelFromSpec(AppContextsMapping[namespace])
+					dash.VerifyFatal(err, nil, fmt.Sprintf("unable to get the label from the application spec %s", AppContextsMapping[namespace].App.Key))
+					log.Infof("Pod label from the spec %s", label)
+					labelSelectors["app"] = label["app"]
 					pods, err := core.Instance().GetPods(namespace, labelSelectors)
 					dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching the pod list"))
 					srcClusterConfigPath, err := GetSourceClusterConfigPath()
 					dash.VerifyFatal(err, nil, fmt.Sprintf("Getting kubeconfig path for source cluster %v", srcClusterConfigPath))
 					for _, pod := range pods.Items {
-						beforeSize, err = getSizeOfMountPoint(pod.GetName(), namespace, srcClusterConfigPath)
-						dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching the size of volume before resizing %v from pod %v", beforeSize, pod.GetName()))
-						podListBeforeSizeMap[pod.Name] = beforeSize
+						volumeMounts, err := GetVolumeMounts(AppContextsMapping[namespace])
+						dash.VerifyFatal(err, nil, fmt.Sprintf("unable to get the mountpoints from the application spec %s", AppContextsMapping[namespace].App.Key))
+						for _, volumeMount := range volumeMounts {
+							beforeSize, err = getSizeOfMountPoint(pod.GetName(), namespace, srcClusterConfigPath, volumeMount)
+							dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching the size of volume before resizing %v from pod %v", beforeSize, pod.GetName()))
+							volListBeforeSizeMap[volumeMount] = beforeSize
+							podList = append(podList, pod.Name)
+						}
 					}
 				})
 				Step("Create schedule policy", func() {
@@ -820,20 +833,23 @@ var _ = Describe("{ResizeVolumeOnScheduleBackup}", func() {
 					postRuleUid, _ := Inst().Backup.GetRuleUid(orgID, ctx, postRuleNameList[0])
 					appContextsToBackup := FilterAppContextsByNamespace(scheduledAppContexts, []string{namespace})
 
-					firstScheduleBackupName, err = CreateScheduleBackupWithValidation(ctx, scheduleName, SourceClusterName, backupLocationName, backupLocationUID, appContextsToBackup, labelSelectors, orgID, preRuleNameList[0], preRuleUid, postRuleNameList[0], postRuleUid, periodicSchedulePolicyName, periodicSchedulePolicyUid)
+					firstScheduleBackupName, err = CreateScheduleBackupWithValidation(ctx, scheduleName, SourceClusterName, backupLocationName, backupLocationUID, appContextsToBackup, make(map[string]string), orgID, preRuleNameList[0], preRuleUid, postRuleNameList[0], postRuleUid, periodicSchedulePolicyName, periodicSchedulePolicyUid)
 					dash.VerifyFatal(err, nil, fmt.Sprintf("Creation and Validation of schedule backup with schedule name [%s]", scheduleName))
 				})
 				Step("Checking size of volume after resize", func() {
 					log.InfoD("Checking size of volume after resize")
 					srcClusterConfigPath, err := GetSourceClusterConfigPath()
 					dash.VerifyFatal(err, nil, fmt.Sprintf("Getting kubeconfig path for source cluster %v", srcClusterConfigPath))
-					for podName := range podListBeforeSizeMap {
-						afterSize, err := getSizeOfMountPoint(podName, namespace, srcClusterConfigPath)
-						dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching the mount size %v from pod %v", afterSize, podName))
-						podListAfterSizeMap[podName] = afterSize
+					for _, podName := range podList {
+						volumeMounts, err = GetVolumeMounts(AppContextsMapping[namespace])
+						for _, volumeMount := range volumeMounts {
+							afterSize, err := getSizeOfMountPoint(podName, namespace, srcClusterConfigPath, volumeMount)
+							dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching the size of volume ater resizing %v from pod %v", afterSize, podName))
+							volListAfterSizeMap[volumeMount] = afterSize
+						}
 					}
-					for podName := range podListBeforeSizeMap {
-						dash.VerifyFatal(podListAfterSizeMap[podName] > podListBeforeSizeMap[podName], true, fmt.Sprintf("Verifying volume size has increased for pod %s", podName))
+					for _, volumeMount := range volumeMounts {
+						dash.VerifyFatal(volListAfterSizeMap[volumeMount] > volListBeforeSizeMap[volumeMount], true, fmt.Sprintf("Verifying volume size has increased for pod %s", volumeMount))
 					}
 				})
 				Step("Verifying backup success after initializing volume resize", func() {

--- a/tests/backup/backup_portworx_test.go
+++ b/tests/backup/backup_portworx_test.go
@@ -764,7 +764,6 @@ var _ = Describe("{ResizeVolumeOnScheduleBackup}", func() {
 					log.InfoD("Getting size of volume before resizing")
 					label, err := GetAppLabelFromSpec(AppContextsMapping[namespace])
 					dash.VerifyFatal(err, nil, fmt.Sprintf("unable to get the label from the application spec %s", AppContextsMapping[namespace].App.Key))
-					log.Infof("Pod label from the spec %s", label)
 					labelSelectors["app"] = label["app"]
 					pods, err := core.Instance().GetPods(namespace, labelSelectors)
 					dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching the pod list"))


### PR DESCRIPTION
**What this PR does / why we need it**:
Get volumemounts independent of application volume type, and pods based on label from deployment spec

**Which issue(s) this PR fixes** (optional)
By fetching labels from the spec it provides support for select only application pods based on label and fetching mount
point independent of app and platform
https://portworx.atlassian.net/browse/PA-1254

Closes #
https://portworx.atlassian.net/browse/PA-1254

**Special notes for your reviewer**: 

Postgres - 
Jenkins : https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/1859/console

Aetos : https://aetos.pwx.purestorage.com/resultSet/testSetID/253275/testCaseID/1372499

mysql - https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/1860/consoleFull

Aetos : https://aetos.pwx.purestorage.com/resultSet/testSetID/253329/testCaseID/1372778

Logs : from S3

postgres -

https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/1877/consoleFull

mysql -

https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/1876/console


