### PR TITLE
Removed the logic of appending px-admin-group in update ownership

### DIFF
--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -3645,7 +3645,6 @@ func GetVolumeMounts(AppContextsMapping *scheduler.Context) ([]string, error) {
 func UpdateBackupLocationOwnership(name string, uid string, userNames []string, groups []string, accessType OwnershipAccessType, publicAccess OwnershipAccessType, ctx context.Context) error {
 	log.Infof("UpdateBackupLocationOwnership for users %v", userNames)
 	backupDriver := Inst().Backup
-	groups = append(groups, "px-admin-group")
 	userIDs := make([]string, 0)
 	groupIDs := make([]string, 0)
 	for _, userName := range userNames {
@@ -3778,7 +3777,6 @@ func AdditionalScheduledBackupRequestParams(backupScheduleRequest *api.BackupSch
 func UpdateSchedulePolicyOwnership(schedulePolicyName string, schedulePolicyUid string, userNames []string, groups []string, accessType OwnershipAccessType, publicAccess OwnershipAccessType, ctx context.Context) error {
 	log.Infof("UpdateScheduleOwnership for users %v", userNames)
 	backupDriver := Inst().Backup
-	groups = append(groups, "px-admin-group")
 	userIDs := make([]string, 0)
 	groupIDs := make([]string, 0)
 	for _, userName := range userNames {
@@ -3841,7 +3839,6 @@ func UpdateSchedulePolicyOwnership(schedulePolicyName string, schedulePolicyUid 
 func UpdateRuleOwnership(ruleName string, ruleUid string, userNames []string, groups []string, accessType OwnershipAccessType, publicAccess OwnershipAccessType, ctx context.Context) error {
 	log.Infof("UpdateruleOwnership for users %v", userNames)
 	backupDriver := Inst().Backup
-	groups = append(groups, "px-admin-group")
 	userIDs := make([]string, 0)
 	groupIDs := make([]string, 0)
 	for _, userName := range userNames {

--- a/tests/common.go
+++ b/tests/common.go
@@ -8977,7 +8977,6 @@ func IsVolumeExits(volName string) bool {
 func UpdateCloudCredentialOwnership(cloudCredentialName string, cloudCredentialUid string, userNames []string, groups []string, accessType OwnershipAccessType, publicAccess OwnershipAccessType, ctx context1.Context, orgID string) error {
 	log.Infof("UpdateCloudCredentialOwnership for users %v", userNames)
 	backupDriver := Inst().Backup
-	groups = append(groups, "px-admin-group")
 	userIDs := make([]string, 0)
 	groupIDs := make([]string, 0)
 	for _, userName := range userNames {


### PR DESCRIPTION
**What this PR does / why we need it**:
Reverting partial code from https://github.com/portworx/torpedo/pull/1690
If we append `px-admin-group` to the `groups` in any update ownership function and we send the access type as invalid, the `px-admin-group` which has full access to it may lose the access and it is also resulting in the following error

```
failed to share the cloud cred with error failed to update CloudCredential ownership : rpc error: code = Unknown desc = group[4a3d3297-052d-4e37-9aa3-5b06e5aee857] has invalid access type[Invalid]
```

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

