### PR TITLE
fix for zones in gke

### DIFF
--- a/drivers/node/gke/gke.go
+++ b/drivers/node/gke/gke.go
@@ -94,11 +94,19 @@ func (g *gke) DeleteNode(node node.Node, timeout time.Duration) error {
 }
 
 func (g *gke) GetZones() ([]string, error) {
-	asgInfo, err := g.ops.InspectInstanceGroupForInstance(g.ops.InstanceID())
-	if err != nil {
-		return []string{}, err
+	storageDriverNodes := node.GetStorageDriverNodes()
+	nZones := make(map[string]bool)
+	for _, sNode := range storageDriverNodes {
+		if _, ok := nZones[sNode.Zone]; !ok {
+			nZones[sNode.Zone] = true
+		}
+
 	}
-	return asgInfo.Zones, nil
+	asgZones := make([]string, 0)
+	for k := range nZones {
+		asgZones = append(asgZones, k)
+	}
+	return asgZones, nil
 }
 
 func init() {

--- a/tests/common.go
+++ b/tests/common.go
@@ -8531,10 +8531,17 @@ outer:
 			defer ginkgo.GinkgoRecover()
 			defer wg.Done()
 
-			poolID, err := GetPoolIDFromPoolUUID(poolUuid)
+			pools, err := Inst().V.ListStoragePools(metav1.LabelSelector{})
 			if err != nil {
 				errCh <- err
 				return
+			}
+			var poolID int32
+			for _, pool := range pools {
+				if pool.Uuid == poolUuid {
+					poolID = pool.ID
+					break
+				}
 			}
 
 			inspectVolume, err := Inst().V.InspectVolume(v.ID)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
With recent change in spawn to use only one zone for torpedo pool for GKE, number of zones giving incorrect value to GetZones in torpedo. This PR fixes that.

**Which issue(s) this PR fixes** (optional)
Closes #PTX-20378

**Special notes for your reviewer**:

