### PR TITLE
Changes to run px-backup tests on GKE cloud

### DIFF
--- a/deployments/deploy-pxb-cloud.sh
+++ b/deployments/deploy-pxb-cloud.sh
@@ -333,6 +333,7 @@ if [ -n "${INTERNAL_DOCKER_REGISTRY}" ]; then
 fi
 
 kubectl create configmap cloud-config --from-file=/config/cloud-json
+kubectl create configmap cloud-source-config --from-file=/cluster/cloud-source-config
 
 # List of additional kubeconfigs of k8s clusters to register with px-backup, px-dr
 FROM_FILE=""

--- a/deployments/deploy-pxb-cloud.sh
+++ b/deployments/deploy-pxb-cloud.sh
@@ -333,7 +333,6 @@ if [ -n "${INTERNAL_DOCKER_REGISTRY}" ]; then
 fi
 
 kubectl create configmap cloud-config --from-file=/config/cloud-json
-kubectl create configmap cloud-source-config --from-file=/cluster/cloud-source-config
 
 # List of additional kubeconfigs of k8s clusters to register with px-backup, px-dr
 FROM_FILE=""

--- a/drivers/scheduler/dcos/dcos.go
+++ b/drivers/scheduler/dcos/dcos.go
@@ -639,7 +639,7 @@ func (d *dcos) SetConfig(configPath string) error {
 	}
 }
 
-func (d *dcos) SetGkeConfig(configPath string, gkeCredString string) error {
+func (d *dcos) SetGkeConfig(configPath string, jsonKey string) error {
 	// TODO: Implement this method
 	return &errors.ErrNotSupported{
 		Type:      "Function",

--- a/drivers/scheduler/dcos/dcos.go
+++ b/drivers/scheduler/dcos/dcos.go
@@ -639,6 +639,14 @@ func (d *dcos) SetConfig(configPath string) error {
 	}
 }
 
+func (d *dcos) SetGkeConfig(configPath string, gkeCredString string) error {
+	// TODO: Implement this method
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "SetGkeConfig()",
+	}
+}
+
 func (d *dcos) Describe(ctx *scheduler.Context) (string, error) {
 	// TODO: Implement this method
 	return "", &errors.ErrNotSupported{

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -375,7 +375,7 @@ func (k *K8s) SetConfig(kubeconfigPath string) error {
 }
 
 // SetGkeConfig sets kubeconfig for cloud provider GKE
-func (k *K8s) SetGkeConfig(kubeconfigPath string, gkeCredString string) error {
+func (k *K8s) SetGkeConfig(kubeconfigPath string, jsonKey string) error {
 
 	var clientConfig *rest.Config
 	var err error
@@ -389,29 +389,7 @@ func (k *K8s) SetGkeConfig(kubeconfigPath string, gkeCredString string) error {
 		}
 	}
 
-	config, err := os.ReadFile(kubeconfigPath)
-	if err != nil {
-		return err
-	}
-
-	// First parse the config
-	client, err := clientcmd.NewClientConfigFromBytes(config)
-	if err != nil {
-		return err
-	}
-
-	rawConfig, err := client.RawConfig()
-	if err != nil {
-		return err
-	}
-
-	// Then create a default client config with the default loading rules
-	client = clientcmd.NewDefaultClientConfig(rawConfig, &clientcmd.ConfigOverrides{})
-	if err != nil {
-		return err
-	}
-
-	clientConfig.AuthProvider.Config["cred-json"] = gkeCredString
+	clientConfig.AuthProvider.Config["cred-json"] = jsonKey
 	if err != nil {
 		return err
 	}

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -374,6 +374,68 @@ func (k *K8s) SetConfig(kubeconfigPath string) error {
 	return nil
 }
 
+// SetGkeConfig sets kubeconfig for cloud provider GKE
+func (k *K8s) SetGkeConfig(kubeconfigPath string, gkeCredString string) error {
+
+	var clientConfig *rest.Config
+	var err error
+
+	if kubeconfigPath == "" {
+		clientConfig = nil
+	} else {
+		clientConfig, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+		if err != nil {
+			return err
+		}
+	}
+
+	config, err := os.ReadFile(kubeconfigPath)
+	if err != nil {
+		return err
+	}
+
+	// First parse the config
+	client, err := clientcmd.NewClientConfigFromBytes(config)
+	if err != nil {
+		return err
+	}
+
+	rawConfig, err := client.RawConfig()
+	if err != nil {
+		return err
+	}
+
+	// Then create a default client config with the default loading rules
+	client = clientcmd.NewDefaultClientConfig(rawConfig, &clientcmd.ConfigOverrides{})
+	if err != nil {
+		return err
+	}
+
+	clientConfig.AuthProvider.Config["cred-json"] = gkeCredString
+	if err != nil {
+		return err
+	}
+
+	k8sCore.SetConfig(clientConfig)
+	k8sApps.SetConfig(clientConfig)
+	k8sApps.SetConfig(clientConfig)
+	k8sStork.SetConfig(clientConfig)
+	k8sStorage.SetConfig(clientConfig)
+	k8sExternalStorage.SetConfig(clientConfig)
+	k8sAutopilot.SetConfig(clientConfig)
+	k8sRbac.SetConfig(clientConfig)
+	k8sMonitoring.SetConfig(clientConfig)
+	k8sPolicy.SetConfig(clientConfig)
+	k8sBatch.SetConfig(clientConfig)
+	k8sMonitoring.SetConfig(clientConfig)
+	k8sAdmissionRegistration.SetConfig(clientConfig)
+	k8sExternalsnap.SetConfig(clientConfig)
+	k8sApiExtensions.SetConfig(clientConfig)
+	k8sOperator.SetConfig(clientConfig)
+
+	return nil
+}
+
 // RescanSpecs Rescan the application spec file for spei
 func (k *K8s) RescanSpecs(specDir, storageDriver string) error {
 	var err error

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -344,11 +344,11 @@ type Driver interface {
 	// GetWorkloadSizeFromAppSpec gets workload size from an application spec
 	GetWorkloadSizeFromAppSpec(ctx *Context) (uint64, error)
 
-	// SetConfig sets connnection config (e.g. kubeconfig in case of k8s) for scheduler driver
+	// SetConfig sets connection config (e.g. kubeconfig in case of k8s) for scheduler driver
 	SetConfig(configPath string) error
 
-	// SetGkeConfig sets connnection config (e.g. kubeconfig in case of GKE cluster) for scheduler driver
-	SetGkeConfig(configPath string, gkeCredString string) error
+	// SetGkeConfig sets connection config (e.g. kubeconfig in case of GKE cluster) for scheduler driver
+	SetGkeConfig(configPath string, jsonKey string) error
 
 	// UpgradeScheduler upgrades the scheduler on the cluster to the specified version
 	UpgradeScheduler(version string) error

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -347,6 +347,9 @@ type Driver interface {
 	// SetConfig sets connnection config (e.g. kubeconfig in case of k8s) for scheduler driver
 	SetConfig(configPath string) error
 
+	// SetGkeConfig sets connnection config (e.g. kubeconfig in case of GKE cluster) for scheduler driver
+	SetGkeConfig(configPath string, gkeCredString string) error
+
 	// UpgradeScheduler upgrades the scheduler on the cluster to the specified version
 	UpgradeScheduler(version string) error
 

--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,8 @@ require (
 	k8s.io/client-go v12.0.0+incompatible
 )
 
+require go.uber.org/multierr v1.7.0 // indirect
+
 require (
 	cloud.google.com/go v0.110.7 // indirect
 	cloud.google.com/go/compute v1.23.0 // indirect

--- a/tests/backup/backup_basic_test.go
+++ b/tests/backup/backup_basic_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 	api "github.com/portworx/px-backup-api/pkg/apis/v1"
+	_ "github.com/portworx/px-backup-api/pkg/kubeauth/gcp"
 	"github.com/portworx/sched-ops/task"
 	"github.com/portworx/torpedo/drivers"
 	"github.com/portworx/torpedo/drivers/backup"
@@ -123,6 +124,7 @@ func BackupInitInstance() {
 	kubeconfigList := strings.Split(kubeconfigs, ",")
 	dash.VerifyFatal(len(kubeconfigList) < 2, false, "minimum 2 kubeconfigs are required for source and destination cluster")
 	DumpKubeconfigs(kubeconfigList)
+	GloabalGkeSecretString, err = GetGkeSecret()
 	if os.Getenv("CLUSTER_PROVIDER") == drivers.ProviderRke {
 		// Switch context to destination cluster to update RancherMap with destination cluster details
 		err = SetDestinationKubeConfig()

--- a/tests/backup/backup_basic_test.go
+++ b/tests/backup/backup_basic_test.go
@@ -23,7 +23,7 @@ import (
 
 func getBucketNameSuffix() string {
 	bucketNameSuffix, present := os.LookupEnv("BUCKET_NAME")
-	if present {
+	if present && bucketNameSuffix != "" {
 		return bucketNameSuffix
 	} else {
 		return "default-suffix"
@@ -124,7 +124,7 @@ func BackupInitInstance() {
 	kubeconfigList := strings.Split(kubeconfigs, ",")
 	dash.VerifyFatal(len(kubeconfigList) < 2, false, "minimum 2 kubeconfigs are required for source and destination cluster")
 	DumpKubeconfigs(kubeconfigList)
-	GloabalGkeSecretString, err = GetGkeSecret()
+	GlobalGkeSecretString, err = GetGkeSecret()
 	if os.Getenv("CLUSTER_PROVIDER") == drivers.ProviderRke {
 		// Switch context to destination cluster to update RancherMap with destination cluster details
 		err = SetDestinationKubeConfig()

--- a/tests/common.go
+++ b/tests/common.go
@@ -2852,18 +2852,11 @@ func SetClusterContext(clusterConfigPath string) error {
 		return fmt.Errorf("failed to switch to context. RefreshDriverEndpoints Error: [%v]", err)
 	}
 
-	// Check if the Node driver is of type SSH
 	if sshNodeDriver, ok := Inst().N.(*ssh.SSH); ok {
-		// If it is an SSH driver, refresh the driver
 		err = ssh.RefreshDriver(sshNodeDriver)
 		if err != nil {
 			return fmt.Errorf("failed to switch to context. RefreshDriver (Node) Error: [%v]", err)
 		}
-	} else {
-		// If the Node driver is not of type SSH, initialize it to create Daemon set to spin up debug pods
-		err = Inst().N.Init(node.InitOptions{
-			SpecDir: Inst().SpecDir,
-		})
 	}
 
 	CurrentClusterConfigPath = clusterConfigPath

--- a/tests/common.go
+++ b/tests/common.go
@@ -170,7 +170,7 @@ const (
 var (
 	clusterProviders       = []string{"k8s"}
 	GlobalCredentialConfig backup.BackupCloudConfig
-	GloabalGkeSecretString string
+	GlobalGkeSecretString  string
 )
 
 type OwnershipAccessType int32
@@ -2824,7 +2824,7 @@ func SetClusterContext(clusterConfigPath string) error {
 	if clusterConfigPath != "" {
 		switch provider {
 		case drivers.ProviderGke:
-			err = Inst().S.SetGkeConfig(clusterConfigPath, GloabalGkeSecretString)
+			err = Inst().S.SetGkeConfig(clusterConfigPath, GlobalGkeSecretString)
 			if err != nil {
 				return fmt.Errorf("failed to switch to context. Set Config Error: [%v]", err)
 			}
@@ -3995,6 +3995,8 @@ func CreateBackupLocation(provider, name, uid, credName, credUID, bucketName, or
 		err = CreateS3BackupLocation(name, uid, credName, credUID, bucketName, orgID, encryptionKey)
 	case drivers.ProviderAzure:
 		err = CreateAzureBackupLocation(name, uid, credName, CloudCredUID, bucketName, orgID)
+	case drivers.ProviderGke:
+		err = CreateGCPBackupLocation(name, uid, credName, credUID, bucketName, orgID)
 	case drivers.ProviderNfs:
 		err = CreateNFSBackupLocation(name, uid, orgID, encryptionKey, bucketName, true)
 	}
@@ -4009,6 +4011,8 @@ func CreateBackupLocationWithContext(provider, name, uid, credName, credUID, buc
 		err = CreateS3BackupLocationWithContext(name, uid, credName, credUID, bucketName, orgID, encryptionKey, ctx)
 	case drivers.ProviderAzure:
 		err = CreateAzureBackupLocationWithContext(name, uid, credName, CloudCredUID, bucketName, orgID, encryptionKey, ctx)
+	case drivers.ProviderGke:
+		err = CreateGCPBackupLocationWithContext(name, uid, credName, credUID, bucketName, orgID, ctx)
 	case drivers.ProviderNfs:
 		err = CreateNFSBackupLocationWithContext(name, uid, subPath, orgID, encryptionKey, ctx, true)
 	}
@@ -4037,6 +4041,18 @@ func CreateCluster(name string, kubeconfigPath string, orgID string, cloud_name 
 					},
 					Kubeconfig: base64.StdEncoding.EncodeToString(kubeconfigRaw),
 					PlatformCredentialRef: &api.ObjectRef{
+						Name: cloud_name,
+						Uid:  uid,
+					},
+				}
+			case drivers.ProviderGke:
+				clusterCreateReq = &api.ClusterCreateRequest{
+					CreateMetadata: &api.CreateMetadata{
+						Name:  name,
+						OrgId: orgID,
+					},
+					Kubeconfig: base64.StdEncoding.EncodeToString(kubeconfigRaw),
+					CloudCredentialRef: &api.ObjectRef{
 						Name: cloud_name,
 						Uid:  uid,
 					},
@@ -4171,7 +4187,22 @@ func CreateCloudCredential(provider, credName string, uid, orgID string, ctx con
 				},
 			},
 		}
-
+	case drivers.ProviderGke:
+		credCreateRequest = &api.CloudCredentialCreateRequest{
+			CreateMetadata: &api.CreateMetadata{
+				Name:  credName,
+				Uid:   uid,
+				OrgId: orgID,
+			},
+			CloudCredential: &api.CloudCredentialInfo{
+				Type: api.CloudCredentialInfo_Google,
+				Config: &api.CloudCredentialInfo_GoogleConfig{
+					GoogleConfig: &api.GoogleConfig{
+						JsonKey: GlobalGkeSecretString,
+					},
+				},
+			},
+		}
 	default:
 		return fmt.Errorf("provider [%s] not supported for creating cloud credential", provider)
 	}
@@ -4313,6 +4344,68 @@ func CreateAzureBackupLocationWithContext(name string, uid string, cloudCred str
 		},
 	}
 	_, err := backupDriver.CreateBackupLocation(ctx, bLocationCreateReq)
+	if err != nil {
+		return fmt.Errorf("failed to create backup location Error: %v", err)
+	}
+	return nil
+}
+
+// CreateGCPBackupLocation creates backup location for Google cloud
+func CreateGCPBackupLocation(name string, uid string, cloudCred string, cloudCredUID string, bucketName string, orgID string) error {
+	backupDriver := Inst().Backup
+	encryptionKey := "torpedo"
+	bLocationCreateReq := &api.BackupLocationCreateRequest{
+		CreateMetadata: &api.CreateMetadata{
+			Name:  name,
+			OrgId: orgID,
+			Uid:   uid,
+		},
+		BackupLocation: &api.BackupLocationInfo{
+			Path:          bucketName,
+			EncryptionKey: encryptionKey,
+			CloudCredentialRef: &api.ObjectRef{
+				Name: cloudCred,
+				Uid:  cloudCredUID,
+			},
+			Type: api.BackupLocationInfo_Google,
+		},
+	}
+	ctx, err := backup.GetAdminCtxFromSecret()
+	if err != nil {
+		return err
+	}
+	_, err = backupDriver.CreateBackupLocation(ctx, bLocationCreateReq)
+	if err != nil {
+		return fmt.Errorf("failed to create backup location Error: %v", err)
+	}
+	return nil
+}
+
+// CreateGCPBackupLocationWithContext creates backup location for Google cloud
+func CreateGCPBackupLocationWithContext(name string, uid string, cloudCred string, cloudCredUID string, bucketName string, orgID string, ctx context1.Context) error {
+	backupDriver := Inst().Backup
+	encryptionKey := "torpedo"
+	bLocationCreateReq := &api.BackupLocationCreateRequest{
+		CreateMetadata: &api.CreateMetadata{
+			Name:  name,
+			OrgId: orgID,
+			Uid:   uid,
+		},
+		BackupLocation: &api.BackupLocationInfo{
+			Path:          bucketName,
+			EncryptionKey: encryptionKey,
+			CloudCredentialRef: &api.ObjectRef{
+				Name: cloudCred,
+				Uid:  cloudCredUID,
+			},
+			Type: api.BackupLocationInfo_Google,
+		},
+	}
+	ctx, err := backup.GetAdminCtxFromSecret()
+	if err != nil {
+		return err
+	}
+	_, err = backupDriver.CreateBackupLocation(ctx, bLocationCreateReq)
 	if err != nil {
 		return fmt.Errorf("failed to create backup location Error: %v", err)
 	}

--- a/vendor/github.com/portworx/px-backup-api/pkg/kubeauth/gcp/gcp.go
+++ b/vendor/github.com/portworx/px-backup-api/pkg/kubeauth/gcp/gcp.go
@@ -1,0 +1,150 @@
+package gcp
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	api "github.com/portworx/px-backup-api/pkg/apis/v1"
+	"github.com/portworx/px-backup-api/pkg/kubeauth"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/grpc"
+	"k8s.io/client-go/rest"
+	clientcmd "k8s.io/client-go/tools/clientcmd/api"
+)
+
+const (
+	pluginName      = "gcp"
+	credOrgIDConfig = "cred-org-id"
+	credOwnerConfig = "cred-owner"
+	credJSON        = "cred-json"
+)
+
+var (
+	defaultScopes = []string{
+		"https://www.googleapis.com/auth/cloud-platform",
+		"https://www.googleapis.com/auth/userinfo.email",
+	}
+)
+
+type gcp struct {
+}
+
+type gcpToken struct {
+	tokenSource oauth2.TokenSource
+}
+
+// Init initializes the gcp auth plugin
+func (g *gcp) Init() error {
+	return nil
+}
+
+func (g *gcp) UpdateClient(
+	conn *grpc.ClientConn,
+	ctx context.Context,
+	cloudCredentialName string,
+	cloudCredentialUID string,
+	orgID string,
+	client *rest.Config,
+	clientConfig *clientcmd.Config,
+) (bool, string, error) {
+	// GCP does not support returning kubeconfigs
+	var emptyKubeconfig string
+	if client.AuthProvider != nil {
+		if client.AuthProvider.Name == pluginName {
+			if cloudCredentialName == "" {
+				return false, emptyKubeconfig, fmt.Errorf("CloudCredential not provided for GKE cluster")
+			}
+			cloudCredentialClient := api.NewCloudCredentialClient(conn)
+			resp, err := cloudCredentialClient.Inspect(
+				ctx,
+				&api.CloudCredentialInspectRequest{
+					Name:           cloudCredentialName,
+					Uid: cloudCredentialUID,
+					OrgId:          orgID,
+					IncludeSecrets: true,
+				},
+			)
+			if err != nil {
+				return false, emptyKubeconfig, err
+			}
+			cloudCred := resp.GetCloudCredential()
+			client.AuthProvider.Config = make(map[string]string)
+			client.AuthProvider.Config[credOrgIDConfig] = cloudCred.GetOrgId()
+			client.AuthProvider.Config[credOwnerConfig] = cloudCred.GetOwnership().GetOwner()
+			client.AuthProvider.Config[credJSON] = cloudCred.GetCloudCredentialInfo().GetGoogleConfig().GetJsonKey()
+			return true, emptyKubeconfig, nil
+		} // else not a gcp kubeauth provider
+	}
+	return false, emptyKubeconfig, nil
+}
+
+func (g *gcp) newGCPAuthProvider(
+	_ string,
+	gcpConfig map[string]string,
+	_ rest.AuthProviderConfigPersister,
+) (rest.AuthProvider, error) {
+	var creds *google.Credentials
+	var err error
+	if creds, err = google.CredentialsFromJSON(context.Background(), []byte(gcpConfig[credJSON]), defaultScopes...); err != nil {
+		return nil, err
+	}
+	return &gcpToken{tokenSource: creds.TokenSource}, nil
+}
+
+func (g *gcpToken) Login() error { return nil }
+
+func (g *gcpToken) WrapTransport(rt http.RoundTripper) http.RoundTripper {
+	return &oauth2.Transport{Source: g.tokenSource, Base: rt}
+}
+
+func (g *gcp) UpdateClientByCredObject(
+	cloudCred *api.CloudCredentialObject,
+	client *rest.Config,
+	clientConfig *clientcmd.Config,
+) (bool, string, error) {
+	// GCP does not support returning kubeconfigs
+	var emptyKubeconfig string
+	if client.AuthProvider != nil {
+		if client.AuthProvider.Name == pluginName {
+			if cloudCred == nil {
+				return false, emptyKubeconfig, fmt.Errorf("CloudCredential not provided for GKE cluster")
+			}
+			client.AuthProvider.Config = make(map[string]string)
+			client.AuthProvider.Config[credOrgIDConfig] = cloudCred.GetOrgId()
+			client.AuthProvider.Config[credOwnerConfig] = cloudCred.GetOwnership().GetOwner()
+			client.AuthProvider.Config[credJSON] = cloudCred.GetCloudCredentialInfo().GetGoogleConfig().GetJsonKey()
+			return true, emptyKubeconfig, nil
+		} // else not a gcp kubeauth provider
+	}
+	return false, emptyKubeconfig, nil
+}
+
+func (g *gcp) GetClient(
+	cloudCredential *api.CloudCredentialObject,
+	clusterName string,
+	region string,
+) (*kubeauth.PluginClient, error) {
+	return nil, fmt.Errorf("not supported")
+}
+
+func (g *gcp) GetAllClients(
+	cloudCredential *api.CloudCredentialObject,
+	maxResult int64,
+	config interface{},
+) (map[string]*kubeauth.PluginClient, *string, error) {
+	return nil, nil, fmt.Errorf("not supported")
+
+}
+
+func init() {
+	g := &gcp{}
+	if err := rest.RegisterAuthProviderPlugin(pluginName, g.newGCPAuthProvider); err != nil {
+		logrus.Panicf("failed to initialize gcp auth plugin: %v", err)
+	}
+	if err := kubeauth.Register(pluginName, g); err != nil {
+		logrus.Panicf("Error registering gcp auth plugin: %v", err)
+	}
+}

--- a/vendor/github.com/portworx/px-backup-api/pkg/kubeauth/kubeauth.go
+++ b/vendor/github.com/portworx/px-backup-api/pkg/kubeauth/kubeauth.go
@@ -1,0 +1,168 @@
+package kubeauth
+
+import (
+	"context"
+
+	api "github.com/portworx/px-backup-api/pkg/apis/v1"
+	"github.com/portworx/sched-ops/k8s/core"
+	"github.com/sirupsen/logrus"
+	"go.uber.org/multierr"
+	"google.golang.org/grpc"
+	"k8s.io/client-go/rest"
+	clientcmd "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// PluginClient returns a k8s client returned by one of the
+// supported plugins
+type PluginClient struct {
+	// Kubeconfig is the string representation of kubeconfig
+	Kubeconfig string
+	//  Restclient is the rest k8s client
+	Rest *rest.Config
+	// Uid uniquely identifies the managed cluster by the cloud provider
+	Uid string
+	// k8s version
+	Version string
+}
+
+// Plugin is the interface the plugins need to implement
+type Plugin interface {
+	UpdateClient(
+		conn *grpc.ClientConn,
+		ctx context.Context,
+		cloudCredentialName string,
+		cloudCredentialUID string,
+		orgID string,
+		restConfig *rest.Config,
+		clientConfig *clientcmd.Config,
+	) (bool, string, error)
+
+	UpdateClientByCredObject(
+		cloudCred *api.CloudCredentialObject,
+		restConfig *rest.Config,
+		clientConfig *clientcmd.Config,
+	) (bool, string, error)
+
+	GetClient(
+		cloudCred *api.CloudCredentialObject,
+		clusterName string,
+		region string,
+	) (*PluginClient, error)
+
+	GetAllClients(
+		cloudCred *api.CloudCredentialObject,
+		maxResults int64,
+		config interface{},
+	) (map[string]*PluginClient, *string, error)
+}
+
+var (
+	plugins = make(map[string]Plugin)
+)
+
+// Register registers the given auth plugin
+func Register(name string, p Plugin) error {
+	logrus.Infof("Registering auth plugin: %v", name)
+	plugins[name] = p
+	return nil
+}
+
+// UpdateClient Updates the k8s client config with the required info
+// from the cloud credential. It will return the new kubeconfig with
+// which the client was updated
+func UpdateClient(
+	conn *grpc.ClientConn,
+	ctx context.Context,
+	cloudCredentialName string,
+	cloudCredentialUID string,
+	orgID string,
+	restConfig *rest.Config,
+	clientConfig *clientcmd.Config,
+) (string, error) {
+	for _, plugin := range plugins {
+		updated, kubeconfig, err := plugin.UpdateClient(conn, ctx, cloudCredentialName, cloudCredentialUID, orgID, restConfig, clientConfig)
+		if err != nil {
+			return "", err
+		}
+		if updated {
+			return kubeconfig, nil
+		}
+	}
+	return "", nil
+}
+
+// UpdateClientByCredObject Updates the k8s client config with the required info
+// from the provided cloud credential object
+func UpdateClientByCredObject(
+	cloudCred *api.CloudCredentialObject,
+	restConfig *rest.Config,
+	clientConfig *clientcmd.Config,
+) (string, error) {
+	for _, plugin := range plugins {
+		updated, kubeconfig, err := plugin.UpdateClientByCredObject(cloudCred, restConfig, clientConfig)
+		if err != nil {
+			return "", err
+		}
+		if updated {
+			return kubeconfig, nil
+		}
+	}
+	return "", nil
+}
+
+// GetClient gets the k8s client config from the cloud credential
+// The provided cloud credentials should have sufficient
+// permissions to fetch a token using the cloud's SDK APIs
+func GetClient(cloudCred *api.CloudCredentialObject, clusterName string, region string) (*PluginClient, error) {
+	var getErr error
+	for _, plugin := range plugins {
+		client, err := plugin.GetClient(cloudCred, clusterName, region)
+		if err == nil {
+			return client, nil
+		}
+		getErr = multierr.Append(getErr, err)
+
+	}
+	return nil, getErr
+
+}
+
+// GetAllClients gets the k8s client config for all the clusters
+// which the provided cloud credential has access to.
+// The provided cloud credentials should have sufficient
+// permissions to fetch a token using the cloud's SDK APIs
+// TODO: In future API needs to have options for accept needed params for GKE and Azure 
+// cluster scan
+func GetAllClients(
+	cloudCred *api.CloudCredentialObject,
+	maxResult int64,
+	config interface{},
+) (map[string]*PluginClient, *string, error) {
+	var getErr, err error
+	var nextToken *string
+	var clients map[string]*PluginClient
+	for _, plugin := range plugins {
+		clients, nextToken, err = plugin.GetAllClients(cloudCred, maxResult, config)
+		if err == nil {
+			return clients, nextToken, nil
+		}
+		getErr = multierr.Append(getErr, err)
+
+	}
+	return nil, nextToken, getErr
+}
+
+// ValidateConfig validates the provided rest config
+func ValidateConfig(restConfig *rest.Config) (bool, error) {
+	// Check if the provided config has expired
+	coreInst, err := core.NewForConfig(restConfig)
+	if err != nil {
+		return false, err
+	}
+	_, err = coreInst.GetVersion()
+	if err == nil {
+		return true, nil
+	}
+
+	return false, err
+}

--- a/vendor/go.uber.org/multierr/.codecov.yml
+++ b/vendor/go.uber.org/multierr/.codecov.yml
@@ -1,0 +1,15 @@
+coverage:
+  range: 80..100
+  round: down
+  precision: 2
+
+  status:
+    project:                   # measuring the overall project coverage
+      default:                 # context, you can create multiple ones with custom titles
+        enabled: yes           # must be yes|true to enable this status
+        target: 100            # specify the target coverage for each commit status
+                               #   option: "auto" (must increase from parent commit or pull request base)
+                               #   option: "X%" a static target percentage to hit
+        if_not_found: success  # if parent is not found report status as success, error, or failure
+        if_ci_failed: error    # if ci fails report status as success, error, or failure
+

--- a/vendor/go.uber.org/multierr/.gitignore
+++ b/vendor/go.uber.org/multierr/.gitignore
@@ -1,0 +1,4 @@
+/vendor
+cover.html
+cover.out
+/bin

--- a/vendor/go.uber.org/multierr/CHANGELOG.md
+++ b/vendor/go.uber.org/multierr/CHANGELOG.md
@@ -1,0 +1,66 @@
+Releases
+========
+
+v1.7.0 (2021-05-06)
+===================
+
+-   Add `AppendInvoke` to append into errors from `defer` blocks.
+
+
+v1.6.0 (2020-09-14)
+===================
+
+-   Actually drop library dependency on development-time tooling.
+
+
+v1.5.0 (2020-02-24)
+===================
+
+-   Drop library dependency on development-time tooling.
+
+
+v1.4.0 (2019-11-04)
+===================
+
+-   Add `AppendInto` function to more ergonomically build errors inside a
+    loop.
+
+
+v1.3.0 (2019-10-29)
+===================
+
+-   Switch to Go modules.
+
+
+v1.2.0 (2019-09-26)
+===================
+
+-   Support extracting and matching against wrapped errors with `errors.As`
+    and `errors.Is`.
+
+
+v1.1.0 (2017-06-30)
+===================
+
+-   Added an `Errors(error) []error` function to extract the underlying list of
+    errors for a multierr error.
+
+
+v1.0.0 (2017-05-31)
+===================
+
+No changes since v0.2.0. This release is committing to making no breaking
+changes to the current API in the 1.X series.
+
+
+v0.2.0 (2017-04-11)
+===================
+
+-   Repeatedly appending to the same error is now faster due to fewer
+    allocations.
+
+
+v0.1.0 (2017-31-03)
+===================
+
+-   Initial release

--- a/vendor/go.uber.org/multierr/LICENSE.txt
+++ b/vendor/go.uber.org/multierr/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2017-2021 Uber Technologies, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/go.uber.org/multierr/Makefile
+++ b/vendor/go.uber.org/multierr/Makefile
@@ -1,0 +1,38 @@
+# Directory to put `go install`ed binaries in.
+export GOBIN ?= $(shell pwd)/bin
+
+GO_FILES := $(shell \
+	find . '(' -path '*/.*' -o -path './vendor' ')' -prune \
+	-o -name '*.go' -print | cut -b3-)
+
+.PHONY: build
+build:
+	go build ./...
+
+.PHONY: test
+test:
+	go test -race ./...
+
+.PHONY: gofmt
+gofmt:
+	$(eval FMT_LOG := $(shell mktemp -t gofmt.XXXXX))
+	@gofmt -e -s -l $(GO_FILES) > $(FMT_LOG) || true
+	@[ ! -s "$(FMT_LOG)" ] || (echo "gofmt failed:" | cat - $(FMT_LOG) && false)
+
+.PHONY: golint
+golint:
+	@cd tools && go install golang.org/x/lint/golint
+	@$(GOBIN)/golint ./...
+
+.PHONY: staticcheck
+staticcheck:
+	@cd tools && go install honnef.co/go/tools/cmd/staticcheck
+	@$(GOBIN)/staticcheck ./...
+
+.PHONY: lint
+lint: gofmt golint staticcheck
+
+.PHONY: cover
+cover:
+	go test -race -coverprofile=cover.out -coverpkg=./... -v ./...
+	go tool cover -html=cover.out -o cover.html

--- a/vendor/go.uber.org/multierr/README.md
+++ b/vendor/go.uber.org/multierr/README.md
@@ -1,0 +1,23 @@
+# multierr [![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov]
+
+`multierr` allows combining one or more Go `error`s together.
+
+## Installation
+
+    go get -u go.uber.org/multierr
+
+## Status
+
+Stable: No breaking changes will be made before 2.0.
+
+-------------------------------------------------------------------------------
+
+Released under the [MIT License].
+
+[MIT License]: LICENSE.txt
+[doc-img]: https://pkg.go.dev/badge/go.uber.org/multierr
+[doc]: https://pkg.go.dev/go.uber.org/multierr
+[ci-img]: https://github.com/uber-go/multierr/actions/workflows/go.yml/badge.svg
+[cov-img]: https://codecov.io/gh/uber-go/multierr/branch/master/graph/badge.svg
+[ci]: https://github.com/uber-go/multierr/actions/workflows/go.yml
+[cov]: https://codecov.io/gh/uber-go/multierr

--- a/vendor/go.uber.org/multierr/error.go
+++ b/vendor/go.uber.org/multierr/error.go
@@ -1,0 +1,639 @@
+// Copyright (c) 2017-2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package multierr allows combining one or more errors together.
+//
+// Overview
+//
+// Errors can be combined with the use of the Combine function.
+//
+// 	multierr.Combine(
+// 		reader.Close(),
+// 		writer.Close(),
+// 		conn.Close(),
+// 	)
+//
+// If only two errors are being combined, the Append function may be used
+// instead.
+//
+// 	err = multierr.Append(reader.Close(), writer.Close())
+//
+// The underlying list of errors for a returned error object may be retrieved
+// with the Errors function.
+//
+// 	errors := multierr.Errors(err)
+// 	if len(errors) > 0 {
+// 		fmt.Println("The following errors occurred:", errors)
+// 	}
+//
+// Appending from a loop
+//
+// You sometimes need to append into an error from a loop.
+//
+// 	var err error
+// 	for _, item := range items {
+// 		err = multierr.Append(err, process(item))
+// 	}
+//
+// Cases like this may require knowledge of whether an individual instance
+// failed. This usually requires introduction of a new variable.
+//
+// 	var err error
+// 	for _, item := range items {
+// 		if perr := process(item); perr != nil {
+// 			log.Warn("skipping item", item)
+// 			err = multierr.Append(err, perr)
+// 		}
+// 	}
+//
+// multierr includes AppendInto to simplify cases like this.
+//
+// 	var err error
+// 	for _, item := range items {
+// 		if multierr.AppendInto(&err, process(item)) {
+// 			log.Warn("skipping item", item)
+// 		}
+// 	}
+//
+// This will append the error into the err variable, and return true if that
+// individual error was non-nil.
+//
+// See AppendInto for more information.
+//
+// Deferred Functions
+//
+// Go makes it possible to modify the return value of a function in a defer
+// block if the function was using named returns. This makes it possible to
+// record resource cleanup failures from deferred blocks.
+//
+// 	func sendRequest(req Request) (err error) {
+// 		conn, err := openConnection()
+// 		if err != nil {
+// 			return err
+// 		}
+// 		defer func() {
+// 			err = multierr.Append(err, conn.Close())
+// 		}()
+// 		// ...
+// 	}
+//
+// multierr provides the Invoker type and AppendInvoke function to make cases
+// like the above simpler and obviate the need for a closure. The following is
+// roughly equivalent to the example above.
+//
+// 	func sendRequest(req Request) (err error) {
+// 		conn, err := openConnection()
+// 		if err != nil {
+// 			return err
+// 		}
+// 		defer multierr.AppendInvoke(err, multierr.Close(conn))
+// 		// ...
+// 	}
+//
+// See AppendInvoke and Invoker for more information.
+//
+// Advanced Usage
+//
+// Errors returned by Combine and Append MAY implement the following
+// interface.
+//
+// 	type errorGroup interface {
+// 		// Returns a slice containing the underlying list of errors.
+// 		//
+// 		// This slice MUST NOT be modified by the caller.
+// 		Errors() []error
+// 	}
+//
+// Note that if you need access to list of errors behind a multierr error, you
+// should prefer using the Errors function. That said, if you need cheap
+// read-only access to the underlying errors slice, you can attempt to cast
+// the error to this interface. You MUST handle the failure case gracefully
+// because errors returned by Combine and Append are not guaranteed to
+// implement this interface.
+//
+// 	var errors []error
+// 	group, ok := err.(errorGroup)
+// 	if ok {
+// 		errors = group.Errors()
+// 	} else {
+// 		errors = []error{err}
+// 	}
+package multierr // import "go.uber.org/multierr"
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+
+	"go.uber.org/atomic"
+)
+
+var (
+	// Separator for single-line error messages.
+	_singlelineSeparator = []byte("; ")
+
+	// Prefix for multi-line messages
+	_multilinePrefix = []byte("the following errors occurred:")
+
+	// Prefix for the first and following lines of an item in a list of
+	// multi-line error messages.
+	//
+	// For example, if a single item is:
+	//
+	// 	foo
+	// 	bar
+	//
+	// It will become,
+	//
+	// 	 -  foo
+	// 	    bar
+	_multilineSeparator = []byte("\n -  ")
+	_multilineIndent    = []byte("    ")
+)
+
+// _bufferPool is a pool of bytes.Buffers.
+var _bufferPool = sync.Pool{
+	New: func() interface{} {
+		return &bytes.Buffer{}
+	},
+}
+
+type errorGroup interface {
+	Errors() []error
+}
+
+// Errors returns a slice containing zero or more errors that the supplied
+// error is composed of. If the error is nil, a nil slice is returned.
+//
+// 	err := multierr.Append(r.Close(), w.Close())
+// 	errors := multierr.Errors(err)
+//
+// If the error is not composed of other errors, the returned slice contains
+// just the error that was passed in.
+//
+// Callers of this function are free to modify the returned slice.
+func Errors(err error) []error {
+	if err == nil {
+		return nil
+	}
+
+	// Note that we're casting to multiError, not errorGroup. Our contract is
+	// that returned errors MAY implement errorGroup. Errors, however, only
+	// has special behavior for multierr-specific error objects.
+	//
+	// This behavior can be expanded in the future but I think it's prudent to
+	// start with as little as possible in terms of contract and possibility
+	// of misuse.
+	eg, ok := err.(*multiError)
+	if !ok {
+		return []error{err}
+	}
+
+	errors := eg.Errors()
+	result := make([]error, len(errors))
+	copy(result, errors)
+	return result
+}
+
+// multiError is an error that holds one or more errors.
+//
+// An instance of this is guaranteed to be non-empty and flattened. That is,
+// none of the errors inside multiError are other multiErrors.
+//
+// multiError formats to a semi-colon delimited list of error messages with
+// %v and with a more readable multi-line format with %+v.
+type multiError struct {
+	copyNeeded atomic.Bool
+	errors     []error
+}
+
+var _ errorGroup = (*multiError)(nil)
+
+// Errors returns the list of underlying errors.
+//
+// This slice MUST NOT be modified.
+func (merr *multiError) Errors() []error {
+	if merr == nil {
+		return nil
+	}
+	return merr.errors
+}
+
+// As attempts to find the first error in the error list that matches the type
+// of the value that target points to.
+//
+// This function allows errors.As to traverse the values stored on the
+// multierr error.
+func (merr *multiError) As(target interface{}) bool {
+	for _, err := range merr.Errors() {
+		if errors.As(err, target) {
+			return true
+		}
+	}
+	return false
+}
+
+// Is attempts to match the provided error against errors in the error list.
+//
+// This function allows errors.Is to traverse the values stored on the
+// multierr error.
+func (merr *multiError) Is(target error) bool {
+	for _, err := range merr.Errors() {
+		if errors.Is(err, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func (merr *multiError) Error() string {
+	if merr == nil {
+		return ""
+	}
+
+	buff := _bufferPool.Get().(*bytes.Buffer)
+	buff.Reset()
+
+	merr.writeSingleline(buff)
+
+	result := buff.String()
+	_bufferPool.Put(buff)
+	return result
+}
+
+func (merr *multiError) Format(f fmt.State, c rune) {
+	if c == 'v' && f.Flag('+') {
+		merr.writeMultiline(f)
+	} else {
+		merr.writeSingleline(f)
+	}
+}
+
+func (merr *multiError) writeSingleline(w io.Writer) {
+	first := true
+	for _, item := range merr.errors {
+		if first {
+			first = false
+		} else {
+			w.Write(_singlelineSeparator)
+		}
+		io.WriteString(w, item.Error())
+	}
+}
+
+func (merr *multiError) writeMultiline(w io.Writer) {
+	w.Write(_multilinePrefix)
+	for _, item := range merr.errors {
+		w.Write(_multilineSeparator)
+		writePrefixLine(w, _multilineIndent, fmt.Sprintf("%+v", item))
+	}
+}
+
+// Writes s to the writer with the given prefix added before each line after
+// the first.
+func writePrefixLine(w io.Writer, prefix []byte, s string) {
+	first := true
+	for len(s) > 0 {
+		if first {
+			first = false
+		} else {
+			w.Write(prefix)
+		}
+
+		idx := strings.IndexByte(s, '\n')
+		if idx < 0 {
+			idx = len(s) - 1
+		}
+
+		io.WriteString(w, s[:idx+1])
+		s = s[idx+1:]
+	}
+}
+
+type inspectResult struct {
+	// Number of top-level non-nil errors
+	Count int
+
+	// Total number of errors including multiErrors
+	Capacity int
+
+	// Index of the first non-nil error in the list. Value is meaningless if
+	// Count is zero.
+	FirstErrorIdx int
+
+	// Whether the list contains at least one multiError
+	ContainsMultiError bool
+}
+
+// Inspects the given slice of errors so that we can efficiently allocate
+// space for it.
+func inspect(errors []error) (res inspectResult) {
+	first := true
+	for i, err := range errors {
+		if err == nil {
+			continue
+		}
+
+		res.Count++
+		if first {
+			first = false
+			res.FirstErrorIdx = i
+		}
+
+		if merr, ok := err.(*multiError); ok {
+			res.Capacity += len(merr.errors)
+			res.ContainsMultiError = true
+		} else {
+			res.Capacity++
+		}
+	}
+	return
+}
+
+// fromSlice converts the given list of errors into a single error.
+func fromSlice(errors []error) error {
+	res := inspect(errors)
+	switch res.Count {
+	case 0:
+		return nil
+	case 1:
+		// only one non-nil entry
+		return errors[res.FirstErrorIdx]
+	case len(errors):
+		if !res.ContainsMultiError {
+			// already flat
+			return &multiError{errors: errors}
+		}
+	}
+
+	nonNilErrs := make([]error, 0, res.Capacity)
+	for _, err := range errors[res.FirstErrorIdx:] {
+		if err == nil {
+			continue
+		}
+
+		if nested, ok := err.(*multiError); ok {
+			nonNilErrs = append(nonNilErrs, nested.errors...)
+		} else {
+			nonNilErrs = append(nonNilErrs, err)
+		}
+	}
+
+	return &multiError{errors: nonNilErrs}
+}
+
+// Combine combines the passed errors into a single error.
+//
+// If zero arguments were passed or if all items are nil, a nil error is
+// returned.
+//
+// 	Combine(nil, nil)  // == nil
+//
+// If only a single error was passed, it is returned as-is.
+//
+// 	Combine(err)  // == err
+//
+// Combine skips over nil arguments so this function may be used to combine
+// together errors from operations that fail independently of each other.
+//
+// 	multierr.Combine(
+// 		reader.Close(),
+// 		writer.Close(),
+// 		pipe.Close(),
+// 	)
+//
+// If any of the passed errors is a multierr error, it will be flattened along
+// with the other errors.
+//
+// 	multierr.Combine(multierr.Combine(err1, err2), err3)
+// 	// is the same as
+// 	multierr.Combine(err1, err2, err3)
+//
+// The returned error formats into a readable multi-line error message if
+// formatted with %+v.
+//
+// 	fmt.Sprintf("%+v", multierr.Combine(err1, err2))
+func Combine(errors ...error) error {
+	return fromSlice(errors)
+}
+
+// Append appends the given errors together. Either value may be nil.
+//
+// This function is a specialization of Combine for the common case where
+// there are only two errors.
+//
+// 	err = multierr.Append(reader.Close(), writer.Close())
+//
+// The following pattern may also be used to record failure of deferred
+// operations without losing information about the original error.
+//
+// 	func doSomething(..) (err error) {
+// 		f := acquireResource()
+// 		defer func() {
+// 			err = multierr.Append(err, f.Close())
+// 		}()
+func Append(left error, right error) error {
+	switch {
+	case left == nil:
+		return right
+	case right == nil:
+		return left
+	}
+
+	if _, ok := right.(*multiError); !ok {
+		if l, ok := left.(*multiError); ok && !l.copyNeeded.Swap(true) {
+			// Common case where the error on the left is constantly being
+			// appended to.
+			errs := append(l.errors, right)
+			return &multiError{errors: errs}
+		} else if !ok {
+			// Both errors are single errors.
+			return &multiError{errors: []error{left, right}}
+		}
+	}
+
+	// Either right or both, left and right, are multiErrors. Rely on usual
+	// expensive logic.
+	errors := [2]error{left, right}
+	return fromSlice(errors[0:])
+}
+
+// AppendInto appends an error into the destination of an error pointer and
+// returns whether the error being appended was non-nil.
+//
+// 	var err error
+// 	multierr.AppendInto(&err, r.Close())
+// 	multierr.AppendInto(&err, w.Close())
+//
+// The above is equivalent to,
+//
+// 	err := multierr.Append(r.Close(), w.Close())
+//
+// As AppendInto reports whether the provided error was non-nil, it may be
+// used to build a multierr error in a loop more ergonomically. For example:
+//
+// 	var err error
+// 	for line := range lines {
+// 		var item Item
+// 		if multierr.AppendInto(&err, parse(line, &item)) {
+// 			continue
+// 		}
+// 		items = append(items, item)
+// 	}
+//
+// Compare this with a version that relies solely on Append:
+//
+// 	var err error
+// 	for line := range lines {
+// 		var item Item
+// 		if parseErr := parse(line, &item); parseErr != nil {
+// 			err = multierr.Append(err, parseErr)
+// 			continue
+// 		}
+// 		items = append(items, item)
+// 	}
+func AppendInto(into *error, err error) (errored bool) {
+	if into == nil {
+		// We panic if 'into' is nil. This is not documented above
+		// because suggesting that the pointer must be non-nil may
+		// confuse users into thinking that the error that it points
+		// to must be non-nil.
+		panic("misuse of multierr.AppendInto: into pointer must not be nil")
+	}
+
+	if err == nil {
+		return false
+	}
+	*into = Append(*into, err)
+	return true
+}
+
+// Invoker is an operation that may fail with an error. Use it with
+// AppendInvoke to append the result of calling the function into an error.
+// This allows you to conveniently defer capture of failing operations.
+//
+// See also, Close and Invoke.
+type Invoker interface {
+	Invoke() error
+}
+
+// Invoke wraps a function which may fail with an error to match the Invoker
+// interface. Use it to supply functions matching this signature to
+// AppendInvoke.
+//
+// For example,
+//
+// 	func processReader(r io.Reader) (err error) {
+// 		scanner := bufio.NewScanner(r)
+// 		defer multierr.AppendInvoke(&err, multierr.Invoke(scanner.Err))
+// 		for scanner.Scan() {
+// 			// ...
+// 		}
+// 		// ...
+// 	}
+//
+// In this example, the following line will construct the Invoker right away,
+// but defer the invocation of scanner.Err() until the function returns.
+//
+// 	defer multierr.AppendInvoke(&err, multierr.Invoke(scanner.Err))
+type Invoke func() error
+
+// Invoke calls the supplied function and returns its result.
+func (i Invoke) Invoke() error { return i() }
+
+// Close builds an Invoker that closes the provided io.Closer. Use it with
+// AppendInvoke to close io.Closers and append their results into an error.
+//
+// For example,
+//
+// 	func processFile(path string) (err error) {
+// 		f, err := os.Open(path)
+// 		if err != nil {
+// 			return err
+// 		}
+// 		defer multierr.AppendInvoke(&err, multierr.Close(f))
+// 		return processReader(f)
+// 	}
+//
+// In this example, multierr.Close will construct the Invoker right away, but
+// defer the invocation of f.Close until the function returns.
+//
+// 	defer multierr.AppendInvoke(&err, multierr.Close(f))
+func Close(closer io.Closer) Invoker {
+	return Invoke(closer.Close)
+}
+
+// AppendInvoke appends the result of calling the given Invoker into the
+// provided error pointer. Use it with named returns to safely defer
+// invocation of fallible operations until a function returns, and capture the
+// resulting errors.
+//
+// 	func doSomething(...) (err error) {
+// 		// ...
+// 		f, err := openFile(..)
+// 		if err != nil {
+// 			return err
+// 		}
+//
+// 		// multierr will call f.Close() when this function returns and
+// 		// if the operation fails, its append its error into the
+// 		// returned error.
+// 		defer multierr.AppendInvoke(&err, multierr.Close(f))
+//
+// 		scanner := bufio.NewScanner(f)
+// 		// Similarly, this scheduled scanner.Err to be called and
+// 		// inspected when the function returns and append its error
+// 		// into the returned error.
+// 		defer multierr.AppendInvoke(&err, multierr.Invoke(scanner.Err))
+//
+// 		// ...
+// 	}
+//
+// Without defer, AppendInvoke behaves exactly like AppendInto.
+//
+// 	err := // ...
+// 	multierr.AppendInvoke(&err, mutltierr.Invoke(foo))
+//
+// 	// ...is roughly equivalent to...
+//
+// 	err := // ...
+// 	multierr.AppendInto(&err, foo())
+//
+// The advantage of the indirection introduced by Invoker is to make it easy
+// to defer the invocation of a function. Without this indirection, the
+// invoked function will be evaluated at the time of the defer block rather
+// than when the function returns.
+//
+// 	// BAD: This is likely not what the caller intended. This will evaluate
+// 	// foo() right away and append its result into the error when the
+// 	// function returns.
+// 	defer multierr.AppendInto(&err, foo())
+//
+// 	// GOOD: This will defer invocation of foo unutil the function returns.
+// 	defer multierr.AppendInvoke(&err, multierr.Invoke(foo))
+//
+// multierr provides a few Invoker implementations out of the box for
+// convenience. See Invoker for more information.
+func AppendInvoke(into *error, invoker Invoker) {
+	AppendInto(into, invoker.Invoke())
+}

--- a/vendor/go.uber.org/multierr/glide.yaml
+++ b/vendor/go.uber.org/multierr/glide.yaml
@@ -1,0 +1,8 @@
+package: go.uber.org/multierr
+import:
+- package: go.uber.org/atomic
+  version: ^1
+testImport:
+- package: github.com/stretchr/testify
+  subpackages:
+  - assert

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1098,6 +1098,8 @@ github.com/portworx/pds-api-go-client/pds/v1alpha1
 # github.com/portworx/px-backup-api v1.2.2-0.20230904054048-eb1f23dd7431
 ## explicit; go 1.19
 github.com/portworx/px-backup-api/pkg/apis/v1
+github.com/portworx/px-backup-api/pkg/kubeauth
+github.com/portworx/px-backup-api/pkg/kubeauth/gcp
 # github.com/portworx/sched-ops v1.20.4-rc1.0.20230802175859-ff4459c520ae => github.com/portworx/sched-ops v1.20.4-rc1.0.20230602054045-e2d377b36700
 ## explicit; go 1.19
 github.com/portworx/sched-ops/k8s/admissionregistration
@@ -1310,6 +1312,9 @@ go.starlark.net/syntax
 # go.uber.org/atomic v1.9.0
 ## explicit; go 1.13
 go.uber.org/atomic
+# go.uber.org/multierr v1.7.0
+## explicit; go 1.14
+go.uber.org/multierr
 # gocloud.dev v0.20.0
 ## explicit; go 1.12
 gocloud.dev/aws


### PR DESCRIPTION
What this PR does / why we need it:
Changes to run px-backup tests on GKE cloud

Made changes to connect to gke cluster using kubeconfig
Fixed switching from source to destination cluster
Switching back to source from destination cluster
Added bringing up of debug pods on destination cluster

Which issue(s) this PR fixes (optional)
Closes #https://portworx.atlassian.net/browse/PA-1307
https://portworx.atlassian.net/browse/PA-1659
https://portworx.atlassian.net/browse/PA-1670

**Special notes for your reviewer**:
Closed the PR  --> https://github.com/portworx/torpedo/pull/1664
Addressed all due to lot of conflict in vendoring review comments in the is PR 
(Extensive switching between source and destination)
Logs : LicensingCountWithNodeLabelledBeforeClusterAddition -> https://jenkins.pwx.dev.purestorage.com/job/Users/job/santoshn/job/gke-new-pipeline-test/8/console

BasicBackupCreation  -> Logs : https://jenkins.pwx.dev.purestorage.com/job/Users/job/santoshn/job/gke-new-pipeline-test/11/console

Latest logs (after fixing debug pod issue) :
https://jenkins.pwx.dev.purestorage.com/job/Users/job/santoshn/job/gke-new-pipeline-test/15/console

