### PR TITLE
PA-1615: Adding First Service Identity TestCase

### DIFF
--- a/drivers/pds/api/api_helper.go
+++ b/drivers/pds/api/api_helper.go
@@ -71,6 +71,7 @@ func GetContext() (context.Context, error) {
 		if err != nil {
 			return nil, err
 		}
+		log.InfoD("Non-ServiceIdentity Token being used is-  %v", token)
 	}
 	ctx := context.WithValue(context.Background(), pds.ContextAPIKeys, map[string]pds.APIKey{"ApiKeyAuth": {Key: token, Prefix: "Bearer"}})
 	return ctx, nil

--- a/drivers/pds/api/iamRoleBindings.go
+++ b/drivers/pds/api/iamRoleBindings.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"github.com/portworx/torpedo/pkg/log"
 	status "net/http"
 
 	pds "github.com/portworx/pds-api-go-client/pds/v1alpha1"
@@ -65,8 +66,9 @@ func (iam *IamRoleBindings) UpdateIamRoleBindings(accountId string, actorId stri
 	}
 	iamModels, res, err := iamClient.ApiAccountsIdIamPut(ctx, accountId).Body(updateRequest).Execute()
 	if err != nil && res.StatusCode != status.StatusOK {
-		return nil, fmt.Errorf("Error when calling `ApiAccountsIdIamPost`: %v\n.Full HTTP response: %v", err, res)
+		return nil, fmt.Errorf("Error when calling `ApiAccountsIdIamPut`: %v\n.Full HTTP response: %v", err, res)
 	}
+	log.InfoD("Successfully updated the IAM Roles")
 	return iamModels, nil
 }
 

--- a/drivers/pds/api/serviceIdentity.go
+++ b/drivers/pds/api/serviceIdentity.go
@@ -87,7 +87,6 @@ func (si *ServiceIdentity) GenerateServiceIdentityToken(clientId string, clientT
 		return "", fmt.Errorf("Error in getting context for api call: %v\n", err)
 	}
 	siModel, res, err := siClient.ServiceIdentityGenerateTokenPost(ctx).Body(createRequest).Execute()
-	log.InfoD("resp status is - %v and resp body is- %v", res.StatusCode, res.Body)
 	if err != nil && res.StatusCode != status.StatusOK {
 		return "", fmt.Errorf("Error when calling `ServiceIdentityGenerateTokenPost`: %v\n.Full HTTP response: %v", err, res)
 	}
@@ -141,4 +140,19 @@ func (si *ServiceIdentity) CreateAndGetServiceIdentityToken(accountID string) (s
 
 func (si *ServiceIdentity) ReturnServiceIdToken() string {
 	return SiToken
+}
+func (si *ServiceIdentity) RegenerateServiceTokenAndSetAuthContext(actorId string) (string, error) {
+	tokenModel, err := si.GetServiceIdentityToken(actorId)
+	if err != nil {
+		return "", fmt.Errorf("error while regenarting and fetching clientid and client token %v", actorId)
+	}
+	newClient := tokenModel.GetClientId()
+	newClientToken := tokenModel.GetClientToken()
+	regeneratedToken, err := si.GenerateServiceIdentityToken(newClient, newClientToken)
+	if err != nil {
+		return "", fmt.Errorf("error while regenarting and fetching new Si token %v", actorId)
+	}
+	SiToken = regeneratedToken
+	log.InfoD("Successfully Regenerated the SiToken- %v", SiToken)
+	return regeneratedToken, nil
 }

--- a/drivers/pds/parameters/parameters_utils.go
+++ b/drivers/pds/parameters/parameters_utils.go
@@ -136,7 +136,11 @@ func (customparams *Customparams) ReturnServiceIdToken() string {
 func (Customparams *Customparams) SetParamsForServiceIdentityTest(params *Parameter, value bool) (bool, error) {
 	params.InfraToTest.ServiceIdentityToken = value
 	json.Marshal(params)
-	ServiceIdFlag = true
+	if value == true {
+		ServiceIdFlag = true
+	} else {
+		ServiceIdFlag = false
+	}
 	log.InfoD("Successfully updated Infra params for ServiceIdentity and RBAC test")
 	log.InfoD("ServiceIdentity flag is set to- %v", ServiceIdFlag)
 	return true, nil

--- a/drivers/pds/pdsrestore/restore_utils.go
+++ b/drivers/pds/pdsrestore/restore_utils.go
@@ -115,6 +115,24 @@ func (restoreClient *RestoreClient) WaitForRestoreAndValidate(restoredModel *pds
 	return nil
 }
 
+func (restoreClient *RestoreClient) RestoreDataServiceWithRbac(pdsRestoreTargetClusterID string, backupJobId string, namespace string, bkpDsEntity DSEntity, pdsNamespaceId string, validate bool) (*pds.ModelsRestore, error) {
+
+	restoredModel, err := restoreClient.Components.Restore.RestoreToNewDeployment(backupJobId, "autom-res", pdsRestoreTargetClusterID, pdsNamespaceId)
+	if err != nil {
+		log.Errorf("Failed during restore.")
+		return nil, fmt.Errorf("failed during restore")
+	}
+
+	if validate {
+		err = restoreClient.WaitForRestoreAndValidate(restoredModel, bkpDsEntity, namespace)
+		if err != nil {
+			log.Errorf("Failed to validate restored dataservice")
+			return nil, fmt.Errorf("failed to validate restored dataservice")
+		}
+	}
+	return restoredModel, nil
+}
+
 func (restoreClient *RestoreClient) getNameSpaceId(pdsClusterId string) (string, string, error) {
 	randomName := generateRandomName("restore")
 	_, err := restoreClient.RestoreTargetCluster.CreateNamespace(randomName)
@@ -126,6 +144,34 @@ func (restoreClient *RestoreClient) getNameSpaceId(pdsClusterId string) (string,
 		return "", "", fmt.Errorf("unable to fetch  %v", randomName)
 	}
 	return randomName, nsId, nil
+}
+func (restoreClient *RestoreClient) getNameSpaceIdCustomNs(pdsClusterId string, nsName string) (string, string, error) {
+	nsId, err := restoreClient.RestoreTargetCluster.GetnameSpaceID(nsName, pdsClusterId)
+	if err != nil {
+		return "", "", fmt.Errorf("unable to fetch  %v", nsName)
+	}
+	return nsName, nsId, nil
+}
+
+func (restoreClient *RestoreClient) GetNameSpaceIdToRestore(backupJobId string, pdsRestoreTargetClusterID string, namespace string, isRestoreInSameNS bool) (string, string, error) {
+	var bkpJob *pds.ModelsBackupJob
+	var nsName string
+	var pdsNamespaceId string
+	var err error
+	if !isRestoreInSameNS {
+		nsName, pdsNamespaceId, err = restoreClient.getNameSpaceIdCustomNs(pdsRestoreTargetClusterID, namespace)
+		if err != nil {
+			return "", "", err
+		}
+	} else {
+		bkpJob, err = restoreClient.Components.BackupJob.GetBackupJob(backupJobId)
+		if err != nil {
+			return "", "", err
+		}
+		nsName, pdsNamespaceId = namespace, bkpJob.GetNamespaceId()
+	}
+	log.Infof("backup Job - %v,Restore Target Cluster Id - %v, NamespaceId - %v", backupJobId, pdsRestoreTargetClusterID, pdsNamespaceId)
+	return nsName, pdsNamespaceId, nil
 }
 
 func (restoreClient *RestoreClient) ValidateRestore(bkpDsEntity, restoreDsEntity DSEntity) error {

--- a/tests/pds/pds_common.go
+++ b/tests/pds/pds_common.go
@@ -139,12 +139,12 @@ var (
 var dataServiceDeploymentWorkloads = []string{cassandra, elasticSearch, postgresql, consul, mysql}
 var dataServicePodWorkloads = []string{redis, rabbitmq, couchbase}
 
-func DeployandValidateDataServicesWithSiAndTls(ds PDSDataService, namespaceName string, namespaceid, projectID string, resourceTemplateID string, appConfigID string, dsVersion string, dsImage string, dsID string) (*pds.ModelsDeployment, map[string][]string, map[string][]string, error) {
+func DeployandValidateDataServicesWithSiAndTls(ds PDSDataService, namespaceName string, namespaceid, projectID string, resourceTemplateID string, appConfigID string, dsVersion string, dsImage string, dsID string, enableTls bool) (*pds.ModelsDeployment, map[string][]string, map[string][]string, error) {
 
 	log.InfoD("Data Service Deployment Triggered")
 	log.InfoD("Deploying ds in namespace %v and servicetype is %v", namespaceName, serviceType)
 
-	deployment, dataServiceImageMap, dataServiceVersionBuildMap, err := dsWithRbac.TriggerDeployDSWithSiAndTls(dataservices.PDSDataService(ds), namespaceName, projectID, true, resourceTemplateID, appConfigID, namespaceid, dsVersion, dsImage, dsID, dataservices.TestParams(TestParams{StorageTemplateId: storageTemplateID, DeploymentTargetId: deploymentTargetID, DnsZone: dnsZone, ServiceType: serviceType}))
+	deployment, dataServiceImageMap, dataServiceVersionBuildMap, err := dsWithRbac.TriggerDeployDSWithSiAndTls(dataservices.PDSDataService(ds), namespaceName, projectID, enableTls, resourceTemplateID, appConfigID, namespaceid, dsVersion, dsImage, dsID, dataservices.TestParams(TestParams{StorageTemplateId: storageTemplateID, DeploymentTargetId: deploymentTargetID, DnsZone: dnsZone, ServiceType: serviceType}))
 	log.FailOnError(err, "Error occured while deploying data service %s", ds.Name)
 
 	Step("Validate Data Service Deployments", func() {

--- a/tests/pds/pds_ds_rbac_test.go
+++ b/tests/pds/pds_ds_rbac_test.go
@@ -11,6 +11,8 @@ import (
 	tc "github.com/portworx/torpedo/drivers/pds/targetcluster"
 	"github.com/portworx/torpedo/pkg/log"
 	. "github.com/portworx/torpedo/tests"
+	"math/rand"
+	"strconv"
 )
 
 var _ = Describe("{ServiceIdentityNsLevel}", func() {
@@ -64,19 +66,19 @@ var _ = Describe("{ServiceIdentityNsLevel}", func() {
 					log.InfoD("Data service: %v doesn't support backup, skipping...", ds.Name)
 					continue
 				}
-				ns1, err := pdslib.CreatePdsLabeledNamespaces()
+				ns1, _, err := targetCluster.CreatePDSNamespace("ns1-" + strconv.Itoa(rand.Int()))
 				log.FailOnError(err, "Error while creating namespace")
 				log.InfoD("Successfully created namespace with PDS Label %v ", ns1)
-				ns1Id1, err := targetCluster.GetnameSpaceID(ns1, deploymentTargetID)
+				ns1Id1, err := targetCluster.GetnameSpaceID(ns1.Name, deploymentTargetID)
 				nsID1 = append(nsID1, ns1Id1)
 				log.FailOnError(err, "Error while fetching namespaceID")
 				log.InfoD("NamespaceID1 fetched is %v ", nsID1)
 				ns1RoleName := "namespace-admin"
 
-				ns2, err := pdslib.CreatePdsLabeledNamespaces()
+				ns2, _, err := targetCluster.CreatePDSNamespace("ns2-" + strconv.Itoa(rand.Int()))
 				log.FailOnError(err, "Error while creating namespace")
 				log.InfoD("Successfully created namespace with PDS Label %v ", ns2)
-				ns2Id2, err := targetCluster.GetnameSpaceID(ns2, deploymentTargetID)
+				ns2Id2, err := targetCluster.GetnameSpaceID(ns2.Name, deploymentTargetID)
 				nsID2 = append(nsID2, ns2Id2)
 				log.FailOnError(err, "Error while fetching namespaceID")
 				log.InfoD("NamespaceID2 fetched is %v ", nsID2)
@@ -105,7 +107,7 @@ var _ = Describe("{ServiceIdentityNsLevel}", func() {
 				log.InfoD("Successfully updated Infra params for Si test")
 
 				isDeploymentsDeleted = false
-				deployment, _, dataServiceVersionBuildMap, err = DeployandValidateDataServicesWithSiAndTls(ds, ns1, ns1Id1, projectID, resTempId, appConfigId, versionId, imageID, dsId)
+				deployment, _, dataServiceVersionBuildMap, err = DeployandValidateDataServicesWithSiAndTls(ds, ns1.Name, ns1Id1, projectID, resTempId, appConfigId, versionId, imageID, dsId, false)
 				log.FailOnError(err, "Error while deploying data services")
 				deploymentsToBeCleaned = append(deploymentsToBeCleaned, deployment)
 				log.FailOnError(err, "Error while deploying data services")
@@ -139,21 +141,30 @@ var _ = Describe("{ServiceIdentityNsLevel}", func() {
 						Deployment:           deployment,
 						RestoreTargetCluster: restoreTarget,
 					}
+					// ListBackupJobsBelongToDeployment will be changed after BUG: DS-6679 will be fixed
+					customParams.SetParamsForServiceIdentityTest(params, false)
 					backupJobs, err := restoreClient.Components.BackupJob.ListBackupJobsBelongToDeployment(projectID, deployment.GetId())
 					log.FailOnError(err, "Error while fetching the backup jobs for the deployment: %v", deployment.GetClusterResourceName())
+					pdsRestoreTargetClusterID, err := targetCluster.GetDeploymentTargetID(clusterID, tenantID)
+
 					for _, backupJob := range backupJobs {
 						log.Infof("[Restoring] Details Backup job name- %v, Id- %v", backupJob.GetName(), backupJob.GetId())
-						restoredModel, _ := restoreClient.TriggerAndValidateRestore(backupJob.GetId(), ns2, dsEntity, false, false)
-						log.InfoD("Failed to trigger restore for - %v", restoredModel.Name)
-						log.InfoD("Restore is failed as expected.")
-						deploymentsToBeCleaned = append(deploymentsToBeCleaned)
+						pdsRestoreNsName, pdsRestoreNsId, err := restoreClient.GetNameSpaceIdToRestore(backupJob.GetId(), pdsRestoreTargetClusterID, ns2.Name, false)
+						log.FailOnError(err, "unable to fetch namespace id to restore")
+						customParams.SetParamsForServiceIdentityTest(params, true)
+						_, err = restoreClient.RestoreDataServiceWithRbac(pdsRestoreTargetClusterID, backupJob.GetId(), pdsRestoreNsName, dsEntity, pdsRestoreNsId, false)
+						dash.VerifyFatal(err != nil, true, "Restore is failed as expected")
+
 					}
 				})
-				//ToDo: Testing is blocked from here because of bug-
+
 				Step("Update IAM Role with ns2 as namespace-admin role", func() {
-					ns2RoleName = "namespace-admin"
-					binding2.RoleName = &ns2RoleName
-					nsRoles = append(nsRoles, binding1, binding2)
+					nsRoles = nil
+					customParams.SetParamsForServiceIdentityTest(params, false)
+					newns2RoleName := "namespace-admin"
+					binding2.ResourceIds = nsID2
+					binding2.RoleName = &newns2RoleName
+					nsRoles := append(nsRoles, binding1, binding2)
 					log.InfoD("Starting to update the IAM Roles for ns2")
 					_, err := components.IamRoleBindings.UpdateIamRoleBindings(accountID, serviceIdentityID, nsRoles)
 					log.FailOnError(err, "Failed while updating IAM Roles for ns2")
@@ -173,9 +184,14 @@ var _ = Describe("{ServiceIdentityNsLevel}", func() {
 					}
 					backupJobs, err := restoreClient.Components.BackupJob.ListBackupJobsBelongToDeployment(projectID, deployment.GetId())
 					log.FailOnError(err, "Error while fetching the backup jobs for the deployment: %v", deployment.GetClusterResourceName())
+					pdsRestoreTargetClusterID, err := targetCluster.GetDeploymentTargetID(clusterID, tenantID)
+
 					for _, backupJob := range backupJobs {
 						log.Infof("[Restoring] Details Backup job name- %v, Id- %v", backupJob.GetName(), backupJob.GetId())
-						restoredModel, _ := restoreClient.TriggerAndValidateRestore(backupJob.GetId(), ns2, dsEntity, false, true)
+						pdsRestoreNsName, pdsRestoreNsId, err := restoreClient.GetNameSpaceIdToRestore(backupJob.GetId(), pdsRestoreTargetClusterID, ns2.Name, false)
+						log.FailOnError(err, "unable to fetch namespace id to restore")
+						customParams.SetParamsForServiceIdentityTest(params, true)
+						restoredModel, _ := restoreClient.RestoreDataServiceWithRbac(pdsRestoreTargetClusterID, backupJob.GetId(), pdsRestoreNsName, dsEntity, pdsRestoreNsId, true)
 						log.FailOnError(err, "Failed during restore.")
 						restoredDeployment, err = restoreClient.Components.DataServiceDeployment.GetDeployment(restoredModel.GetDeploymentId())
 						resDeployments[ds] = restoredDeployment
@@ -188,8 +204,8 @@ var _ = Describe("{ServiceIdentityNsLevel}", func() {
 				Step("Scale up the restored deployments on ns2", func() {
 					log.InfoD("Starting to scale up the restore deployment")
 					for ds, resDep := range resDeployments {
-						log.InfoD("Scaling up DataService %v ", ds.Name)
-
+						customParams.SetParamsForServiceIdentityTest(params, false)
+						log.InfoD("Scaling up DataService %v ", &resDep.Name)
 						dataServiceDefaultAppConfigID, err = controlPlane.GetAppConfTemplate(tenantID, ds.Name)
 						log.FailOnError(err, "Error while getting app configuration template")
 						dash.VerifyFatal(dataServiceDefaultAppConfigID != "", true, "Validating dataServiceDefaultAppConfigID")
@@ -198,15 +214,18 @@ var _ = Describe("{ServiceIdentityNsLevel}", func() {
 						log.FailOnError(err, "Error while getting resource setting template")
 						dash.VerifyFatal(dataServiceDefaultAppConfigID != "", true, "Validating dataServiceDefaultAppConfigID")
 
-						updatedDeployment, err := pdslib.UpdateDataServices(deployment.GetId(),
+						customParams.SetParamsForServiceIdentityTest(params, true)
+
+						updatedDeployment, err := pdslib.UpdateDataServices(resDep.GetId(),
 							dataServiceDefaultAppConfigID, deployment.GetImageId(),
-							int32(ds.ScaleReplicas), dataServiceDefaultResourceTemplateID, ns2)
+							int32(ds.ScaleReplicas), dataServiceDefaultResourceTemplateID, ns2.Name)
 						log.FailOnError(err, "Error while updating dataservices")
 
-						err = dsTest.ValidateDataServiceDeployment(updatedDeployment, ns2)
+						err = dsTest.ValidateDataServiceDeployment(updatedDeployment, ns2.Name)
 						log.FailOnError(err, "Error while validating data service deployment")
 
-						_, _, config, err := pdslib.ValidateDataServiceVolumes(updatedDeployment, *resDep.Name, dataServiceDefaultResourceTemplateID, storageTemplateID, ns2)
+						customParams.SetParamsForServiceIdentityTest(params, false)
+						_, _, config, err := pdslib.ValidateDataServiceVolumes(updatedDeployment, *resDep.Name, dataServiceDefaultResourceTemplateID, storageTemplateID, ns2.Name)
 						log.FailOnError(err, "error on ValidateDataServiceVolumes method")
 						dash.VerifyFatal(int32(ds.ScaleReplicas), config.Spec.Nodes, "Validating replicas after scaling up of dataservice")
 					}
@@ -218,6 +237,15 @@ var _ = Describe("{ServiceIdentityNsLevel}", func() {
 					CleanupServiceIdentitiesAndIamRoles(siToBeCleaned, iamRolesToBeCleaned, actorId)
 					customParams.SetParamsForServiceIdentityTest(params, false)
 				})
+			}
+		})
+	})
+	JustAfterEach(func() {
+		defer EndTorpedoTest()
+		err := bkpClient.AWSStorageClient.DeleteBucket()
+		log.FailOnError(err, "Failed while deleting the bucket")
+	})
+})
 
 			}
 

--- a/tests/pds/pds_ds_rbac_test.go
+++ b/tests/pds/pds_ds_rbac_test.go
@@ -246,12 +246,3 @@ var _ = Describe("{ServiceIdentityNsLevel}", func() {
 		log.FailOnError(err, "Failed while deleting the bucket")
 	})
 })
-
-			}
-
-		})
-		JustAfterEach(func() {
-			defer EndTorpedoTest()
-		})
-	})
-})

--- a/vendor/kubevirt.io/client-go/kubecli/kubevirt_test_utils.go
+++ b/vendor/kubevirt.io/client-go/kubecli/kubevirt_test_utils.go
@@ -1,5 +1,3 @@
-// +build skipcompile
-
 package kubecli
 
 import (

--- a/vendor/kubevirt.io/client-go/kubecli/kubevirt_test_utils.go
+++ b/vendor/kubevirt.io/client-go/kubecli/kubevirt_test_utils.go
@@ -1,3 +1,5 @@
+// +build skipcompile
+
 package kubecli
 
 import (

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1118,9 +1118,9 @@ github.com/portworx/pds-api-go-client/pds/v1alpha1
 # github.com/portworx/px-backup-api v1.2.2-0.20230904054048-eb1f23dd7431
 ## explicit; go 1.19
 github.com/portworx/px-backup-api/pkg/apis/v1
+# github.com/portworx/sched-ops v1.20.4-rc1.0.20230926074552-5a61e22be0a4
 github.com/portworx/px-backup-api/pkg/kubeauth
 github.com/portworx/px-backup-api/pkg/kubeauth/gcp
-# github.com/portworx/sched-ops v1.20.4-rc1.0.20230926074552-5a61e22be0a4
 ## explicit; go 1.19
 github.com/portworx/sched-ops/k8s/admissionregistration
 github.com/portworx/sched-ops/k8s/apiextensions

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1118,9 +1118,9 @@ github.com/portworx/pds-api-go-client/pds/v1alpha1
 # github.com/portworx/px-backup-api v1.2.2-0.20230904054048-eb1f23dd7431
 ## explicit; go 1.19
 github.com/portworx/px-backup-api/pkg/apis/v1
-# github.com/portworx/sched-ops v1.20.4-rc1.0.20230926074552-5a61e22be0a4
 github.com/portworx/px-backup-api/pkg/kubeauth
 github.com/portworx/px-backup-api/pkg/kubeauth/gcp
+# github.com/portworx/sched-ops v1.20.4-rc1.0.20230926074552-5a61e22be0a4
 ## explicit; go 1.19
 github.com/portworx/sched-ops/k8s/admissionregistration
 github.com/portworx/sched-ops/k8s/apiextensions


### PR DESCRIPTION
Initial Commit for Service Identity feature automation.

Added supporting libraries and added the Auth-token context switch feature.
Added the first testcase as well, which performs the below steps -

1. Create Service Identity with PDS Admin User
2. IAM roles - for service id a. namespace-admin - ns1 b. namespace-reader - ns2
3. Deploy TLS Enabled PG on ns1 with service identity token
4. Validate the Deployment
5. Run Workloads
6. Take Backup
7. Restore to ns2 -> expect failure
8. Update IAM for ns2 with admin role
9. Restore again on ns2 -> restore shuould be successful
10. Scale up restored dep on ns2
11. Clear all created entities.

Bug reported - https://portworx.atlassian.net/browse/DS-6679
Aetos Link - https://aetos.pwx.purestorage.com/resultSet/testSetID/360375
Jenkins Log - https://jenkins.pwx.dev.purestorage.com/job/PDS/job/pds-branch-build-test/535/consoleFull
