### PR TITLE
PWX-32564: Disable core file check for pool tests

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -13,6 +13,12 @@ if [ -z "${DASH_UID}" ]; then
 fi
 
 SECURITY_CONTEXT=false
+
+TORPEDO_SKIP_SYSTEM_CHECKS=false
+if [ -z "${TORPEDO_SKIP_SYSTEM_CHECKS}" ]; then
+    TORPEDO_SKIP_SYSTEM_CHECKS=true
+fi
+
 if [ "${IS_OCP}" == true ]; then
     SECURITY_CONTEXT=true
 fi
@@ -525,6 +531,7 @@ spec:
             "--product=$PRODUCT",
             "--torpedo-job-name=$TORPEDO_JOB_NAME",
             "--torpedo-job-type=$TORPEDO_JOB_TYPE",
+            "--torpedo-skip-system-checks=$TORPEDO_SKIP_SYSTEM_CHECKS",
             "$APP_DESTROY_TIMEOUT_ARG",
     ]
     tty: true

--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -14,6 +14,9 @@ fi
 
 SECURITY_CONTEXT=false
 
+# System checks https://github.com/portworx/torpedo/blob/86232cb195400d05a9f83d57856f8f29bdc9789d/tests/common.go#L2173
+# should be skipped from AfterSuite() if this flag is set to true. This is to avoid distracting test failures due to
+# unstable testing environments.
 TORPEDO_SKIP_SYSTEM_CHECKS=false
 if [ -z "${TORPEDO_SKIP_SYSTEM_CHECKS}" ]; then
     TORPEDO_SKIP_SYSTEM_CHECKS=true

--- a/tests/basic/basic_test.go
+++ b/tests/basic/basic_test.go
@@ -57,23 +57,24 @@ var _ = BeforeSuite(func() {
 
 var _ = AfterSuite(func() {
 	TestLogger = CreateLogger("SystemCheck.log")
-
 	defer dash.TestSetEnd()
 	defer CloseLogger(TestLogger)
 	defer dash.TestCaseEnd()
 	// making sure validate clean up executed even if systemcheck failed
 	defer func() {
 		if wantAllAfterSuiteActions || wantAfterSuiteValidateCleanup {
+			dash.TestCaseBegin("Validate Cleanup", "Validating clean up", "", nil)
 			ValidateCleanup()
 		}
 	}()
 
 	log.SetTorpedoFileOutput(TestLogger)
-	dash.TestCaseBegin("System check", "validating system check and clean up", "", nil)
-	if wantAllAfterSuiteActions || wantAfterSuiteSystemCheck {
-		PerformSystemCheck()
+	if !Inst().SkipSystemChecks {
+		if wantAllAfterSuiteActions || wantAfterSuiteSystemCheck {
+			dash.TestCaseBegin("System Checks", "Perform system checks", "", nil)
+			PerformSystemCheck()
+		}
 	}
-
 })
 
 func TestMain(m *testing.M) {

--- a/tests/common.go
+++ b/tests/common.go
@@ -5142,7 +5142,10 @@ func ParseFlags() {
 	flag.StringVar(&pdsDriverName, pdsDriveCliFlag, defaultPdsDriver, "Name of the pdsdriver to use")
 	flag.StringVar(&anthosWsNodeIp, anthosWsNodeIpCliFlag, "", "Anthos admin work station node IP")
 	flag.StringVar(&anthosInstPath, anthosInstPathCliFlag, "", "Anthos config path where all conf files present")
-	flag.BoolVar(&skipSystemChecks, skipSystemCheckCliFlag, false, "Skip system check")
+	// System checks https://github.com/portworx/torpedo/blob/86232cb195400d05a9f83d57856f8f29bdc9789d/tests/common.go#L2173
+	// should be skipped from AfterSuite() if this flag is set to true. This is to avoid distracting test failures due to
+	// unstable testing environments.
+	flag.BoolVar(&skipSystemChecks, skipSystemCheckCliFlag, false, "Skip system checks during after suite")
 	flag.Parse()
 
 	log.SetLoglevel(logLevel)

--- a/tests/common.go
+++ b/tests/common.go
@@ -240,6 +240,8 @@ const (
 	// Anthos
 	anthosWsNodeIpCliFlag = "anthos-ws-node-ip"
 	anthosInstPathCliFlag = "anthos-inst-path"
+
+	skipSystemCheckCliFlag = "torpedo-skip-system-checks"
 )
 
 // Dashboard params
@@ -5012,6 +5014,7 @@ type Torpedo struct {
 	IsPDSApps                           bool
 	AnthosAdminWorkStationNodeIP        string
 	AnthosInstPath                      string
+	SkipSystemChecks                    bool
 }
 
 // ParseFlags parses command line flags
@@ -5050,6 +5053,7 @@ func ParseFlags() {
 	// We should make this more robust.
 	var customAppConfig map[string]scheduler.AppConfig = make(map[string]scheduler.AppConfig)
 
+	var skipSystemChecks bool
 	var enableStorkUpgrade bool
 	var secretType string
 	var pureVolumes bool
@@ -5138,6 +5142,7 @@ func ParseFlags() {
 	flag.StringVar(&pdsDriverName, pdsDriveCliFlag, defaultPdsDriver, "Name of the pdsdriver to use")
 	flag.StringVar(&anthosWsNodeIp, anthosWsNodeIpCliFlag, "", "Anthos admin work station node IP")
 	flag.StringVar(&anthosInstPath, anthosInstPathCliFlag, "", "Anthos config path where all conf files present")
+	flag.BoolVar(&skipSystemChecks, skipSystemCheckCliFlag, false, "Skip system check")
 	flag.Parse()
 
 	log.SetLoglevel(logLevel)
@@ -5367,6 +5372,7 @@ func ParseFlags() {
 				AnthosAdminWorkStationNodeIP:        anthosWsNodeIp,
 				AnthosInstPath:                      anthosInstPath,
 				IsPDSApps:                           deployPDSApps,
+				SkipSystemChecks:                    skipSystemChecks,
 			}
 		})
 	}
@@ -7724,7 +7730,6 @@ func GetPoolCapacityUsed(poolUUID string) (float64, error) {
 
 	return poolSizeUsed, nil
 }
-
 
 func AddCloudDrive(stNode node.Node, poolID int32) error {
 	driveSpecs, err := GetCloudDriveDeviceSpecs()


### PR DESCRIPTION
**Why we need this**
https://purestorage.slack.com/archives/C04TQ6QDF8F/p1689963537894969

**Overview**
This PR provides a switch that allows jobs to bypass running system checks. 

**Example usage:** 
Job parameter `TORPEDO_SKIP_SYSTEM_CHECKS` configured at https://jenkins.pwx.dev.purestorage.com/job/Users/job/alyu/job/pxdv-5-dev/configure


**Testing:**
System tests were kSystem checks were skipped:  
https://jenkins.pwx.dev.purestorage.com/job/Users/job/alyu/job/pxdv-5-dev/66/console 
`"--torpedo-skip-system-checks=true",` can be found from logs. 

Compared to when system checks are run: 
https://jenkins.pwx.dev.purestorage.com/job/Users/job/alyu/job/pxdv-5-dev/63/console 
where these logs can be found: 
```
18:00:59 INFO[2023-07-28 01:00:58] --------Test Start------                     
18:00:59 INFO[2023-07-28 01:00:58] #Test: System Checks                         
18:00:59 INFO[2023-07-28 01:00:58] #Description: Perform system checks 
...
```
 