### PR TITLE
[PB-4425] Add ActivityTimeLine Support

### DIFF
--- a/drivers/backup/backup.go
+++ b/drivers/backup/backup.go
@@ -73,6 +73,8 @@ type Driver interface {
 	Rule
 	// Version
 	Version
+	//ActivityTimeLine interface
+	ActivityTimeLine
 
 	// Init initializes the backup driver under a given scheduler
 	Init(schedulerDriverName string, nodeDriverName string, volumeDriverName string, token string) error
@@ -381,6 +383,13 @@ type Rule interface {
 
 	// GetRuleUid fetches uid for the given rule
 	GetRuleUid(orgID string, ctx context.Context, ruleName string) (string, error)
+}
+
+// ActivityTimeLine object interface
+type ActivityTimeLine interface {
+
+	// EnumerateActivityTimeLine enumerates ActivityData
+	EnumerateActivityTimeLine(ctx context.Context, req *api.ActivityEnumerateRequest) (*api.ActivityEnumerateResponse, error)
 }
 
 var backupDrivers = make(map[string]Driver)

--- a/drivers/backup/portworx/portworx.go
+++ b/drivers/backup/portworx/portworx.go
@@ -47,18 +47,19 @@ const (
 )
 
 type portworx struct {
-	clusterManager         api.ClusterClient
-	backupLocationManager  api.BackupLocationClient
-	cloudCredentialManager api.CloudCredentialClient
-	backupManager          api.BackupClient
-	restoreManager         api.RestoreClient
-	backupScheduleManager  api.BackupScheduleClient
-	schedulePolicyManager  api.SchedulePolicyClient
-	organizationManager    api.OrganizationClient
-	licenseManager         api.LicenseClient
-	healthManager          api.HealthClient
-	ruleManager            api.RulesClient
-	versionManager         api.VersionClient
+	clusterManager          api.ClusterClient
+	backupLocationManager   api.BackupLocationClient
+	cloudCredentialManager  api.CloudCredentialClient
+	backupManager           api.BackupClient
+	restoreManager          api.RestoreClient
+	backupScheduleManager   api.BackupScheduleClient
+	schedulePolicyManager   api.SchedulePolicyClient
+	organizationManager     api.OrganizationClient
+	licenseManager          api.LicenseClient
+	healthManager           api.HealthClient
+	ruleManager             api.RulesClient
+	versionManager          api.VersionClient
+	activityTimeLineManager api.ActivityTimeLineClient
 
 	schedulerDriver scheduler.Driver
 	nodeDriver      node.Driver
@@ -181,6 +182,7 @@ func (p *portworx) testAndSetEndpoint(endpoint string) error {
 	p.licenseManager = api.NewLicenseClient(conn)
 	p.ruleManager = api.NewRulesClient(conn)
 	p.versionManager = api.NewVersionClient(conn)
+	p.activityTimeLineManager = api.NewActivityTimeLineClient(conn)
 
 	log.Infof("Using %v as endpoint for portworx backup driver", pxEndpoint)
 
@@ -1533,6 +1535,10 @@ func (p *portworx) DeleteBackupSchedulePolicy(orgID string, policyList []string)
 		}
 	}
 	return nil
+}
+
+func (p *portworx) EnumerateActivityTimeLine(ctx context.Context, req *api.ActivityEnumerateRequest) (*api.ActivityEnumerateResponse, error) {
+	return p.activityTimeLineManager.Enumerate(ctx, req)
 }
 
 func init() {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
For having ActivityTimeLine support in px-backup repository which will be used for functional automation.

**Which issue(s) this PR fixes** (optional)
Closes #PB-4425

**Special notes for your reviewer**:
Have ran basic backup test creation and verified the enumerateActivityTimeLine is working fine.Attaching below the link of successful run in jenkins and aetos :

https://jenkins.pwx.dev.purestorage.com/blue/organizations/jenkins/portworx-backup%2Fsystem-tests%2Fbyoc%2Fpx-backup-on-demand-system-test-byoc/detail/px-backup-on-demand-system-test-byoc/2566/pipeline/145/

 https://aetos.pwx.purestorage.com/resultSet/testSetID/340684 