### PR TITLE
[PTX-20334] Fix TriggerDeployNewApps

### DIFF
--- a/tests/testTriggers.go
+++ b/tests/testTriggers.go
@@ -595,9 +595,8 @@ func TriggerDeployNewApps(contexts *[]*scheduler.Context, recordChan *chan *Even
 		for _, ctx := range *contexts {
 			log.Infof("Validating context: %v", ctx.App.Key)
 			ctx.SkipVolumeValidation = false
+			errorChan = make(chan error, errorChannelSize)
 			ValidateContext(ctx, &errorChan)
-			// BUG: Execution doesn't resume here after ValidateContext called
-			// Below code is never executed
 			for err := range errorChan {
 				log.Infof("Error: %v", err)
 				UpdateOutcome(event, err)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR fixes a panic that occurs when attempting to close an already-closed channel in test trigger TriggerDeployNewApps.

**Which issue(s) this PR fixes** (optional)
Closes #PTX-20334

**Special notes for your reviewer**:
Please review the following Jenkins build for the test trigger "TriggerDeployNewApps"

Before fix: https://jenkins.pwx.dev.purestorage.com/job/Users/job/Leela/job/tp-upgrade-longevity-pipeline/117/

Aetos Dashboard: https://aetos.pwx.purestorage.com/resultSet/testSetID/360051 [This might show `PASS` because the error was not captured due to panic. This does not show any logs related to `elasticsearch`]

After fix: https://jenkins.pwx.dev.purestorage.com/job/Users/job/Leela/job/tp-upgrade-longevity-pipeline/119/

Aetos Dashboard: https://aetos.pwx.purestorage.com/resultSet/testSetID/360149