### PR TITLE
[PA-1667] Add GinkgoRecover()

### DIFF
--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -3142,6 +3142,7 @@ func TaskHandler(taskInputs interface{}, task interface{}, executionMode Executi
 		for i := 0; i < length; i++ {
 			wg.Add(1)
 			go func(i int) {
+				defer GinkgoRecover()
 				defer wg.Done()
 				if isMap {
 					callTask(keys[i], v.MapIndex(keys[i]))

--- a/tests/backup/backup_orphaned_test.go
+++ b/tests/backup/backup_orphaned_test.go
@@ -1216,6 +1216,7 @@ var _ = Describe("{DeleteFailedInProgressBackupAndRestoreOfUserFromAdmin}", func
 							}
 							wg.Add(1)
 							go func(backup *api.BackupObject, ctx context.Context) {
+								defer GinkgoRecover()
 								defer wg.Done()
 								_, err := DeleteBackup(backup.GetName(), backup.GetUid(), orgID, ctx)
 								if err != nil {
@@ -1428,6 +1429,7 @@ var _ = Describe("{DeleteFailedInProgressBackupAndRestoreOfUserFromAdmin}", func
 							}
 							wg.Add(1)
 							go func(restore *api.RestoreObject, ctx context.Context) {
+								defer GinkgoRecover()
 								defer wg.Done()
 								err := DeleteRestoreWithUID(restore.GetName(), restore.GetUid(), orgID, ctx)
 								if err != nil {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR adds GinkgoRecover() wherever necessary in backup orphaned tests and in TaskHandler.

**Which issue(s) this PR fixes** (optional)
Closes #PA-1667

**Special notes for your reviewer**:
Please review the Jenkins build for the test case "" using the link below

https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/2652/

Aetos Dashboard: https://aetos.pwx.purestorage.com/resultSet/testSetID/350550

Thanks to @ak-px for identifying the issue and suggesting the fix.
