### PR TITLE
[PA-1681] Rename WaitForClusterDeletion

### DIFF
--- a/drivers/backup/backup.go
+++ b/drivers/backup/backup.go
@@ -159,6 +159,16 @@ type Cluster interface {
 	WaitForClusterDeletion(
 		ctx context.Context,
 		clusterName,
+		orgID string,
+		timeout time.Duration,
+		timeBeforeRetry time.Duration,
+	) error
+
+	// WaitForClusterDeletionWithUID waits for cluster to be deleted successfully
+	// or till timeout is reached. API should poll every `timeBeforeRetry` duration using cluster uid
+	WaitForClusterDeletionWithUID(
+		ctx context.Context,
+		clusterName,
 		clusterUid,
 		orgID string,
 		timeout time.Duration,

--- a/drivers/backup/portworx/portworx.go
+++ b/drivers/backup/portworx/portworx.go
@@ -429,6 +429,43 @@ func (p *portworx) ClusterUpdateBackupShare(ctx context.Context, req *api.Cluste
 func (p *portworx) WaitForClusterDeletion(
 	ctx context.Context,
 	clusterName,
+	orgID string,
+	timeout time.Duration,
+	timeBeforeRetry time.Duration,
+) error {
+	req := &api.ClusterInspectRequest{
+		Name:  clusterName,
+		OrgId: orgID,
+	}
+	f := func() (interface{}, bool, error) {
+		inspectClusterResp, err := p.clusterManager.Inspect(ctx, req)
+		if err == nil {
+			// Object still exists, just retry
+			currentStatus := inspectClusterResp.GetCluster().GetStatus().GetStatus()
+			return nil, true, fmt.Errorf("cluster [%v] is in [%s] state. Waiting to become complete",
+				req.GetName(), currentStatus)
+		}
+		code := status.Code(err)
+		// If error has code.NotFound, the cluster object is deleted.
+		if code == codes.NotFound {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("Fetching cluster[%v] failed with err: %v", req.GetName(), err.Error())
+	}
+
+	_, err := task.DoRetryWithTimeout(f, timeout, timeBeforeRetry)
+	if err != nil {
+		return fmt.Errorf("failed to wait for cluster deletion. Error:[%v]", err)
+	}
+
+	return nil
+}
+
+// WaitForClusterDeletionWithUID waits for cluster to be deleted successfully
+// or till timeout is reached. API should poll every `timeBeforeRetry` duration using cluster uid
+func (p *portworx) WaitForClusterDeletionWithUID(
+	ctx context.Context,
+	clusterName,
 	clusterUid,
 	orgID string,
 	timeout time.Duration,

--- a/tests/common.go
+++ b/tests/common.go
@@ -3606,7 +3606,7 @@ func DeleteClusterWithUID(name string, uid string, orgID string, ctx context1.Co
 	if err != nil {
 		return err
 	}
-	err = backupDriver.WaitForClusterDeletion(ctx, name, uid, orgID, clusterDeleteTimeout, clusterCreationRetryTime)
+	err = backupDriver.WaitForClusterDeletionWithUID(ctx, name, uid, orgID, clusterDeleteTimeout, clusterCreationRetryTime)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR renames WaitForClusterDeletion to WaitForClusterDeletionWithUID to prevent breaking Px-Backup integration tests.

**Which issue(s) this PR fixes** (optional)
Closes #PA-1681

**Special notes for your reviewer**:
Please review the Jenkins build for the test case "DeleteObjectsByMultipleUsersFromNewAdmin" using the link below

https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/2740/

Aetos Dashboard: https://aetos.pwx.purestorage.com/resultSet/testSetID/357287
