### PR TITLE
PWX-32562: low IO fio

### DIFF
--- a/drivers/scheduler/k8s/specs/fio-low-io/fio-config-map.yaml
+++ b/drivers/scheduler/k8s/specs/fio-low-io/fio-config-map.yaml
@@ -24,7 +24,7 @@ data:
         nrfiles=10000
         ioengine=libaio
         iodepth=4
-        rate_min=125k
+        rate_min=64k
         rate_iops=64
 ---
 apiVersion: v1

--- a/drivers/scheduler/k8s/specs/fio-low-io/fio-config-map.yaml
+++ b/drivers/scheduler/k8s/specs/fio-low-io/fio-config-map.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fio-job-config
+data:
+    fio.job: |
+        [global]
+        name=fio-rand-RW
+        directory=/scratch/
+        rw=randwrite
+        rwmixread=90
+        randrepeat=1
+        blocksize=4k
+        direct=1
+        end_fsync=1
+        do_verify=1
+        verify=crc32c
+        verify_pattern=0xdeadbeef
+        disable_lat=0
+        time_based=1
+        runtime=99999999
+        [file1]
+        filesize=1M-10M
+        nrfiles=10000
+        ioengine=libaio
+        iodepth=4
+        rate_min=125k
+        rate_iops=64
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fio-ready-probe
+data:
+  ready-probe.sh: |
+    #!/bin/bash
+    if [ `cat /root/fio.log | grep 'error\|bad magic header' | wc -l` -ge 1 ]; then
+      exit 1;
+    else
+      exit 0;
+    fi

--- a/drivers/scheduler/k8s/specs/fio-low-io/fio-low-io.yaml
+++ b/drivers/scheduler/k8s/specs/fio-low-io/fio-low-io.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: fio-low-io
+spec:
+  serviceName: fio-low-io
+  {{ if .Replicas }}
+  replicas: {{ .Replicas }}
+  {{ else }}
+  replicas: 1
+  {{ end }}
+  selector:
+    matchLabels:
+      app: fio
+  template:
+    metadata:
+      labels:
+        app: fio
+    spec:
+      schedulerName: stork
+      containers:
+      - name: fio
+        # image: portworx/fio_drv
+        image: alicelol/fio_drv:alyu-test
+        command: ["fio"]
+        resources:
+          limits:
+            cpu: "2"
+            memory: 4Gi
+          requests:
+            cpu: "1"
+            memory: 4Gi
+        args: ["/configs/fio.job", "--status-interval=1", "--eta=never", "--output=/logs/fio.log"]
+        volumeMounts:
+        - name: fio-config-vol
+          mountPath: /configs
+        - name: fio-data
+          mountPath: /scratch
+        - name: fio-log
+          mountPath: /logs
+      volumes:
+      - name: fio-config-vol
+        configMap:
+          name: fio-job-config
+  volumeClaimTemplates:
+  - metadata:
+      name: fio-data
+    spec:
+      storageClassName: fio-sc
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+        {{ if .VolumeSize }}
+          storage: {{ .VolumeSize }}
+        {{ else }}
+          storage: 200Gi{{ end }}
+  - metadata:
+      name: fio-log
+    spec:
+      storageClassName: fio-log
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 50Gi

--- a/drivers/scheduler/k8s/specs/fio-low-io/fio-low-io.yaml
+++ b/drivers/scheduler/k8s/specs/fio-low-io/fio-low-io.yaml
@@ -20,8 +20,7 @@ spec:
       schedulerName: stork
       containers:
       - name: fio
-        # image: portworx/fio_drv
-        image: alicelol/fio_drv:alyu-test
+        image: portworx/fio_drv:3.16
         command: ["fio"]
         resources:
           limits:

--- a/drivers/scheduler/k8s/specs/fio-low-io/pxd/px-storage-class.yaml
+++ b/drivers/scheduler/k8s/specs/fio-low-io/pxd/px-storage-class.yaml
@@ -1,0 +1,39 @@
+##### Portworx storage class
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: fio-sc
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  {{ if .Repl }}
+  repl : "{{ .Repl }}"
+  {{ else }}
+  repl: "2"{{ end }}
+  priority_io: "high"
+  {{ if .IoProfile }}
+  io_profile: "{{ .IoProfile }}"
+  {{ else }}
+  io_profile: "db_remote"{{ end }}
+  {{ if .Fs }}
+  fs: {{ .Fs }}{{ end }}
+allowVolumeExpansion: true
+---
+##### Portworx storage class
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: fio-log
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  {{ if .Repl }}
+  repl: "{{ .Repl }}"
+  {{ else }}
+  repl: "2"{{ end }}
+  priority_io: "high"
+  {{ if .IoProfile }}
+  io_profile: "{{ .IoProfile }}"
+  {{ else }}
+  io_profile: "db_remote"{{ end }}
+  {{ if .Fs }}
+  fs: {{ .Fs }}{{ end }}
+allowVolumeExpansion: true


### PR DESCRIPTION
### Why we need this:
https://portworx.atlassian.net/browse/PWX-32405?focusedCommentId=255978

### Changes
- The fio app currently in use is from 8 years ago: 
```
➜  torpedo git:(PWX-32562) docker run --rm 47f3c451e80a --version
fio-2.2.8
```
  the low-io fio app introduced in this PR uses the newest version (fio-3.16)
- configuration changes
The changes in the new FIO configuration compared to the original aim to control and limit the IO rate, leading to more predictable and controlled IO behavior.

The primary changes revolve around the following parameters:

rwmixread=90 from rwmixread=75: This increases the proportion of read operations to 90% of all operations, from the original 75%. This will significantly reduce the write operations, as now only 10% of operations are writes as opposed to the original 25%.

blocksize=4k from blocksize_range=4k-512k: The new configuration uses a fixed block size of 4k for all operations, replacing a variable block size that ranged from 4k to 512k. This means that the IO operations are now more predictable, and there is less chance for extremely high IO rates that could happen with larger block sizes in the original configuration.

iodepth=4 from iodepth=128: The new configuration limits the number of IO operations queued at once to 4, significantly reducing from the original 128. This means there will be fewer simultaneous operations, which will reduce the peak IO rate.

rate_min=64k and rate_iops=64: These are new parameters that aim to further control the IO rate. rate_min=125k specifies the minimum IO rate fio should try to maintain, and rate_iops=64 specifies the number of IO operations per second. These additions introduce an additional layer of rate control to ensure that the IO does not exceed the desired rate.

### Impacts
assume a scenario where every IO operation writes a full block. In the original configuration, the IO rate could potentially reach up to 128 * 512k = **_64MB/s_** if all IO operations are writes with 512k block size. The new configuration limits the IO rate to a much lower value. Assuming the block size is 4k, even at the maximum IO depth of 4, the maximum IO rate would be 4 * 4k = **_16KB/s_**. Furthermore, given the addition of rate_min=64k, FIO will try to maintain at least a bandwidth of 64KB/s, and the rate_iops=64 will limit the number of IO operations to 64 per second. The actual IO rate could be lower than these limits depending on the system capabilities and workload at the time of execution. 
  

### Testing:
https://jenkins.pwx.dev.purestorage.com/job/Users/job/alyu/job/pxdv-5-dev/68/

Used this low-io app in the testing of PWX-32647: obtained an 8 consecutive successes. 
<img width="446" alt="image" src="https://github.com/portworx/torpedo/assets/19244687/bbef2d2c-5325-47ab-bd0e-0ea6057ed8b6">



Note: it is observed from test run trails that a little over 2GB of data was written in ~30 minutes by the fio-low-io app. With 150GB cloud drive, it gives us 35-40 hours before test fails due to running out of storage space. 

   