### PR TITLE
Made Pure groupsnap/cloudsnap errors more broad

### DIFF
--- a/tests/common.go
+++ b/tests/common.go
@@ -359,8 +359,8 @@ var (
 
 var (
 	errPureFileSnapshotNotSupported    = errors.New("snapshot feature is not supported for pure_file volumes")
-	errPureCloudsnapNotSupported       = errors.New("cloudsnap feature is not supported for pure volumes")
-	errPureGroupsnapNotSupported       = errors.New("groupsnap feature is not supported for pure volumes")
+	errPureCloudsnapNotSupported       = errors.New("not supported")
+	errPureGroupsnapNotSupported       = errors.New("not supported")
 	errUnexpectedSizeChangeAfterPureIO = errors.New("the size change in bytes is not expected after write to Pure volume")
 )
 


### PR DESCRIPTION
Due to recent changes in master(?), the error message has changed from "cloudsnap feature is not supported for pure volumes" to "cloudsnaps are not supported for FA-Direct Access volumes". This change makes either one a valid option.