### PR TITLE
Added an addtional parameter in DeleteCluster

### DIFF
--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -999,9 +999,9 @@ func CleanupCloudSettingsAndClusters(backupLocationMap map[string]string, credNa
 			Inst().Dash.VerifySafely(err, nil, fmt.Sprintf("Deleting cloud cred %s", credName))
 		}
 	}
-	err := DeleteCluster(SourceClusterName, orgID, ctx)
+	err := DeleteCluster(SourceClusterName, orgID, ctx, true)
 	Inst().Dash.VerifySafely(err, nil, fmt.Sprintf("Deleting cluster %s", SourceClusterName))
-	err = DeleteCluster(destinationClusterName, orgID, ctx)
+	err = DeleteCluster(destinationClusterName, orgID, ctx, true)
 	Inst().Dash.VerifySafely(err, nil, fmt.Sprintf("Deleting cluster %s", destinationClusterName))
 }
 

--- a/tests/backup/backup_license_test.go
+++ b/tests/backup/backup_license_test.go
@@ -174,7 +174,7 @@ var _ = Describe("{LicensingCountWithNodeLabelledBeforeClusterAddition}", func()
 			enumerateRsp, err := Inst().Backup.EnumerateCluster(ctx, clusterEnumerateReq)
 			log.FailOnError(err, "cluster enumeration failed")
 			for _, cluster := range enumerateRsp.GetClusters() {
-				err := DeleteCluster(cluster.GetName(), orgID, ctx)
+				err := DeleteCluster(cluster.GetName(), orgID, ctx, true)
 				dash.VerifyFatal(err, nil, fmt.Sprintf("Deleting cluster %s", cluster.GetName()))
 			}
 		})

--- a/tests/backup/backup_locked_bucket_test.go
+++ b/tests/backup/backup_locked_bucket_test.go
@@ -193,9 +193,9 @@ var _ = Describe("{BackupAlternatingBetweenLockedAndUnlockedBuckets}", func() {
 		log.FailOnError(err, "Fetching px-central-admin ctx")
 
 		log.Infof("Deleting registered clusters for admin context")
-		err = DeleteCluster(SourceClusterName, orgID, ctx)
+		err = DeleteCluster(SourceClusterName, orgID, ctx, true)
 		dash.VerifySafely(err, nil, fmt.Sprintf("Deleting cluster %s", SourceClusterName))
-		err = DeleteCluster(destinationClusterName, orgID, ctx)
+		err = DeleteCluster(destinationClusterName, orgID, ctx, true)
 		dash.VerifySafely(err, nil, fmt.Sprintf("Deleting cluster %s", destinationClusterName))
 	})
 })

--- a/tests/backup/backup_restore_basic_test.go
+++ b/tests/backup/backup_restore_basic_test.go
@@ -3146,7 +3146,7 @@ var _ = Describe("{DeleteNSDeleteClusterRestore}", func() {
 		Step("Delete source cluster where application is deployed", func() {
 			log.InfoD("Delete source cluster where application is deployed")
 			ctx, err := backup.GetAdminCtxFromSecret()
-			err = DeleteCluster(SourceClusterName, orgID, ctx)
+			err = DeleteCluster(SourceClusterName, orgID, ctx, false)
 			Inst().Dash.VerifyFatal(err, nil, fmt.Sprintf("Deleting cluster %s", SourceClusterName))
 		})
 		Step("Add source cluster back with px-central-admin ctx", func() {

--- a/tests/backup/backup_share_test.go
+++ b/tests/backup/backup_share_test.go
@@ -1206,16 +1206,16 @@ var _ = Describe("{ShareLargeNumberOfBackupsWithLargeNumberOfUsers}", func() {
 		log.FailOnError(err, "Fetching px-central-admin ctx")
 
 		log.Infof("Deleting registered clusters for admin context")
-		err = DeleteCluster(SourceClusterName, orgID, ctx)
+		err = DeleteCluster(SourceClusterName, orgID, ctx, true)
 		dash.VerifySafely(err, nil, fmt.Sprintf("Deleting cluster %s", SourceClusterName))
-		err = DeleteCluster(destinationClusterName, orgID, ctx)
+		err = DeleteCluster(destinationClusterName, orgID, ctx, true)
 		dash.VerifySafely(err, nil, fmt.Sprintf("Deleting cluster %s", destinationClusterName))
 
 		log.Infof("Deleting registered clusters for non-admin context")
 		for _, ctxNonAdmin := range userContexts {
-			err = DeleteCluster(SourceClusterName, orgID, ctxNonAdmin)
+			err = DeleteCluster(SourceClusterName, orgID, ctxNonAdmin, true)
 			dash.VerifySafely(err, nil, fmt.Sprintf("Deleting cluster %s", SourceClusterName))
-			err = DeleteCluster(destinationClusterName, orgID, ctxNonAdmin)
+			err = DeleteCluster(destinationClusterName, orgID, ctxNonAdmin, true)
 			dash.VerifySafely(err, nil, fmt.Sprintf("Deleting cluster %s", destinationClusterName))
 		}
 
@@ -2520,9 +2520,9 @@ var _ = Describe("{ShareBackupsAndClusterWithUser}", func() {
 		log.FailOnError(err, fmt.Sprintf("Failed while waiting for backup %s to be deleted", userBackupName))
 
 		log.Infof("Deleting registered clusters for non-admin context")
-		err = DeleteCluster(SourceClusterName, orgID, ctxNonAdmin)
+		err = DeleteCluster(SourceClusterName, orgID, ctxNonAdmin, true)
 		dash.VerifySafely(err, nil, fmt.Sprintf("Deleting cluster %s", SourceClusterName))
-		err = DeleteCluster(destinationClusterName, orgID, ctxNonAdmin)
+		err = DeleteCluster(destinationClusterName, orgID, ctxNonAdmin, true)
 		dash.VerifySafely(err, nil, fmt.Sprintf("Deleting cluster %s", destinationClusterName))
 
 		CleanupCloudSettingsAndClusters(backupLocationMap, cloudCredName, cloudCredUID, ctx)
@@ -2882,9 +2882,9 @@ var _ = Describe("{DeleteSharedBackup}", func() {
 
 		log.Infof("Deleting registered clusters for non-admin context")
 		for _, ctxNonAdmin := range userContexts {
-			err := DeleteCluster(SourceClusterName, orgID, ctxNonAdmin)
+			err := DeleteCluster(SourceClusterName, orgID, ctxNonAdmin, true)
 			dash.VerifySafely(err, nil, fmt.Sprintf("Deleting cluster %s", SourceClusterName))
-			err = DeleteCluster(destinationClusterName, orgID, ctxNonAdmin)
+			err = DeleteCluster(destinationClusterName, orgID, ctxNonAdmin, true)
 			dash.VerifySafely(err, nil, fmt.Sprintf("Deleting cluster %s", destinationClusterName))
 		}
 
@@ -3341,9 +3341,9 @@ var _ = Describe("{ViewOnlyFullBackupRestoreIncrementalBackup}", func() {
 
 		log.Infof("Deleting registered clusters for non-admin context")
 		for _, ctxNonAdmin := range userContexts {
-			err = DeleteCluster(SourceClusterName, orgID, ctxNonAdmin)
+			err = DeleteCluster(SourceClusterName, orgID, ctxNonAdmin, true)
 			dash.VerifySafely(err, nil, fmt.Sprintf("Deleting cluster %s", SourceClusterName))
-			err = DeleteCluster(destinationClusterName, orgID, ctxNonAdmin)
+			err = DeleteCluster(destinationClusterName, orgID, ctxNonAdmin, true)
 			dash.VerifySafely(err, nil, fmt.Sprintf("Deleting cluster %s", destinationClusterName))
 		}
 

--- a/tests/common.go
+++ b/tests/common.go
@@ -3439,14 +3439,14 @@ func DeleteBackup(backupName string, backupUID string, orgID string, ctx context
 }
 
 // DeleteCluster deletes/de-registers cluster from px-backup
-func DeleteCluster(name string, orgID string, ctx context1.Context) error {
+func DeleteCluster(name string, orgID string, ctx context1.Context, cleanupBackupsRestores bool) error {
 
 	backupDriver := Inst().Backup
 	clusterDeleteReq := &api.ClusterDeleteRequest{
 		OrgId:          orgID,
 		Name:           name,
-		DeleteBackups:  true,
-		DeleteRestores: true,
+		DeleteBackups:  cleanupBackupsRestores,
+		DeleteRestores: cleanupBackupsRestores,
 	}
 	_, err := backupDriver.DeleteCluster(ctx, clusterDeleteReq)
 	return err


### PR DESCRIPTION
**What this PR does / why we need it**:

I introduced a regression when I added `DeleteBackups` and `DeleteRestores` in `DeleteCluster` function.

**Why was this added in the first place?**
To make sure that all the backups and restores are cleaned up before deleting the cluster. This was working fine with Px based backups. But when we tested on PSO with KDMP backups, we saw that the backups were not getting cleaned up during backup location deletion, so we added another check in `DeleteCluster` function to be fully sure that the backups are deleted before deleting the cluster. This was necessary because, once we delete the cluster, deleting the backups was getting stuck because KDMP/CSI backups need cluster reference to delete the backups.

**Why and where did it regress?**
In the test `DeleteNSDeleteClusterRestore` we are actually trying to just remove the cluster and add it again without cleaning up the backups. Here we saw that the backups are also getting cleaned up when we removed the cluster and the restores were failing in the subsequent steps.

**What is the fix?**
Added another parameter `cleanupBackupsRestores` to `DeleteCluster` function. Now the caller can decide whether we need to cleanup all backups and restores before deleting the cluster or retain the backups and restores and just delete the cluster

**Which issue(s) this PR fixes** (optional)
Closes # To be created

**Special notes for your reviewer**:

