### PR TITLE
Adding virtual machine specs to support Kubevirt

### DIFF
--- a/drivers/scheduler/k8s/specs/kubevirt-multi-vm/aws/sc-aws-ebs.yaml
+++ b/drivers/scheduler/k8s/specs/kubevirt-multi-vm/aws/sc-aws-ebs.yaml
@@ -1,0 +1,9 @@
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: kubevirt-sc
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp2
+  fsType: ext4

--- a/drivers/scheduler/k8s/specs/kubevirt-multi-vm/pvc-cdi-app-ubuntu.yaml
+++ b/drivers/scheduler/k8s/specs/kubevirt-multi-vm/pvc-cdi-app-ubuntu.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-cdi-ubuntu
+  labels:
+    app: containerized-data-importer
+  annotations:
+    cdi.kubevirt.io/storage.import.endpoint: http://kubevirt-disk-registry.pwx.dev.purestorage.com/mysql-postgres-sysbench.img
+spec:
+  storageClassName: kubevirt-sc
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 15Gi

--- a/drivers/scheduler/k8s/specs/kubevirt-multi-vm/pvc-cdi-ubuntu.yaml
+++ b/drivers/scheduler/k8s/specs/kubevirt-multi-vm/pvc-cdi-ubuntu.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-cdi-ubuntu
+  labels:
+    app: containerized-data-importer
+  annotations:
+    cdi.kubevirt.io/storage.import.endpoint: http://kubevirt-disk-registry.pwx.dev.purestorage.com/disk_0.img
+spec:
+  storageClassName: kubevirt-sc
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi

--- a/drivers/scheduler/k8s/specs/kubevirt-multi-vm/pvc-plane.yaml
+++ b/drivers/scheduler/k8s/specs/kubevirt-multi-vm/pvc-plane.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-plane-volume
+spec:
+  storageClassName: kubevirt-sc
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi

--- a/drivers/scheduler/k8s/specs/kubevirt-multi-vm/pxd/sc-px-csi.yaml
+++ b/drivers/scheduler/k8s/specs/kubevirt-multi-vm/pxd/sc-px-csi.yaml
@@ -1,0 +1,10 @@
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: kubevirt-sc
+provisioner: pxd.portworx.com
+parameters:
+  repl: "3"
+  io_profile: db_remote
+allowVolumeExpansion: true

--- a/drivers/scheduler/k8s/specs/kubevirt-multi-vm/svc-clusterip.yaml
+++ b/drivers/scheduler/k8s/specs/kubevirt-multi-vm/svc-clusterip.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubevirt-svc-clusterip
+spec:
+  ports:
+    - port: 27017
+      protocol: TCP
+      targetPort: 22
+  selector:
+    kubevirt-key: kubevirt-val
+  type: ClusterIP

--- a/drivers/scheduler/k8s/specs/kubevirt-multi-vm/svc-loadbalancer.yaml
+++ b/drivers/scheduler/k8s/specs/kubevirt-multi-vm/svc-loadbalancer.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubevirt-svc-lb
+spec:
+  externalTrafficPolicy: Cluster
+  ports:
+    - port: 27017
+      protocol: TCP
+      targetPort: 3389
+  selector:
+    special: key
+  type: LoadBalancer

--- a/drivers/scheduler/k8s/specs/kubevirt-multi-vm/svc-nodeport.yaml
+++ b/drivers/scheduler/k8s/specs/kubevirt-multi-vm/svc-nodeport.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubevirt-svc-nodeport
+spec:
+  externalTrafficPolicy: Cluster
+  ports:
+    - name: nodeport
+      nodePort: 30000
+      port: 27017
+      protocol: TCP
+      targetPort: 22
+  selector:
+    kubevirt-key: kubevirt-val
+  type: NodePort

--- a/drivers/scheduler/k8s/specs/kubevirt-multi-vm/vm-ubuntu-containerdisk-pvc.yaml
+++ b/drivers/scheduler/k8s/specs/kubevirt-multi-vm/vm-ubuntu-containerdisk-pvc.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-data-volume
+spec:
+  storageClassName: kubevirt-sc
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: vm-ubuntu-containerdisk-pvc
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt.io/size: small
+        kubevirt.io/domain: ubuntu-bionic
+        kubevirt-key: kubevirt-val
+    spec:
+      domain:
+        cpu:
+          cores: 2
+        devices:
+          disks:
+            - name: containervolume
+              disk:
+                bus: virtio
+            - name: cloudinitvolume
+              cdrom:
+                bus: sata
+                readonly: true
+            - name: datavolume
+              disk:
+                bus: virtio
+          interfaces:
+            - name: default
+              masquerade: {}
+        resources:
+          requests:
+            memory: 2048M
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containervolume
+          containerDisk:
+            image: docker.pwx.dev.purestorage.com/portworx/ubuntu-container-disk:20.0
+        - name: datavolume
+          dataVolume:
+            name: pvc-data-volume
+        - name: cloudinitvolume
+          cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              chpasswd:
+                list: |
+                  ubuntu:ubuntu
+                  root:toor
+                expire: False

--- a/drivers/scheduler/k8s/specs/kubevirt-multi-vm/vm-ubuntu-containerdisk.yaml
+++ b/drivers/scheduler/k8s/specs/kubevirt-multi-vm/vm-ubuntu-containerdisk.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: vm-ubuntu-containerdisk
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt.io/size: small
+        kubevirt.io/domain: vm-ubuntu-containerdisk
+        kubevirt-key: kubevirt-val
+    spec:
+      domain:
+        cpu:
+          cores: 2
+        devices:
+          disks:
+            - name: containervolume
+              disk:
+                bus: virtio
+            - name: cloudinitvolume
+              disk:
+                bus: virtio
+          interfaces:
+            - name: default
+              masquerade: {}
+        resources:
+          requests:
+            memory: 2048M
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containervolume
+          containerDisk:
+            image: docker.pwx.dev.purestorage.com/portworx/ubuntu-container-disk:20.0
+        - name: cloudinitvolume
+          cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              chpasswd:
+                list: |
+                  ubuntu:ubuntu
+                  root:toor
+                expire: False

--- a/drivers/scheduler/k8s/specs/kubevirt-multi-vm/vm-ubuntu-pvc-datavolume.yaml
+++ b/drivers/scheduler/k8s/specs/kubevirt-multi-vm/vm-ubuntu-pvc-datavolume.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-data-volume
+spec:
+  storageClassName: kubevirt-sc
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: vm-ubuntu-pvc-datavolume
+spec:
+  running: false
+  template:
+    metadata:
+      labels:
+        kubevirt.io/domain: ubuntu-bionic
+        kubevirt-key: kubevirt-val
+    spec:
+      domain:
+        cpu:
+          cores: 2
+        devices:
+          disks:
+            - name: containervolume
+              disk:
+                bus: virtio
+            - name: datavolume
+              disk:
+                bus: virtio
+            - name: cloudinitvolume
+              disk:
+                bus: virtio
+          interfaces:
+            - name: default
+              masquerade: {}
+        resources:
+          requests:
+            memory: 2048M
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containervolume
+          persistentVolumeClaim:
+            claimName: pvc-cdi-ubuntu
+        - name: datavolume
+          dataVolume:
+            name: pvc-data-volume
+        - name: cloudinitvolume
+          cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              chpasswd:
+                list: |
+                  ubuntu:ubuntu
+                  root:toor
+                expire: False

--- a/drivers/scheduler/k8s/specs/kubevirt-multi-vm/vm-ubuntu-pvc.yaml
+++ b/drivers/scheduler/k8s/specs/kubevirt-multi-vm/vm-ubuntu-pvc.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  labels:
+    kubevirt.io/os: linux
+  name: vm-ubuntu-pvc
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt.io/domain: vm-ubuntu-pvc
+    spec:
+      domain:
+        cpu:
+          cores: 2
+        devices:
+          interfaces:
+            - name: default
+              masquerade: {}
+          disks:
+            - name: containerdisk
+              disk:
+                bus: virtio
+            - cdrom:
+                bus: sata
+                readonly: true
+              name: cloudinitdisk
+        machine:
+          type: q35
+        resources:
+          requests:
+            memory: 2048M
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          persistentVolumeClaim:
+            claimName: pvc-cdi-ubuntu
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              chpasswd:
+                list: |
+                  ubuntu:ubuntu
+                  root:toor
+                expire: False


### PR DESCRIPTION

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PA-1698

**Special notes for your reviewer**:
```
[root@vm-vpinisetti:~/kubevirt/working]# kc get vm -A
NAMESPACE       NAME                          AGE     STATUS    READY
default         centos7-um6b40cbo5mwg5w5      3d20h   Running   True
test2           ubuntu-mysql-vm               32h     Running   True
test3           vm-ubuntu-containerdisk       149m    Running   True
test5           vm-ubuntu-containerdisk-pvc   47m     Running   True
ubuntu-bionic   ubuntu-bionic                 3d23h   Running   True
ubuntu-pvc      ubuntu-pvc-vm                 3d23h   Running   True
[root@vm-vpinisetti:~/kubevirt/working]#
```
