### PR TITLE
Measure and fail test if node takes more than the desired time to upgrade anthos user cluster node.

### DIFF
--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -2028,7 +2028,7 @@ func (k *K8s) addSecurityAnnotation(spec interface{}, configMap *corev1.ConfigMa
 					obj.Parameters[encryptionName] = "true"
 				}
 				if app.IsCSI {
-					obj.Parameters [CsiProvisionerSecretName] = configMap.Data[secretNameKey]
+					obj.Parameters[CsiProvisionerSecretName] = configMap.Data[secretNameKey]
 					obj.Parameters[CsiProvisionerSecretNamespace] = configMap.Data[secretNamespaceKey]
 					obj.Parameters[CsiNodePublishSecretName] = configMap.Data[secretNameKey]
 					obj.Parameters[CsiNodePublishSecretNamespace] = configMap.Data[secretNamespaceKey]


### PR DESCRIPTION
**What this PR does / why we need it**:
These changes will measure each node upgrade time and fail the test if any node takes more than required timeout to upgrade a node.

**Which issue(s) this PR fixes** (optional)
Closes # PTX-18551

**Special notes for your reviewer**:
```
2023-07-20 01:15:07 +0000:[INFO] [{UpgradeCluster}] [anthos.(*anthos).checkUserClusterNodesUpgradeTime:#546] - Validating user cluster nodes upgrade time

2023-07-20 01:15:07 +0000:[INFO] [{UpgradeCluster}] [anthos.(*anthos).getUserClusterName:#577] - Retrieving user cluster name

2023-07-20 01:15:08 +0000:[INFO] [{UpgradeCluster}] [anthos.(*anthos).getUserClusterName:#597] - Successfully retrieved user cluster name: [tp-anthos-upgrade]

2023-07-20 01:15:08 +0000:[INFO] [{UpgradeCluster}] [anthos.(*anthos).getStartTimeForNodePoolUpgrade:#603] - Getting start time for node pool upgrade

2023-07-20 01:15:08 +0000:[DEBUG] [{UpgradeCluster}] [anthos.(*anthos).getStartTimeForNodePoolUpgrade:#610] - Executing command: gkectl describe clusters --kubeconfig /home/ubuntu/kubeconfig --cluster tp-anthos-upgrade

2023-07-20 01:15:08 +0000:[DEBUG] [{UpgradeCluster}] [anthos.(*anthos).getStartTimeForNodePoolUpgrade:#624] - Successfully retrieved startTime: 2023-07-19 18:45:10 +0000 UTC

2023-07-20 01:15:08 +0000:[DEBUG] [{UpgradeCluster}] [anthos.(*anthos).checkUserClusterNodesUpgradeTime:#555] - User cluster node pool upgrade started at: [Wed Jul 19 18:45:10 UTC 2023]

2023-07-20 01:15:08 +0000:[INFO] [{UpgradeCluster}] [anthos.getNodesSortByAge:#630] - Getting nodes by age

2023-07-20 01:15:08 +0000:[INFO] [{UpgradeCluster}] [anthos.getNodesSortByAge:#651] - Successfully retrieved sorted nodes

2023-07-20 01:15:08 +0000:[INFO] [{UpgradeCluster}] [anthos.(*anthos).checkUserClusterNodesUpgradeTime:#568] - [tp-anthos-upgrade-5] node took: [6m13s] time to upgrade the node

2023-07-20 01:15:08 +0000:[INFO] [{UpgradeCluster}] [anthos.(*anthos).checkUserClusterNodesUpgradeTime:#568] - [tp-anthos-upgrade-0] node took: [10m19s] time to upgrade the node

2023-07-20 01:15:08 +0000:[INFO] [{UpgradeCluster}] [anthos.(*anthos).checkUserClusterNodesUpgradeTime:#568] - [tp-anthos-upgrade-4] node took: [5m54s] time to upgrade the node

2023-07-20 01:15:08 +0000:[INFO] [{UpgradeCluster}] [anthos.(*anthos).checkUserClusterNodesUpgradeTime:#568] - [tp-anthos-upgrade-1] node took: [5m18s] time to upgrade the node
[1mSTEP[0m: validate storage components
```
Example of a job which fails when node takes longer time to upgrade
https://jenkins.pwx.dev.purestorage.com/job/Torpedo/job/tp-anthos-upgrade/192/console

```
2023-07-20 02:30:06 +0000:[INFO] [{UpgradeCluster}] [anthos.(*anthos).checkUserClusterNodesUpgradeTime:#568] - [tp-anthos-upgrade-2] node took: [4m43s] time to upgrade the node
2023-07-20 02:30:06 +0000:[INFO] [{UpgradeCluster}] [anthos.(*anthos).checkUserClusterNodesUpgradeTime:#568] - [tp-anthos-upgrade-4] node took: [5m37s] time to upgrade the node
2023-07-20 02:30:06 +0000:[INFO] [{UpgradeCluster}] [anthos.(*anthos).checkUserClusterNodesUpgradeTime:#568] - [tp-anthos-upgrade-3] node took: [5m37s] time to upgrade the node
2023-07-20 02:30:06 +0000:[INFO] [{UpgradeCluster}] [tests.AfterEachTest:#2710] - >>>> FAILED TEST: {UpgradeCluster} upgrade scheduler and ensure everything is running fine
2023-07-20 02:30:06 +0000:[INFO] [{UpgradeCluster}] generating support bundle...
INFO[2023-07-20 02:30:06] Verifying : Description : Worker nodes found ? 
INFO[2023-07-20 02:30:06] Actual:true, Expected: true                  
STEP: Describe Namespace objects for test upgrade scheduler and ensure everything is running fine 

2023-07-20 02:30:07 +0000:[ERROR] [{UpgradeCluster}] [tests.DescribeNamespace.func1.1:#2009] - failed to save file /var/cores/nginx-sharedv4-upgradecluster-0-07-20-01h28m34s.namespace.log. Cause: open /var/cores/nginx-sharedv4-upgradecluster-0-07-20-01h28m34s.namespace.log: no such file or directory
INFO[2023-07-20 02:30:08] Verifying : Description : Test completed successfully ? 
INFO[2023-07-20 02:30:08] Actual:PASS, Expected: PASS         
INFO[2023-07-20 02:30:08] --------Test End------                       
INFO[2023-07-20 02:30:08] #Test: UpgradeCluster                        
INFO[2023-07-20 02:30:08] #Description: Upgrade cluster test           
INFO[2023-07-20 02:30:08] ------------------------                     

• Failure [3547.080 seconds]
{UpgradeCluster}
/go/src/github.com/portworx/torpedo/tests/basic/upgrade_cluster_test.go:14
  upgrade scheduler and ensure everything is running fine [It]
  /go/src/github.com/portworx/torpedo/tests/basic/upgrade_cluster_test.go:23

  Unexpected error:
      <*errors.errorString | 0xc0001f75e0>: {
          s: "[tp-anthos-upgrade-1] node upgrade took: [17m28s] minutes which is longer than the expected timeout value: [15m0s]",
      }
      [tp-anthos-upgrade-1] node upgrade took: [17m28s] minutes which is longer than the expected timeout value: [15m0s]
  occurred

  /go/src/github.com/portworx/torpedo/tests/basic/upgrade_cluster_test.go:41

  Full Stack Trace
  github.com/portworx/torpedo/tests/basic.glob..func170.2.1()
  	/go/src/github.com/portworx/torpedo/tests/basic/upgrade_cluster_test.go:41 +0x6a
  github.com/portworx/torpedo/tests/basic.glob..func170.2()
  	/go/src/github.com/portworx/torpedo/tests/basic/upgrade_cluster_test.go:39 +0x3f6
  github.com/portworx/torpedo/tests/basic.TestBasic(0x0?)
  	/go/src/github.com/portworx/torpedo/tests/basic/basic_test.go:47 +0xb9
  testing.tRunner(0xc00085c340, 0x7587fd0)
  	/usr/local/go/src/testing/testing.go:1446 +0x10b
  created by testing.(*T).Run
  	/usr/local/go/src/testing/testing.go:1493 +0x35f
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS2023-07-20 02:30:08 +0000:[INFO] Log Dir: /testresults//SystemCheck.log
INFO[2023-07-20 02:30:08] --------Test Start------                     
INFO[2023-07-20 02:30:08] #Test: System check                          
INFO[2023-07-20 02:30:08] #Description: validating system check and clean up  
INFO[2023-07-20 02:30:08] ------------------------                     
INFO[2023-07-20 02:30:08] Running test from file torpedo/tests/basic/basic_test.go, module: System check 
2023-07-20 02:30:08 +0000:[INFO] [tests.PerformSystemCheck.func1:#2172] - checking for core files...
```


