### PR TITLE
PA-1615: Adding First Service Identity TestCase and Lib Files

### DIFF
--- a/drivers/pds/api/api_helper.go
+++ b/drivers/pds/api/api_helper.go
@@ -63,7 +63,7 @@ func GetContext() (context.Context, error) {
 			token, err = getBearerToken()
 		} else {
 			token = serviceIdToken
-			log.InfoD("ServiceIdentity Token being used is-  %v", serviceIdToken)
+			log.InfoD("ServiceIdentity Token being used")
 		}
 
 	} else {
@@ -71,7 +71,7 @@ func GetContext() (context.Context, error) {
 		if err != nil {
 			return nil, err
 		}
-		log.InfoD("Non-ServiceIdentity Token being used is-  %v", token)
+		log.InfoD("Non-ServiceIdentity Token being used")
 	}
 	ctx := context.WithValue(context.Background(), pds.ContextAPIKeys, map[string]pds.APIKey{"ApiKeyAuth": {Key: token, Prefix: "Bearer"}})
 	return ctx, nil

--- a/drivers/pds/api/api_helper.go
+++ b/drivers/pds/api/api_helper.go
@@ -71,6 +71,7 @@ func GetContext() (context.Context, error) {
 		if err != nil {
 			return nil, err
 		}
+		log.InfoD("Non-ServiceIdentity Token being used is-  %v", token)
 	}
 	ctx := context.WithValue(context.Background(), pds.ContextAPIKeys, map[string]pds.APIKey{"ApiKeyAuth": {Key: token, Prefix: "Bearer"}})
 	return ctx, nil

--- a/drivers/pds/api/iamRoleBindings.go
+++ b/drivers/pds/api/iamRoleBindings.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"github.com/portworx/torpedo/pkg/log"
 	status "net/http"
 
 	pds "github.com/portworx/pds-api-go-client/pds/v1alpha1"
@@ -65,8 +66,9 @@ func (iam *IamRoleBindings) UpdateIamRoleBindings(accountId string, actorId stri
 	}
 	iamModels, res, err := iamClient.ApiAccountsIdIamPut(ctx, accountId).Body(updateRequest).Execute()
 	if err != nil && res.StatusCode != status.StatusOK {
-		return nil, fmt.Errorf("Error when calling `ApiAccountsIdIamPost`: %v\n.Full HTTP response: %v", err, res)
+		return nil, fmt.Errorf("Error when calling `ApiAccountsIdIamPut`: %v\n.Full HTTP response: %v", err, res)
 	}
+	log.InfoD("Successfully updated the IAM Roles")
 	return iamModels, nil
 }
 

--- a/drivers/pds/api/serviceIdentity.go
+++ b/drivers/pds/api/serviceIdentity.go
@@ -87,7 +87,6 @@ func (si *ServiceIdentity) GenerateServiceIdentityToken(clientId string, clientT
 		return "", fmt.Errorf("Error in getting context for api call: %v\n", err)
 	}
 	siModel, res, err := siClient.ServiceIdentityGenerateTokenPost(ctx).Body(createRequest).Execute()
-	log.InfoD("resp status is - %v and resp body is- %v", res.StatusCode, res.Body)
 	if err != nil && res.StatusCode != status.StatusOK {
 		return "", fmt.Errorf("Error when calling `ServiceIdentityGenerateTokenPost`: %v\n.Full HTTP response: %v", err, res)
 	}
@@ -141,4 +140,19 @@ func (si *ServiceIdentity) CreateAndGetServiceIdentityToken(accountID string) (s
 
 func (si *ServiceIdentity) ReturnServiceIdToken() string {
 	return SiToken
+}
+func (si *ServiceIdentity) RegenerateServiceTokenAndSetAuthContext(actorId string) (string, error) {
+	tokenModel, err := si.GetServiceIdentityToken(actorId)
+	if err != nil {
+		return "", fmt.Errorf("error while regenarting and fetching clientid and client token %v", actorId)
+	}
+	newClient := tokenModel.GetClientId()
+	newClientToken := tokenModel.GetClientToken()
+	regeneratedToken, err := si.GenerateServiceIdentityToken(newClient, newClientToken)
+	if err != nil {
+		return "", fmt.Errorf("error while regenarting and fetching new Si token %v", actorId)
+	}
+	SiToken = regeneratedToken
+	log.InfoD("Successfully Regenerated the SiToken- %v", SiToken)
+	return regeneratedToken, nil
 }

--- a/drivers/pds/parameters/parameters_utils.go
+++ b/drivers/pds/parameters/parameters_utils.go
@@ -136,7 +136,11 @@ func (customparams *Customparams) ReturnServiceIdToken() string {
 func (Customparams *Customparams) SetParamsForServiceIdentityTest(params *Parameter, value bool) (bool, error) {
 	params.InfraToTest.ServiceIdentityToken = value
 	json.Marshal(params)
-	ServiceIdFlag = true
+	if value == true {
+		ServiceIdFlag = true
+	} else {
+		ServiceIdFlag = false
+	}
 	log.InfoD("Successfully updated Infra params for ServiceIdentity and RBAC test")
 	log.InfoD("ServiceIdentity flag is set to- %v", ServiceIdFlag)
 	return true, nil

--- a/drivers/pds/pdsrestore/restore_utils.go
+++ b/drivers/pds/pdsrestore/restore_utils.go
@@ -115,6 +115,24 @@ func (restoreClient *RestoreClient) WaitForRestoreAndValidate(restoredModel *pds
 	return nil
 }
 
+func (restoreClient *RestoreClient) RestoreDataServiceWithRbac(pdsRestoreTargetClusterID string, backupJobId string, namespace string, bkpDsEntity DSEntity, pdsNamespaceId string, validate bool) (*pds.ModelsRestore, error) {
+
+	restoredModel, err := restoreClient.Components.Restore.RestoreToNewDeployment(backupJobId, "autom-res", pdsRestoreTargetClusterID, pdsNamespaceId)
+	if err != nil {
+		log.Errorf("Failed during restore.")
+		return nil, fmt.Errorf("failed during restore")
+	}
+
+	if validate {
+		err = restoreClient.WaitForRestoreAndValidate(restoredModel, bkpDsEntity, namespace)
+		if err != nil {
+			log.Errorf("Failed to validate restored dataservice")
+			return nil, fmt.Errorf("failed to validate restored dataservice")
+		}
+	}
+	return restoredModel, nil
+}
+
 func (restoreClient *RestoreClient) getNameSpaceId(pdsClusterId string) (string, string, error) {
 	randomName := generateRandomName("restore")
 	_, err := restoreClient.RestoreTargetCluster.CreateNamespace(randomName)
@@ -126,6 +144,34 @@ func (restoreClient *RestoreClient) getNameSpaceId(pdsClusterId string) (string,
 		return "", "", fmt.Errorf("unable to fetch  %v", randomName)
 	}
 	return randomName, nsId, nil
+}
+func (restoreClient *RestoreClient) getNameSpaceIdCustomNs(pdsClusterId string, nsName string) (string, string, error) {
+	nsId, err := restoreClient.RestoreTargetCluster.GetnameSpaceID(nsName, pdsClusterId)
+	if err != nil {
+		return "", "", fmt.Errorf("unable to fetch  %v", nsName)
+	}
+	return nsName, nsId, nil
+}
+
+func (restoreClient *RestoreClient) GetNameSpaceIdToRestore(backupJobId string, pdsRestoreTargetClusterID string, namespace string, isRestoreInSameNS bool) (string, string, error) {
+	var bkpJob *pds.ModelsBackupJob
+	var nsName string
+	var pdsNamespaceId string
+	var err error
+	if !isRestoreInSameNS {
+		nsName, pdsNamespaceId, err = restoreClient.getNameSpaceIdCustomNs(pdsRestoreTargetClusterID, namespace)
+		if err != nil {
+			return "", "", err
+		}
+	} else {
+		bkpJob, err = restoreClient.Components.BackupJob.GetBackupJob(backupJobId)
+		if err != nil {
+			return "", "", err
+		}
+		nsName, pdsNamespaceId = namespace, bkpJob.GetNamespaceId()
+	}
+	log.Infof("backup Job - %v,Restore Target Cluster Id - %v, NamespaceId - %v", backupJobId, pdsRestoreTargetClusterID, pdsNamespaceId)
+	return nsName, pdsNamespaceId, nil
 }
 
 func (restoreClient *RestoreClient) ValidateRestore(bkpDsEntity, restoreDsEntity DSEntity) error {

--- a/tests/pds/pds_common.go
+++ b/tests/pds/pds_common.go
@@ -139,12 +139,12 @@ var (
 var dataServiceDeploymentWorkloads = []string{cassandra, elasticSearch, postgresql, consul, mysql}
 var dataServicePodWorkloads = []string{redis, rabbitmq, couchbase}
 
-func DeployandValidateDataServicesWithSiAndTls(ds PDSDataService, namespaceName string, namespaceid, projectID string, resourceTemplateID string, appConfigID string, dsVersion string, dsImage string, dsID string) (*pds.ModelsDeployment, map[string][]string, map[string][]string, error) {
+func DeployandValidateDataServicesWithSiAndTls(ds PDSDataService, namespaceName string, namespaceid, projectID string, resourceTemplateID string, appConfigID string, dsVersion string, dsImage string, dsID string, enableTls bool) (*pds.ModelsDeployment, map[string][]string, map[string][]string, error) {
 
 	log.InfoD("Data Service Deployment Triggered")
 	log.InfoD("Deploying ds in namespace %v and servicetype is %v", namespaceName, serviceType)
 
-	deployment, dataServiceImageMap, dataServiceVersionBuildMap, err := dsWithRbac.TriggerDeployDSWithSiAndTls(dataservices.PDSDataService(ds), namespaceName, projectID, true, resourceTemplateID, appConfigID, namespaceid, dsVersion, dsImage, dsID, dataservices.TestParams(TestParams{StorageTemplateId: storageTemplateID, DeploymentTargetId: deploymentTargetID, DnsZone: dnsZone, ServiceType: serviceType}))
+	deployment, dataServiceImageMap, dataServiceVersionBuildMap, err := dsWithRbac.TriggerDeployDSWithSiAndTls(dataservices.PDSDataService(ds), namespaceName, projectID, enableTls, resourceTemplateID, appConfigID, namespaceid, dsVersion, dsImage, dsID, dataservices.TestParams(TestParams{StorageTemplateId: storageTemplateID, DeploymentTargetId: deploymentTargetID, DnsZone: dnsZone, ServiceType: serviceType}))
 	log.FailOnError(err, "Error occured while deploying data service %s", ds.Name)
 
 	Step("Validate Data Service Deployments", func() {


### PR DESCRIPTION
Initial Commit for Service Identity feature automation.

Added supporting libraries and added the Auth-token context switch feature.
Added the first testcase as well, which performs the below steps -

Create Service Identity with PDS Admin User
IAM roles - for service id a. namespace-admin - ns1 b. namespace-reader - ns2
Deploy TLS Enabled PG on ns1 with service identity token
Validate the Deployment
Run Workloads
Take Backup
Restore to ns2 -> expect failure
Update IAM for ns2 with admin role
Restore again on ns2 -> restore shuould be successful
Scale up restored dep on ns2
Clear all created entities.
Bug reported - https://portworx.atlassian.net/browse/DS-6679
Aetos Link - https://aetos.pwx.purestorage.com/resultSet/testSetID/360375
Jenkins Log - https://jenkins.pwx.dev.purestorage.com/job/PDS/job/pds-branch-build-test/540/console
