### PR TITLE
FIO application specs for FADA RAW block testing

### DIFF
--- a/drivers/scheduler/k8s/specs/fio-raw-block/fio-config.yaml
+++ b/drivers/scheduler/k8s/specs/fio-raw-block/fio-config.yaml
@@ -1,0 +1,83 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fio-job-config
+data:
+    fio.job: |
+        [global]
+        name=fio-raw-rand-RW
+        rw=randrw
+        blocksize_range=4k-512k
+        iodepth=128
+        direct=1
+        group_reporting
+        do_verify=1
+        verify=crc32c
+        verify_pattern=0xdeadbeef
+        disable_lat=0
+        ioengine=libaio
+        time_based=1
+        runtime=99999999
+        [job1]
+        filename=/dev/pure-block-device
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grok-exporter
+data:
+  config.yml: |-
+    global:
+      config_version: 3
+    input:
+      type: file
+      path: /logs/fio.log
+      readall: false
+      fail_on_missing_logfile: true
+    imports:
+    - type: grok_patterns
+      dir: ./patterns
+    grok_patterns:
+    - 'FIO_IOPS [0-9]*[.][0-9]k$|[0-9]*'
+    metrics:
+        - type: gauge
+          name: iops
+          help: FIO IOPS Write Gauge Metrics
+          match: '  write: %{GREEDYDATA}, iops=%{NUMBER:val1}%{GREEDYDATA:thsd}, %{GREEDYDATA}'
+          value: '{{`{{if eq .thsd "k"}}{{multiply .val1 1000}}{{else}}{{.val1}}{{end}}`}}'
+          labels:
+              iops_suffix: '{{`{{.thsd}}`}}'
+          cumulative: false
+          retention: 1s
+        - type: gauge
+          name: bandwidth
+          help: FIO Bandwidth Write Gauge Metrics
+          match: '  write: io=%{GREEDYDATA}, bw=%{NUMBER:val2}%{GREEDYDATA:kbs}, %{GREEDYDATA}, %{GREEDYDATA}'
+          value: '{{`{{if eq .kbs "KB/s"}}{{divide .val2 1024}}{{else}}{{.val2}}{{end}}`}}'
+          labels:
+              bw_unit: '{{`{{.kbs}}`}}'
+          cumulative: false
+          retention: 1s
+        - type: gauge
+          name: avg_latency
+          help: FIO AVG Latency Write Gauge Metrics
+          match: '     lat (%{GREEDYDATA:nsec}): min=%{GREEDYDATA}, max=%{GREEDYDATA}, avg=%{NUMBER:val3}, stdev=%{GREEDYDATA}'
+          value: '{{`{{if eq .msec "(msec)"}}{{divide .val3 1000}}{{else}}{{.val3}}{{end}}`}}'
+          labels:
+              lat_unit: '{{`{{.msec}}`}}'
+          cumulative: false
+          retention: 1s
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fio-live-probe
+data:
+  live-probe.sh: |
+    #!/bin/bash
+    if [ `ps -aef|grep fio|grep -v grep` -ne 0 ]; then 
+      exit 1; 
+    else 
+      exit 0; 
+    fi
+

--- a/drivers/scheduler/k8s/specs/fio-raw-block/fio.yaml
+++ b/drivers/scheduler/k8s/specs/fio-raw-block/fio.yaml
@@ -1,0 +1,108 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: fio
+spec:
+  serviceName: fio
+  {{ if .Replicas }}
+  replicas: {{ .Replicas }}
+  {{ else }}
+  replicas: 1{{ end }}
+  selector:
+    matchLabels:
+      app: fio
+  template:
+    metadata:
+      labels:
+        app: fio
+    spec:
+      schedulerName: stork
+      containers:
+      - name: fio
+        image: docker.pwx.dev.purestorage.com/portworx/fio_drv
+        command: ["fio"]
+        resources:
+          limits:
+            cpu: "2"
+            memory: 4Gi
+          requests:
+            cpu: "1"
+            memory: 4Gi
+        args: ["/configs/fio.job", "--status-interval=1", "--eta=never", "--output=/logs/fio.log"]
+        livenessProbe:
+          exec:
+            command:
+            - /fioliveProbe/live-probe.sh
+          initialDelaySeconds: 60
+          periodSeconds: 30
+        volumeDevices:
+        - name: pure-vol
+          devicePath: /dev/pure-block-device
+        volumeMounts:
+        - name: fio-config-vol
+          mountPath: /configs
+        - name: fio-log
+          mountPath: /logs
+        - name: live-probe
+          mountPath: /fioliveProbe
+      - name: grok
+        image: docker.pwx.dev.purestorage.com/pwxvin/grok-exporter:v1.0.0-RC4
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: grok-port
+          containerPort: 9144
+          protocol: TCP
+        volumeMounts:
+        - name: grok-config-volume
+          mountPath: /etc/grok_exporter
+        - name: fio-log
+          mountPath: /logs
+      volumes:
+      - name: fio-config-vol
+        configMap:
+          name: fio-job-config
+      - name: grok-config-volume
+        configMap:
+          name: grok-exporter
+      - name: live-probe
+        configMap:
+          defaultMode: 0777
+          name: fio-live-probe
+  volumeClaimTemplates:
+  - metadata:
+      name: pure-vol
+    spec:
+      storageClassName: fio-raw-block-sc
+      accessModes:
+      - ReadWriteOnce
+      volumeMode: Block
+      resources:
+        requests:
+         {{ if .VolumeSize }}
+          storage: {{ .VolumeSize }}
+        {{ else }}
+          storage: 200Gi {{ end  }}
+  - metadata:
+      name: fio-log
+    spec:
+      storageClassName: fio-raw-block-sc
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 50Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grok-exporter-svc
+  labels:
+      app: fio
+spec:
+  clusterIP: None
+  selector: 
+    app: fio
+  ports:
+  - name: grok-port
+    port: 9144
+    targetPort: 9144

--- a/drivers/scheduler/k8s/specs/fio-raw-block/px-storage-class.yaml
+++ b/drivers/scheduler/k8s/specs/fio-raw-block/px-storage-class.yaml
@@ -1,0 +1,9 @@
+##### FA direct access storage class
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: fio-raw-block-sc
+provisioner: pxd.portworx.com
+parameters:
+  backend: "pure_block"
+allowVolumeExpansion: true


### PR DESCRIPTION
**What this PR does / why we need it**:
This is to test FADA RAW Block using fio

**Which issue(s) this PR fixes** (optional)
Closes # PTX-19687

**Special notes for your reviewer**:
Minor change
```
bash-3.2$ kubectl get pods -n fio-rawblock-test  -o wide -o wide
NAME    READY   STATUS    RESTARTS   AGE   IP               NODE                                   NOMINATED NODE   READINESS GATES
fio-0   2/2     Running   0          9s    10.233.102.139   ip-10-13-105-219.pwx.purestorage.com   <none>           <none>
bash-3.2$ kubectl get cm -n fio-rawblock-test
NAME               DATA   AGE
fio-job-config     1      94m
fio-live-probe     1      94m
grok-exporter      1      94m
kube-root-ca.crt   1      4h27m
bash-3.2$

bash-3.2$ kubectl get pvc -n fio-rawblock-test
NAME             STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS       AGE
fio-log-fio-0    Bound    pvc-637c4697-25f0-45e6-850e-0047a3698807   50Gi       RWO            fio-raw-block-sc   3h10m
pure-vol-fio-0   Bound    pvc-712f512b-7c6d-4dee-b279-f2ed5df4072e   200Gi      RWO            fio-raw-block-sc   3h10m
bash-3.2$ 

bash-3.2$ kubectl exec -it fio-0 -n fio-rawblock-test -- /bin/sh
Defaulted container "fio" out of: fio, grok
sh-4.2# ls -l /dev/pure-block-device
brw-rw---- 1 root disk 253, 2 Aug 21 22:59 /dev/pure-block-device
sh-4.2# 

sh-4.2# ps -aef |grep -i fio
root         1     0  1 22:57 ?        00:00:01 fio /configs/fio.job --status-interval=1 --eta=never --output=/logs/fio.log
root        16     1 55 22:57 ?        00:01:16 fio /configs/fio.job --status-interval=1 --eta=never --output=/logs/fio.log
root        47    17  0 23:00 pts/0    00:00:00 grep -i fio
sh-4.2# 

```


