### PR TITLE
Added new testcase:Kill NFS executor pod during backup and restore

### DIFF
--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -118,6 +118,7 @@ const (
 	volumeSnapshotClassEnv                    = "VOLUME_SNAPSHOT_CLASS"
 	rancherActiveCluster                      = "local"
 	rancherProjectDescription                 = "new project"
+	multiAppNfsPodDeploymentNamespace         = "kube-system"
 )
 
 var (
@@ -141,7 +142,9 @@ var (
 		{"app.kubernetes.io/component": "keycloak"},
 		{"app.kubernetes.io/component": "pxcentral-lh-middleware"},
 		{"app.kubernetes.io/component": "pxcentral-mysql"}}
-	cloudPlatformList = []string{"rke", "aws", "azure", "gke"}
+	cloudPlatformList          = []string{"rke", "aws", "azure", "gke"}
+	nfsBackupExecutorPodLabel  = map[string]string{"kdmp.portworx.com/driver-name": "nfsbackup"}
+	nfsRestoreExecutorPodLabel = map[string]string{"kdmp.portworx.com/driver-name": "nfsrestore"}
 )
 
 type userRoleAccess struct {
@@ -350,8 +353,8 @@ func UpdateBackup(backupName string, backupUid string, orgId string, cloudCred s
 	return status, err
 }
 
-// CreateBackupWithCustomResourceType creates backup with custom resources
-func CreateBackupWithCustomResourceType(backupName string, clusterName string, bLocation string, bLocationUID string,
+// CreateBackupWithCustomResourceTypeWithoutValidation creates backup with custom resources without validation
+func CreateBackupWithCustomResourceTypeWithoutValidation(backupName string, clusterName string, bLocation string, bLocationUID string,
 	namespaces []string, labelSelectors map[string]string, orgID string, uid string, preRuleName string,
 	preRuleUid string, postRuleName string, postRuleUid string, resourceTypes []string, ctx context.Context) error {
 
@@ -391,10 +394,6 @@ func CreateBackupWithCustomResourceType(backupName string, clusterName string, b
 	if err != nil {
 		return err
 	}
-	err = backupSuccessCheck(backupName, orgID, maxWaitPeriodForBackupCompletionInMinutes*time.Minute, 30*time.Second, ctx)
-	if err != nil {
-		return err
-	}
 	log.Infof("Backup [%s] created successfully", backupName)
 	return nil
 }
@@ -408,7 +407,7 @@ func CreateBackupWithCustomResourceTypeWithValidation(ctx context.Context, backu
 			namespaces = append(namespaces, namespace)
 		}
 	}
-	err := CreateBackupWithCustomResourceType(backupName, clusterName, bLocation, bLocationUID, namespaces, labelSelectors, orgID, uid, preRuleName, preRuleUid, postRuleName, postRuleUid, resourceTypesFilter, ctx)
+	err := CreateBackupWithCustomResourceTypeWithoutValidation(backupName, clusterName, bLocation, bLocationUID, namespaces, labelSelectors, orgID, uid, preRuleName, preRuleUid, postRuleName, postRuleUid, resourceTypesFilter, ctx)
 	if err != nil {
 		return err
 	}
@@ -1438,12 +1437,29 @@ func GetAllRestoresNonAdminCtx(ctx context.Context) ([]string, error) {
 
 // DeletePodWithLabelInNamespace kills pod with the given label in the given namespace
 func DeletePodWithLabelInNamespace(namespace string, label map[string]string) error {
-	pods, err := core.Instance().GetPods(namespace, label)
+	var pods *corev1.PodList
+	var err error
+	podList := func() (interface{}, bool, error) {
+		pods, err = core.Instance().GetPods(namespace, label)
+		if err != nil {
+			if strings.Contains(err.Error(), "no pod found with the label") {
+				return "", true, fmt.Errorf("waiting for pod with the given label %v to come up in namespace %s", label, namespace)
+			} else {
+				return "", false, err
+			}
+		}
+		if len(pods.Items) < 1 {
+			return "", true, fmt.Errorf("waiting for atleast one pod with the given label %v to come up in namespace %s", label, namespace)
+		}
+		return "", false, nil
+	}
+	_, err = DoRetryWithTimeoutWithGinkgoRecover(podList, 5*time.Minute, 30*time.Second)
 	if err != nil {
 		return err
 	}
 	for _, pod := range pods.Items {
-		err := core.Instance().DeletePod(pod.GetName(), namespace, false)
+		log.Infof("Deleting pod %s with label %v", pod.GetName(), label)
+		err = core.Instance().DeletePod(pod.GetName(), namespace, false)
 		if err != nil {
 			return err
 		}
@@ -1502,18 +1518,18 @@ func backupSuccessCheck(backupName string, orgID string, retryDuration time.Dura
 }
 
 // backupSuccessCheckWithValidation checks if backup is Success and then validates the backup
-func backupSuccessCheckWithValidation(ctx context.Context, backupName string, scheduledAppContextsToBackup []*scheduler.Context, orgID string, retryDuration time.Duration, retryInterval time.Duration) error {
+func backupSuccessCheckWithValidation(ctx context.Context, backupName string, scheduledAppContextsToBackup []*scheduler.Context, orgID string, retryDuration time.Duration, retryInterval time.Duration, resourceTypeFilter ...[]string) error {
 	err := backupSuccessCheck(backupName, orgID, retryDuration, retryInterval, ctx)
 	if err != nil {
 		return err
 	}
-	return ValidateBackup(ctx, backupName, orgID, scheduledAppContextsToBackup, make([]string, 0))
+	return ValidateBackup(ctx, backupName, orgID, scheduledAppContextsToBackup, resourceTypeFilter[0])
 }
 
 // ValidateBackup validates a backup's spec's objects (resources) and volumes. resourceTypesFilter can be used to select specific types to validate (nil means all types). This function must be called after switching to the context on which `scheduledAppContexts` exists. Cluster level resources aren't validated.
 func ValidateBackup(ctx context.Context, backupName string, orgID string, scheduledAppContexts []*scheduler.Context, resourceTypesFilter []string) error {
+	var backupInspectResponse *api.BackupInspectResponse
 	log.InfoD("Validating backup [%s] in org [%s]", backupName, orgID)
-
 	log.Infof("Obtaining backup info for backup [%s]", backupName)
 	backupDriver := Inst().Backup
 	backupUid, err := backupDriver.GetBackupUID(ctx, backupName, orgID)
@@ -1525,23 +1541,28 @@ func ValidateBackup(ctx context.Context, backupName string, orgID string, schedu
 		Uid:   backupUid,
 		OrgId: orgID,
 	}
-	backupInspectResponse, err := backupDriver.InspectBackup(ctx, backupInspectRequest)
-	if err != nil {
-		return fmt.Errorf("InspectBackup Err: %v", err)
+	backupStatusCheck := func() (interface{}, bool, error) {
+		backupInspectResponse, err = backupDriver.InspectBackup(ctx, backupInspectRequest)
+		if err != nil {
+			return "", false, fmt.Errorf("InspectBackup Err: %v", err)
+		}
+		backupStatus := backupInspectResponse.GetBackup().GetStatus().Status
+		if backupStatus == api.BackupInfo_StatusInfo_Success ||
+			backupStatus == api.BackupInfo_StatusInfo_PartialSuccess {
+			return "", false, nil
+		}
+		return "", true, fmt.Errorf("ValidateBackup requires backup [%s] to have a status of Success or PartialSuccess,got -%v", backupName, backupStatus)
 	}
-
-	backupStatus := backupInspectResponse.GetBackup().GetStatus().Status
-	if backupStatus != api.BackupInfo_StatusInfo_Success &&
-		backupStatus != api.BackupInfo_StatusInfo_PartialSuccess {
-		return fmt.Errorf("ValidateBackup requires backup [%s] to have a status of Success or PartialSuccess", backupName)
+	_, err = DoRetryWithTimeoutWithGinkgoRecover(backupStatusCheck, maxWaitPeriodForBackupCompletionInMinutes*time.Minute, 30*time.Second)
+	if err != nil {
+		return err
 	}
 
 	var errors []error
-
 	theBackup := backupInspectResponse.GetBackup()
 	backupName = theBackup.GetName()
 	resourceInfos := theBackup.GetResources()
-	backedupVolumes := theBackup.GetVolumes()
+	backedUpVolumes := theBackup.GetVolumes()
 	backupNamespaces := theBackup.GetNamespaces()
 
 	for _, scheduledAppContext := range scheduledAppContexts {
@@ -1609,7 +1630,7 @@ func ValidateBackup(ctx context.Context, backupName string, orgID string, schedu
 
 		// collect the backup resources whose VOLUMES should be present in this scheduledAppContext (namespace)
 		namespacedBackedUpVolumes := make([]*api.BackupInfo_Volume, 0)
-		for _, vol := range backedupVolumes {
+		for _, vol := range backedUpVolumes {
 			if vol.GetNamespace() == scheduledAppContextNamespace {
 				if vol.Status.Status != api.BackupInfo_StatusInfo_Success /*Can this also be partialsuccess?*/ {
 					err := fmt.Errorf("the status of the backedup volume [%s] was not Success. It was [%s] with reason [%s]", vol.Name, vol.Status.Status, vol.Status.Reason)
@@ -2269,12 +2290,21 @@ func GetOrdinalScheduleBackupName(ctx context.Context, scheduleName string, ordi
 
 // GetFirstScheduleBackupName returns the name of the first schedule backup for the given schedule
 func GetFirstScheduleBackupName(ctx context.Context, scheduleName string, orgID string) (string, error) {
-	allScheduleBackupNames, err := Inst().Backup.GetAllScheduleBackupNames(ctx, scheduleName, orgID)
+	var allScheduleBackupNames []string
+	var err error
+	getFirstScheduleBackup := func() (interface{}, bool, error) {
+		allScheduleBackupNames, err = Inst().Backup.GetAllScheduleBackupNames(ctx, scheduleName, orgID)
+		if err != nil {
+			return "", false, err
+		}
+		if len(allScheduleBackupNames) == 0 {
+			return "", true, fmt.Errorf("no backups found for schedule %s yet", scheduleName)
+		}
+		return "", false, nil
+	}
+	_, err = task.DoRetryWithTimeout(getFirstScheduleBackup, 20*time.Second, 5*time.Second)
 	if err != nil {
 		return "", err
-	}
-	if len(allScheduleBackupNames) == 0 {
-		return "", fmt.Errorf("no backups found for schedule %s", scheduleName)
 	}
 	return allScheduleBackupNames[0], nil
 }
@@ -4585,6 +4615,103 @@ func DeleteBackupSchedulePolicyWithContext(orgID string, policyList []string, ct
 			err = fmt.Errorf("Failed to delete schedule policy %s with error [%v]", policyList[i], err)
 			return err
 		}
+	}
+	return nil
+}
+
+// DeletePodWhileBackupInProgress deletes pod with given label and in given namespace when backup is in progress
+func DeletePodWhileBackupInProgress(ctx context.Context, orgId string, backupName string, namespace string, label map[string]string, clusterName string) error {
+	log.InfoD("Deleting pod while backup is in progress")
+	backupInProgressStatus := api.BackupInfo_StatusInfo_InProgress
+	backupPendingStatus := api.BackupInfo_StatusInfo_Pending
+	backupUID, err := Inst().Backup.GetBackupUID(ctx, backupName, orgId)
+	if err != nil {
+		return err
+	}
+	backupInspectRequest := &api.BackupInspectRequest{
+		Name:  backupName,
+		Uid:   backupUID,
+		OrgId: orgId,
+	}
+	backupProgressCheckFunc := func() (interface{}, bool, error) {
+		backupResponse, err := Inst().Backup.InspectBackup(ctx, backupInspectRequest)
+		if err != nil {
+			return "", false, err
+		}
+		actual := backupResponse.GetBackup().GetStatus().Status
+		if actual == backupInProgressStatus {
+			return "", false, nil
+		}
+		if actual == backupPendingStatus {
+			return "", true, fmt.Errorf("backup status for [%s] expected was [%v] but got [%s]", backupName, backupInProgressStatus, actual)
+		} else {
+			return "", false, fmt.Errorf("backup status for [%s] expected was [%v] but got [%s]", backupName, backupInProgressStatus, actual)
+		}
+	}
+	_, err = DoRetryWithTimeoutWithGinkgoRecover(backupProgressCheckFunc, maxWaitPeriodForBackupJobCancellation*time.Minute, backupJobCancellationRetryTime*time.Second)
+	if err != nil {
+		return err
+	}
+	if clusterName == SourceClusterName {
+		err = SetSourceKubeConfig()
+		if err != nil {
+			return err
+		}
+	} else if clusterName == destinationClusterName {
+		err = SetDestinationKubeConfig()
+		if err != nil {
+			return err
+		}
+	}
+	err = DeletePodWithLabelInNamespace(namespace, label)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// DeletePodWhileRestoreInProgress deletes pod with given label and in given namespace when restore is in progress
+func DeletePodWhileRestoreInProgress(ctx context.Context, orgId string, restoreName string, namespace string, label map[string]string, clusterName string) error {
+	log.InfoD("Deleting pod while restore is in progress")
+	restoreInspectRequest := &api.RestoreInspectRequest{
+		Name:  restoreName,
+		OrgId: orgId,
+	}
+	restoreInProgressStatus := api.RestoreInfo_StatusInfo_InProgress
+	restorePendingStatus := api.RestoreInfo_StatusInfo_Pending
+	restoreProgressCheckFunc := func() (interface{}, bool, error) {
+		resp, err := Inst().Backup.InspectRestore(ctx, restoreInspectRequest)
+		if err != nil {
+			return "", false, err
+		}
+		actual := resp.GetRestore().GetStatus().Status
+		if actual == restoreInProgressStatus {
+			return "", false, nil
+		}
+		if actual == restorePendingStatus {
+			return "", true, fmt.Errorf("restore status for [%s] expected was [%v] but got [%s]", restoreName, restoreInProgressStatus, actual)
+		} else {
+			return "", false, fmt.Errorf("restore status for [%s] expected was [%v] but got [%s]", restoreName, restoreInProgressStatus, actual)
+		}
+	}
+	_, err := DoRetryWithTimeoutWithGinkgoRecover(restoreProgressCheckFunc, maxWaitPeriodForRestoreCompletionInMinute*time.Minute, restoreJobProgressRetryTime*time.Second)
+	if err != nil {
+		return err
+	}
+	if clusterName == SourceClusterName {
+		err = SetSourceKubeConfig()
+		if err != nil {
+			return err
+		}
+	} else if clusterName == destinationClusterName {
+		err = SetDestinationKubeConfig()
+		if err != nil {
+			return err
+		}
+	}
+	err = DeletePodWithLabelInNamespace(namespace, label)
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/tests/backup/backup_nfs_test.go
+++ b/tests/backup/backup_nfs_test.go
@@ -1,0 +1,204 @@
+package tests
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	"github.com/pborman/uuid"
+	api "github.com/portworx/px-backup-api/pkg/apis/v1"
+	"github.com/portworx/torpedo/drivers/backup"
+	"github.com/portworx/torpedo/drivers/scheduler"
+	"github.com/portworx/torpedo/pkg/log"
+	. "github.com/portworx/torpedo/tests"
+	"time"
+)
+
+// DeleteNfsExecutorPodWhileBackupAndRestoreInProgress deletes the nfs executor pod while backup and restore are in progress and validates their status
+var _ = Describe("{DeleteNfsExecutorPodWhileBackupAndRestoreInProgress}", func() {
+	var (
+		bkpLocationName          string
+		backupLocationUID        string
+		schedulePolicyName       string
+		schedulePolicyUID        string
+		scheduleName             string
+		firstSchBackupName       string
+		customResourceBackupName string
+		clusterUid               string
+		singleNamespaceBackup    string
+		multiNamespaceRestore    string
+		singleNamespaceRestore   string
+		currentBackupName        string
+		scheduleBackup           string
+		customResourceBackup     string
+		singleNamespaceBkp       string
+		appNamespaces            []string
+		restoreNames             []string
+		schedulePolicyInterval   = int64(15)
+		currentContext           []*scheduler.Context
+		contexts                 []*scheduler.Context
+		appContexts              []*scheduler.Context
+		scheduledAppContexts     []*scheduler.Context
+		appContextsToBackup      []*scheduler.Context
+		schedulePolicyInfo       *api.SchedulePolicyInfo
+	)
+	backupLocationMap := make(map[string]string)
+	scheduleBackup = "scheduleBackup"
+	customResourceBackup = "customResourceBackup"
+	singleNamespaceBkp = "singleNamespaceBkp"
+
+	JustBeforeEach(func() {
+		StartTorpedoTest("DeleteNfsExecutorPodWhileBackupAndRestoreInProgress", "Delete nfs executor pod while backup and restore are in progress and validate the status", nil, 86105)
+		log.InfoD("Scheduling Applications")
+		scheduledAppContexts = make([]*scheduler.Context, 0)
+		for i := 0; i < 5; i++ {
+			taskName := fmt.Sprintf("%s-%d", taskNamePrefix, i)
+			appContexts = ScheduleApplications(taskName)
+			contexts = append(contexts, appContexts...)
+			for _, ctx := range appContexts {
+				ctx.ReadinessTimeout = appReadinessTimeout
+				namespace := GetAppNamespace(ctx, taskName)
+				appNamespaces = append(appNamespaces, namespace)
+				scheduledAppContexts = append(scheduledAppContexts, ctx)
+			}
+		}
+		log.Infof("The list of namespaces deployed are", appNamespaces)
+
+	})
+	It("To validate backup and restore status after deleting the respective nfs executor pod while in progress", func() {
+		Step("Validate applications", func() {
+			log.InfoD("Validating applications")
+			ValidateApplications(scheduledAppContexts)
+		})
+
+		Step("Creating NFS backup location", func() {
+			log.InfoD("Creating NFS backup location")
+			backupLocationProviders := getProviders()
+			for _, provider := range backupLocationProviders {
+				bkpLocationName = fmt.Sprintf("%s-%s-%s", provider, getGlobalBucketName(provider), RandomString(10))
+				backupLocationUID = uuid.New()
+				backupLocationMap[backupLocationUID] = bkpLocationName
+				err := CreateBackupLocation(provider, bkpLocationName, backupLocationUID, "", "", getGlobalBucketName(provider), orgID, "")
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Creating NFS backup location %s", bkpLocationName))
+			}
+		})
+
+		Step("Registering application clusters for backup", func() {
+			log.InfoD("Registering application clusters for backup")
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			err = CreateApplicationClusters(orgID, "", "", ctx)
+			dash.VerifyFatal(err, nil, "Creating source and destination cluster")
+			clusterUid, err = Inst().Backup.GetClusterUID(ctx, orgID, SourceClusterName)
+			log.FailOnError(err, "Fetching [%s] uid", SourceClusterName)
+		})
+
+		Step("Create schedule policy", func() {
+			log.InfoD("Creating schedule policy")
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			schedulePolicyName = fmt.Sprintf("%s-%v", "periodic-schedule-policy", RandomString(5))
+			schedulePolicyInfo = Inst().Backup.CreateIntervalSchedulePolicy(5, schedulePolicyInterval, 5)
+			userSchedulePolicyCreateRequest := &api.SchedulePolicyCreateRequest{
+				CreateMetadata: &api.CreateMetadata{
+					Name:  schedulePolicyName,
+					OrgId: orgID,
+				},
+				SchedulePolicy: schedulePolicyInfo,
+			}
+			_, err = Inst().Backup.CreateSchedulePolicy(ctx, userSchedulePolicyCreateRequest)
+			dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation schedule policy %s", schedulePolicyName))
+			schedulePolicyUID, err = Inst().Backup.GetSchedulePolicyUid(orgID, ctx, schedulePolicyName)
+			log.FailOnError(err, "failed to fetch uid for schedule policy- %s", schedulePolicyName)
+		})
+
+		Step("Validating backup status after deleting the respective nfs executor pod while backup is in progress", func() {
+			log.InfoD("Validating backup status after deleting the respective nfs executor pod while backup is in progress")
+			backupToNfsExecutorPodNamespaceMapping := map[string]string{scheduleBackup: multiAppNfsPodDeploymentNamespace, customResourceBackup: multiAppNfsPodDeploymentNamespace, singleNamespaceBkp: appNamespaces[0]}
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			for backupType, namespace := range backupToNfsExecutorPodNamespaceMapping {
+				resourceTypeFilter := make([]string, 0)
+				switch backupType {
+				case "scheduleBackup":
+					log.InfoD("Taking schedule backup of multiple namespaces")
+					scheduleName = fmt.Sprintf("schedule-bkp-%v", RandomString(5))
+					_, err = CreateScheduleBackupWithoutCheck(scheduleName, SourceClusterName, bkpLocationName, backupLocationUID, appNamespaces, make(map[string]string), orgID, "", "", "", "", schedulePolicyName, schedulePolicyUID, ctx)
+					dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation of scheduled backup with schedule name [%s]", schedulePolicyName))
+					firstSchBackupName, err = GetFirstScheduleBackupName(ctx, scheduleName, orgID)
+					dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching the name of the first schedule backup"))
+					err = suspendBackupSchedule(scheduleName, schedulePolicyName, orgID, ctx)
+					dash.VerifyFatal(err, nil, fmt.Sprintf("Suspending backup schedule [%s] so that no new nfs executor pod is deployed for this schedule", scheduleName))
+					currentBackupName = firstSchBackupName
+					currentContext = scheduledAppContexts
+				case "customResourceBackup":
+					log.InfoD("Taking custom resource backup of all namespaces")
+					customResourceBackupName = fmt.Sprintf("%s-custom-resource-%v", BackupNamePrefix, RandomString(5))
+					err = CreateBackupWithCustomResourceTypeWithoutValidation(customResourceBackupName, SourceClusterName, bkpLocationName, backupLocationUID, appNamespaces, make(map[string]string), orgID, clusterUid, "", "", "", "", []string{"PersistentVolumeClaim"}, ctx)
+					dash.VerifyFatal(err, nil, fmt.Sprintf("Creation of custom resource backup - %s", customResourceBackupName))
+					resourceTypeFilter = append(resourceTypeFilter, "PersistentVolumeClaim")
+					currentBackupName = customResourceBackupName
+					currentContext = scheduledAppContexts
+				case "singleNamespaceBkp":
+					log.InfoD("Taking backup of single namespace")
+					singleNamespaceBackup = fmt.Sprintf("single-ns-%s-%v-backup", appNamespaces[0], RandomString(5))
+					appContextsToBackup = FilterAppContextsByNamespace(scheduledAppContexts, []string{appNamespaces[0]})
+					_, err = CreateBackupWithoutCheck(ctx, singleNamespaceBackup, SourceClusterName, bkpLocationName, backupLocationUID, appContextsToBackup, make(map[string]string), orgID, clusterUid, "", "", "", "")
+					dash.VerifyFatal(err, nil, fmt.Sprintf("Creating backup %s with single namespace", singleNamespaceBackup))
+					currentBackupName = singleNamespaceBackup
+					currentContext = appContextsToBackup
+				default:
+					log.InfoD("Backup type provided is not supported for this testcase")
+				}
+				log.InfoD("Deleting nfs executor pod while backup %s of type %s is in progress", currentBackupName, backupType)
+				err = DeletePodWhileBackupInProgress(ctx, orgID, currentBackupName, namespace, nfsBackupExecutorPodLabel, SourceClusterName)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Delete nfs executor pod while backup %s of type %s is in progress", currentBackupName, backupType))
+				log.InfoD("Verifying backup %s status of type %s after deleting nfs executor pod", currentBackupName, backupType)
+				err = backupSuccessCheckWithValidation(ctx, currentBackupName, currentContext, orgID, maxWaitPeriodForBackupCompletionInMinutes*time.Minute, 30*time.Second, resourceTypeFilter)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Verification of backup:[%s] status of type %s after deleting nfs executor pod", currentBackupName, backupType))
+			}
+		})
+
+		Step("Validating restore status after deleting the respective nfs executor pod while restore is in progress", func() {
+			log.InfoD("Validating restore status after deleting the respective nfs executor pod while restore is in progress")
+			multiNamespaceRestore = fmt.Sprintf("multi-ns-%s-%s-%v", restoreNamePrefix, firstSchBackupName, RandomString(5))
+			singleNamespaceRestore = fmt.Sprintf("single-ns-%s-%s-%v", restoreNamePrefix, singleNamespaceBackup, RandomString(5))
+			restoreToNfsExecutorPodNamespaceAndBackupMapping := map[string][]string{multiNamespaceRestore: {multiAppNfsPodDeploymentNamespace, firstSchBackupName}, singleNamespaceRestore: {appNamespaces[0], singleNamespaceBackup}}
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			for restoreName, namespaceBackup := range restoreToNfsExecutorPodNamespaceAndBackupMapping {
+				log.InfoD("Restoring the backup %s without check", namespaceBackup[1])
+				_, err = CreateRestoreWithoutCheck(restoreName, namespaceBackup[1], make(map[string]string), destinationClusterName, orgID, ctx)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Creating in-progress restore [%s] from backup %s", restoreName, namespaceBackup[1]))
+				restoreNames = append(restoreNames, restoreName)
+				log.InfoD("Deleting nfs executor pod while restore %s is in progress", restoreName)
+				err = DeletePodWhileRestoreInProgress(ctx, orgID, restoreName, namespaceBackup[0], nfsRestoreExecutorPodLabel, destinationClusterName)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Deleting nfs executor pod while restore %s is in progress", restoreName))
+				err := SetSourceKubeConfig()
+				log.FailOnError(err, "Switching context to source cluster failed")
+				log.InfoD("Verifying restore %s status after deleting nfs executor pod", restoreName)
+				err = restoreSuccessCheck(restoreName, orgID, maxWaitPeriodForRestoreCompletionInMinute*time.Minute, restoreJobProgressRetryTime*time.Minute, ctx)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying restore %s taken from backup %v after deleting nfs executor pod", restoreName, namespaceBackup[1]))
+			}
+		})
+	})
+	JustAfterEach(func() {
+		defer EndPxBackupTorpedoTest(scheduledAppContexts)
+		err := SetSourceKubeConfig()
+		log.FailOnError(err, "Switching context to source cluster failed")
+		ctx, err := backup.GetAdminCtxFromSecret()
+		log.FailOnError(err, "Fetching px-central-admin ctx")
+		log.Infof("Deleting the deployed applications")
+		opts := make(map[string]bool)
+		opts[SkipClusterScopedObjects] = true
+		DestroyApps(scheduledAppContexts, opts)
+		log.InfoD("Deleting the restores taken")
+		for _, restoreName := range restoreNames {
+			err = DeleteRestore(restoreName, orgID, ctx)
+			dash.VerifySafely(err, nil, fmt.Sprintf("Deleting restore %s", restoreName))
+		}
+		err = DeleteSchedule(scheduleName, SourceClusterName, orgID, ctx)
+		dash.VerifySafely(err, nil, fmt.Sprintf("Verification of deleting backup schedule - %s", scheduleName))
+		err = Inst().Backup.DeleteBackupSchedulePolicy(orgID, []string{schedulePolicyName})
+		dash.VerifySafely(err, nil, fmt.Sprintf("Deleting backup schedule policies %s ", []string{schedulePolicyName}))
+		CleanupCloudSettingsAndClusters(backupLocationMap, "", "", ctx)
+	})
+})


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes # PA-1671

**Special notes for your reviewer**:
1)Added a retry in DeletePodWithLabelInNamespace as nfs executor pod takes time to come up after backup/restore starts
2)Added retry in ValidateBackup as backup takes time to complete once we delete the nfs executor pod
3)Added helper method DeletePodWhileBackupInProgress and DeletePodWhileRestoreInProgress(
4)Added new testcase: DeleteNfsExecutorPodWhileBackupAndRestoreInProgress
5)Renamed CreateBackupWithCustomResourceType to CreateBackupWithCustomResourceTypeWithoutValidation as this method is to check backup with custom resource without validation.
There already exist a method : CreateBackupWithCustomResourceTypeWithValidation

log: https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/2837/consoleFull

RKE: https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/2849/consoleFull

https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/basic-system-test/job/px/job/NFS/job/PX-Cloud-Vanilla-NFS/177/consoleFull