### PR TITLE
[PA-1597] Fix test names in StartTorpedoTest

### DIFF
--- a/tests/backup/backup_locked_bucket_test.go
+++ b/tests/backup/backup_locked_bucket_test.go
@@ -35,7 +35,7 @@ var _ = Describe("{BackupAlternatingBetweenLockedAndUnlockedBuckets}", func() {
 	var clusterStatus api.ClusterInfo_StatusInfo_Status
 	bkpNamespaces = make([]string, 0)
 	JustBeforeEach(func() {
-		StartTorpedoTest("BackupAlternatingBetweenLockedAndUnlockedBucket", "Deploying backup", nil, 60018)
+		StartTorpedoTest("BackupAlternatingBetweenLockedAndUnlockedBuckets", "Deploying backup", nil, 60018)
 		log.InfoD("Verifying if the pre/post rules for the required apps are present in the list or not")
 		for i := 0; i < len(appList); i++ {
 			if Contains(postRuleApp, appList[i]) {
@@ -229,7 +229,7 @@ var _ = Describe("{LockedBucketResizeOnRestoredVolume}", func() {
 	bkpNamespaces = make([]string, 0)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("ResizeOnRestoredVolumeFromLockedBucket", "Resize after the volume is restored from a backup from locked bucket", nil, 59904)
+		StartTorpedoTest("LockedBucketResizeOnRestoredVolume", "Resize after the volume is restored from a backup from locked bucket", nil, 59904)
 		log.InfoD("Verifying if the pre/post rules for the required apps are present in the list or not")
 		for i := 0; i < len(appList); i++ {
 			if Contains(postRuleApp, appList[i]) {

--- a/tests/backup/backup_restore_basic_test.go
+++ b/tests/backup/backup_restore_basic_test.go
@@ -515,7 +515,7 @@ var _ = Describe("{ScheduleBackupCreationSingleNS}", func() {
 		restoreName             string
 		clusterStatus           api.ClusterInfo_StatusInfo_Status
 	)
-	var testrailID = 58014 // testrailID corresponds to: https://portworx.testrail.net/index.php?/cases/view/58014
+	// testrailID corresponds to: https://portworx.testrail.net/index.php?/cases/view/58014
 	namespaceMapping := make(map[string]string)
 	labelSelectors := make(map[string]string)
 	cloudCredUIDMap := make(map[string]string)
@@ -525,7 +525,7 @@ var _ = Describe("{ScheduleBackupCreationSingleNS}", func() {
 	periodicPolicyName := fmt.Sprintf("%s-%s", "periodic", timeStamp)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("ScheduleBackupCreationSingleNS", "Create schedule backup creation with a single namespace", nil, testrailID)
+		StartTorpedoTest("ScheduleBackupCreationSingleNS", "Create schedule backup creation with a single namespace", nil, 58014)
 		log.Infof("Application installation")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -655,7 +655,7 @@ var _ = Describe("{ScheduleBackupCreationAllNS}", func() {
 		restoreName             string
 		clusterStatus           api.ClusterInfo_StatusInfo_Status
 	)
-	var testrailID = 58015 // testrailID corresponds to: https://portworx.testrail.net/index.php?/cases/view/58015
+	// testrailID corresponds to: https://portworx.testrail.net/index.php?/cases/view/58015
 	namespaceMapping := make(map[string]string)
 	labelSelectors := make(map[string]string)
 	cloudCredUIDMap := make(map[string]string)
@@ -665,7 +665,7 @@ var _ = Describe("{ScheduleBackupCreationAllNS}", func() {
 	periodicPolicyName := fmt.Sprintf("%s-%s", "periodic", timeStamp)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("ScheduleBackupCreationAllNS", "Create schedule backup creation with all namespaces", nil, testrailID)
+		StartTorpedoTest("ScheduleBackupCreationAllNS", "Create schedule backup creation with all namespaces", nil, 58015)
 		log.Infof("Application installation")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {

--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -18,7 +18,7 @@ import (
 var _ = Describe("{BackupClusterVerification}", func() {
 	JustBeforeEach(func() {
 		log.Infof("No pre-setup required for this testcase")
-		StartTorpedoTest("Backup: BackupClusterVerification", "Validating backup cluster pods", nil, 0)
+		StartTorpedoTest("BackupClusterVerification", "Validating backup cluster pods", nil, 0)
 	})
 	It("Backup Cluster Verification", func() {
 		Step("Check the status of backup pods", func() {
@@ -38,7 +38,7 @@ var _ = Describe("{BackupClusterVerification}", func() {
 var _ = Describe("{UserGroupManagement}", func() {
 	JustBeforeEach(func() {
 		log.Infof("No pre-setup required for this testcase")
-		StartTorpedoTest("Backup: UserGroupManagement", "Creating users and adding them to groups", nil, 0)
+		StartTorpedoTest("UserGroupManagement", "Creating users and adding them to groups", nil, 0)
 	})
 	It("User and group role mappings", func() {
 		Step("Create Users", func() {
@@ -110,7 +110,7 @@ var _ = Describe("{BasicBackupCreation}", func() {
 	)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("Backup: BasicBackupCreation", "Deploying backup", nil, 0)
+		StartTorpedoTest("BasicBackupCreation", "Deploying backup", nil, 0)
 
 		appList = Inst().AppList
 		backupLocationMap = make(map[string]string)

--- a/tests/backup/backup_upgrade_test.go
+++ b/tests/backup/backup_upgrade_test.go
@@ -53,7 +53,7 @@ var _ = Describe("{StorkUpgradeWithBackup}", func() {
 		clusterUid           string
 		clusterStatus        api.ClusterInfo_StatusInfo_Status
 	)
-	var testrailID = 58023 // testrailID corresponds to: https://portworx.testrail.net/index.php?/cases/view/58023
+	// testrailID corresponds to: https://portworx.testrail.net/index.php?/cases/view/58023
 	labelSelectors := make(map[string]string)
 	cloudCredUIDMap := make(map[string]string)
 	backupLocationMap := make(map[string]string)
@@ -63,7 +63,7 @@ var _ = Describe("{StorkUpgradeWithBackup}", func() {
 	appContextsToBackupMap := make(map[string][]*scheduler.Context)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("StorkUpgradeWithBackup", "Validates the scheduled backups and creation of new backup after stork upgrade", nil, testrailID)
+		StartTorpedoTest("StorkUpgradeWithBackup", "Validates the scheduled backups and creation of new backup after stork upgrade", nil, 58023)
 		log.Infof("Application installation")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR ensures testName parameter in StartTorpedoTest and test case name in Describe matches.

**Which issue(s) this PR fixes** (optional)
Closes #PA-1597

**Special notes for your reviewer**:
Total test cases: 74

Test cases common in Junit_Basic.xml and output of curl command: [AddMultipleNamespaceLabels AllNSBackupWithIncludeNewNSOption BackupAlternatingBetweenLockedAndUnlockedBuckets BackupCRsThenMultipleRestoresOnHigherK8sVersion BackupClusterVerification BackupLocationWithEncryptionKey BackupMultipleNsWithSameLabel BackupRestartPX BackupRestoreOnDifferentK8sVersions BackupScheduleForOldAndNewNS BackupSyncBasicTest BasicBackupCreation BasicSelectiveRestore CancelAllRunningBackupJobs CancelAllRunningRestoreJobs CancelClusterBackupShare CloudSnapsSafeWhenBackupLocationDeleteTest ClusterBackupShareToggle CreateMultipleUsersAndGroups CustomResourceBackupAndRestore CustomResourceRestore DeleteAllBackupObjects DeleteBackupAndCheckIfBucketIsEmpty DeleteBucketVerifyCloudBackupMissing DeleteIncrementalBackupsAndRecreateNew DeleteNSDeleteClusterRestore DeleteSharedBackup DeleteUsersRole DifferentAccessSameUser DuplicateSharedBackup IssueDeleteOfIncrementalBackupsAndRestore IssueMultipleDeletesForSharedBackup IssueMultipleRestoresWithNamespaceAndStorageClassMapping KillStorkWithBackupsAndRestoresInProgress LicensingCountBeforeAndAfterBackupPodRestart LicensingCountWithNodeLabelledBeforeClusterAddition LockedBucketResizeOnRestoredVolume LockedBucketResizeVolumeOnScheduleBackup ManualAndScheduleBackupUsingNSLabelWithMaxCharLimit ManualAndScheduleBackupUsingNamespaceLabel ManualAndScheduledBackupUsingNamespaceAndResourceLabel MultipleCustomRestoreSameTimeDiffStorageClassMapping MultipleInPlaceRestoreSameTime MultipleProjectsAndNamespacesBackupAndRestore NamespaceLabelledBackupSharedWithDifferentAccessMode NamespaceMoveFromProjectToProjectToNoProjectWhileRestore NodeCountForLicensing PXBackupEndToEndBackupAndRestoreWithUpgrade RebootNodesWhenBackupsAreInProgress ReplicaChangeWhileRestore ResizeOnRestoredVolume ResizeVolumeOnScheduleBackup RestartBackupPodDuringBackupSharing RestoreEncryptedAndNonEncryptedBackups ScaleDownPxBackupPodWhileBackupAndRestoreIsInProgress ScaleMongoDBWhileBackupAndRestore ScheduleBackupCreationAllNS ScheduleBackupCreationSingleNS ScheduleBackupDeleteAndRecreateNS ScheduleBackupWithAdditionAndRemovalOfNS SetUnsetNSLabelDuringScheduleBackup ShareAndRemoveBackupLocation ShareBackupAndEdit ShareBackupWithDifferentRoleUsers ShareBackupWithUsersAndGroups ShareBackupsAndClusterWithUser ShareLargeNumberOfBackupsWithLargeNumberOfUsers SharedBackupDelete SingleNamespaceBackupRestoreToNamespaceInSameAndDifferentProject StorkUpgradeWithBackup SwapShareBackup UpgradePxBackup UserGroupManagement ViewOnlyFullBackupRestoreIncrementalBackup]

Test cases only in Junit_Basic.xml: []
Test cases only in Curl command: [Environment cleanup Setup buckets]