### PR TITLE
PB-4015: To support pure file volume driver

### DIFF
--- a/drivers/volume/pso/pso.go
+++ b/drivers/volume/pso/pso.go
@@ -2,24 +2,27 @@ package pso
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/portworx/sched-ops/k8s/core"
 	torpedovolume "github.com/portworx/torpedo/drivers/volume"
 	"github.com/portworx/torpedo/drivers/volume/portworx"
 	"github.com/portworx/torpedo/drivers/volume/portworx/schedops"
 	"github.com/portworx/torpedo/pkg/log"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
 )
 
 const (
 	// PureDriverName is the name of the portworx-pure driver implementation
-	PureDriverName = "pso"
-	PsoServiceName = "pso-csi-controller"
+	PureDriverName     = "pso"
+	PureFileDriverName = "pso-file"
+	PsoServiceName     = "pso-csi-controller"
 )
 
 // Provisioners types of supported provisioners
 var provisionersForPure = map[torpedovolume.StorageProvisionerType]torpedovolume.StorageProvisionerType{
-	PureDriverName: "pure-csi",
+	PureDriverName:     "pure-csi",
+	PureFileDriverName: "pure-csi",
 }
 
 // pure is essentially the same as the portworx volume driver, just different in name. This way,
@@ -108,4 +111,5 @@ func GetPsoNamespace() (string, error) {
 func init() {
 	log.Infof("Registering pso driver")
 	torpedovolume.Register(PureDriverName, provisionersForPure, &pso{})
+	torpedovolume.Register(PureFileDriverName, provisionersForPure, &pso{})
 }

--- a/tests/backup/backup_portworx_test.go
+++ b/tests/backup/backup_portworx_test.go
@@ -611,7 +611,7 @@ var _ = Describe("{RestoreEncryptedAndNonEncryptedBackups}", func() {
 			for i := 1; i < len(backupNames); i++ {
 				restoreName := fmt.Sprintf("%s-%s-encrypted", restoreNamePrefix, backupNames[i])
 				restoreNames = append(restoreNames, restoreName)
-				for i, _ := range scheduledAppContexts {
+				for i := range scheduledAppContexts {
 					err = CreateRestoreWithValidation(ctx, restoreName, backupNames[i], make(map[string]string), make(map[string]string), destinationClusterName, orgID, scheduledAppContexts[i:i+1])
 				}
 				log.FailOnError(err, "%s restore failed", restoreName)


### PR DESCRIPTION

- update pso volume driver to register pure file. if the default pure driver is used for pure block.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
add support for pure-file volume driver

**Which issue(s) this PR fixes** (optional)
Closes #PB-4015

**Special notes for your reviewer**:
**TestResults**:
![Screenshot from 2023-07-12 14-09-31](https://github.com/portworx/torpedo/assets/116876049/a62cf5ef-aa0c-4eb9-a194-853989fe12a5)
![Screenshot from 2023-07-12 10-20-46](https://github.com/portworx/torpedo/assets/116876049/d8823468-0ad8-47ae-9cd5-07ea822c0526)
![Screenshot from 2023-07-11 23-04-03](https://github.com/portworx/torpedo/assets/116876049/64511672-b0ba-43dd-b7f4-20bcedaedbd9)
![Screenshot from 2023-07-11 23-03-50](https://github.com/portworx/torpedo/assets/116876049/8bc79901-d563-4dae-b110-dfff681c6cee)
![Screenshot from 2023-07-11 22-20-18](https://github.com/portworx/torpedo/assets/116876049/a27c9a45-a9a8-4343-9664-ab508d261b77)
![Screenshot from 2023-07-11 22-20-06](https://github.com/portworx/torpedo/assets/116876049/ead9e1c4-5c77-4313-853c-966f4c8b21b9)
![Screenshot from 2023-07-11 22-16-49](https://github.com/portworx/torpedo/assets/116876049/24a60002-b9fd-4e84-8571-234d094357de)

