### PR TITLE
Enabled `ibm` as `CLUSTER_PROVIDER`

### DIFF
--- a/deployments/deploy-pxb-cloud.sh
+++ b/deployments/deploy-pxb-cloud.sh
@@ -332,6 +332,8 @@ if [ -n "${INTERNAL_DOCKER_REGISTRY}" ]; then
     TORPEDO_IMG="${INTERNAL_DOCKER_REGISTRY}/${TORPEDO_IMG}"
 fi
 
+kubectl create configmap cloud-config --from-file=/config/cloud-json
+
 # List of additional kubeconfigs of k8s clusters to register with px-backup, px-dr
 FROM_FILE=""
 CLUSTER_CONFIGS=""

--- a/deployments/deploy-pxb-cloud.sh
+++ b/deployments/deploy-pxb-cloud.sh
@@ -599,6 +599,8 @@ spec:
       value: "${DIAGS_BUCKET}"
     - name: PROVIDERS
       value: "${PROVIDERS}"
+    - name: CLUSTER_PROVIDER
+      value: "${CLUSTER_PROVIDER}"
     - name: INTERNAL_DOCKER_REGISTRY
       value: "$INTERNAL_DOCKER_REGISTRY"
     - name: IMAGE_PULL_SERVER

--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -13,6 +13,8 @@ const (
 	ProviderNfs = "nfs"
 	// ProviderRke for rke provider
 	ProviderRke = "rke"
+	// ProviderIbm for ibm provider
+	ProviderIbm = "ibm"
 )
 
 // Driver specifies the most basic methods to be implemented by a Torpedo driver.

--- a/tests/backup/backup_basic_test.go
+++ b/tests/backup/backup_basic_test.go
@@ -20,8 +20,6 @@ import (
 	"time"
 )
 
-var GlobalCredentialConfig *backup.BackupCloudConfig
-
 func getBucketNameSuffix() string {
 	bucketNameSuffix, present := os.LookupEnv("BUCKET_NAME")
 	if present {

--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -3981,8 +3981,8 @@ func IsClusterPresent(clusterName string, ctx context.Context, orgID string) (bo
 }
 
 // GetConfigObj reads the configuration file and returns a BackupCloudConfig object.
-func GetConfigObj() (*backup.BackupCloudConfig, error) {
-	var config *backup.BackupCloudConfig
+func GetConfigObj() (backup.BackupCloudConfig, error) {
+	var config backup.BackupCloudConfig
 	var found bool
 	cmList, err := core.Instance().ListConfigMap("default", meta_v1.ListOptions{})
 	log.FailOnError(err, fmt.Sprintf("Error listing Configmaps in default namespace"))
@@ -3997,7 +3997,7 @@ func GetConfigObj() (*backup.BackupCloudConfig, error) {
 		cm, err := core.Instance().GetConfigMap(cloudCredConfigMap, "default")
 		if err != nil {
 			log.Errorf("Error reading Configmap: %v", err)
-			return nil, err
+			return config, err
 		}
 		log.Infof("Fetch the cloud-config from the Configmap")
 		configData := cm.Data["cloud-json"]

--- a/tests/common.go
+++ b/tests/common.go
@@ -3899,12 +3899,10 @@ func CreateCloudCredential(provider, credName string, uid, orgID string, ctx con
 	switch provider {
 	case drivers.ProviderAws:
 		log.Infof("Create creds for Aws")
-		// PA-1328
 		id := os.Getenv("AWS_ACCESS_KEY_ID")
 		if id == "" {
 			return fmt.Errorf("environment variable AWS_ACCESS_KEY_ID should not be empty")
 		}
-		// PA-1328
 		secret := os.Getenv("AWS_SECRET_ACCESS_KEY")
 		if secret == "" {
 			return fmt.Errorf("environment variable AWS_SECRET_ACCESS_KEY should not be empty")
@@ -3928,7 +3926,6 @@ func CreateCloudCredential(provider, credName string, uid, orgID string, ctx con
 
 	case drivers.ProviderAzure:
 		log.Infof("Create creds for azure")
-		// PA-1328
 		tenantID, clientID, clientSecret, subscriptionID, accountName, accountKey := GetAzureCredsFromEnv()
 		credCreateRequest = &api.CloudCredentialCreateRequest{
 			CreateMetadata: &api.CreateMetadata{
@@ -3975,7 +3972,6 @@ func CreateCloudCredential(provider, credName string, uid, orgID string, ctx con
 
 	case drivers.ProviderIbm:
 		log.Infof("Create creds for IBM")
-		// PA-1328
 		apiKey, err := GetIBMApiKey("default")
 		if err != nil {
 			return err
@@ -4465,7 +4461,6 @@ func GetDestinationClusterConfigPath() (string, error) {
 }
 
 // GetAzureCredsFromEnv get creds for azure
-// PA-1328
 func GetAzureCredsFromEnv() (tenantID, clientID, clientSecret, subscriptionID, accountName, accountKey string) {
 	accountName = os.Getenv("AZURE_ACCOUNT_NAME")
 	expect(accountName).NotTo(equal(""),
@@ -4495,6 +4490,7 @@ func GetAzureCredsFromEnv() (tenantID, clientID, clientSecret, subscriptionID, a
 	return tenantID, clientID, clientSecret, subscriptionID, accountName, accountKey
 }
 
+// GetIBMApiKey will return the IBM API Key from GlobalCredentialConfig
 func GetIBMApiKey(cluster string) (string, error) {
 	return GlobalCredentialConfig.CloudProviders.GetIBMCredential(cluster).APIKey, nil
 }

--- a/tests/common.go
+++ b/tests/common.go
@@ -168,7 +168,8 @@ const (
 )
 
 var (
-	clusterProviders = []string{"k8s"}
+	clusterProviders       = []string{"k8s"}
+	GlobalCredentialConfig backup.BackupCloudConfig
 )
 
 type OwnershipAccessType int32
@@ -3974,7 +3975,7 @@ func CreateCloudCredential(provider, credName string, uid, orgID string, ctx con
 	case drivers.ProviderIbm:
 		log.Infof("Create creds for IBM")
 		// PA-1328
-		apiKey, err := GetIBMApiKey()
+		apiKey, err := GetIBMApiKey("default")
 		if err != nil {
 			return err
 		}
@@ -4493,9 +4494,8 @@ func GetAzureCredsFromEnv() (tenantID, clientID, clientSecret, subscriptionID, a
 	return tenantID, clientID, clientSecret, subscriptionID, accountName, accountKey
 }
 
-func GetIBMApiKey() (string, error) {
-	return "", nil
-
+func GetIBMApiKey(cluster string) (string, error) {
+	return GlobalCredentialConfig.CloudProviders.GetIBMCredential(cluster).APIKey, nil
 }
 
 type NfsInfo struct {

--- a/tests/common.go
+++ b/tests/common.go
@@ -3780,11 +3780,9 @@ func CreateApplicationClusters(orgID string, cloudName string, uid string, ctx c
 				}
 			}
 		case drivers.ProviderIbm:
-			log.Infof("Inside IBM")
 			for _, kubeconfig := range kubeconfigList {
-				log.Infof("Creating creds for IBM")
 				clusterCredName = fmt.Sprintf("%v-%v-cloud-cred-%v", provider, kubeconfig, RandomString(5))
-				log.Infof("Cluster creds for IBM - %s", clusterCredName)
+				log.Infof("Cluster credential with name [%s] for IBM", clusterCredName)
 				clusterCredUid = uuid.New()
 				err = CreateCloudCredential(provider, clusterCredName, clusterCredUid, orgID, ctx)
 				if err != nil {

--- a/tests/common.go
+++ b/tests/common.go
@@ -3780,8 +3780,11 @@ func CreateApplicationClusters(orgID string, cloudName string, uid string, ctx c
 				}
 			}
 		case drivers.ProviderIbm:
+			log.Infof("Inside IBM")
 			for _, kubeconfig := range kubeconfigList {
+				log.Infof("Creating creds for IBM")
 				clusterCredName = fmt.Sprintf("%v-%v-cloud-cred-%v", provider, kubeconfig, RandomString(5))
+				log.Infof("Cluster creds for IBM - %s", clusterCredName)
 				clusterCredUid = uuid.New()
 				err = CreateCloudCredential(provider, clusterCredName, clusterCredUid, orgID, ctx)
 				if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Enabled `ibm` as `CLUSTER_PROVIDER`. This will be used in the IBM pipelines and cluster addition will happen using actual IBM API keys.

**Which issue(s) this PR fixes** (optional)
Closes #PA-1535

**Special notes for your reviewer**:
[Jenkins Run with BasicBackupCreation on IBM with nonpx](https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/basic-system-test/job/nonpx/job/Px-Backup-IKS-non-px-s3/48/console)

