### PR TITLE
PTX-19044: Fixing issue with azure-cli install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN apk add --no-cache ca-certificates bash curl jq libc6-compat
 
  # Install Azure Cli
 RUN apk add --no-cache --update python3 py3-pip
-RUN apk add --no-cache --update --virtual=build gcc musl-dev python3-dev libffi-dev openssl-dev cargo make && pip3 install --no-cache-dir --prefer-binary azure-cli && apk del build
+RUN apk add --no-cache --update --virtual=build gcc musl-dev python3-dev libffi-dev openssl-dev cargo make && pip3 install "pyyaml<=5.3.1" && pip3 install --no-cache-dir --prefer-binary azure-cli && apk del build
 
 # Install kubectl from Docker Hub.
 COPY --from=lachlanevenson/k8s-kubectl:latest /usr/local/bin/kubectl /usr/local/bin/kubectl


### PR DESCRIPTION
We have an open issue with PyYaml which is causing azure-cli install to fail. As a workaround we are switching to stable version on PyYaml.

**What this PR does / why we need it**:
Install specific stable version of PyYaml

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PTX-19044

**Special notes for your reviewer**:

