### PR TITLE
Vanilla pipeline is failing intermittently while getting the Targetcl…

### DIFF
--- a/drivers/pds/targetcluster/targetcluster.go
+++ b/drivers/pds/targetcluster/targetcluster.go
@@ -37,6 +37,7 @@ const (
 	MaxTimeout     = 30 * time.Minute
 	timeOut        = 30 * time.Minute
 	timeInterval   = 10 * time.Second
+	minTimeOut     = 5 * time.Minute
 
 	// PDSNamespace PDS
 	PDSNamespace = "pds-system"
@@ -69,14 +70,14 @@ type TargetCluster struct {
 
 func (tc *TargetCluster) GetDeploymentTargetID(clusterID, tenantID string) (string, error) {
 	log.InfoD("Get the Target cluster details")
-	err = wait.Poll(DefaultRetryInterval, 5*time.Minute, func() (bool, error) {
+	err = wait.Poll(DefaultRetryInterval, minTimeOut, func() (bool, error) {
 		targetClusters, err := components.DeploymentTarget.ListDeploymentTargetsBelongsToTenant(tenantID)
 		var targetClusterStatus string
 		if err != nil {
-			return true, fmt.Errorf("error while listing deployments: %v", err)
+			return true, fmt.Errorf("error while listing deployment targets: %v", err)
 		}
 		if targetClusters == nil {
-			return true, fmt.Errorf("target cluster passed is not available to the account/tenant %v", err)
+			return true, fmt.Errorf("target cluster passed is not available to the account/tenant")
 		}
 		for i := 0; i < len(targetClusters); i++ {
 			if targetClusters[i].GetClusterId() == clusterID {

--- a/drivers/pds/targetcluster/targetcluster.go
+++ b/drivers/pds/targetcluster/targetcluster.go
@@ -69,14 +69,14 @@ type TargetCluster struct {
 
 func (tc *TargetCluster) GetDeploymentTargetID(clusterID, tenantID string) (string, error) {
 	log.InfoD("Get the Target cluster details")
-	err = wait.Poll(DefaultRetryInterval, 5*time.Minute, func() (bool, error) {
+	err = wait.Poll(DefaultRetryInterval, MaxTimeout, func() (bool, error) {
 		targetClusters, err := components.DeploymentTarget.ListDeploymentTargetsBelongsToTenant(tenantID)
 		var targetClusterStatus string
 		if err != nil {
-			return true, fmt.Errorf("error while listing deployments: %v", err)
+			return "", fmt.Errorf("error while listing deployments: %v", err)
 		}
 		if targetClusters == nil {
-			return true, fmt.Errorf("target cluster passed is not available to the account/tenant %v", err)
+			return "", fmt.Errorf("target cluster passed is not available to the account/tenant %v", err)
 		}
 		for i := 0; i < len(targetClusters); i++ {
 			if targetClusters[i].GetClusterId() == clusterID {
@@ -87,9 +87,8 @@ func (tc *TargetCluster) GetDeploymentTargetID(clusterID, tenantID string) (stri
 			}
 		}
 		if targetClusterStatus != "healthy" {
-			return true, fmt.Errorf("target Cluster is not in healthy state due to error : %v", err)
+			return "", fmt.Errorf("target Cluster is not in healthy state due to error : %v", err)
 		}
-
 		log.Infof("There are %d pods present in the namespace %s", len(pods.Items), PDSNamespace)
 		return false, nil
 	})

--- a/drivers/pds/targetcluster/targetcluster.go
+++ b/drivers/pds/targetcluster/targetcluster.go
@@ -85,9 +85,13 @@ func (tc *TargetCluster) GetDeploymentTargetID(clusterID, tenantID string) (stri
 			targetClusterStatus = targetClusters[i].GetStatus()
 		}
 	}
-	if targetClusterStatus != "healthy" {
-		return "", fmt.Errorf("target Cluster is not in healthy state due to error : %v", err)
-	}
+	err = wait.Poll(DefaultRetryInterval, 5*time.Minute, func() (bool, error) {
+		if targetClusterStatus != "healthy" {
+			return true, fmt.Errorf("target Cluster is not in healthy state due to error : %v", err)
+		}
+		log.Infof("There cluster is Healthy and Ready to use")
+		return false, nil
+	})
 	return deploymentTargetID, nil
 }
 

--- a/drivers/pds/targetcluster/targetcluster.go
+++ b/drivers/pds/targetcluster/targetcluster.go
@@ -73,10 +73,10 @@ func (tc *TargetCluster) GetDeploymentTargetID(clusterID, tenantID string) (stri
 		targetClusters, err := components.DeploymentTarget.ListDeploymentTargetsBelongsToTenant(tenantID)
 		var targetClusterStatus string
 		if err != nil {
-			return "", fmt.Errorf("error while listing deployments: %v", err)
+			return true, fmt.Errorf("error while listing deployments: %v", err)
 		}
 		if targetClusters == nil {
-			return "", fmt.Errorf("target cluster passed is not available to the account/tenant %v", err)
+			return true, fmt.Errorf("target cluster passed is not available to the account/tenant %v", err)
 		}
 		for i := 0; i < len(targetClusters); i++ {
 			if targetClusters[i].GetClusterId() == clusterID {
@@ -87,12 +87,11 @@ func (tc *TargetCluster) GetDeploymentTargetID(clusterID, tenantID string) (stri
 			}
 		}
 		if targetClusterStatus != "healthy" {
-			return "", fmt.Errorf("target Cluster is not in healthy state due to error : %v", err)
+			return true, fmt.Errorf("target Cluster is not in healthy state due to error : %v", err)
 		}
-		log.Infof("There are %d pods present in the namespace %s", len(pods.Items), PDSNamespace)
+		log.Infof("Target cluster %v is in Healthy State ", deploymentTargetID)
 		return false, nil
 	})
-
 	return deploymentTargetID, nil
 }
 


### PR DESCRIPTION
Added a polling logic to check the cluster health check and error-out if not in "Healthy" state. 

Supporting Logs - 
1. When cluster is HEALTHY - https://aetos.pwx.purestorage.com/resultSet/testSetID/281979
2. When cluster is NOT HEALTHY - Attached screenshot in the JIRA Ticket. 
     https://portworx.atlassian.net/browse/PA-1440

