### PR TITLE
[PA-1523] Fix ManualAndScheduleBackupUsingNamespaceLabel

### DIFF
--- a/tests/backup/backup_namespace_labelled_test.go
+++ b/tests/backup/backup_namespace_labelled_test.go
@@ -1307,7 +1307,7 @@ var _ = Describe("{ManualAndScheduleBackupUsingNamespaceLabel}", func() {
 			log.FailOnError(err, "Unable to fetch px-central-admin ctx")
 			err = CreateApplicationClusters(orgID, "", "", ctx)
 			dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation of source [%s] and destination [%s] clusters with px-central-admin ctx", SourceClusterName, destinationClusterName))
-			appClusterName := destinationClusterName
+			appClusterName := SourceClusterName
 			clusterStatus, err := Inst().Backup.GetClusterStatus(orgID, appClusterName, ctx)
 			log.FailOnError(err, fmt.Sprintf("Fetching [%s] cluster status", appClusterName))
 			dash.VerifyFatal(clusterStatus, api.ClusterInfo_StatusInfo_Online, fmt.Sprintf("Verifying if [%s] cluster is online", appClusterName))


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR addresses the issue in the "ManualAndScheduleBackupUsingNamespaceLabel" test case where an incorrect cluster UID was passed during backup creation.

**Which issue(s) this PR fixes** (optional)
Closes #PA-1523

**Special notes for your reviewer**:
This test case is failing because of changes made to Px-Backup since version 2.5.2.

Please review the Jenkins build for the test case "ManualAndScheduleBackupUsingNamespaceLabel" before fix using the link below

https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/2179/

Aetos Dashboard: https://aetos.pwx.purestorage.com/resultSet/testSetID/297536/testCaseID/1653422

Please review the Jenkins build for the test case "ManualAndScheduleBackupUsingNamespaceLabel" after fix using the link below

~~https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/2177~~

~~Aetos Dashboard: https://aetos.pwx.purestorage.com/resultSet/testSetID/297452/testCaseID/1652779~~

https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/2181/

Aetos Dashboard: https://aetos.pwx.purestorage.com/resultSet/testSetID/297566