### PR TITLE
[PA-1621] Add StartPxBackupTorpedoTest

### DIFF
--- a/tests/backup/backup_basic_test.go
+++ b/tests/backup/backup_basic_test.go
@@ -22,6 +22,33 @@ import (
 	"time"
 )
 
+// TestcaseAuthor List
+const (
+	Ak             TestcaseAuthor = "ak-px"
+	Apimpalgaonkar TestcaseAuthor = "apimpalgaonkar"
+	KPhalgun       TestcaseAuthor = "kphalgun-px"
+	Kshithijiyer   TestcaseAuthor = "kshithijiyer-px"
+	Mkoppal        TestcaseAuthor = "mkoppal-px"
+	Sagrawal       TestcaseAuthor = "sagrawal-px"
+	Skonda         TestcaseAuthor = "skonda-px"
+	Sn             TestcaseAuthor = "sn-px"
+	Tthurlapati    TestcaseAuthor = "tthurlapati-px"
+	Vpinisetti     TestcaseAuthor = "vpinisetti-px"
+	Sabrarhussaini TestcaseAuthor = "sabrarhussaini"
+)
+
+// TestcaseQuarter List
+const (
+	Q4FY23 TestcaseQuarter = "Q4FY23"
+	Q1FY24 TestcaseQuarter = "Q1FY24"
+	Q2FY24 TestcaseQuarter = "Q2FY24"
+	Q3FY24 TestcaseQuarter = "Q3FY24"
+	Q4FY24 TestcaseQuarter = "Q4FY24"
+	Q1FY25 TestcaseQuarter = "Q1FY25"
+	Q2FY25 TestcaseQuarter = "Q2FY25"
+	Q3FY25 TestcaseQuarter = "Q3FY25"
+)
+
 func getBucketNameSuffix() string {
 	bucketNameSuffix, present := os.LookupEnv("BUCKET_NAME")
 	if present && bucketNameSuffix != "" {

--- a/tests/backup/backup_delete_test.go
+++ b/tests/backup/backup_delete_test.go
@@ -44,8 +44,8 @@ var _ = Describe("{IssueDeleteOfIncrementalBackupsAndRestore}", func() {
 	backupLocationMap := make(map[string]string)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("IssueDeleteOfIncrementalBackupsAndRestore",
-			"Issue delete of incremental backups and try to restore the newest backup", nil, 58056)
+		StartPxBackupTorpedoTest("IssueDeleteOfIncrementalBackupsAndRestore",
+			"Issue delete of incremental backups and try to restore the newest backup", nil, 58056, Kshithijiyer, Q1FY24)
 		log.InfoD("Deploy applications")
 
 		scheduledAppContexts = make([]*scheduler.Context, 0)
@@ -222,8 +222,8 @@ var _ = Describe("{DeleteIncrementalBackupsAndRecreateNew}", func() {
 	backupLocationMap := make(map[string]string)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("DeleteIncrementalBackupsAndRecreateNew",
-			"Delete incremental Backups and re-create them", nil, 58039)
+		StartPxBackupTorpedoTest("DeleteIncrementalBackupsAndRecreateNew",
+			"Delete incremental Backups and re-create them", nil, 58039, Kshithijiyer, Q1FY24)
 		log.InfoD("Deploy applications")
 
 		scheduledAppContexts = make([]*scheduler.Context, 0)
@@ -375,7 +375,7 @@ var _ = Describe("{DeleteBucketVerifyCloudBackupMissing}", func() {
 	appContextsToBackupMap := make(map[string][]*scheduler.Context)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("DeleteBucketVerifyCloudBackupMissing", "Validates the backup state (CloudBackupMissing) when bucket is deleted.", nil, 58070)
+		StartPxBackupTorpedoTest("DeleteBucketVerifyCloudBackupMissing", "Validates the backup state (CloudBackupMissing) when bucket is deleted.", nil, 58070, Ak, Q1FY24)
 		log.Infof("Deploying applications required for the testcase")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -601,8 +601,8 @@ var _ = Describe("{DeleteBackupAndCheckIfBucketIsEmpty}", func() {
 	appContextsToBackupMap := make(map[string][]*scheduler.Context)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("DeleteBackupAndCheckIfBucketIsEmpty",
-			"Delete backups and verify if contents are deleted from backup location or not", nil, 58071)
+		StartPxBackupTorpedoTest("DeleteBackupAndCheckIfBucketIsEmpty",
+			"Delete backups and verify if contents are deleted from backup location or not", nil, 58071, Kshithijiyer, Q2FY24)
 		log.InfoD("Deploy applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {

--- a/tests/backup/backup_kubevirt_test.go
+++ b/tests/backup/backup_kubevirt_test.go
@@ -43,7 +43,7 @@ var _ = Describe("{KubevirtVMBackupRestoreWithDifferentStates}", func() {
 	)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("KubevirtVMBackupRestoreWithDifferentStates", "Verify backup and restore of Kubevirt VMs in different states", nil, 93011)
+		StartPxBackupTorpedoTest("KubevirtVMBackupRestoreWithDifferentStates", "Verify backup and restore of Kubevirt VMs in different states", nil, 93011, Mkoppal, Q3FY24)
 
 		backupLocationMap = make(map[string]string)
 		labelSelectors = make(map[string]string)

--- a/tests/backup/backup_license_test.go
+++ b/tests/backup/backup_license_test.go
@@ -25,8 +25,8 @@ var _ = Describe("{NodeCountForLicensing}", func() {
 		destClusterStatus             api.ClusterInfo_StatusInfo_Status
 	)
 	JustBeforeEach(func() {
-		StartTorpedoTest("NodeCountForLicensing",
-			"Verify worker node on application cluster with label portworx.io/nobackup=true is not counted for licensing", nil, 82777)
+		StartPxBackupTorpedoTest("NodeCountForLicensing",
+			"Verify worker node on application cluster with label portworx.io/nobackup=true is not counted for licensing", nil, 82777, Sagrawal, Q1FY24)
 	})
 
 	It("Verify worker node on application cluster with label portworx.io/nobackup=true is not counted for licensing", func() {
@@ -148,8 +148,8 @@ var _ = Describe("{LicensingCountWithNodeLabelledBeforeClusterAddition}", func()
 	)
 	backupLocationMap := make(map[string]string)
 	JustBeforeEach(func() {
-		StartTorpedoTest("LicensingCountWithNodeLabelledBeforeClusterAddition",
-			"Applies label portworx.io/nobackup=true before adding of application cluster to backup and verifies the license count", nil, 82954)
+		StartPxBackupTorpedoTest("LicensingCountWithNodeLabelledBeforeClusterAddition",
+			"Applies label portworx.io/nobackup=true before adding of application cluster to backup and verifies the license count", nil, 82954, Sagrawal, Q1FY24)
 		log.InfoD("Deploy applications needed for taking backup")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -325,8 +325,8 @@ var _ = Describe("{LicensingCountBeforeAndAfterBackupPodRestart}", func() {
 		contexts                      []*scheduler.Context
 	)
 	JustBeforeEach(func() {
-		StartTorpedoTest("LicensingCountBeforeAndAfterBackupPodRestart",
-			"Verifies the license count before and after the backup pod restarts", nil, 82956)
+		StartPxBackupTorpedoTest("LicensingCountBeforeAndAfterBackupPodRestart",
+			"Verifies the license count before and after the backup pod restarts", nil, 82956, Sagrawal, Q1FY24)
 	})
 
 	It("Verify the license count before and after the backup pod restarts", func() {

--- a/tests/backup/backup_locked_bucket_test.go
+++ b/tests/backup/backup_locked_bucket_test.go
@@ -37,7 +37,7 @@ var _ = Describe("{BackupAlternatingBetweenLockedAndUnlockedBuckets}", func() {
 	var clusterStatus api.ClusterInfo_StatusInfo_Status
 	bkpNamespaces = make([]string, 0)
 	JustBeforeEach(func() {
-		StartTorpedoTest("BackupAlternatingBetweenLockedAndUnlockedBuckets", "Deploying backup", nil, 60018)
+		StartPxBackupTorpedoTest("BackupAlternatingBetweenLockedAndUnlockedBuckets", "Deploying backup", nil, 60018, Kshithijiyer, Q4FY23)
 		log.InfoD("Verifying if the pre/post rules for the required apps are present in the list or not")
 		for i := 0; i < len(appList); i++ {
 			if Contains(postRuleApp, appList[i]) {
@@ -233,7 +233,7 @@ var _ = Describe("{LockedBucketResizeOnRestoredVolume}", func() {
 	bkpNamespaces = make([]string, 0)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("LockedBucketResizeOnRestoredVolume", "Resize after the volume is restored from a backup from locked bucket", nil, 59904)
+		StartPxBackupTorpedoTest("LockedBucketResizeOnRestoredVolume", "Resize after the volume is restored from a backup from locked bucket", nil, 59904, Kshithijiyer, Q4FY23)
 		log.InfoD("Verifying if the pre/post rules for the required apps are present in the list or not")
 		for i := 0; i < len(appList); i++ {
 			if Contains(postRuleApp, appList[i]) {
@@ -466,7 +466,7 @@ var _ = Describe("{LockedBucketResizeVolumeOnScheduleBackup}", func() {
 	volListAfterSizeMap := make(map[string]int)
 	modes := [2]string{"GOVERNANCE", "COMPLIANCE"}
 	JustBeforeEach(func() {
-		StartTorpedoTest("LockedBucketResizeVolumeOnScheduleBackup", "Verify schedule backups are successful while volume resize is in progress for locked bucket", nil, 59899)
+		StartPxBackupTorpedoTest("LockedBucketResizeVolumeOnScheduleBackup", "Verify schedule backups are successful while volume resize is in progress for locked bucket", nil, 59899, Apimpalgaonkar, Q1FY24)
 		log.InfoD("Verifying if the pre/post rules for the required apps are present in the list or not")
 		for i := 0; i < len(appList); i++ {
 			if Contains(postRuleApp, appList[i]) {
@@ -705,7 +705,7 @@ var _ = Describe("{DeleteLockedBucketUserObjectsFromAdmin}", func() {
 	)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("DeleteLockedBucketUserObjectsFromAdmin", "Delete backups, backup schedules, restore and cluster objects created with locked bucket from the admin", nil, 87566)
+		StartPxBackupTorpedoTest("DeleteLockedBucketUserObjectsFromAdmin", "Delete backups, backup schedules, restore and cluster objects created with locked bucket from the admin", nil, 87566, Kshithijiyer, Q3FY24)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
 			taskName := fmt.Sprintf("%s-%d", taskNamePrefix, i)
 			appContexts := ScheduleApplications(taskName)

--- a/tests/backup/backup_namespace_labelled_test.go
+++ b/tests/backup/backup_namespace_labelled_test.go
@@ -42,8 +42,8 @@ var _ = Describe("{NamespaceLabelledBackupSharedWithDifferentAccessMode}", func(
 	accessUserBackupContext := make(map[userAccessContext]string)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("NamespaceLabelledBackupSharedWithDifferentAccessMode",
-			"Take namespace labelled backup and share with users having different access mode", nil, 85040)
+		StartPxBackupTorpedoTest("NamespaceLabelledBackupSharedWithDifferentAccessMode",
+			"Take namespace labelled backup and share with users having different access mode", nil, 85040, Sagrawal, Q3FY24)
 		log.Infof("Deploy applications needed for backup")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		// Here we have deployed 2*numberOfUsers namespaces/application
@@ -239,7 +239,7 @@ var _ = Describe("{BackupScheduleForOldAndNewNS}", func() {
 	bkpNamespaces = make([]string, 0)
 	initialNSCount = 3
 	JustBeforeEach(func() {
-		StartTorpedoTest("BackupScheduleForOldAndNewNS", "Schedule backup with old and new namespace using namespace label", nil, 84852)
+		StartPxBackupTorpedoTest("BackupScheduleForOldAndNewNS", "Schedule backup with old and new namespace using namespace label", nil, 84852, Vpinisetti, Q2FY24)
 		log.InfoD("Deploy applications")
 		contexts = make([]*scheduler.Context, 0)
 		for i := 0; i < initialNSCount; i++ {
@@ -459,7 +459,7 @@ var _ = Describe("{ManualAndScheduledBackupUsingNamespaceAndResourceLabel}", fun
 	backupLocationMap := make(map[string]string)
 	bkpNamespaces = make([]string, 0)
 	JustBeforeEach(func() {
-		StartTorpedoTest("ManualAndScheduledBackupUsingNamespaceAndResourceLabel", "Manual, schedule backup and restore, using namespace label and resource label", nil, 84850)
+		StartPxBackupTorpedoTest("ManualAndScheduledBackupUsingNamespaceAndResourceLabel", "Manual, schedule backup and restore, using namespace label and resource label", nil, 84850, Vpinisetti, Q2FY24)
 		log.InfoD("Deploy applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < 3; i++ {
@@ -653,7 +653,7 @@ var _ = Describe("{ScheduleBackupWithAdditionAndRemovalOfNS}", func() {
 	namespaceMapping := make(map[string]string)
 	bkpNamespaces = make([]string, 0)
 	JustBeforeEach(func() {
-		StartTorpedoTest("ScheduleBackupWithAdditionAndRemovalOfNS", "Perform schedule backup during which remove and add namespace and verify restoration of removed namespace", nil, 84848)
+		StartPxBackupTorpedoTest("ScheduleBackupWithAdditionAndRemovalOfNS", "Perform schedule backup during which remove and add namespace and verify restoration of removed namespace", nil, 84848, Vpinisetti, Q2FY24)
 		log.InfoD("Deploy applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < 5; i++ {
@@ -895,7 +895,7 @@ var _ = Describe("{ManualAndScheduleBackupUsingNSLabelWithMaxCharLimit}", func()
 	labelSelectors := make(map[string]string)
 	bkpNamespaces = make([]string, 0)
 	JustBeforeEach(func() {
-		StartTorpedoTest("ManualAndScheduleBackupUsingNSLabelWithMaxCharLimit", "Manual, schedule backup and restore of single, multiple and all namespaces with namespace labeled as max character limit", nil, 84853)
+		StartPxBackupTorpedoTest("ManualAndScheduleBackupUsingNSLabelWithMaxCharLimit", "Manual, schedule backup and restore of single, multiple and all namespaces with namespace labeled as max character limit", nil, 84853, Vpinisetti, Q2FY24)
 		log.InfoD("Deploy applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < 3; i++ {
@@ -1245,7 +1245,7 @@ var _ = Describe("{ManualAndScheduleBackupUsingNamespaceLabel}", func() {
 	backupLocationMap := make(map[string]string)
 	bkpNamespaces = make([]string, 0)
 	JustBeforeEach(func() {
-		StartTorpedoTest("ManualAndScheduleBackupUsingNamespaceLabel", "Namespace labeled manual and schedule backup of single and multiple namespaces along with default and custom restore", nil, 84842)
+		StartPxBackupTorpedoTest("ManualAndScheduleBackupUsingNamespaceLabel", "Namespace labeled manual and schedule backup of single and multiple namespaces along with default and custom restore", nil, 84842, Apimpalgaonkar, Q2FY24)
 		log.InfoD("Deploy applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < 3; i++ {
@@ -1535,7 +1535,7 @@ var _ = Describe("{NamespaceLabelledBackupOfEmptyNamespace}", func() {
 	bkpNamespaces = make([]string, 0)
 	schPolicyInterval = 15
 	JustBeforeEach(func() {
-		StartTorpedoTest("NamespaceLabelledBackupOfEmptyNamespace", "NamespaceLabelledBackupOfEmptyNamespace takes namespace labelled backup of empty namespace and restores it", nil, 86693)
+		StartPxBackupTorpedoTest("NamespaceLabelledBackupOfEmptyNamespace", "NamespaceLabelledBackupOfEmptyNamespace takes namespace labelled backup of empty namespace and restores it", nil, 86693, Sagrawal, Q3FY24)
 		log.InfoD("Deploy applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < 3; i++ {

--- a/tests/backup/backup_nfs_test.go
+++ b/tests/backup/backup_nfs_test.go
@@ -46,7 +46,7 @@ var _ = Describe("{DeleteNfsExecutorPodWhileBackupAndRestoreInProgress}", func()
 	singleNamespaceBkp = "singleNamespaceBkp"
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("DeleteNfsExecutorPodWhileBackupAndRestoreInProgress", "Delete nfs executor pod while backup and restore are in progress and validate the status", nil, 86105)
+		StartPxBackupTorpedoTest("DeleteNfsExecutorPodWhileBackupAndRestoreInProgress", "Delete nfs executor pod while backup and restore are in progress and validate the status", nil, 86105, Sagrawal, Q3FY24)
 		log.InfoD("Scheduling Applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < 5; i++ {

--- a/tests/backup/backup_orphaned_test.go
+++ b/tests/backup/backup_orphaned_test.go
@@ -42,7 +42,7 @@ var _ = Describe("{DeleteSameNameObjectsByMultipleUsersFromAdmin}", func() {
 	)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("DeleteSameNameObjectsByMultipleUsersFromAdmin", "Delete backups, backup schedules, restore and cluster objects created by multiple user with same name from the admin", nil, 87563)
+		StartPxBackupTorpedoTest("DeleteSameNameObjectsByMultipleUsersFromAdmin", "Delete backups, backup schedules, restore and cluster objects created by multiple user with same name from the admin", nil, 87563, KPhalgun, Q3FY24)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
 			taskName := fmt.Sprintf("%s-%d", taskNamePrefix, i)
 			appContexts := ScheduleApplications(taskName)
@@ -390,7 +390,7 @@ var _ = Describe("{DeleteUserBackupsAndRestoresOfDeletedAndInActiveClusterFromAd
 	)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("DeleteUserBackupsAndRestoresOfDeletedAndInActiveClusterFromAdmin", "Delete user backups and restores of the deleted and inactive cluster from the admin", nil, 87569)
+		StartPxBackupTorpedoTest("DeleteUserBackupsAndRestoresOfDeletedAndInActiveClusterFromAdmin", "Delete user backups and restores of the deleted and inactive cluster from the admin", nil, 87569, KPhalgun, Q3FY24)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
 			taskName := fmt.Sprintf("%s-%d", taskNamePrefix, i)
 			appContexts := ScheduleApplications(taskName)
@@ -718,7 +718,7 @@ var _ = Describe("{DeleteObjectsByMultipleUsersFromNewAdmin}", func() {
 	)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("DeleteObjectsByMultipleUsersFromNewAdmin", "Delete backups, backup schedules, restore and cluster objects created by multiple user from the new admin", nil, 87567)
+		StartPxBackupTorpedoTest("DeleteObjectsByMultipleUsersFromNewAdmin", "Delete backups, backup schedules, restore and cluster objects created by multiple user from the new admin", nil, 87567, KPhalgun, Q3FY24)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
 			taskName := fmt.Sprintf("%s-%d", taskNamePrefix, i)
 			appContexts := ScheduleApplications(taskName)
@@ -1124,7 +1124,7 @@ var _ = Describe("{DeleteFailedInProgressBackupAndRestoreOfUserFromAdmin}", func
 	)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("DeleteFailedInProgressBackupAndRestoreOfUserFromAdmin", "Delete failed and in-progress backups and restores of user from the admin side", nil, 87564)
+		StartPxBackupTorpedoTest("DeleteFailedInProgressBackupAndRestoreOfUserFromAdmin", "Delete failed and in-progress backups and restores of user from the admin side", nil, 87564, KPhalgun, Q3FY24)
 		log.InfoD("Scheduling applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -1609,7 +1609,7 @@ var _ = Describe("{DeleteSharedBackupOfUserFromAdmin}", func() {
 	)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("DeleteSharedBackupOfUserFromAdmin", "Delete backups shared by the user from the admin", nil, 87562)
+		StartPxBackupTorpedoTest("DeleteSharedBackupOfUserFromAdmin", "Delete backups shared by the user from the admin", nil, 87562, KPhalgun, Q3FY24)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
 			taskName := fmt.Sprintf("%s-%d", taskNamePrefix, i)
 			appContexts := ScheduleApplications(taskName)
@@ -1886,8 +1886,8 @@ var _ = Describe("{DeleteBackupOfUserNonSharedRBAC}", func() {
 	backupDriver := Inst().Backup
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("DeleteBackupOfUserNonSharedRBAC",
-			"Delete backups,restores,schedules,clusters created by non-admin user with non-shared RBAC resources from px-admin ", nil, 87561)
+		StartPxBackupTorpedoTest("DeleteBackupOfUserNonSharedRBAC",
+			"Delete backups,restores,schedules,clusters created by non-admin user with non-shared RBAC resources from px-admin ", nil, 87561, Ak, Q3FY24)
 		log.InfoD("Deploy applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < numOfNS; i++ {
@@ -2544,8 +2544,8 @@ var _ = Describe("{DeleteBackupOfUserSharedRBAC}", func() {
 	)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("DeleteBackupOfUserSharedRBAC",
-			"Delete backups,restores,schedules,clusters created by non-admin user with shared RBAC resources from px-admin", nil, 87560)
+		StartPxBackupTorpedoTest("DeleteBackupOfUserSharedRBAC",
+			"Delete backups,restores,schedules,clusters created by non-admin user with shared RBAC resources from px-admin", nil, 87560, Ak, Q3FY24)
 		log.InfoD("Deploy applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < numOfNS; i++ {
@@ -3115,8 +3115,8 @@ var _ = Describe("{UpdatesBackupOfUserFromAdmin}", func() {
 	)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("UpdatesBackupOfUserFromAdmin",
-			"Updates backups of non admin user from px-admin with valid/in-valid account", nil, 87568)
+		StartPxBackupTorpedoTest("UpdatesBackupOfUserFromAdmin",
+			"Updates backups of non admin user from px-admin with valid/in-valid account", nil, 87568, Ak, Q3FY24)
 		log.InfoD("Deploy applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -3357,8 +3357,8 @@ var _ = Describe("{DeleteBackupSharedByMultipleUsersFromAdmin}", func() {
 	)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("DeleteBackupSharedByMultipleUsersFromAdmin",
-			"Delete backups of non admin user from px-admin when backup is shared by multiple users", nil, 87565)
+		StartPxBackupTorpedoTest("DeleteBackupSharedByMultipleUsersFromAdmin",
+			"Delete backups of non admin user from px-admin when backup is shared by multiple users", nil, 87565, Ak, Q3FY24)
 		log.InfoD("Deploy applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {

--- a/tests/backup/backup_portworx_test.go
+++ b/tests/backup/backup_portworx_test.go
@@ -44,7 +44,7 @@ var _ = Describe("{BackupLocationWithEncryptionKey}", func() {
 	)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("BackupLocationWithEncryptionKey", "Creating Backup Location with Encryption Keys", nil, 79918)
+		StartPxBackupTorpedoTest("BackupLocationWithEncryptionKey", "Creating Backup Location with Encryption Keys", nil, 79918, Skonda, Q4FY23)
 
 		log.InfoD("Deploy applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
@@ -157,7 +157,7 @@ var _ = Describe("{ReplicaChangeWhileRestore}", func() {
 	var scName string
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("ReplicaChangeWhileRestore", "Change replica while restoring backup", nil, 58065)
+		StartPxBackupTorpedoTest("ReplicaChangeWhileRestore", "Change replica while restoring backup", nil, 58065, Kshithijiyer, Q4FY23)
 		log.InfoD("Deploy applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -314,7 +314,7 @@ var _ = Describe("{ResizeOnRestoredVolume}", func() {
 	backupNamespaceMap := make(map[string]string)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("ResizeOnRestoredVolume", "Resize after the volume is restored from a backup", nil, 58064)
+		StartPxBackupTorpedoTest("ResizeOnRestoredVolume", "Resize after the volume is restored from a backup", nil, 58064, Kshithijiyer, Q4FY23)
 		log.InfoD("Verifying if the pre/post rules for the required apps are present in the list or not")
 		for i := 0; i < len(appList); i++ {
 			if Contains(postRuleApp, appList[i]) {
@@ -498,7 +498,7 @@ var _ = Describe("{RestoreEncryptedAndNonEncryptedBackups}", func() {
 	backupLocationMap := make(map[string]string)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("RestoreEncryptedAndNonEncryptedBackups", "Restore encrypted and non encrypted backups", nil, 79915)
+		StartPxBackupTorpedoTest("RestoreEncryptedAndNonEncryptedBackups", "Restore encrypted and non encrypted backups", nil, 79915, Skonda, Q4FY23)
 
 		log.InfoD("Deploy applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
@@ -677,7 +677,7 @@ var _ = Describe("{ResizeVolumeOnScheduleBackup}", func() {
 	scheduledAppContexts = make([]*scheduler.Context, 0)
 	appNamespaces = make([]string, 0)
 	JustBeforeEach(func() {
-		StartTorpedoTest("ResizeVolumeOnScheduleBackup", "Verify schedule backups are successful while volume resize is in progress", nil, 58050)
+		StartPxBackupTorpedoTest("ResizeVolumeOnScheduleBackup", "Verify schedule backups are successful while volume resize is in progress", nil, 58050, Sn, Q1FY24)
 		log.InfoD("Verifying if the pre/post rules for the required apps are present in the list or not")
 		for i := 0; i < len(appList); i++ {
 			if Contains(postRuleApp, appList[i]) {

--- a/tests/backup/backup_rancher_test.go
+++ b/tests/backup/backup_rancher_test.go
@@ -47,8 +47,8 @@ var _ = Describe("{SingleNamespaceBackupRestoreToNamespaceInSameAndDifferentProj
 	projectAnnotation := make(map[string]string)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("SingleNamespaceBackupRestoreToNamespaceInSameAndDifferentProject",
-			"Take backup of single namespace and restore to namespace in same and different project", nil, 84872)
+		StartPxBackupTorpedoTest("SingleNamespaceBackupRestoreToNamespaceInSameAndDifferentProject",
+			"Take backup of single namespace and restore to namespace in same and different project", nil, 84872, Sagrawal, Q2FY24)
 		log.InfoD("Deploying applications required for the testcase")
 		contexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -306,8 +306,8 @@ var _ = Describe("{NamespaceMoveFromProjectToProjectToNoProjectWhileRestore}", f
 	projectAnnotation := make(map[string]string)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("NamespaceMoveFromProjectToProjectToNoProjectWhileRestore",
-			"Take backup and move the namespace from project to project to no project during restore", nil, 84881)
+		StartPxBackupTorpedoTest("NamespaceMoveFromProjectToProjectToNoProjectWhileRestore",
+			"Take backup and move the namespace from project to project to no project during restore", nil, 84881, Sagrawal, Q3FY24)
 		log.InfoD("Deploying applications required for the testcase")
 		contexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -537,8 +537,8 @@ var _ = Describe("{MultipleProjectsAndNamespacesBackupAndRestore}", func() {
 	projectAnnotation := make(map[string]string)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("MultipleProjectsAndNamespacesBackupAndRestore",
-			"Take backups and restores of multiple namespaces belonging to multiple projects", nil, 84874)
+		StartPxBackupTorpedoTest("MultipleProjectsAndNamespacesBackupAndRestore",
+			"Take backups and restores of multiple namespaces belonging to multiple projects", nil, 84874, Sagrawal, Q3FY24)
 		log.InfoD("Deploying multiple instances of applications required for the testcase")
 		contexts = make([]*scheduler.Context, 0)
 		for i := 0; i < 4; i++ {

--- a/tests/backup/backup_rbac_test.go
+++ b/tests/backup/backup_rbac_test.go
@@ -51,7 +51,7 @@ var _ = Describe("{VerifyRBACforInfraAdmin}", func() {
 	)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("VerifyRBACforInfraAdmin", "Validates the RBAC operation for infra-admin user.", nil, 87886)
+		StartPxBackupTorpedoTest("VerifyRBACforInfraAdmin", "Validates the RBAC operation for infra-admin user.", nil, 87886, Ak, Q3FY24)
 		backupLocationMap = make(map[string]string)
 		log.InfoD("scheduling applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
@@ -532,7 +532,7 @@ var _ = Describe("{VerifyRBACForPxAdmin}", func() {
 	)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("VerifyRBACForPxAdmin", "Validates the RBAC operation for px-admin group user.", nil, 87887)
+		StartPxBackupTorpedoTest("VerifyRBACForPxAdmin", "Validates the RBAC operation for px-admin group user.", nil, 87887, Ak, Q3FY24)
 		log.InfoD("scheduling applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -862,7 +862,7 @@ var _ = Describe("{VerifyRBACForAppAdmin}", func() {
 	)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("VerifyRBACForAppAdmin", "Validates the RBAC operation for app-admin user.", nil, 87888)
+		StartPxBackupTorpedoTest("VerifyRBACForAppAdmin", "Validates the RBAC operation for app-admin user.", nil, 87888, Ak, Q3FY24)
 		log.InfoD("scheduling applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -1285,7 +1285,7 @@ var _ = Describe("{VerfiyRBACforAppUser}", func() {
 	)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("VerfiyRBACforAppUser", "To verify all the RBAC operations for an app-user", nil, 87889)
+		StartPxBackupTorpedoTest("VerfiyRBACforAppUser", "To verify all the RBAC operations for an app-user", nil, 87889, Sabrarhussaini, Q3FY24)
 		log.InfoD("scheduling applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {

--- a/tests/backup/backup_resiliency_test.go
+++ b/tests/backup/backup_resiliency_test.go
@@ -44,7 +44,7 @@ var _ = Describe("{BackupRestartPX}", func() {
 	appContextsToBackupMap := make(map[string][]*scheduler.Context)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("BackupRestartPX", "Restart PX when backup in progress", nil, 55818)
+		StartPxBackupTorpedoTest("BackupRestartPX", "Restart PX when backup in progress", nil, 55818, Kshithijiyer, Q4FY23)
 		log.InfoD("Verifying if the pre/post rules for the required apps are present in the list or not")
 		for i := 0; i < len(appList); i++ {
 			if Contains(postRuleApp, appList[i]) {
@@ -209,7 +209,7 @@ var _ = Describe("{KillStorkWithBackupsAndRestoresInProgress}", func() {
 	var backupNames []string
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("KillStorkWithBackupsAndRestoresInProgress", "Kill Stork when backups and restores in progress", nil, 55819)
+		StartPxBackupTorpedoTest("KillStorkWithBackupsAndRestoresInProgress", "Kill Stork when backups and restores in progress", nil, 55819, Kshithijiyer, Q4FY23)
 		log.InfoD("Verifying if the pre/post rules for the required apps are present in the list or not")
 		for i := 0; i < len(appList); i++ {
 			if Contains(postRuleApp, appList[i]) {
@@ -402,7 +402,7 @@ var _ = Describe("{RestartBackupPodDuringBackupSharing}", func() {
 	userContextsList := make([]context.Context, 0)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("RestartBackupPodDuringBackupSharing", "Restart backup pod during backup sharing", nil, 82948)
+		StartPxBackupTorpedoTest("RestartBackupPodDuringBackupSharing", "Restart backup pod during backup sharing", nil, 82948, Skonda, Q4FY23)
 		log.InfoD("Deploy applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -632,8 +632,8 @@ var _ = Describe("{CancelAllRunningBackupJobs}", func() {
 	numberOfBackups := 4
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("CancelAllRunningBackupJobs",
-			"Cancel all the running backup jobs while backups are in progress", nil, 58045)
+		StartPxBackupTorpedoTest("CancelAllRunningBackupJobs",
+			"Cancel all the running backup jobs while backups are in progress", nil, 58045, Sagrawal, Q1FY24)
 
 		log.InfoD("Deploying applications required for the testcase")
 		contexts = make([]*scheduler.Context, 0)
@@ -825,8 +825,8 @@ var _ = Describe("{ScaleMongoDBWhileBackupAndRestore}", func() {
 	scaledDownReplica := int32(0)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("ScaleMongoDBWhileBackupAndRestore",
-			"Scale down MongoDB to repl=0 when backups and restores are in progress", nil, 58075)
+		StartPxBackupTorpedoTest("ScaleMongoDBWhileBackupAndRestore",
+			"Scale down MongoDB to repl=0 when backups and restores are in progress", nil, 58075, Sagrawal, Q1FY24)
 		log.InfoD("Deploying applications required for the testcase")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -1095,8 +1095,8 @@ var _ = Describe("{RebootNodesWhenBackupsAreInProgress}", func() {
 	newAppContextsToBackupMap := make(map[string][]*scheduler.Context)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("RebootNodesWhenBackupsAreInProgress",
-			"Reboots node when backup is in progress", nil, 55817)
+		StartPxBackupTorpedoTest("RebootNodesWhenBackupsAreInProgress",
+			"Reboots node when backup is in progress", nil, 55817, Sagrawal, Q1FY24)
 		var err error
 		ctx, err = backup.GetAdminCtxFromSecret()
 		log.FailOnError(err, "Fetching px-central-admin ctx")
@@ -1349,8 +1349,8 @@ var _ = Describe("{ScaleDownPxBackupPodWhileBackupAndRestoreIsInProgress}", func
 	scaledDownReplica := int32(0)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("ScaleDownPxBackupPodWhileBackupAndRestoreIsInProgress",
-			"Scale down px-backup deployment to 0 when backups and restores are in progress", nil, 58074)
+		StartPxBackupTorpedoTest("ScaleDownPxBackupPodWhileBackupAndRestoreIsInProgress",
+			"Scale down px-backup deployment to 0 when backups and restores are in progress", nil, 58074, Sagrawal, Q1FY24)
 		log.InfoD("Deploying applications required for the testcase")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -1611,7 +1611,7 @@ var _ = Describe("{CancelAllRunningRestoreJobs}", func() {
 	numberOfBackups := 4
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("CancelAllRunningRestoreJobs", "Cancel all the running restore jobs while restores are in progress", nil, 58058)
+		StartPxBackupTorpedoTest("CancelAllRunningRestoreJobs", "Cancel all the running restore jobs while restores are in progress", nil, 58058, Ak, Q1FY24)
 		log.InfoD("Deploying applications required for the testcase")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {

--- a/tests/backup/backup_restore_basic_test.go
+++ b/tests/backup/backup_restore_basic_test.go
@@ -56,7 +56,7 @@ var _ = Describe("{BasicSelectiveRestore}", func() {
 		numDeployments = 6 // For this test case to have relevance, it is necessary to raise the number of deployments.
 		providers = getProviders()
 
-		StartTorpedoTest("BasicSelectiveRestore", "All namespace backup and restore selective namespaces", nil, 83717)
+		StartPxBackupTorpedoTest("BasicSelectiveRestore", "All namespace backup and restore selective namespaces", nil, 83717, KPhalgun, Q1FY24)
 		log.InfoD(fmt.Sprintf("App list %v", Inst().AppList))
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		log.InfoD("Starting to deploy applications")
@@ -173,7 +173,7 @@ var _ = Describe("{CustomResourceBackupAndRestore}", func() {
 	bkpNamespaces = make([]string, 0)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("CustomResourceBackupAndRestore", "Create custom resource backup and restore", nil, 83720)
+		StartPxBackupTorpedoTest("CustomResourceBackupAndRestore", "Create custom resource backup and restore", nil, 83720, Kshithijiyer, Q4FY23)
 		log.InfoD("Deploy applications")
 
 		scheduledAppContexts = make([]*scheduler.Context, 0)
@@ -320,7 +320,7 @@ var _ = Describe("{DeleteAllBackupObjects}", func() {
 	namespaceMapping = make(map[string]string)
 	intervalName := fmt.Sprintf("%s-%v", "interval", time.Now().Unix())
 	JustBeforeEach(func() {
-		StartTorpedoTest("DeleteAllBackupObjects", "Create the backup Objects and Delete", nil, 58088)
+		StartPxBackupTorpedoTest("DeleteAllBackupObjects", "Create the backup Objects and Delete", nil, 58088, Skonda, Q4FY23)
 		log.InfoD("Verifying if the pre/post rules for the required apps are present in the AppParameters or not ")
 		for i := 0; i < len(appList); i++ {
 			if Contains(postRuleApp, appList[i]) {
@@ -526,7 +526,7 @@ var _ = Describe("{ScheduleBackupCreationSingleNS}", func() {
 	periodicPolicyName := fmt.Sprintf("%s-%s", "periodic", timeStamp)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("ScheduleBackupCreationSingleNS", "Create schedule backup creation with a single namespace", nil, 58014)
+		StartPxBackupTorpedoTest("ScheduleBackupCreationSingleNS", "Create schedule backup creation with a single namespace", nil, 58014, Vpinisetti, Q4FY23)
 		log.Infof("Application installation")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -666,7 +666,7 @@ var _ = Describe("{ScheduleBackupCreationAllNS}", func() {
 	periodicPolicyName := fmt.Sprintf("%s-%s", "periodic", timeStamp)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("ScheduleBackupCreationAllNS", "Create schedule backup creation with all namespaces", nil, 58015)
+		StartPxBackupTorpedoTest("ScheduleBackupCreationAllNS", "Create schedule backup creation with all namespaces", nil, 58015, Vpinisetti, Q4FY23)
 		log.Infof("Application installation")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -800,7 +800,7 @@ var _ = Describe("{CustomResourceRestore}", func() {
 	bkpNamespaces = make([]string, 0)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("CustomResourceRestore", "Create custom resource restore", nil, 58041)
+		StartPxBackupTorpedoTest("CustomResourceRestore", "Create custom resource restore", nil, 58041, Apimpalgaonkar, Q1FY24)
 		log.InfoD("Deploy applications")
 
 		scheduledAppContexts = make([]*scheduler.Context, 0)
@@ -946,7 +946,7 @@ var _ = Describe("{AllNSBackupWithIncludeNewNSOption}", func() {
 	)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("AllNSBackupWithIncludeNewNSOption", "Verification of schedule backups created with include new namespaces option", nil, 84760)
+		StartPxBackupTorpedoTest("AllNSBackupWithIncludeNewNSOption", "Verification of schedule backups created with include new namespaces option", nil, 84760, KPhalgun, Q1FY24)
 
 		var err error
 		ctx, err = backup.GetAdminCtxFromSecret()
@@ -1137,8 +1137,8 @@ var _ = Describe("{BackupSyncBasicTest}", func() {
 	backupLocationMap := make(map[string]string)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("BackupSyncBasicTest",
-			"Validate that the backup sync syncs all the backups present in bucket", nil, 58040)
+		StartPxBackupTorpedoTest("BackupSyncBasicTest",
+			"Validate that the backup sync syncs all the backups present in bucket", nil, 58040, Kshithijiyer, Q1FY24)
 		log.InfoD("Deploy applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -1356,7 +1356,7 @@ var _ = Describe("{BackupMultipleNsWithSameLabel}", func() {
 	namespaceMapping := make(map[string]string)
 	bkpNamespaces = make([]string, 0)
 	JustBeforeEach(func() {
-		StartTorpedoTest("BackupMultipleNsWithSameLabel", "Taking backup and restoring multiple namespace having same labels", nil, 84851)
+		StartPxBackupTorpedoTest("BackupMultipleNsWithSameLabel", "Taking backup and restoring multiple namespace having same labels", nil, 84851, Apimpalgaonkar, Q1FY24)
 		log.InfoD("Deploy applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < 10; i++ {
@@ -1486,8 +1486,8 @@ var _ = Describe("{MultipleCustomRestoreSameTimeDiffStorageClassMapping}", func(
 	params := make(map[string]string)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("MultipleCustomRestoreSameTimeDiffStorageClassMapping",
-			"Issue multiple custom restores at the same time using different storage class mapping", nil, 58052)
+		StartPxBackupTorpedoTest("MultipleCustomRestoreSameTimeDiffStorageClassMapping",
+			"Issue multiple custom restores at the same time using different storage class mapping", nil, 58052, Sn, Q1FY24)
 		log.InfoD("Deploy applications needed for backup")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -1646,7 +1646,7 @@ var _ = Describe("{AddMultipleNamespaceLabels}", func() {
 	backupLocationMap := make(map[string]string)
 	scheduleRestoreMapping = make(map[string]string)
 	JustBeforeEach(func() {
-		StartTorpedoTest("AddMultipleNamespaceLabels", "Add multiple labels to namespaces, perform manual backup, schedule backup using namespace labels and restore", nil, 85583)
+		StartPxBackupTorpedoTest("AddMultipleNamespaceLabels", "Add multiple labels to namespaces, perform manual backup, schedule backup using namespace labels and restore", nil, 85583, Apimpalgaonkar, Q2FY24)
 		log.InfoD("Deploy applications")
 		batchSize = 10
 		desiredNumLabels = 1000
@@ -1825,8 +1825,8 @@ var _ = Describe("{MultipleInPlaceRestoreSameTime}", func() {
 	sleepToGetUniqueTimeStamp := 2 * time.Second
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("MultipleInPlaceRestoreSameTime",
-			"Issue multiple in-place restores at the same time", nil, 58051)
+		StartPxBackupTorpedoTest("MultipleInPlaceRestoreSameTime",
+			"Issue multiple in-place restores at the same time", nil, 58051, Sn, Q1FY24)
 		log.InfoD("Deploy applications needed for backup")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < 5; i++ {
@@ -1985,8 +1985,8 @@ var _ = Describe("{CloudSnapsSafeWhenBackupLocationDeleteTest}", func() {
 	appContextsToBackupMap := make(map[string][]*scheduler.Context)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("CloudSnapsSafeWhenBackupLocationDeleteTest",
-			"Validate if cloud snaps present if backup location is deleted", nil, 58069)
+		StartPxBackupTorpedoTest("CloudSnapsSafeWhenBackupLocationDeleteTest",
+			"Validate if cloud snaps present if backup location is deleted", nil, 58069, Kshithijiyer, Q1FY24)
 		log.InfoD("Deploy applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -2221,7 +2221,7 @@ var _ = Describe("{SetUnsetNSLabelDuringScheduleBackup}", func() {
 	backupLocationMap := make(map[string]string)
 	bkpNamespaces = make([]string, 0)
 	JustBeforeEach(func() {
-		StartTorpedoTest("SetUnsetNSLabelDuringScheduleBackup", "Create multiple namespaces and set unset namespace labels during the backup schedule", nil, 84849)
+		StartPxBackupTorpedoTest("SetUnsetNSLabelDuringScheduleBackup", "Create multiple namespaces and set unset namespace labels during the backup schedule", nil, 84849, Apimpalgaonkar, Q1FY24)
 		log.InfoD("Deploy applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < 3; i++ {
@@ -2384,7 +2384,7 @@ var _ = Describe("{BackupRestoreOnDifferentK8sVersions}", func() {
 	namespaceMapping := make(map[string]string)
 	duplicateBackupNameMap := make(map[string]string)
 	JustBeforeEach(func() {
-		StartTorpedoTest("BackupRestoreOnDifferentK8sVersions", "Restoring from a duplicate backup on a cluster with a different kubernetes version", nil, 83721)
+		StartPxBackupTorpedoTest("BackupRestoreOnDifferentK8sVersions", "Restoring from a duplicate backup on a cluster with a different kubernetes version", nil, 83721, Apimpalgaonkar, Q1FY24)
 		log.InfoD("Scheduling applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -2535,7 +2535,7 @@ var _ = Describe("{BackupCRsThenMultipleRestoresOnHigherK8sVersion}", func() {
 	)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("BackupCRsThenMultipleRestoresOnHigherK8sVersion", "Deploy CRs (CRD + webhook); then backup; create two simultaneous restores on cluster with higher K8s version; one restore is Success and other PartialSuccess", nil, 83716)
+		StartPxBackupTorpedoTest("BackupCRsThenMultipleRestoresOnHigherK8sVersion", "Deploy CRs (CRD + webhook); then backup; create two simultaneous restores on cluster with higher K8s version; one restore is Success and other PartialSuccess", nil, 83716, Tthurlapati, Q2FY24)
 
 		log.InfoD("specs (apps) allowed in execution of test: %v", appsWithCRDsAndWebhooks)
 		Inst().AppList = appsWithCRDsAndWebhooks
@@ -2856,7 +2856,7 @@ var _ = Describe("{BackupCRsThenMultipleRestoresOnHigherK8sVersion}", func() {
 			log.FailOnError(err, "failed to SetClusterContext to default cluster")
 		}()
 
-		defer EndTorpedoTest()
+		defer EndPxBackupTorpedoTest(scheduledAppContexts)
 
 		ctx, err := backup.GetAdminCtxFromSecret()
 		log.FailOnError(err, "fetching px-central-admin ctx")
@@ -2908,7 +2908,7 @@ var _ = Describe("{ScheduleBackupDeleteAndRecreateNS}", func() {
 	)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("ScheduleBackupDeleteAndRecreateNS", "Verification of schedule backups when namespaces are deleted and recreated", nil, 58037)
+		StartPxBackupTorpedoTest("ScheduleBackupDeleteAndRecreateNS", "Verification of schedule backups when namespaces are deleted and recreated", nil, 58037, Ak, Q2FY24)
 		numDeployments = Inst().GlobalScaleFactor
 		if len(Inst().AppList) == 1 && numDeployments < 2 {
 			numDeployments = 2
@@ -3077,7 +3077,7 @@ var _ = Describe("{DeleteNSDeleteClusterRestore}", func() {
 	)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("DeleteNSDeleteClusterRestore", "Delete namespace from application cluster and delete cluster and add it back then restore for last backup", nil, 58061)
+		StartPxBackupTorpedoTest("DeleteNSDeleteClusterRestore", "Delete namespace from application cluster and delete cluster and add it back then restore for last backup", nil, 58061, Sn, Q2FY24)
 		numDeployments = Inst().GlobalScaleFactor
 		if len(Inst().AppList) == 1 && numDeployments < 2 {
 			numDeployments = 2
@@ -3229,7 +3229,7 @@ var _ = Describe("{AlternateBackupBetweenNfsAndS3}", func() {
 	)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("AlternateBackupBetweenNfsAndS3", "To perform alternate backups between NFS and S3, and then perform the restore", nil, 86088)
+		StartPxBackupTorpedoTest("AlternateBackupBetweenNfsAndS3", "To perform alternate backups between NFS and S3, and then perform the restore", nil, 86088, Sabrarhussaini, Q3FY24)
 		backupLocationMap = make(map[string]string)
 		labelSelectors = make(map[string]string)
 		log.InfoD("scheduling applications")
@@ -3387,7 +3387,7 @@ var _ = Describe("{BackupNamespaceInNfsRestoredFromS3}", func() {
 	destinationClusterNamespaceMapping := make(map[string]string)
 	restoredAppContexts := make([]*scheduler.Context, 0)
 	JustBeforeEach(func() {
-		StartTorpedoTest("BackupNamespaceInNfsRestoredFromS3", "Take a backup of namespace in NFS which is restored from s3 bucket or vice-versa", nil, 86089)
+		StartPxBackupTorpedoTest("BackupNamespaceInNfsRestoredFromS3", "Take a backup of namespace in NFS which is restored from s3 bucket or vice-versa", nil, 86089, Sagrawal, Q3FY24)
 		log.InfoD("Scheduling Applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < 5; i++ {
@@ -3579,7 +3579,7 @@ var _ = Describe("{DeleteS3ScheduleAndCreateNfsSchedule}", func() {
 	)
 	backupLocationMap := make(map[string]string)
 	JustBeforeEach(func() {
-		StartTorpedoTest("DeleteS3ScheduleAndCreateNfsSchedule", "Take a schedule backup of namespace in S3 backup location,delete the s3 schedule, create new schedule backup with NFS backup location or vice-versa", nil, 86099)
+		StartPxBackupTorpedoTest("DeleteS3ScheduleAndCreateNfsSchedule", "Take a schedule backup of namespace in S3 backup location,delete the s3 schedule, create new schedule backup with NFS backup location or vice-versa", nil, 86099, Sagrawal, Q3FY24)
 		log.InfoD("Scheduling Applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < 5; i++ {
@@ -3736,7 +3736,7 @@ var _ = Describe("{KubeAndPxNamespacesSkipOnAllNSBackup}", func() {
 	)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("KubeAndPxNamespacesSkipOnAllNSBackup", "Verify if kube-system, kube-node-lease, kube-public and Px Namespace is skipped on all namespace backup", nil, 92858)
+		StartPxBackupTorpedoTest("KubeAndPxNamespacesSkipOnAllNSBackup", "Verify if kube-system, kube-node-lease, kube-public and Px Namespace is skipped on all namespace backup", nil, 92858, Ak, Q3FY24)
 
 		var err error
 		ctx, err = backup.GetAdminCtxFromSecret()

--- a/tests/backup/backup_sanity_test.go
+++ b/tests/backup/backup_sanity_test.go
@@ -18,7 +18,7 @@ import (
 var _ = Describe("{BackupClusterVerification}", func() {
 	JustBeforeEach(func() {
 		log.Infof("No pre-setup required for this testcase")
-		StartTorpedoTest("BackupClusterVerification", "Validating backup cluster pods", nil, 0)
+		StartPxBackupTorpedoTest("BackupClusterVerification", "Validating backup cluster pods", nil, 0, Sagrawal, Q4FY23)
 	})
 	It("Backup Cluster Verification", func() {
 		Step("Check the status of backup pods", func() {
@@ -38,7 +38,7 @@ var _ = Describe("{BackupClusterVerification}", func() {
 var _ = Describe("{UserGroupManagement}", func() {
 	JustBeforeEach(func() {
 		log.Infof("No pre-setup required for this testcase")
-		StartTorpedoTest("UserGroupManagement", "Creating users and adding them to groups", nil, 0)
+		StartPxBackupTorpedoTest("UserGroupManagement", "Creating users and adding them to groups", nil, 0, Mkoppal, Q4FY23)
 	})
 	It("User and group role mappings", func() {
 		Step("Create Users", func() {
@@ -110,7 +110,7 @@ var _ = Describe("{BasicBackupCreation}", func() {
 	)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("BasicBackupCreation", "Deploying backup", nil, 84755)
+		StartPxBackupTorpedoTest("BasicBackupCreation", "Deploying backup", nil, 84755, Sagrawal, Q4FY23)
 
 		appList = Inst().AppList
 		backupLocationMap = make(map[string]string)

--- a/tests/backup/backup_scale_test.go
+++ b/tests/backup/backup_scale_test.go
@@ -37,7 +37,7 @@ var _ = Describe("{MutipleBackupLocationWithSameEndpoint}", func() {
 	)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("MutipleBackupLocationWithSameEndpoint", "Create Backup and Restore for Mutiple backup location added using same endpoint", nil, 84902)
+		StartPxBackupTorpedoTest("MutipleBackupLocationWithSameEndpoint", "Create Backup and Restore for Mutiple backup location added using same endpoint", nil, 84902, Ak, Q3FY24)
 		log.InfoD("scheduling applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {

--- a/tests/backup/backup_share_test.go
+++ b/tests/backup/backup_share_test.go
@@ -36,7 +36,7 @@ var _ = Describe("{CreateMultipleUsersAndGroups}", func() {
 	var userNotCreated string
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("CreateMultipleUsersAndGroups", "Creation of multiple users and groups", nil, 58032)
+		StartPxBackupTorpedoTest("CreateMultipleUsersAndGroups", "Creation of multiple users and groups", nil, 58032, Apimpalgaonkar, Q4FY23)
 	})
 	It("Create multiple users and Group", func() {
 
@@ -161,8 +161,8 @@ var _ = Describe("{DuplicateSharedBackup}", func() {
 	backupLocationMap := make(map[string]string)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("DuplicateSharedBackup",
-			"Share backup with user and duplicate it", nil, 82942)
+		StartPxBackupTorpedoTest("DuplicateSharedBackup",
+			"Share backup with user and duplicate it", nil, 82942, Apimpalgaonkar, Q4FY23)
 		log.InfoD("Deploy applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -299,8 +299,8 @@ var _ = Describe("{DifferentAccessSameUser}", func() {
 	bkpNamespaces = make([]string, 0)
 	numberOfUsers := 1
 	JustBeforeEach(func() {
-		StartTorpedoTest("DifferentAccessSameUser",
-			"Take a backup and add user with readonly access and the group  with full access", nil, 82938)
+		StartPxBackupTorpedoTest("DifferentAccessSameUser",
+			"Take a backup and add user with readonly access and the group  with full access", nil, 82938, Sagrawal, Q4FY23)
 		log.InfoD("Deploy applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -457,8 +457,8 @@ var _ = Describe("{ShareBackupWithUsersAndGroups}", func() {
 	var chosenUser string
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("ShareBackupWithUsersAndGroups",
-			"Share large number of backups with multiple users and groups with View only, Restore and Full Access", nil, 82934)
+		StartPxBackupTorpedoTest("ShareBackupWithUsersAndGroups",
+			"Share large number of backups with multiple users and groups with View only, Restore and Full Access", nil, 82934, Mkoppal, Q4FY23)
 		log.InfoD("Deploy applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -913,8 +913,8 @@ var _ = Describe("{ShareLargeNumberOfBackupsWithLargeNumberOfUsers}", func() {
 	bkpNamespaces = make([]string, 0)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("ShareLargeNumberOfBackupsWithLargeNumberOfUsers",
-			"Share large number of backups to large number of users", nil, 82941)
+		StartPxBackupTorpedoTest("ShareLargeNumberOfBackupsWithLargeNumberOfUsers",
+			"Share large number of backups to large number of users", nil, 82941, Mkoppal, Q4FY23)
 		log.InfoD("Deploy applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -1261,8 +1261,8 @@ var _ = Describe("{CancelClusterBackupShare}", func() {
 	noAccessCheckRetryDuration := 30 * time.Second
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("CancelClusterBackupShare",
-			"Share all backups at cluster level with a user group and revoke it and validate", nil, 82935)
+		StartPxBackupTorpedoTest("CancelClusterBackupShare",
+			"Share all backups at cluster level with a user group and revoke it and validate", nil, 82935, Sagrawal, Q1FY24)
 		log.InfoD("Deploy applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -1790,8 +1790,8 @@ var _ = Describe("{ShareBackupAndEdit}", func() {
 	bkpNamespaces = make([]string, 0)
 	backupLocationMap := make(map[string]string)
 	JustBeforeEach(func() {
-		StartTorpedoTest("ShareBackupAndEdit",
-			"Share backup with restore and full access mode and edit the shared backup", nil, 82950)
+		StartPxBackupTorpedoTest("ShareBackupAndEdit",
+			"Share backup with restore and full access mode and edit the shared backup", nil, 82950, Skonda, Q4FY23)
 		log.InfoD("Deploy applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -2025,8 +2025,8 @@ var _ = Describe("{SharedBackupDelete}", func() {
 	bkpNamespaces = make([]string, 0)
 	backupLocationMap := make(map[string]string)
 	JustBeforeEach(func() {
-		StartTorpedoTest("SharedBackupDelete",
-			"Share backup with multiple users and delete the backup", nil, 82946)
+		StartPxBackupTorpedoTest("SharedBackupDelete",
+			"Share backup with multiple users and delete the backup", nil, 82946, Skonda, Q4FY23)
 		log.InfoD("Deploy applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -2232,7 +2232,7 @@ var _ = Describe("{ClusterBackupShareToggle}", func() {
 	)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("ClusterBackupShareToggle", "Verification of backup sharing and access level functionality", nil, 82936)
+		StartPxBackupTorpedoTest("ClusterBackupShareToggle", "Verification of backup sharing and access level functionality", nil, 82936, Apimpalgaonkar, Q4FY23)
 		log.InfoD("Scheduling applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -2418,8 +2418,8 @@ var _ = Describe("{ShareBackupsAndClusterWithUser}", func() {
 	bkpNamespaces = make([]string, 0)
 	numberOfUsers := 1
 	JustBeforeEach(func() {
-		StartTorpedoTest("ShareBackupsAndClusterWithUser",
-			"Share backup to user with full access and try to duplicate the backup from the shared user", nil, 82943)
+		StartPxBackupTorpedoTest("ShareBackupsAndClusterWithUser",
+			"Share backup to user with full access and try to duplicate the backup from the shared user", nil, 82943, Sagrawal, Q4FY23)
 		log.InfoD("Deploy applications need for taking backup")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -2549,8 +2549,8 @@ var _ = Describe("{ShareBackupWithDifferentRoleUsers}", func() {
 	labelSelectors := make(map[string]string)
 	bkpNamespaces = make([]string, 0)
 	JustBeforeEach(func() {
-		StartTorpedoTest("ShareBackupWithDifferentRoleUsers",
-			"Take backups and share it with multiple user with different access permissions and different roles", nil, 82947)
+		StartPxBackupTorpedoTest("ShareBackupWithDifferentRoleUsers",
+			"Take backups and share it with multiple user with different access permissions and different roles", nil, 82947, Sagrawal, Q4FY23)
 		log.InfoD("Deploy applications needed for backup")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -2723,8 +2723,8 @@ var _ = Describe("{DeleteSharedBackup}", func() {
 	backupLocationMap := make(map[string]string)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("DeleteSharedBackup",
-			"Share backup with multiple users and delete the backup", nil, 82937)
+		StartPxBackupTorpedoTest("DeleteSharedBackup",
+			"Share backup with multiple users and delete the backup", nil, 82937, Apimpalgaonkar, Q4FY23)
 		log.InfoD("Deploy applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -2928,8 +2928,8 @@ var _ = Describe("{ShareAndRemoveBackupLocation}", func() {
 	labelSelectors := make(map[string]string)
 	bkpNamespaces = make([]string, 0)
 	JustBeforeEach(func() {
-		StartTorpedoTest("ShareAndRemoveBackupLocation",
-			"Share and remove backup location and add it back and check from other users if they show up", nil, 82949)
+		StartPxBackupTorpedoTest("ShareAndRemoveBackupLocation",
+			"Share and remove backup location and add it back and check from other users if they show up", nil, 82949, Sagrawal, Q4FY23)
 		log.Infof("Deploy applications needed for backup")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -3163,8 +3163,8 @@ var _ = Describe("{ViewOnlyFullBackupRestoreIncrementalBackup}", func() {
 	backupLocationMap := make(map[string]string)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("ViewOnlyFullBackupRestoreIncrementalBackup",
-			"Full backup view only and incremental backup restore access", nil, 82939)
+		StartPxBackupTorpedoTest("ViewOnlyFullBackupRestoreIncrementalBackup",
+			"Full backup view only and incremental backup restore access", nil, 82939, Mkoppal, Q4FY23)
 		log.InfoD("Deploy applications")
 
 		scheduledAppContexts = make([]*scheduler.Context, 0)
@@ -3385,8 +3385,8 @@ var _ = Describe("{IssueMultipleRestoresWithNamespaceAndStorageClassMapping}", f
 	params := make(map[string]string)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("IssueMultipleRestoresWithNamespaceAndStorageClassMapping",
-			"Issue multiple restores with namespace and storage class mapping", nil, 82945)
+		StartPxBackupTorpedoTest("IssueMultipleRestoresWithNamespaceAndStorageClassMapping",
+			"Issue multiple restores with namespace and storage class mapping", nil, 82945, Sagrawal, Q4FY23)
 		log.InfoD("Deploy applications needed for backup")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -3634,7 +3634,7 @@ var _ = Describe("{DeleteUsersRole}", func() {
 	userRoleMapping := map[string]backup.PxBackupRole{}
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("DeleteUsersRole", "Delete role and users", nil, 58089)
+		StartPxBackupTorpedoTest("DeleteUsersRole", "Delete role and users", nil, 58089, Sn, Q4FY23)
 	})
 	It("Delete user and roles", func() {
 		Step("Create Users add roles", func() {
@@ -3728,8 +3728,8 @@ var _ = Describe("{IssueMultipleDeletesForSharedBackup}", func() {
 	var credName string
 	bkpNamespaces = make([]string, 0)
 	JustBeforeEach(func() {
-		StartTorpedoTest("IssueMultipleDeletesForSharedBackup",
-			"Share backup with multiple users and delete the backup", nil, 82944)
+		StartPxBackupTorpedoTest("IssueMultipleDeletesForSharedBackup",
+			"Share backup with multiple users and delete the backup", nil, 82944, Skonda, Q4FY23)
 		log.InfoD("Deploy applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -3934,8 +3934,8 @@ var _ = Describe("{SwapShareBackup}", func() {
 	var backupLocationCreationInterval time.Duration
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("SwapShareBackup",
-			"Share backup with same name between two users", nil, 82940)
+		StartPxBackupTorpedoTest("SwapShareBackup",
+			"Share backup with same name between two users", nil, 82940, Sn, Q4FY23)
 		log.InfoD("Deploy applications")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {

--- a/tests/backup/backup_upgrade_test.go
+++ b/tests/backup/backup_upgrade_test.go
@@ -20,7 +20,7 @@ import (
 var _ = Describe("{UpgradePxBackup}", func() {
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("UpgradePxBackup", "Upgrading backup", nil, 0)
+		StartPxBackupTorpedoTest("UpgradePxBackup", "Upgrading backup", nil, 0, Mkoppal, Q1FY24)
 	})
 	It("Upgrade Px Backup", func() {
 		Step("Upgrade Px Backup", func() {
@@ -63,7 +63,7 @@ var _ = Describe("{StorkUpgradeWithBackup}", func() {
 	appContextsToBackupMap := make(map[string][]*scheduler.Context)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("StorkUpgradeWithBackup", "Validates the scheduled backups and creation of new backup after stork upgrade", nil, 58023)
+		StartPxBackupTorpedoTest("StorkUpgradeWithBackup", "Validates the scheduled backups and creation of new backup after stork upgrade", nil, 58023, Ak, Q1FY24)
 		log.Infof("Application installation")
 		scheduledAppContexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -250,7 +250,7 @@ var _ = Describe("{PXBackupEndToEndBackupAndRestoreWithUpgrade}", func() {
 	)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("PXBackupEndToEndBackupAndRestoreWithUpgrade", "Validates end-to-end backup and restore operations with PX-Backup upgrade", nil, 84757)
+		StartPxBackupTorpedoTest("PXBackupEndToEndBackupAndRestoreWithUpgrade", "Validates end-to-end backup and restore operations with PX-Backup upgrade", nil, 84757, KPhalgun, Q1FY24)
 		log.Infof("Scheduling applications")
 		numDeployments = Inst().GlobalScaleFactor
 		if len(Inst().AppList) == 1 && numDeployments < 2 {

--- a/tests/common.go
+++ b/tests/common.go
@@ -9,9 +9,9 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/portworx/torpedo/drivers/scheduler/openshift"
 	optest "github.com/libopenstorage/operator/pkg/util/test"
 	"github.com/portworx/sched-ops/k8s/operator"
+	"github.com/portworx/torpedo/drivers/scheduler/openshift"
 
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
@@ -473,6 +473,13 @@ type PlatformCredentialStruct struct {
 	credName string
 	credUID  string
 }
+
+type (
+	// TestcaseAuthor represents the owner of a Testcase
+	TestcaseAuthor string
+	// TestcaseQuarter represents the fiscal quarter during which the Testcase is automated
+	TestcaseQuarter string
+)
 
 // InitInstance is the ginkgo spec for initializing torpedo
 func InitInstance() {
@@ -6811,6 +6818,11 @@ func EnableAutoFSTrim() {
 func EndTorpedoTest() {
 	CloseLogger(TestLogger)
 	dash.TestCaseEnd()
+}
+
+// StartPxBackupTorpedoTest starts the logging for Px Backup torpedo test
+func StartPxBackupTorpedoTest(testName string, testDescription string, tags map[string]string, testRepoID int, _ TestcaseAuthor, _ TestcaseQuarter) {
+	StartTorpedoTest(testName, testDescription, tags, testRepoID)
 }
 
 // EndPxBackupTorpedoTest ends the logging for Px Backup torpedo test and updates results in testrail


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR adds StartPxBackupTorpedoTest with test case owner and quarter as params in an attempt to automate updating test case data in automation tracker.

**Which issue(s) this PR fixes** (optional)
Closes #PA-1621

**Special notes for your reviewer**:
Please review the Jenkins build for the "BasicBackupCreation" test cases using the link below

https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/3164/

Aetos Dashboard: https://aetos.pwx.purestorage.com/resultSet/testSetID/404016