### PR TITLE
Added clusterRef to Backup Delete

### DIFF
--- a/drivers/backup/backup.go
+++ b/drivers/backup/backup.go
@@ -159,6 +159,7 @@ type Cluster interface {
 	WaitForClusterDeletion(
 		ctx context.Context,
 		clusterName,
+		clusterUid,
 		orgID string,
 		timeout time.Duration,
 		timeBeforeRetry time.Duration,

--- a/drivers/backup/portworx/portworx.go
+++ b/drivers/backup/portworx/portworx.go
@@ -429,6 +429,7 @@ func (p *portworx) ClusterUpdateBackupShare(ctx context.Context, req *api.Cluste
 func (p *portworx) WaitForClusterDeletion(
 	ctx context.Context,
 	clusterName,
+	clusterUid,
 	orgID string,
 	timeout time.Duration,
 	timeBeforeRetry time.Duration,
@@ -436,6 +437,7 @@ func (p *portworx) WaitForClusterDeletion(
 	req := &api.ClusterInspectRequest{
 		Name:  clusterName,
 		OrgId: orgID,
+		Uid:   clusterUid,
 	}
 	f := func() (interface{}, bool, error) {
 		inspectClusterResp, err := p.clusterManager.Inspect(ctx, req)

--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -1085,7 +1085,7 @@ func CleanupCloudSettingsAndClusters(backupLocationMap map[string]string, credNa
 		OrgId: orgID,
 	}
 	enumerateClusterResponse, err := Inst().Backup.EnumerateAllCluster(ctx, enumerateClusterRequest)
-	Inst().Dash.VerifySafely(err, nil, fmt.Sprintf("failed to enumerate cluster in organization %s", orgID))
+	Inst().Dash.VerifySafely(err, nil, fmt.Sprintf("Verifying enumerate cluster in organization %s", orgID))
 	for _, clusterObj := range enumerateClusterResponse.GetClusters() {
 		clusterProvider := GetClusterProviders()
 		for _, provider := range clusterProvider {


### PR DESCRIPTION
**What this PR does / why we need it**:
Testcase were failing since DeleteBackup function was taking only cluster name . 

[backup.glob..func27.2.14.1.1:#3576] - Failed to delete backup - tp-backup-schedule-single-ns-testuser1-1694802208-without-rules-njxn-091c864-interval-2023-09-15-182540. Err: rpc error: code = Internal desc = failed to retrieve cluster [source-cluster]: more than one object found with same name, please use the object UID along with name

https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/basic-system-test/job/px/job/s3/job/px-backup-system-test-vanilla/440/consoleFull
https://aetos.pwx.purestorage.com/resultSet/testSetID/343532/testCaseID/1965316

Added Fix for clusterRef and wait for cluster Deletion.


**Which issue(s) this PR fixes** (optional)
Closes #PA-1634

**Special notes for your reviewer**:

Tested logs:
https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/basic-system-test/job/px/job/s3/job/px-backup-system-test-vanilla/447/
https://aetos.pwx.purestorage.com/resultSet/testSetID/346238

The failures in test log are due to intermittent issue with s3.