### PR TITLE
Topic/krishna px/pa 1528 v2

### DIFF
--- a/drivers/backup/auth.go
+++ b/drivers/backup/auth.go
@@ -30,6 +30,8 @@ var PxCentralAdminPwd string
 const (
 	// PxCentralAdminUser px central admin
 	PxCentralAdminUser = "px-central-admin"
+	// PxCentralAdminGivenName is the given name of the PxCentralAdminUser
+	PxCentralAdminGivenName = "pxcentraladmin"
 	// PxCentralAdminSecretName secret for PxCentralAdminUser
 	PxCentralAdminSecretName = "px-central-admin"
 	// PxCentralAdminSecretNamespace namespace of PxCentralAdminSecretName
@@ -761,7 +763,7 @@ func GetPxCentralAdminToken() (string, error) {
 	return token, nil
 }
 
-// GetCtxWithToken getx ctx with passed token
+// GetCtxWithToken gets ctx with passed token
 func GetCtxWithToken(token string) context.Context {
 	ctx := context.Background()
 	md := metadata.New(map[string]string{

--- a/drivers/backup/backup.go
+++ b/drivers/backup/backup.go
@@ -134,6 +134,9 @@ type Cluster interface {
 	// EnumerateCluster enumerates the cluster objects
 	EnumerateCluster(ctx context.Context, req *api.ClusterEnumerateRequest) (*api.ClusterEnumerateResponse, error)
 
+	// EnumerateAllCluster enumerates all cluster objects
+	EnumerateAllCluster(ctx context.Context, req *api.ClusterEnumerateRequest) (*api.ClusterEnumerateResponse, error)
+
 	// InspectCluster describes a cluster
 	InspectCluster(ctx context.Context, req *api.ClusterInspectRequest) (*api.ClusterInspectResponse, error)
 

--- a/tests/backup/backup_basic_test.go
+++ b/tests/backup/backup_basic_test.go
@@ -188,30 +188,9 @@ var _ = AfterSuite(func() {
 	StartTorpedoTest("Environment cleanup", "Removing Px-Backup entities created during the test execution", nil, 0)
 	defer dash.TestSetEnd()
 	defer EndTorpedoTest()
-	// Cleanup all non admin users
+
 	ctx, err := backup.GetAdminCtxFromSecret()
 	log.FailOnError(err, "Fetching px-central-admin ctx")
-	allUsers, err := backup.GetAllUsers()
-	dash.VerifySafely(err, nil, "Verifying cleaning up of all users from keycloak")
-	for _, user := range allUsers {
-		if !strings.Contains(user.Name, "admin") {
-			err = backup.DeleteUser(user.Name)
-			dash.VerifySafely(err, nil, fmt.Sprintf("Verifying user [%s] deletion", user.Name))
-		} else {
-			log.Infof("User %s was not deleted", user.Name)
-		}
-	}
-	// Cleanup all non admin groups
-	allGroups, err := backup.GetAllUsers()
-	dash.VerifySafely(err, nil, "Verifying cleaning up of all groups from keycloak")
-	for _, group := range allGroups {
-		if !strings.Contains(group.Name, "admin") && !strings.Contains(group.Name, "app") {
-			err = backup.DeleteGroup(group.Name)
-			dash.VerifySafely(err, nil, fmt.Sprintf("Verifying group [%s] deletion", group.Name))
-		} else {
-			log.Infof("Group %s was not deleted", group.Name)
-		}
-	}
 
 	// Cleanup all backups
 	allBackups, err := GetAllBackupsAdmin()
@@ -236,27 +215,45 @@ var _ = AfterSuite(func() {
 	kubeconfigList := strings.Split(kubeconfigs, ",")
 	for _, kubeconfig := range kubeconfigList {
 		clusterName := strings.Split(kubeconfig, "-")[0] + "-cluster"
-		clusterReq := &api.ClusterInspectRequest{OrgId: orgID, Name: clusterName}
-		clusterResp, err := Inst().Backup.InspectCluster(ctx, clusterReq)
-		if err != nil && strings.Contains(err.Error(), "object not found") {
-			log.InfoD("Cluster %s is deleted", clusterName)
-		} else {
-			clusterObj := clusterResp.GetCluster()
-			clusterProvider := GetClusterProviders()
-			for _, provider := range clusterProvider {
-				switch provider {
-				case drivers.ProviderRke:
-					clusterCredName = clusterObj.PlatformCredentialRef.Name
-					clusterCredUID = clusterObj.PlatformCredentialRef.Uid
-				default:
-					clusterCredName = clusterObj.CloudCredentialRef.Name
-					clusterCredUID = clusterObj.CloudCredentialRef.Uid
+		isPresent, err := IsClusterPresent(clusterName, ctx, orgID)
+		if err != nil {
+			Inst().Dash.VerifySafely(err, nil, fmt.Sprintf("Verifying if cluster [%s] is present", clusterName))
+		}
+		if isPresent {
+			clusterReq := &api.ClusterInspectRequest{OrgId: orgID, Name: clusterName}
+			clusterResp, err := Inst().Backup.InspectCluster(ctx, clusterReq)
+			if err != nil {
+				if strings.Contains(err.Error(), "object not found") {
+					log.InfoD("Cluster %s is deleted", clusterName)
+				} else {
+					Inst().Dash.VerifySafely(err, nil, fmt.Sprintf("Inspecting cluster [%s]", clusterName))
 				}
-				err = DeleteCluster(clusterName, orgID, ctx, true)
-				Inst().Dash.VerifySafely(err, nil, fmt.Sprintf("Deleting cluster %s", clusterName))
-				if clusterCredName != "" {
-					err = DeleteCloudCredential(clusterCredName, orgID, clusterCredUID)
-					Inst().Dash.VerifySafely(err, nil, fmt.Sprintf("Verifying deletion of cluster cloud cred [%s]", clusterCredName))
+			} else {
+				clusterObj := clusterResp.GetCluster()
+				clusterProvider := GetClusterProviders()
+				for _, provider := range clusterProvider {
+					switch provider {
+					case drivers.ProviderRke:
+						if clusterObj.PlatformCredentialRef != nil {
+							clusterCredName = clusterObj.PlatformCredentialRef.Name
+							clusterCredUID = clusterObj.PlatformCredentialRef.Uid
+						} else {
+							log.Warnf("the platform credential ref of the cluster [%s] is nil", clusterName)
+						}
+					default:
+						if clusterObj.CloudCredentialRef != nil {
+							clusterCredName = clusterObj.CloudCredentialRef.Name
+							clusterCredUID = clusterObj.CloudCredentialRef.Uid
+						} else {
+							log.Warnf("the cloud credential ref of the cluster [%s] is nil", clusterName)
+						}
+					}
+					err = DeleteCluster(clusterName, orgID, ctx, true)
+					Inst().Dash.VerifySafely(err, nil, fmt.Sprintf("Deleting cluster %s", clusterName))
+					if clusterCredName != "" {
+						err = DeleteCloudCredential(clusterCredName, orgID, clusterCredUID)
+						Inst().Dash.VerifySafely(err, nil, fmt.Sprintf("Verifying deletion of cluster cloud cred [%s]", clusterCredName))
+					}
 				}
 			}
 		}
@@ -317,6 +314,30 @@ var _ = AfterSuite(func() {
 		case drivers.ProviderNfs:
 			DeleteBucket(provider, globalNFSBucketName)
 			log.Infof("NFS subpath deleted - %s", globalNFSBucketName)
+		}
+	}
+
+	// Cleanup all non admin users
+	allUsers, err := backup.GetAllUsers()
+	dash.VerifySafely(err, nil, "Verifying cleaning up of all users from keycloak")
+	for _, user := range allUsers {
+		if !strings.Contains(user.Name, "admin") {
+			err = backup.DeleteUser(user.Name)
+			dash.VerifySafely(err, nil, fmt.Sprintf("Verifying user [%s] deletion", user.Name))
+		} else {
+			log.Infof("User %s was not deleted", user.Name)
+		}
+	}
+
+	// Cleanup all non admin groups
+	allGroups, err := backup.GetAllUsers()
+	dash.VerifySafely(err, nil, "Verifying cleaning up of all groups from keycloak")
+	for _, group := range allGroups {
+		if !strings.Contains(group.Name, "admin") && !strings.Contains(group.Name, "app") {
+			err = backup.DeleteGroup(group.Name)
+			dash.VerifySafely(err, nil, fmt.Sprintf("Verifying group [%s] deletion", group.Name))
+		} else {
+			log.Infof("Group %s was not deleted", group.Name)
 		}
 	}
 })

--- a/tests/backup/backup_restore_basic_test.go
+++ b/tests/backup/backup_restore_basic_test.go
@@ -1404,7 +1404,7 @@ var _ = Describe("{BackupMultipleNsWithSameLabel}", func() {
 			log.FailOnError(err, "Unable to fetch px-central-admin ctx")
 			err = CreateApplicationClusters(orgID, "", "", ctx)
 			dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation of source [%s] and destination [%s] clusters with px-central-admin ctx", SourceClusterName, destinationClusterName))
-			appClusterName := destinationClusterName
+			appClusterName := SourceClusterName
 			clusterStatus, err := Inst().Backup.GetClusterStatus(orgID, appClusterName, ctx)
 			log.FailOnError(err, fmt.Sprintf("Fetching [%s] cluster status", appClusterName))
 			dash.VerifyFatal(clusterStatus, api.ClusterInfo_StatusInfo_Online, fmt.Sprintf("Verifying if [%s] cluster is online", appClusterName))
@@ -1702,7 +1702,7 @@ var _ = Describe("{AddMultipleNamespaceLabels}", func() {
 			log.FailOnError(err, "Unable to fetch px-central-admin ctx")
 			err = CreateApplicationClusters(orgID, "", "", ctx)
 			dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation of source [%s] and destination [%s] clusters with px-central-admin ctx", SourceClusterName, destinationClusterName))
-			appClusterName := destinationClusterName
+			appClusterName := SourceClusterName
 			clusterStatus, err := Inst().Backup.GetClusterStatus(orgID, appClusterName, ctx)
 			log.FailOnError(err, fmt.Sprintf("Fetching [%s] cluster status", appClusterName))
 			dash.VerifyFatal(clusterStatus, api.ClusterInfo_StatusInfo_Online, fmt.Sprintf("Verifying if [%s] cluster is online", appClusterName))


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR aims to prevent test case failures caused by changes since Px-Backup version 2.5.2.

**Which issue(s) this PR fixes** (optional)
Closes #PA-1528

**Special notes for your reviewer**:
To test this fix, I registered a user and added a cluster named 'source-cluster' before starting the test. We expect the InspectCluster to fail when verifying the 'source-cluster' addition using admin ctx, because there are two clusters with the same name. To fix this we need to the pass the cluster UID in the InspectClusterRequest.

Please review the Jenkins build for the test case "BasicBackupCreation" before fix using the link below

Aetos Dashboard: 

Please review the Jenkins build for the test case "BasicBackupCreation" after fix using the link below

https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/2219/

Aetos Dashboard: https://aetos.pwx.purestorage.com/resultSet/testSetID/299311

I have started a run on both the S3 and NFS nightly pipelines. I will provide an update once they are completed.