### PR TITLE
Perform backup and restore post increasing the PX Pool size

### DIFF
--- a/drivers/pds/lib/resiliency_utils.go
+++ b/drivers/pds/lib/resiliency_utils.go
@@ -11,7 +11,8 @@ import (
 
 	pds "github.com/portworx/pds-api-go-client/pds/v1alpha1"
 	"github.com/portworx/torpedo/drivers/node"
-
+	restoreBkp "github.com/portworx/torpedo/drivers/pds/pdsrestore"
+	tc "github.com/portworx/torpedo/drivers/pds/targetcluster"
 	_ "github.com/portworx/torpedo/drivers/scheduler/dcos"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -34,6 +35,9 @@ const (
 	UpdateTemplate                    = "medium"
 	RebootNodeDuringAppVersionUpdate  = "reboot-node-during-app-version-update"
 	KillTeleportPodDuringDeployment   = "kill-teleport-pod-during-deployment"
+	RestoreDSDuringPXPoolExpansion    = "restore-ds-during-px-pool-expansion"
+	poolResizeTimeout                 = time.Minute * 120
+	retryTimeout                      = time.Minute * 2
 )
 
 // PDS vars
@@ -46,6 +50,8 @@ var (
 	CapturedErrors            = make(chan error, 10)
 	checkTillReplica          int32
 	ResiliencyCondition       = make(chan bool)
+	restoredDeployment        *pds.ModelsDeployment
+	dsEntity                  restoreBkp.DSEntity
 )
 
 // Struct Definition for kind of Failure the framework needs to trigger
@@ -181,6 +187,15 @@ func InduceFailureAfterWaitingForCondition(deployment *pds.ModelsDeployment, nam
 			InduceFailure(FailureType.Type, namespace)
 		}
 		ExecuteInParallel(func1, func2)
+	case RestoreDSDuringPXPoolExpansion:
+		log.InfoD("Entering to restore the Data service, while it does increase the PX-Pool size")
+		func1 := func() {
+			RestoreAndValidateConfiguration(namespace, deployment)
+		}
+		func2 := func() {
+			InduceFailure(FailureType.Type, namespace)
+		}
+		ExecuteInParallel(func1, func2)
 	}
 
 	var aggregatedError error
@@ -255,6 +270,46 @@ func RestartPXDuringDSScaleUp(ns string, deployment *pds.ModelsDeployment) error
 
 	log.InfoD("PX restarted successfully on node %v", podName)
 	return testError
+}
+
+func RestoreAndValidateConfiguration(ns string, deployment *pds.ModelsDeployment) (bool, error) {
+
+	ctx := GetAndExpectStringEnvVar("PDS_RESTORE_TARGET_CLUSTER")
+	restoreTarget := tc.NewTargetCluster(ctx)
+	restoreClient := restoreBkp.RestoreClient{
+		TenantId:             deployment.GetTenantId(),
+		ProjectId:            deployment.GetProjectId(),
+		Components:           components,
+		Deployment:           deployment,
+		RestoreTargetCluster: restoreTarget,
+	}
+	dsEntity = restoreBkp.DSEntity{
+		Deployment: deployment,
+	}
+	
+	backupJobs, err := restoreClient.Components.BackupJob.ListBackupJobsBelongToDeployment(restoreClient.ProjectId, deployment.GetId())
+	log.FailOnError(err, "Error while fetching the backup jobs for the deployment: %v", deployment.GetClusterResourceName())
+	for _, backupJob := range backupJobs {
+		log.Infof("[Restoring] Details Backup job name- %v, Id- %v", backupJob.GetName(), backupJob.GetId())
+		restoredModel, error := restoreClient.TriggerAndValidateRestore(backupJob.GetId(), ns, dsEntity, true, false)
+		if error != nil {
+			CapturedErrors <- error
+			return false, error
+		}
+		if ResiliencyFlag {
+			ResiliencyCondition <- true
+		}
+		restoredDeployment, error = restoreClient.Components.DataServiceDeployment.GetDeployment(restoredModel.GetDeploymentId())
+		if error != nil {
+			CapturedErrors <- error
+			return false, error
+		}
+		log.Debugf("restoredDeployment ********* is : %v", restoredDeployment)
+		log.InfoD("Restored successfully")
+		//log.InfoD("Restored successfully. Details: Deployment- %v, Status - %v", restoredModel.GetClusterResourceName(), restoredModel.GetStatus())
+	}
+
+	return true, nil
 }
 
 func NodeRebootDurinAppVersionUpdate(ns string, deployment *pds.ModelsDeployment) error {

--- a/drivers/pds/lib/utils.go
+++ b/drivers/pds/lib/utils.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	pdsdriver "github.com/portworx/torpedo/drivers/pds"
 	"io/ioutil"
 	"math/rand"
 	"net/http"
@@ -14,7 +13,16 @@ import (
 	"strings"
 	"time"
 
+	pdsdriver "github.com/portworx/torpedo/drivers/pds"
+
+	"github.com/libopenstorage/openstorage/api"
+
+	"github.com/portworx/torpedo/drivers/scheduler"
+	"github.com/portworx/torpedo/tests"
+	. "github.com/portworx/torpedo/tests"
+
 	"github.com/portworx/torpedo/pkg/log"
+	"github.com/portworx/torpedo/pkg/units"
 
 	state "net/http"
 
@@ -22,6 +30,7 @@ import (
 	"github.com/portworx/sched-ops/k8s/apiextensions"
 	"github.com/portworx/sched-ops/k8s/apps"
 	"github.com/portworx/sched-ops/k8s/core"
+	"github.com/portworx/sched-ops/task"
 	pdsapi "github.com/portworx/torpedo/drivers/pds/api"
 	pdscontrolplane "github.com/portworx/torpedo/drivers/pds/controlplane"
 	v1 "k8s.io/api/apps/v1"
@@ -2426,4 +2435,195 @@ func UpdateDeploymentResourceConfig(deployment *pds.ModelsDeployment, namespace 
 		return err
 	}
 	return nil
+}
+
+func ExpandAndValidatePxPool(context []*scheduler.Context) error {
+	log.InfoD("Entering into PX-POOL Expansion...")
+	log.FailOnError(err, "Failed to list storage pools")
+	poolIDToResize := pickPoolToResize(context)
+	poolToBeResized := getStoragePool(poolIDToResize)
+	log.InfoD("Pool to be resized is %v", poolToBeResized)
+
+	log.InfoD("Verify that pool resize is not in progress")
+	if val, err := poolResizeIsInProgress(poolToBeResized); val {
+		// wait until resize is completed and get the updated pool again
+		poolToBeResized, err = GetStoragePoolByUUID(poolIDToResize)
+		log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", poolIDToResize))
+	} else {
+		log.FailOnError(err, fmt.Sprintf("pool [%s] cannot be expanded due to error: %v", poolIDToResize, err))
+	}
+	var expectedSize uint64
+	var expectedSizeWithJournal uint64
+	log.InfoD("Calculate expected pool size and trigger pool resize")
+	expectedSize = poolToBeResized.TotalSize * 2 / units.GiB
+	expectedSize = roundUpValue(expectedSize)
+	isjournal, err := IsJournalEnabled()
+	log.FailOnError(err, "Failed to check is Journal enabled")
+
+	expectedSizeWithJournal = expectedSize
+	if isjournal {
+		expectedSizeWithJournal = expectedSizeWithJournal - 3
+	}
+
+	log.InfoD("Current Size of the pool %s is %d", poolIDToResize, poolToBeResized.TotalSize/units.GiB)
+
+	err = tests.Inst().V.ExpandPool(poolIDToResize, api.SdkStoragePool_RESIZE_TYPE_ADD_DISK, expectedSize, false)
+
+	resizeErr := waitForPoolToBeResized(expectedSize, poolIDToResize, isjournal)
+	if resizeErr != nil {
+		log.FailOnError(resizeErr, fmt.Sprintf("Failed to resize pool with ID-  %s", poolIDToResize))
+	}
+	ValidateApplications(context)
+	resizedPool, err := GetStoragePoolByUUID(poolIDToResize)
+	log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", poolIDToResize))
+	newPoolSize := resizedPool.TotalSize / units.GiB
+	isExpansionSuccess := false
+	if newPoolSize >= expectedSizeWithJournal {
+		isExpansionSuccess = true
+	} else {
+		if ResiliencyFlag {
+			CapturedErrors <- err
+		}
+		log.FailOnError(err, fmt.Sprintf("Failed to resize pool with ID-  %s", poolIDToResize))
+		return err
+	}
+	log.InfoD("Px-Pool expansion status is - %v", isExpansionSuccess)
+	log.InfoD("expected new pool size to be %v or %v if pool has journal, got %v", expectedSize, expectedSizeWithJournal, newPoolSize)
+	return nil
+}
+
+func getStoragePool(poolIDToResize string) *api.StoragePool {
+	pool, err := GetStoragePoolByUUID(poolIDToResize)
+	log.FailOnError(err, "Failed to get pool using UUID %s", poolIDToResize)
+	return pool
+}
+
+func pickPoolToResize(contexts []*scheduler.Context) string {
+	poolWithIO, err := GetPoolIDWithIOs(contexts)
+	if poolWithIO == "" || err != nil {
+		log.Warnf("No pool with IO found, picking a random pool in use to resize")
+	}
+	poolIDsInUseByTestingApp, err := GetPoolsInUse()
+	log.FailOnError(err, "Error identifying pool to run test")
+	poolIDToResize := poolIDsInUseByTestingApp[0]
+	return poolIDToResize
+}
+func roundUpValue(toRound uint64) uint64 {
+
+	if toRound%10 == 0 {
+		return toRound
+	}
+	rs := (10 - toRound%10) + toRound
+	return rs
+
+}
+
+func poolResizeIsInProgress(poolToBeResized *api.StoragePool) (bool, error) {
+	if poolToBeResized.LastOperation != nil {
+		f := func() (interface{}, bool, error) {
+			pools, err := tests.Inst().V.ListStoragePools(metav1.LabelSelector{})
+			if err != nil || len(pools) == 0 {
+				return nil, true, fmt.Errorf("error getting pools list, err %v", err)
+			}
+
+			updatedPoolToBeResized := pools[poolToBeResized.Uuid]
+			if updatedPoolToBeResized == nil {
+				return nil, false, fmt.Errorf("error getting pool with given pool id %s", poolToBeResized.Uuid)
+			}
+
+			if updatedPoolToBeResized.LastOperation.Status != api.SdkStoragePool_OPERATION_SUCCESSFUL {
+				log.Infof("Current pool status : %v", updatedPoolToBeResized.LastOperation)
+				if updatedPoolToBeResized.LastOperation.Status == api.SdkStoragePool_OPERATION_FAILED {
+					return nil, false, fmt.Errorf("PoolResize has failed. Error: %s", updatedPoolToBeResized.LastOperation)
+				}
+				log.Infof("Pool Resize is already in progress: %v", updatedPoolToBeResized.LastOperation)
+				return nil, true, nil
+			}
+			return nil, false, nil
+		}
+
+		_, err := task.DoRetryWithTimeout(f, poolResizeTimeout, retryTimeout)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	stNode, err := GetNodeWithGivenPoolID(poolToBeResized.Uuid)
+	if err != nil {
+		return false, err
+	}
+
+	t := func() (interface{}, bool, error) {
+		status, err := tests.Inst().V.GetNodePoolsStatus(*stNode)
+		if err != nil {
+			return "", false, err
+		}
+		currStatus := status[poolToBeResized.Uuid]
+
+		if currStatus == "Offline" {
+			return "", true, fmt.Errorf("pool [%s] has current status [%s].Waiting rebalance to complete if in-progress", poolToBeResized.Uuid, currStatus)
+		}
+		return "", false, nil
+	}
+
+	_, err = task.DoRetryWithTimeout(t, 120*time.Minute, 2*time.Second)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func waitForPoolToBeResized(expectedSize uint64, poolIDToResize string, isJournalEnabled bool) error {
+
+	currentLastMsg := ""
+	f := func() (interface{}, bool, error) {
+		expandedPool, err := GetStoragePoolByUUID(poolIDToResize)
+		if err != nil {
+			return nil, true, fmt.Errorf("error getting pool by using id %s", poolIDToResize)
+		}
+
+		if expandedPool == nil {
+			return nil, false, fmt.Errorf("expanded pool value is nil")
+		}
+		if expandedPool.LastOperation != nil {
+			log.Infof("Pool Resize Status : %v, Message : %s", expandedPool.LastOperation.Status, expandedPool.LastOperation.Msg)
+			if expandedPool.LastOperation.Status == api.SdkStoragePool_OPERATION_FAILED {
+				return nil, false, fmt.Errorf("pool %s expansion has failed. Error: %s", poolIDToResize, expandedPool.LastOperation)
+			}
+			if expandedPool.LastOperation.Status == api.SdkStoragePool_OPERATION_PENDING {
+				return nil, true, fmt.Errorf("pool %s is in pending state, waiting to start", poolIDToResize)
+			}
+			if expandedPool.LastOperation.Status == api.SdkStoragePool_OPERATION_IN_PROGRESS {
+				if strings.Contains(expandedPool.LastOperation.Msg, "Rebalance in progress") {
+					if currentLastMsg == expandedPool.LastOperation.Msg {
+						return nil, false, fmt.Errorf("pool reblance is not progressing")
+					}
+					currentLastMsg = expandedPool.LastOperation.Msg
+					return nil, true, fmt.Errorf("wait for pool rebalance to complete")
+				}
+
+				if strings.Contains(expandedPool.LastOperation.Msg, "No pending operation pool status: Maintenance") ||
+					strings.Contains(expandedPool.LastOperation.Msg, "Storage rebalance complete pool status: Maintenance") {
+					return nil, false, nil
+				}
+
+				return nil, true, fmt.Errorf("waiting for pool status to update")
+			}
+		}
+		newPoolSize := expandedPool.TotalSize / units.GiB
+
+		expectedSizeWithJournal := expectedSize
+		if isJournalEnabled {
+			expectedSizeWithJournal = expectedSizeWithJournal - 3
+		}
+		if newPoolSize >= expectedSizeWithJournal {
+			// storage pool resize has been completed
+			return nil, false, nil
+		}
+		return nil, true, fmt.Errorf("pool has not been resized to %d or %d yet. Waiting...Current size is %d", expectedSize, expectedSizeWithJournal, newPoolSize)
+	}
+
+	_, err := task.DoRetryWithTimeout(f, poolResizeTimeout, retryTimeout)
+	return err
 }

--- a/drivers/pds/pdsrestore/restore_utils.go
+++ b/drivers/pds/pdsrestore/restore_utils.go
@@ -66,7 +66,19 @@ func (restoreClient *RestoreClient) TriggerAndValidateRestore(backupJobId string
 		log.Errorf("Failed during restore.")
 		return nil, fmt.Errorf("failed during restore")
 	}
-	err = wait.Poll(restoreTimeInterval, restoreTimeOut, func() (bool, error) {
+
+	if validate {
+		err = restoreClient.WaitForRestoreAndValidate(restoredModel, bkpDsEntity, nsName)
+		if err != nil {
+			log.Errorf("Failed to validate restored dataservice")
+			return nil, fmt.Errorf("failed to validate restored dataservice")
+		}
+	}
+	return restoredModel, nil
+}
+
+func (restoreClient *RestoreClient) WaitForRestoreAndValidate(restoredModel *pds.ModelsRestore, bkpDsEntity DSEntity, nsName string) error {
+	err := wait.Poll(restoreTimeInterval, restoreTimeOut, func() (bool, error) {
 		restore, err := restoreClient.Components.Restore.GetRestore(restoredModel.GetId())
 		state := restore.GetStatus()
 		if err != nil {
@@ -80,27 +92,25 @@ func (restoreClient *RestoreClient) TriggerAndValidateRestore(backupJobId string
 		return true, nil
 	})
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	if validate {
-		newDeploymentId := restoredModel.GetDeploymentId()
-		newDeploymentModel, err := restoreClient.Components.DataServiceDeployment.GetDeployment(newDeploymentId)
-		if err != nil {
-			return nil, fmt.Errorf("error while fetching restored deployment object")
-		}
-		dsType := ds.DataserviceType{}
-		err = dsType.ValidateDataServiceDeployment(newDeploymentModel, nsName)
-		if err != nil {
-			return nil, fmt.Errorf("error while validating the restored deployment")
-		}
-		restoreDsEntity := DSEntity{Deployment: newDeploymentModel}
-		err = restoreClient.ValidateRestore(bkpDsEntity, restoreDsEntity)
-		if err != nil {
-			return nil, fmt.Errorf("error while validation data service entities(i.e App config, resource etc). Err: %v", err)
-		}
+	newDeploymentId := restoredModel.GetDeploymentId()
+	newDeploymentModel, err := restoreClient.Components.DataServiceDeployment.GetDeployment(newDeploymentId)
+	if err != nil {
+		return fmt.Errorf("error while fetching restored deployment object")
 	}
-	return restoredModel, nil
+	dsType := ds.DataserviceType{}
+	err = dsType.ValidateDataServiceDeployment(newDeploymentModel, nsName)
+	if err != nil {
+		return fmt.Errorf("error while validating the restored deployment")
+	}
+	restoreDsEntity := DSEntity{Deployment: newDeploymentModel}
+	err = restoreClient.ValidateRestore(bkpDsEntity, restoreDsEntity)
+	if err != nil {
+		return fmt.Errorf("error while validation data service entities(i.e App config, resource etc). Err: %v", err)
+	}
+	return nil
 }
 
 func (restoreClient *RestoreClient) getNameSpaceId(pdsClusterId string) (string, string, error) {

--- a/tests/pds/pds_common.go
+++ b/tests/pds/pds_common.go
@@ -64,6 +64,7 @@ const (
 	RebootNodesDuringDeployment      = "reboot-multiple-nodes-during-deployment"
 	KillAgentPodDuringDeployment     = "kill-agent-pod-during-deployment"
 	KillTeleportPodDuringDeployment  = "kill-teleport-pod-during-deployment"
+	RestoreDSDuringPXPoolExpansion   = "restore-ds-during-px-pool-expansion"
 )
 
 var (

--- a/tests/pds/pds_resiliency_test.go
+++ b/tests/pds/pds_resiliency_test.go
@@ -2,13 +2,18 @@ package tests
 
 import (
 	"fmt"
+	pdsdriver "github.com/portworx/torpedo/drivers/pds"
+	"net/http"
+
 	. "github.com/onsi/ginkgo"
 	pds "github.com/portworx/pds-api-go-client/pds/v1alpha1"
 	dss "github.com/portworx/torpedo/drivers/pds/dataservice"
 	pdslib "github.com/portworx/torpedo/drivers/pds/lib"
+	pdsbkp "github.com/portworx/torpedo/drivers/pds/pdsbackup"
+	restoreBkp "github.com/portworx/torpedo/drivers/pds/pdsrestore"
+	tc "github.com/portworx/torpedo/drivers/pds/targetcluster"
 	"github.com/portworx/torpedo/pkg/log"
 	. "github.com/portworx/torpedo/tests"
-	"net/http"
 )
 
 var _ = Describe("{RestartPXDuringAppScaleUp}", func() {
@@ -1047,5 +1052,169 @@ var _ = Describe("{KillTeleportDuringWorkloadRun}", func() {
 	})
 	JustAfterEach(func() {
 		EndTorpedoTest()
+	})
+})
+
+var _ = Describe("{RestoreDSDuringPXPoolExpansion}", func() {
+	var deps []*pds.ModelsDeployment
+	//pdsdeploymentsmd5Hash := make(map[string]string)
+	//restoredDeploymentsmd5Hash := make(map[string]string)
+	var deploymentsToBeCleaned []*pds.ModelsDeployment
+	//var wlDeploymentsToBeCleaned []*v1.Deployment
+	JustBeforeEach(func() {
+		StartTorpedoTest("RestoreDSDuringPXPoolExpansion", "Restore DataService during the PX Pool expansion", pdsLabels, 0)
+		pdslib.MarkResiliencyTC(true)
+		bkpClient, err = pdsbkp.InitializePdsBackup()
+		log.FailOnError(err, "Failed to initialize backup for pds.")
+		bkpTarget, err = bkpClient.CreateAwsS3BackupCredsAndTarget(tenantID, fmt.Sprintf("%v-aws", bkpTargetName), deploymentTargetID)
+		log.FailOnError(err, "Failed to create S3 backup target.")
+		log.InfoD("AWS S3 target - %v created successfully", bkpTarget.GetName())
+		awsBkpTargets = append(awsBkpTargets, bkpTarget)
+
+		//Initializing the parameters required for workload generation
+		wkloadParams = pdsdriver.LoadGenParams{
+			LoadGenDepName: params.LoadGen.LoadGenDepName,
+			Namespace:      params.InfraToTest.Namespace,
+			NumOfRows:      params.LoadGen.NumOfRows,
+			Timeout:        params.LoadGen.Timeout,
+			Replicas:       params.LoadGen.Replicas,
+			TableName:      params.LoadGen.TableName,
+			Iterations:     params.LoadGen.Iterations,
+			FailOnError:    params.LoadGen.FailOnError,
+		}
+	})
+
+	It("Deploy Dataservices and Restore during PX-Pool Expansion", func() {
+		var deployments = make(map[PDSDataService]*pds.ModelsDeployment)
+		var depList []*pds.ModelsDeployment
+
+		Step("Deploy Data Services", func() {
+			for _, ds := range params.DataServiceToTest {
+
+				Step("Deploy and validate data service", func() {
+					isDeploymentsDeleted = false
+					deployment, _, _, err = DeployandValidateDataServices(ds, params.InfraToTest.Namespace, tenantID, projectID)
+					log.FailOnError(err, "Error while deploying data services")
+					deployments[ds] = deployment
+					depList = append(depList, deployment)
+					deploymentsToBeCleaned = append(deploymentsToBeCleaned, deployment)
+					deps = append(deps, deployment)
+					dsEntity = restoreBkp.DSEntity{
+						Deployment: deployment,
+					}
+				})
+
+			}
+		})
+
+		defer func() {
+			for _, newDeployment := range deployments {
+				Step("Delete created deployments")
+				resp, err := pdslib.DeleteDeployment(newDeployment.GetId())
+				log.FailOnError(err, "Error while deleting data services")
+				dash.VerifyFatal(resp.StatusCode, http.StatusAccepted, "validating the status response")
+				err = pdslib.DeletePvandPVCs(*newDeployment.ClusterResourceName, false)
+				log.FailOnError(err, "Error while deleting PV and PVCs")
+			}
+		}()
+
+		//Step("Running Workloads before taking backups", func() {
+		//	for _, pdsDeployment := range deps {
+		//		ckSum, wlDep, err := dsTest.InsertDataAndReturnChecksum(pdsDeployment, wkloadParams)
+		//		wlDeploymentsToBeCleaned = append(wlDeploymentsToBeCleaned, wlDep)
+		//		log.FailOnError(err, "Error while Running workloads")
+		//		log.Debugf("Checksum for the deployment %s is %s", *pdsDeployment.ClusterResourceName, ckSum)
+		//		pdsdeploymentsmd5Hash[*pdsDeployment.ClusterResourceName] = ckSum
+		//
+		//	}
+		//})
+		Step("Perform adhoc backup and validate them", func() {
+
+			log.Infof("Deployment ID: %v, backup target ID: %v", deployment.GetId(), bkpTarget.GetId())
+			err = bkpClient.TriggerAndValidateAdhocBackup(deployment.GetId(), bkpTarget.GetId(), "s3")
+			log.FailOnError(err, "Failed while performing adhoc backup")
+		})
+
+		Step("Resize PX-POOL and trigger restore at the same time", func() {
+			for _, deployment := range deployments {
+				failuretype := pdslib.TypeOfFailure{
+					Type: RestoreDSDuringPXPoolExpansion,
+					Method: func() error {
+						ctx, err := Inst().Pds.CreateSchedulerContextForPDSApps(depList)
+						log.Infof("Created scheduler context", ctx)
+						log.FailOnError(err, "Unable to create scheduler context")
+						return pdslib.ExpandAndValidatePxPool(ctx)
+					},
+				}
+				pdslib.DefineFailureType(failuretype)
+
+				err = pdslib.InduceFailureAfterWaitingForCondition(deployment, namespace, params.ResiliencyTest.CheckTillReplica)
+				log.FailOnError(err, fmt.Sprintf("Error happened while restarting px for data service %v", *deployment.ClusterResourceName))
+
+			}
+		})
+		Step("Validate Deployments after Px-pool Resize", func() {
+			for ds, deployment := range deployments {
+				err = dsTest.ValidateDataServiceDeployment(deployment, namespace)
+				log.FailOnError(err, "Error while validating dataservices")
+				log.InfoD("Data-service: %v is up and healthy", ds.Name)
+			}
+			dsEntity = restoreBkp.DSEntity{
+				Deployment: deployment,
+			}
+		})
+		Step("Taking adhoc backup and trigger restore again", func() {
+
+			log.Infof("Deployment ID: %v, backup target ID: %v", deployment.GetId(), bkpTarget.GetId())
+			err = bkpClient.TriggerAndValidateAdhocBackup(deployment.GetId(), bkpTarget.GetId(), "s3")
+			log.FailOnError(err, "Failed while performing adhoc backup")
+			ctx := pdslib.GetAndExpectStringEnvVar("PDS_RESTORE_TARGET_CLUSTER")
+			restoreTarget := tc.NewTargetCluster(ctx)
+			restoreClient := restoreBkp.RestoreClient{
+				TenantId:             tenantID,
+				ProjectId:            projectID,
+				Components:           components,
+				Deployment:           deployment,
+				RestoreTargetCluster: restoreTarget,
+			}
+			backupJobs, err := restoreClient.Components.BackupJob.ListBackupJobsBelongToDeployment(projectID, deployment.GetId())
+			log.FailOnError(err, "Error while fetching the backup jobs for the deployment: %v", deployment.GetClusterResourceName())
+			for _, backupJob := range backupJobs {
+				log.InfoD("[Restoring] Details Backup job name- %v, Id- %v", backupJob.GetName(), backupJob.GetId())
+				restoredModel, err := restoreClient.TriggerAndValidateRestore(backupJob.GetId(), params.InfraToTest.Namespace, dsEntity, true, true)
+				log.FailOnError(err, "Failed during restore.")
+				restoredDeployment, err = restoreClient.Components.DataServiceDeployment.GetDeployment(restoredModel.GetDeploymentId())
+				log.FailOnError(err, fmt.Sprintf("Failed while fetching the restore data service instance: %v", restoredModel.GetClusterResourceName()))
+				deploymentsToBeCleaned = append(deploymentsToBeCleaned, restoredDeployment)
+				log.InfoD("Restored successfully. Deployment- %v", restoredModel.GetClusterResourceName())
+			}
+		})
+
+		//Step("Validate md5hash for the restored deployments", func() {
+		//	for _, pdsDeployment := range deploymentsToBeCleaned {
+		//		ckSum, wlDep, err := dsTest.ReadDataAndReturnChecksum(pdsDeployment, wkloadParams)
+		//		wlDeploymentsToBeCleaned = append(wlDeploymentsToBeCleaned, wlDep)
+		//		log.FailOnError(err, "Error while Running workloads")
+		//		log.Debugf("Checksum for the deployment %s is %s", *pdsDeployment.ClusterResourceName, ckSum)
+		//		restoredDeploymentsmd5Hash[*pdsDeployment.ClusterResourceName] = ckSum
+		//	}
+		//
+		//	defer func() {
+		//		for _, wlDep := range wlDeploymentsToBeCleaned {
+		//			err := k8sApps.DeleteDeployment(wlDep.Name, wlDep.Namespace)
+		//			log.FailOnError(err, "Failed while deleting the workload deployment")
+		//		}
+		//	}()
+		//
+		//	dash.VerifyFatal(dsTest.ValidateDataMd5Hash(pdsdeploymentsmd5Hash, restoredDeploymentsmd5Hash),
+		//		true, "Validate md5 hash after restore")
+		//})
+		Step("Delete Deployments", func() {
+			CleanupDeployments(deploymentsToBeCleaned)
+		})
+	})
+	JustAfterEach(func() {
+		EndTorpedoTest()
+
 	})
 })


### PR DESCRIPTION
Integrated Restore utility with Resiliency Utility. 
Added a new testcase which does the following - 

Configure the cluster
1.Deploy back up suppported data service.

Start a long running workload on the data service.

Take backup and Validate if the backup job succeeded.

Perform restore from above backup

Perform following validation:

a. Application data
b. Resource specification
c. Application configuration
d. PDS Control plane UI should be able to detect them.
e. Existing data service should be intact.
f. Restored data service endpoint should be accessible and in term workload should succeed on the restored DS.

Wait till the Pool get filled ~80% and increase the Pool size.

Trigger few backup job while pool expansion going on.

Repeat STEP 3,4,59. Delete all the restored data services.


Jenkins Run - Coming Soon
