### PR TITLE
fixing kafka broker spec

### DIFF
--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -72,6 +72,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	storageapi "k8s.io/api/storage/v1"
@@ -710,7 +711,7 @@ func validateSpec(in interface{}) (interface{}, error) {
 		return specObj, nil
 	} else if specObj, ok := in.(*apiextensionsv1.CustomResourceDefinition); ok {
 		return specObj, nil
-	} else if specObj, ok := in.(*policyv1beta1.PodDisruptionBudget); ok {
+	} else if specObj, ok := in.(*policyv1.PodDisruptionBudget); ok {
 		return specObj, nil
 	} else if specObj, ok := in.(*netv1.NetworkPolicy); ok {
 		return specObj, nil

--- a/drivers/scheduler/k8s/specs/kafka-stack/kafka-producer.yaml
+++ b/drivers/scheduler/k8s/specs/kafka-stack/kafka-producer.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: producer
-          image: portworx/kafka-broker:v0.1
+          image: portworx/kafka-producer
           imagePullPolicy: Always
           ports:
             - containerPort: 8083

--- a/drivers/scheduler/k8s/specs/kafka-stack/kafka.yaml
+++ b/drivers/scheduler/k8s/specs/kafka-stack/kafka.yaml
@@ -27,7 +27,7 @@ spec:
   selector:
     app: kafka
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: kafka-pdb
@@ -68,7 +68,7 @@ spec:
       containers:
       - name: k8skafka
         imagePullPolicy: Always
-        image: portworx/kafka-broker:v0.1
+        image: portworx/kafka-broker
         # resources:
         #   requests:
         #     memory: "1Gi"

--- a/drivers/scheduler/k8s/specs/kafka-stack/zookeeper.yaml
+++ b/drivers/scheduler/k8s/specs/kafka-stack/zookeeper.yaml
@@ -27,7 +27,7 @@ spec:
   selector:
     app: zk
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: zk-pdb


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
fixing kafka broker spec

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

```
[root@lsrinivas-33-0 ~]# kubectl -n kafka-stack-setupteardown-0-08-22-05h04m56s get po
NAME                                 READY   STATUS    RESTARTS        AGE
es-client-7445cbb47-t52bv            1/1     Running   0               4m43s
es-client-7445cbb47-t9259            1/1     Running   0               4m43s
es-data-0                            1/1     Running   0               4m43s
es-data-1                            1/1     Running   0               4m9s
es-data-2                            1/1     Running   0               3m47s
es-exporter-77f85df7dc-56k5p         1/1     Running   0               4m43s
es-master-59f7d4cc8f-2dxxv           1/1     Running   0               4m43s
es-master-59f7d4cc8f-55qbr           1/1     Running   0               4m43s
es-master-59f7d4cc8f-v4dld           1/1     Running   0               4m43s
kafka-0                              1/1     Running   2 (2m36s ago)   4m42s
kafka-1                              1/1     Running   1 (2m21s ago)   2m56s
kafka-2                              1/1     Running   0               2m20s
kafka-es-connector-7f7db9754-l5qw5   1/1     Running   2 (2m23s ago)   4m42s
kafka-exporter-6db5c6cd47-9hpcw      1/1     Running   4 (2m24s ago)   4m42s
kafka-producer-69c56684f8-22mtv      1/1     Running   5 (2m17s ago)   4m42s
kafka-producer-69c56684f8-2j4w8      1/1     Running   5 (92s ago)     4m42s
kafka-producer-69c56684f8-7bx56      1/1     Running   5 (2m9s ago)    4m42s
zk-0                                 1/1     Running   0               4m41s
zk-1                                 1/1     Running   0               2m56s
zk-2                                 1/1     Running   0               2m31s

```

