### PR TITLE
PA-1615: Adding IAMroles libraries and Automation testcases

### DIFF
--- a/drivers/pds/api/api_helper.go
+++ b/drivers/pds/api/api_helper.go
@@ -61,9 +61,10 @@ func GetContext() (context.Context, error) {
 		serviceIdToken := siID.ReturnServiceIdToken()
 		if serviceIdToken == "" {
 			token, err = getBearerToken()
+			log.InfoD("Non-ServiceIdentity Token being used ")
 		} else {
 			token = serviceIdToken
-			log.InfoD("ServiceIdentity Token being used is-  %v", serviceIdToken)
+			log.InfoD("ServiceIdentity Token being used")
 		}
 
 	} else {
@@ -71,6 +72,7 @@ func GetContext() (context.Context, error) {
 		if err != nil {
 			return nil, err
 		}
+		log.InfoD("Non-ServiceIdentity Token being used ")
 	}
 	ctx := context.WithValue(context.Background(), pds.ContextAPIKeys, map[string]pds.APIKey{"ApiKeyAuth": {Key: token, Prefix: "Bearer"}})
 	return ctx, nil

--- a/drivers/pds/api/iamRoleBindings.go
+++ b/drivers/pds/api/iamRoleBindings.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"github.com/portworx/torpedo/pkg/log"
 	status "net/http"
 
 	pds "github.com/portworx/pds-api-go-client/pds/v1alpha1"
@@ -65,8 +66,9 @@ func (iam *IamRoleBindings) UpdateIamRoleBindings(accountId string, actorId stri
 	}
 	iamModels, res, err := iamClient.ApiAccountsIdIamPut(ctx, accountId).Body(updateRequest).Execute()
 	if err != nil && res.StatusCode != status.StatusOK {
-		return nil, fmt.Errorf("Error when calling `ApiAccountsIdIamPost`: %v\n.Full HTTP response: %v", err, res)
+		return nil, fmt.Errorf("Error when calling `ApiAccountsIdIamPut`: %v\n.Full HTTP response: %v", err, res)
 	}
+	log.InfoD("Successfully updated the IAM Roles")
 	return iamModels, nil
 }
 
@@ -85,13 +87,13 @@ func (iam *IamRoleBindings) GetIamRoleBindingByID(iamId string, actorId string) 
 }
 
 // DeleteIamRoleBinding delete IAM RoleBinding and return status.
-func (iam *IamRoleBindings) DeleteIamRoleBinding(iamId string, actorId string) (*status.Response, error) {
+func (iam *IamRoleBindings) DeleteIamRoleBinding(accountId string, actorId string) (*status.Response, error) {
 	iamClient := iam.apiClient.IAMApi
 	ctx, err := GetContext()
 	if err != nil {
 		return nil, fmt.Errorf("Error in getting context for api call: %v\n", err)
 	}
-	res, err := iamClient.ApiAccountsIdIamActorIdDelete(ctx, iamId, actorId).Execute()
+	res, err := iamClient.ApiAccountsIdIamActorIdDelete(ctx, accountId, actorId).Execute()
 	if err != nil && res.StatusCode != status.StatusOK {
 		return nil, fmt.Errorf("Error when calling `ApiAccountsIdIamActorIdDelete`: %v\n.Full HTTP response: %v", err, res)
 	}

--- a/drivers/pds/api/serviceIdentity.go
+++ b/drivers/pds/api/serviceIdentity.go
@@ -87,7 +87,6 @@ func (si *ServiceIdentity) GenerateServiceIdentityToken(clientId string, clientT
 		return "", fmt.Errorf("Error in getting context for api call: %v\n", err)
 	}
 	siModel, res, err := siClient.ServiceIdentityGenerateTokenPost(ctx).Body(createRequest).Execute()
-	log.InfoD("resp status is - %v and resp body is- %v", res.StatusCode, res.Body)
 	if err != nil && res.StatusCode != status.StatusOK {
 		return "", fmt.Errorf("Error when calling `ServiceIdentityGenerateTokenPost`: %v\n.Full HTTP response: %v", err, res)
 	}
@@ -119,7 +118,7 @@ func (si *ServiceIdentity) CreateIAMRoleBindingsWithSi(actorID string, accountID
 	if err != nil {
 		return nil, fmt.Errorf("error generating service identity token for serviceId- %v", iamModels.Id)
 	}
-	SiToken = siToken
+	//SiToken = siToken
 	return iamModels, nil
 }
 
@@ -141,4 +140,20 @@ func (si *ServiceIdentity) CreateAndGetServiceIdentityToken(accountID string) (s
 
 func (si *ServiceIdentity) ReturnServiceIdToken() string {
 	return SiToken
+}
+func (si *ServiceIdentity) GenerateServiceTokenAndSetAuthContext(actorId string) (string, error) {
+
+	tokenModel, err := si.GetServiceIdentityToken(actorId)
+	if err != nil {
+		return "", fmt.Errorf("error while regenarting and fetching clientid and client token %v", actorId)
+	}
+	newClient := tokenModel.GetClientId()
+	newClientToken := tokenModel.GetClientToken()
+	regeneratedToken, err := si.GenerateServiceIdentityToken(newClient, newClientToken)
+	if err != nil {
+		return "", fmt.Errorf("error while regenarting and fetching new Si token %v", actorId)
+	}
+	SiToken = regeneratedToken
+	log.InfoD("Successfully Generated the SiToken- [%v] for ActorId- [%v]", SiToken, actorId)
+	return regeneratedToken, nil
 }

--- a/drivers/pds/parameters/parameters_utils.go
+++ b/drivers/pds/parameters/parameters_utils.go
@@ -136,7 +136,11 @@ func (customparams *Customparams) ReturnServiceIdToken() string {
 func (Customparams *Customparams) SetParamsForServiceIdentityTest(params *Parameter, value bool) (bool, error) {
 	params.InfraToTest.ServiceIdentityToken = value
 	json.Marshal(params)
-	ServiceIdFlag = true
+	if value == true {
+		ServiceIdFlag = true
+	} else {
+		ServiceIdFlag = false
+	}
 	log.InfoD("Successfully updated Infra params for ServiceIdentity and RBAC test")
 	log.InfoD("ServiceIdentity flag is set to- %v", ServiceIdFlag)
 	return true, nil

--- a/drivers/pds/parameters/pds_default_parameters.json
+++ b/drivers/pds/parameters/pds_default_parameters.json
@@ -2,10 +2,10 @@
   "DataServiceToTest": [
     {
       "Name": "PostgreSQL",
-      "Version": "14.6",
-      "Image": "37490df",
-      "Replicas": 3,
-      "ScaleReplicas": 6,
+      "Version": "15.3",
+      "Image": "64f33ae",
+      "Replicas": 1,
+      "ScaleReplicas": 2,
       "OldVersion": "14.4",
       "OldImage": "b64d741"
     },
@@ -100,11 +100,15 @@
     "PDSNamespace": "pds-system",
     "ServiceIdentityToken": false
   },
-  "CleanUpParams": {
-    "AppTemplatePrefix": ["integration-test"],
-    "ResourceTemplatePrefix": ["integration-test"],
-    "StorageTemplatePrefix": ["integration-test"],
-    "SkipTargetClusterCheck": true
+  "LoadGen": {
+    "LoadGenDepName": "workload",
+    "FailOnError": "false",
+    "Mode": "write",
+    "TableName": "wltesting",
+    "NumOfRows": "100",
+    "Iterations": "1",
+    "Timeout": "120s",
+    "Replicas": 1
   },
   "ResiliencyTest": {
     "CheckTillReplica": 1

--- a/drivers/pds/pdsrestore/restore_utils.go
+++ b/drivers/pds/pdsrestore/restore_utils.go
@@ -146,14 +146,14 @@ func (restoreClient *RestoreClient) getNameSpaceId(pdsClusterId string) (string,
 	return randomName, nsId, nil
 }
 func (restoreClient *RestoreClient) getNameSpaceIdCustomNs(pdsClusterId string, nsName string) (string, string, error) {
-	nsId, err := restoreClient.RestoreTargetCluster.GetnameSpaceID(nsName, pdsClusterId)
+	nsName, nsId, err := restoreClient.getNameSpaceId(pdsClusterId)
 	if err != nil {
 		return "", "", fmt.Errorf("unable to fetch  %v", nsName)
 	}
 	return nsName, nsId, nil
 }
 
-func (restoreClient *RestoreClient) GetNameSpaceNameToRestore(backupJobId string, pdsRestoreTargetClusterID string, namespace string, isRestoreInSameNS bool) (string, error) {
+func (restoreClient *RestoreClient) GetNameSpaceNameToRestore(backupJobId string, pdsRestoreTargetClusterID string, namespace string, isRestoreInSameNS bool) (string, string, error) {
 	var bkpJob *pds.ModelsBackupJob
 	var nsName string
 	var pdsNamespaceId string
@@ -162,17 +162,17 @@ func (restoreClient *RestoreClient) GetNameSpaceNameToRestore(backupJobId string
 		log.InfoD("I AM HERE")
 		nsName, pdsNamespaceId, err = restoreClient.getNameSpaceIdCustomNs(pdsRestoreTargetClusterID, namespace)
 		if err != nil {
-			return "", err
+			return "", "", nil
 		}
 	} else {
 		bkpJob, err = restoreClient.Components.BackupJob.GetBackupJob(backupJobId)
 		if err != nil {
-			return "", err
+			return "", "", nil
 		}
 		nsName, pdsNamespaceId = namespace, bkpJob.GetNamespaceId()
 	}
 	log.Infof("backup Job - %v,Restore Target Cluster Id - %v, NamespaceId - %v", backupJobId, pdsRestoreTargetClusterID, pdsNamespaceId)
-	return nsName, nil
+	return nsName, pdsNamespaceId, nil
 }
 
 func (restoreClient *RestoreClient) ValidateRestore(bkpDsEntity, restoreDsEntity DSEntity) error {

--- a/drivers/pds/pdsrestore/restore_utils.go
+++ b/drivers/pds/pdsrestore/restore_utils.go
@@ -115,6 +115,24 @@ func (restoreClient *RestoreClient) WaitForRestoreAndValidate(restoredModel *pds
 	return nil
 }
 
+func (restoreClient *RestoreClient) RestoreDataServiceWithRbac(pdsRestoreTargetClusterID string, backupJobId string, namespace string, bkpDsEntity DSEntity, pdsNamespaceId string, validate bool) (*pds.ModelsRestore, error) {
+
+	restoredModel, err := restoreClient.Components.Restore.RestoreToNewDeployment(backupJobId, "autom-res", pdsRestoreTargetClusterID, pdsNamespaceId)
+	if err != nil {
+		log.Errorf("Failed during restore.")
+		return nil, fmt.Errorf("failed during restore")
+	}
+
+	if validate {
+		err = restoreClient.WaitForRestoreAndValidate(restoredModel, bkpDsEntity, namespace)
+		if err != nil {
+			log.Errorf("Failed to validate restored dataservice")
+			return nil, fmt.Errorf("failed to validate restored dataservice")
+		}
+	}
+	return restoredModel, nil
+}
+
 func (restoreClient *RestoreClient) getNameSpaceId(pdsClusterId string) (string, string, error) {
 	randomName := generateRandomName("restore")
 	_, err := restoreClient.RestoreTargetCluster.CreateNamespace(randomName)
@@ -126,6 +144,35 @@ func (restoreClient *RestoreClient) getNameSpaceId(pdsClusterId string) (string,
 		return "", "", fmt.Errorf("unable to fetch  %v", randomName)
 	}
 	return randomName, nsId, nil
+}
+func (restoreClient *RestoreClient) getNameSpaceIdCustomNs(pdsClusterId string, nsName string) (string, string, error) {
+	nsId, err := restoreClient.RestoreTargetCluster.GetnameSpaceID(nsName, pdsClusterId)
+	if err != nil {
+		return "", "", fmt.Errorf("unable to fetch  %v", nsName)
+	}
+	return nsName, nsId, nil
+}
+
+func (restoreClient *RestoreClient) GetNameSpaceNameToRestore(backupJobId string, pdsRestoreTargetClusterID string, namespace string, isRestoreInSameNS bool) (string, error) {
+	var bkpJob *pds.ModelsBackupJob
+	var nsName string
+	var pdsNamespaceId string
+	var err error
+	if !isRestoreInSameNS {
+		log.InfoD("I AM HERE")
+		nsName, pdsNamespaceId, err = restoreClient.getNameSpaceIdCustomNs(pdsRestoreTargetClusterID, namespace)
+		if err != nil {
+			return "", err
+		}
+	} else {
+		bkpJob, err = restoreClient.Components.BackupJob.GetBackupJob(backupJobId)
+		if err != nil {
+			return "", err
+		}
+		nsName, pdsNamespaceId = namespace, bkpJob.GetNamespaceId()
+	}
+	log.Infof("backup Job - %v,Restore Target Cluster Id - %v, NamespaceId - %v", backupJobId, pdsRestoreTargetClusterID, pdsNamespaceId)
+	return nsName, nil
 }
 
 func (restoreClient *RestoreClient) ValidateRestore(bkpDsEntity, restoreDsEntity DSEntity) error {

--- a/drivers/pds/targetcluster/targetcluster.go
+++ b/drivers/pds/targetcluster/targetcluster.go
@@ -337,6 +337,18 @@ func (targetCluster *TargetCluster) GetClusterID() (string, error) {
 	return output, nil
 }
 
+// GetClusterID of target cluster.
+func (targetCluster *TargetCluster) GetClusterIDFromKubePath(kubePath string) (string, error) {
+	log.Infof("Fetch Cluster id ")
+	cmd := fmt.Sprintf("kubectl get ns kube-system -o jsonpath={.metadata.uid} --kubeconfig %s", kubePath)
+	output, _, err := osutils.ExecShell(cmd)
+	if err != nil {
+		log.Error(err)
+		return "Unable to fetch the cluster ID.", err
+	}
+	return output, nil
+}
+
 // SetConfig sets kubeconfig for the target cluster
 func (targetCluster *TargetCluster) SetConfig() error {
 	var config *rest.Config

--- a/tests/pds/pds_common.go
+++ b/tests/pds/pds_common.go
@@ -139,12 +139,12 @@ var (
 var dataServiceDeploymentWorkloads = []string{cassandra, elasticSearch, postgresql, consul, mysql}
 var dataServicePodWorkloads = []string{redis, rabbitmq, couchbase}
 
-func DeployandValidateDataServicesWithSiAndTls(ds PDSDataService, namespaceName string, namespaceid, projectID string, resourceTemplateID string, appConfigID string, dsVersion string, dsImage string, dsID string) (*pds.ModelsDeployment, map[string][]string, map[string][]string, error) {
+func DeployandValidateDataServicesWithSiAndTls(ds PDSDataService, namespaceName string, namespaceid, projectID string, resourceTemplateID string, appConfigID string, dsVersion string, dsImage string, dsID string, enableTls bool) (*pds.ModelsDeployment, map[string][]string, map[string][]string, error) {
 
 	log.InfoD("Data Service Deployment Triggered")
 	log.InfoD("Deploying ds in namespace %v and servicetype is %v", namespaceName, serviceType)
 
-	deployment, dataServiceImageMap, dataServiceVersionBuildMap, err := dsWithRbac.TriggerDeployDSWithSiAndTls(dataservices.PDSDataService(ds), namespaceName, projectID, true, resourceTemplateID, appConfigID, namespaceid, dsVersion, dsImage, dsID, dataservices.TestParams(TestParams{StorageTemplateId: storageTemplateID, DeploymentTargetId: deploymentTargetID, DnsZone: dnsZone, ServiceType: serviceType}))
+	deployment, dataServiceImageMap, dataServiceVersionBuildMap, err := dsWithRbac.TriggerDeployDSWithSiAndTls(dataservices.PDSDataService(ds), namespaceName, projectID, enableTls, resourceTemplateID, appConfigID, namespaceid, dsVersion, dsImage, dsID, dataservices.TestParams(TestParams{StorageTemplateId: storageTemplateID, DeploymentTargetId: deploymentTargetID, DnsZone: dnsZone, ServiceType: serviceType}))
 	log.FailOnError(err, "Error occured while deploying data service %s", ds.Name)
 
 	Step("Validate Data Service Deployments", func() {
@@ -421,11 +421,11 @@ func GetReplicaNodes(appVolume *volume.Volume) ([]string, []string, error) {
 func CleanupServiceIdentitiesAndIamRoles(siToBeCleaned []string, iamRolesToBeCleaned []string, actorID string) {
 	log.InfoD("Starting to delete the Iam Roles first...")
 	for _, iam := range iamRolesToBeCleaned {
-		resp, err := components.IamRoleBindings.DeleteIamRoleBinding(iam, actorID)
+		resp, err := components.IamRoleBindings.DeleteIamRoleBinding(accountID, actorID)
 		if err != nil {
 			log.FailOnError(err, "Error while deleting IamRoles")
 		}
-		log.InfoD("Successfully deleted IAMRoles- %v", resp.StatusCode)
+		log.InfoD("Successfully deleted IAMRoles with ID- %v and ResponseStatus is- %v", iam, resp.StatusCode)
 	}
 	log.InfoD("Starting to delete the Service Identities...")
 	for _, si := range siToBeCleaned {

--- a/tests/pds/pds_ds_rbac_test.go
+++ b/tests/pds/pds_ds_rbac_test.go
@@ -55,6 +55,7 @@ var _ = Describe("{ServiceIdentityNsLevel}", func() {
 			nsID1                  []string
 			nsID2                  []string
 			serviceIdentityID      string
+			pdsRestoreNsName       string
 		)
 
 		Step("Deploy Data Services", func() {
@@ -150,7 +151,7 @@ var _ = Describe("{ServiceIdentityNsLevel}", func() {
 
 					for _, backupJob := range backupJobs {
 						log.Infof("[Restoring] Details Backup job name- %v, Id- %v", backupJob.GetName(), backupJob.GetId())
-						pdsRestoreNsName, err := restoreClient.GetNameSpaceNameToRestore(backupJob.GetId(), pdsRestoreTargetClusterID, ns2.Name, false)
+						pdsRestoreNsName, _, err = restoreClient.GetNameSpaceNameToRestore(backupJob.GetId(), pdsRestoreTargetClusterID, ns2.Name, false)
 						log.FailOnError(err, "unable to fetch namespace id to restore")
 						components.ServiceIdentity.GenerateServiceTokenAndSetAuthContext(actorId)
 						customParams.SetParamsForServiceIdentityTest(params, true)
@@ -190,7 +191,7 @@ var _ = Describe("{ServiceIdentityNsLevel}", func() {
 
 					for _, backupJob := range backupJobs {
 						log.Infof("[Restoring] Details Backup job name- %v, Id- %v", backupJob.GetName(), backupJob.GetId())
-						pdsRestoreNsName, err := restoreClient.GetNameSpaceNameToRestore(backupJob.GetId(), pdsRestoreTargetClusterID, ns2.Name, false)
+						pdsRestoreNsName, _, err = restoreClient.GetNameSpaceNameToRestore(backupJob.GetId(), pdsRestoreTargetClusterID, ns2.Name, false)
 						log.FailOnError(err, "unable to fetch namespace id to restore")
 						components.ServiceIdentity.GenerateServiceTokenAndSetAuthContext(actorId)
 						customParams.SetParamsForServiceIdentityTest(params, true)
@@ -239,7 +240,6 @@ var _ = Describe("{ServiceIdentityNsLevel}", func() {
 				Step("Delete Deployments", func() {
 					CleanupDeployments(deploymentsToBeCleaned)
 					CleanupServiceIdentitiesAndIamRoles(siToBeCleaned, iamRolesToBeCleaned, actorId)
-					customParams.SetParamsForServiceIdentityTest(params, false)
 				})
 			}
 		})
@@ -298,6 +298,7 @@ var _ = Describe("{ServiceIdentityTargetClusterLevel}", func() {
 			serviceIdentityIDSrc           string
 			serviceIdentityIDDesti         string
 			destinationTargetID            string
+			pdsRestoreNsName               string
 		)
 
 		Step("Deploy Data Services", func() {
@@ -421,7 +422,7 @@ var _ = Describe("{ServiceIdentityTargetClusterLevel}", func() {
 					err = SetDestinationKubeConfig()
 					for _, backupJob := range backupJobs {
 						log.Infof("[Restoring] Details Backup job name- %v, Id- %v", backupJob.GetName(), backupJob.GetId())
-						pdsRestoreNsName, err := restoreClient.GetNameSpaceNameToRestore(backupJob.GetId(), destinationTargetID, namespaceName, true)
+						pdsRestoreNsName, _, err = restoreClient.GetNameSpaceNameToRestore(backupJob.GetId(), destinationTargetID, namespaceName, true)
 						log.FailOnError(err, "unable to fetch namespace id to restore")
 						components.ServiceIdentity.GenerateServiceTokenAndSetAuthContext(actorId1)
 						customParams.SetParamsForServiceIdentityTest(params, true)
@@ -462,7 +463,7 @@ var _ = Describe("{ServiceIdentityTargetClusterLevel}", func() {
 					err = SetDestinationKubeConfig()
 					for _, backupJob := range backupJobs {
 						log.Infof("[Restoring] Details Backup job name- %v, Id- %v", backupJob.GetName(), backupJob.GetId())
-						pdsRestoreNsName, err := restoreClient.GetNameSpaceNameToRestore(backupJob.GetId(), destinationTargetID, namespaceName, true)
+						pdsRestoreNsName, _, err = restoreClient.GetNameSpaceNameToRestore(backupJob.GetId(), destinationTargetID, namespaceName, true)
 						log.FailOnError(err, "unable to fetch namespace id to restore")
 						components.ServiceIdentity.GenerateServiceTokenAndSetAuthContext(actorId2)
 						customParams.SetParamsForServiceIdentityTest(params, true)
@@ -499,7 +500,7 @@ var _ = Describe("{ServiceIdentityTargetClusterLevel}", func() {
 					log.FailOnError(err, "Error while fetching the backup jobs for the deployment: %v", deployment.GetClusterResourceName())
 					for _, backupJob := range backupJobs {
 						log.Infof("[Restoring] Details Backup job name- %v, Id- %v", backupJob.GetName(), backupJob.GetId())
-						pdsRestoreNsName, err := restoreClient.GetNameSpaceNameToRestore(backupJob.GetId(), destinationTargetID, namespaceName, true)
+						pdsRestoreNsName, _, err = restoreClient.GetNameSpaceNameToRestore(backupJob.GetId(), destinationTargetID, namespaceName, true)
 						log.FailOnError(err, "unable to fetch namespace id to restore")
 						components.ServiceIdentity.GenerateServiceTokenAndSetAuthContext(actorId2)
 						customParams.SetParamsForServiceIdentityTest(params, true)
@@ -553,7 +554,7 @@ var _ = Describe("{ServiceIdentityTargetClusterLevel}", func() {
 					err = SetDestinationKubeConfig()
 					for _, backupJob := range backupJobs {
 						log.Infof("[Restoring] Details Backup job name- %v, Id- %v", backupJob.GetName(), backupJob.GetId())
-						pdsRestoreNsName, err := restoreClient.GetNameSpaceNameToRestore(backupJob.GetId(), destinationTargetID, namespaceName, true)
+						pdsRestoreNsName, _, err = restoreClient.GetNameSpaceNameToRestore(backupJob.GetId(), destinationTargetID, namespaceName, true)
 						log.FailOnError(err, "unable to fetch namespace id to restore")
 						components.ServiceIdentity.GenerateServiceTokenAndSetAuthContext(actorId2)
 						customParams.SetParamsForServiceIdentityTest(params, true)
@@ -630,7 +631,8 @@ var _ = Describe("{ServiceIdentitySiDLevel}", func() {
 			nsID1                  []string
 			nsID2                  []string
 			resDepNamespaceID      []string
-			resDepNamespaceName    string
+			pdsRestoreNsName       string
+			pdsRestoreNsId         string
 			serviceIdentityID2     string
 		)
 
@@ -665,7 +667,6 @@ var _ = Describe("{ServiceIdentitySiDLevel}", func() {
 				actorId1, iamId1, err := pdslib.CreateSiAndIamRoleBindings(accountID, nsAdminRoles)
 				log.FailOnError(err, "Error while creating and fetching IAM Roles")
 				log.InfoD("Successfully created ServiceIdentity- %v and IAM Roles- %v ", actorId1, iamId1)
-				iamRolesToBeCleaned = append(iamRolesToBeCleaned, iamId1)
 
 				actorId2, iamId2, err := pdslib.CreateSiAndIamRoleBindings(accountID, nsReaderRoles)
 				log.FailOnError(err, "Error while creating and fetching IAM Roles")
@@ -740,7 +741,7 @@ var _ = Describe("{ServiceIdentitySiDLevel}", func() {
 
 				Step("Perform restore for the backup jobs to diff namespace with general token", func() {
 					ctx, err := GetSourceClusterConfigPath()
-					log.FailOnError(err, "failed while getting src cluster path")
+					log.FailOnError(err, "failed while getting dest cluster path")
 					restoreTarget := tc.NewTargetCluster(ctx)
 					restoreClient := restoreBkp.RestoreClient{
 						TenantId:             tenantID,
@@ -749,17 +750,21 @@ var _ = Describe("{ServiceIdentitySiDLevel}", func() {
 						Deployment:           deployment,
 						RestoreTargetCluster: restoreTarget,
 					}
+					// ListBackupJobsBelongToDeployment will be changed after BUG: DS-6679 will be fixed
+
 					backupJobs, err := restoreClient.Components.BackupJob.ListBackupJobsBelongToDeployment(projectID, deployment.GetId())
 					log.FailOnError(err, "Error while fetching the backup jobs for the deployment: %v", deployment.GetClusterResourceName())
 					for _, backupJob := range backupJobs {
 						log.Infof("[Restoring] Details Backup job name- %v, Id- %v", backupJob.GetName(), backupJob.GetId())
-						restoredModel, err := restoreClient.TriggerAndValidateRestore(backupJob.GetId(), params.InfraToTest.Namespace, dsEntity, false, true)
+						pdsRestoreNsName, pdsRestoreNsId, err = restoreClient.GetNameSpaceNameToRestore(backupJob.GetId(), deploymentTargetID, ns1.Name, false)
+						log.FailOnError(err, "unable to fetch namespace id to restore")
+						resDepNamespaceID = append(resDepNamespaceID, pdsRestoreNsId)
+						components.ServiceIdentity.GenerateServiceTokenAndSetAuthContext(actorId2)
+						restoredModel, _ := restoreClient.RestoreDataServiceWithRbac(deploymentTargetID, backupJob.GetId(), pdsRestoreNsName, dsEntity, pdsRestoreNsId, true)
 						log.FailOnError(err, "Failed during restore.")
 						restoredDeployment, err = restoreClient.Components.DataServiceDeployment.GetDeployment(restoredModel.GetDeploymentId())
-						resDepNamespaceID = append(resDepNamespaceID, *restoredDeployment.NamespaceId)
-						log.FailOnError(err, fmt.Sprintf("Failed while fetching the restore data service instance: %v", restoredModel.GetClusterResourceName()))
 						resDeployments[ds] = restoredDeployment
-						restoredDeployments = append(restoredDeployments, restoredDeployment)
+						log.FailOnError(err, fmt.Sprintf("Failed while fetching the restore data service instance: %v", restoredModel.GetClusterResourceName()))
 						deploymentsToBeCleaned = append(deploymentsToBeCleaned, restoredDeployment)
 						log.InfoD("Restored successfully. Details: Deployment- %v, Status - %v", restoredModel.GetClusterResourceName(), restoredModel.GetStatus())
 					}
@@ -786,7 +791,6 @@ var _ = Describe("{ServiceIdentitySiDLevel}", func() {
 				Step("Scale up the restored deployments with updated IAM2 Sitoken", func() {
 					log.InfoD("Starting to scale up the restore deployment")
 					for rds, resDep := range resDeployments {
-						resDepNamespaceName = *resDep.Namespace.Name
 						customParams.SetParamsForServiceIdentityTest(params, false)
 						log.InfoD("Scaling up DataService %v ", rds.Name)
 						dataServiceDefaultAppConfigID, err = controlPlane.GetAppConfTemplate(tenantID, rds.Name)
@@ -802,13 +806,13 @@ var _ = Describe("{ServiceIdentitySiDLevel}", func() {
 
 						updatedDeployment, err := pdslib.UpdateDataServices(resDep.GetId(),
 							dataServiceDefaultAppConfigID, deployment.GetImageId(),
-							int32(ds.ScaleReplicas), dataServiceDefaultResourceTemplateID, resDepNamespaceName)
+							int32(ds.ScaleReplicas), dataServiceDefaultResourceTemplateID, pdsRestoreNsName)
 						log.FailOnError(err, "Error while updating dataservices")
 						customParams.SetParamsForServiceIdentityTest(params, false)
-						log.InfoD("PDS RESTORE NAMESPACE IS- %v", resDepNamespaceName)
-						err = dsTest.ValidateDataServiceDeployment(updatedDeployment, resDepNamespaceName)
+						log.InfoD("PDS RESTORE NAMESPACE IS- %v", pdsRestoreNsName)
+						err = dsTest.ValidateDataServiceDeployment(updatedDeployment, pdsRestoreNsName)
 						log.FailOnError(err, "Error while validating data service deployment")
-						_, _, config, err := pdslib.ValidateDataServiceVolumes(updatedDeployment, *resDep.Name, dataServiceDefaultResourceTemplateID, storageTemplateID, resDepNamespaceName)
+						_, _, config, err := pdslib.ValidateDataServiceVolumes(updatedDeployment, *resDep.Name, dataServiceDefaultResourceTemplateID, storageTemplateID, pdsRestoreNsName)
 						log.FailOnError(err, "error on ValidateDataServiceVolumes method")
 						dash.VerifyFatal(int32(ds.ScaleReplicas), config.Spec.Nodes, "Validating replicas after scaling up of dataservice")
 					}
@@ -841,7 +845,6 @@ var _ = Describe("{ServiceIdentitySiDLevel}", func() {
 					log.FailOnError(err, "Error while fetching the backup jobs for the deployment: %v", restoredDeployment.GetClusterResourceName())
 					for _, backupJob := range backupJobs {
 						log.Infof("[Restoring] Details Backup job name- %v, Id- %v", backupJob.GetName(), backupJob.GetId())
-						pdsRestoreNsName, err := restoreClient.GetNameSpaceNameToRestore(backupJob.GetId(), deploymentTargetID, resDepNamespaceName, true)
 						log.FailOnError(err, "unable to fetch namespace id to restore")
 						customParams.SetParamsForServiceIdentityTest(params, true)
 						restoredModel, _ := restoreClient.RestoreDataServiceWithRbac(deploymentTargetID, backupJob.GetId(), pdsRestoreNsName, dsEntity, resDepNamespaceID[0], true)

--- a/tests/pds/pds_ds_rbac_test.go
+++ b/tests/pds/pds_ds_rbac_test.go
@@ -11,12 +11,14 @@ import (
 	tc "github.com/portworx/torpedo/drivers/pds/targetcluster"
 	"github.com/portworx/torpedo/pkg/log"
 	. "github.com/portworx/torpedo/tests"
+	"math/rand"
+	"strconv"
 )
 
 var _ = Describe("{ServiceIdentityNsLevel}", func() {
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("ServiceIdentityForNsLevel", "Create and Update Service Identity with N namespaces with different roles ", pdsLabels, 0)
+		StartTorpedoTest("ServiceIdentityNsLevel", "Create and Update Service Identity with N namespaces with different roles ", pdsLabels, 0)
 		bkpClient, err = pdsbkp.InitializePdsBackup()
 		log.FailOnError(err, "Failed to initialize backup for pds.")
 		bkpTarget, err = bkpClient.CreateAwsS3BackupCredsAndTarget(tenantID, fmt.Sprintf("%v-aws", bkpTargetName), deploymentTargetID)
@@ -64,19 +66,19 @@ var _ = Describe("{ServiceIdentityNsLevel}", func() {
 					log.InfoD("Data service: %v doesn't support backup, skipping...", ds.Name)
 					continue
 				}
-				ns1, err := pdslib.CreatePdsLabeledNamespaces()
+				ns1, _, err := targetCluster.CreatePDSNamespace("ns1-" + strconv.Itoa(rand.Int()))
 				log.FailOnError(err, "Error while creating namespace")
 				log.InfoD("Successfully created namespace with PDS Label %v ", ns1)
-				ns1Id1, err := targetCluster.GetnameSpaceID(ns1, deploymentTargetID)
+				ns1Id1, err := targetCluster.GetnameSpaceID(ns1.Name, deploymentTargetID)
 				nsID1 = append(nsID1, ns1Id1)
 				log.FailOnError(err, "Error while fetching namespaceID")
 				log.InfoD("NamespaceID1 fetched is %v ", nsID1)
 				ns1RoleName := "namespace-admin"
 
-				ns2, err := pdslib.CreatePdsLabeledNamespaces()
+				ns2, _, err := targetCluster.CreatePDSNamespace("ns2-" + strconv.Itoa(rand.Int()))
 				log.FailOnError(err, "Error while creating namespace")
 				log.InfoD("Successfully created namespace with PDS Label %v ", ns2)
-				ns2Id2, err := targetCluster.GetnameSpaceID(ns2, deploymentTargetID)
+				ns2Id2, err := targetCluster.GetnameSpaceID(ns2.Name, deploymentTargetID)
 				nsID2 = append(nsID2, ns2Id2)
 				log.FailOnError(err, "Error while fetching namespaceID")
 				log.InfoD("NamespaceID2 fetched is %v ", nsID2)
@@ -101,11 +103,12 @@ var _ = Describe("{ServiceIdentityNsLevel}", func() {
 				dsId, err := dsTest.GetDataServiceID(ds.Name)
 				versionId, imageID, err := dsWithRbac.GetDSImageVersionToBeDeployed(false, ds, dsId)
 
+				components.ServiceIdentity.GenerateServiceTokenAndSetAuthContext(actorId)
 				customParams.SetParamsForServiceIdentityTest(params, true)
 				log.InfoD("Successfully updated Infra params for Si test")
 
 				isDeploymentsDeleted = false
-				deployment, _, dataServiceVersionBuildMap, err = DeployandValidateDataServicesWithSiAndTls(ds, ns1, ns1Id1, projectID, resTempId, appConfigId, versionId, imageID, dsId)
+				deployment, _, dataServiceVersionBuildMap, err = DeployandValidateDataServicesWithSiAndTls(ds, ns1.Name, ns1Id1, projectID, resTempId, appConfigId, versionId, imageID, dsId, false)
 				log.FailOnError(err, "Error while deploying data services")
 				deploymentsToBeCleaned = append(deploymentsToBeCleaned, deployment)
 				log.FailOnError(err, "Error while deploying data services")
@@ -139,21 +142,31 @@ var _ = Describe("{ServiceIdentityNsLevel}", func() {
 						Deployment:           deployment,
 						RestoreTargetCluster: restoreTarget,
 					}
+					// ListBackupJobsBelongToDeployment will be changed after BUG: DS-6679 will be fixed
+					customParams.SetParamsForServiceIdentityTest(params, false)
 					backupJobs, err := restoreClient.Components.BackupJob.ListBackupJobsBelongToDeployment(projectID, deployment.GetId())
 					log.FailOnError(err, "Error while fetching the backup jobs for the deployment: %v", deployment.GetClusterResourceName())
+					pdsRestoreTargetClusterID, err := targetCluster.GetDeploymentTargetID(clusterID, tenantID)
+
 					for _, backupJob := range backupJobs {
 						log.Infof("[Restoring] Details Backup job name- %v, Id- %v", backupJob.GetName(), backupJob.GetId())
-						restoredModel, _ := restoreClient.TriggerAndValidateRestore(backupJob.GetId(), ns2, dsEntity, false, false)
-						log.InfoD("Failed to trigger restore for - %v", restoredModel.Name)
-						log.InfoD("Restore is failed as expected.")
-						deploymentsToBeCleaned = append(deploymentsToBeCleaned)
+						pdsRestoreNsName, err := restoreClient.GetNameSpaceNameToRestore(backupJob.GetId(), pdsRestoreTargetClusterID, ns2.Name, false)
+						log.FailOnError(err, "unable to fetch namespace id to restore")
+						components.ServiceIdentity.GenerateServiceTokenAndSetAuthContext(actorId)
+						customParams.SetParamsForServiceIdentityTest(params, true)
+						_, err = restoreClient.RestoreDataServiceWithRbac(pdsRestoreTargetClusterID, backupJob.GetId(), pdsRestoreNsName, dsEntity, ns2Id2, false)
+						dash.VerifyFatal(err != nil, true, "Restore is failed as expected")
+
 					}
 				})
-				//ToDo: Testing is blocked from here because of bug-
+
 				Step("Update IAM Role with ns2 as namespace-admin role", func() {
-					ns2RoleName = "namespace-admin"
-					binding2.RoleName = &ns2RoleName
-					nsRoles = append(nsRoles, binding1, binding2)
+					nsRoles = nil
+					customParams.SetParamsForServiceIdentityTest(params, false)
+					newns2RoleName := "namespace-admin"
+					binding2.ResourceIds = nsID2
+					binding2.RoleName = &newns2RoleName
+					nsRoles := append(nsRoles, binding1, binding2)
 					log.InfoD("Starting to update the IAM Roles for ns2")
 					_, err := components.IamRoleBindings.UpdateIamRoleBindings(accountID, serviceIdentityID, nsRoles)
 					log.FailOnError(err, "Failed while updating IAM Roles for ns2")
@@ -173,9 +186,15 @@ var _ = Describe("{ServiceIdentityNsLevel}", func() {
 					}
 					backupJobs, err := restoreClient.Components.BackupJob.ListBackupJobsBelongToDeployment(projectID, deployment.GetId())
 					log.FailOnError(err, "Error while fetching the backup jobs for the deployment: %v", deployment.GetClusterResourceName())
+					pdsRestoreTargetClusterID, err := targetCluster.GetDeploymentTargetID(clusterID, tenantID)
+
 					for _, backupJob := range backupJobs {
 						log.Infof("[Restoring] Details Backup job name- %v, Id- %v", backupJob.GetName(), backupJob.GetId())
-						restoredModel, _ := restoreClient.TriggerAndValidateRestore(backupJob.GetId(), ns2, dsEntity, false, true)
+						pdsRestoreNsName, err := restoreClient.GetNameSpaceNameToRestore(backupJob.GetId(), pdsRestoreTargetClusterID, ns2.Name, false)
+						log.FailOnError(err, "unable to fetch namespace id to restore")
+						components.ServiceIdentity.GenerateServiceTokenAndSetAuthContext(actorId)
+						customParams.SetParamsForServiceIdentityTest(params, true)
+						restoredModel, _ := restoreClient.RestoreDataServiceWithRbac(pdsRestoreTargetClusterID, backupJob.GetId(), pdsRestoreNsName, dsEntity, ns2Id2, true)
 						log.FailOnError(err, "Failed during restore.")
 						restoredDeployment, err = restoreClient.Components.DataServiceDeployment.GetDeployment(restoredModel.GetDeploymentId())
 						resDeployments[ds] = restoredDeployment
@@ -188,8 +207,8 @@ var _ = Describe("{ServiceIdentityNsLevel}", func() {
 				Step("Scale up the restored deployments on ns2", func() {
 					log.InfoD("Starting to scale up the restore deployment")
 					for ds, resDep := range resDeployments {
-						log.InfoD("Scaling up DataService %v ", ds.Name)
-
+						customParams.SetParamsForServiceIdentityTest(params, false)
+						log.InfoD("Scaling up DataService %v ", &resDep.Name)
 						dataServiceDefaultAppConfigID, err = controlPlane.GetAppConfTemplate(tenantID, ds.Name)
 						log.FailOnError(err, "Error while getting app configuration template")
 						dash.VerifyFatal(dataServiceDefaultAppConfigID != "", true, "Validating dataServiceDefaultAppConfigID")
@@ -198,15 +217,19 @@ var _ = Describe("{ServiceIdentityNsLevel}", func() {
 						log.FailOnError(err, "Error while getting resource setting template")
 						dash.VerifyFatal(dataServiceDefaultAppConfigID != "", true, "Validating dataServiceDefaultAppConfigID")
 
-						updatedDeployment, err := dsTest.UpdateDataServices(deployment.GetId(),
+						components.ServiceIdentity.GenerateServiceTokenAndSetAuthContext(actorId)
+						customParams.SetParamsForServiceIdentityTest(params, true)
+
+						updatedDeployment, err := pdslib.UpdateDataServices(resDep.GetId(),
 							dataServiceDefaultAppConfigID, deployment.GetImageId(),
-							int32(ds.ScaleReplicas), dataServiceDefaultResourceTemplateID, ns2)
+							int32(ds.ScaleReplicas), dataServiceDefaultResourceTemplateID, ns2.Name)
 						log.FailOnError(err, "Error while updating dataservices")
 
-						err = dsTest.ValidateDataServiceDeployment(updatedDeployment, ns2)
+						err = dsTest.ValidateDataServiceDeployment(updatedDeployment, ns2.Name)
 						log.FailOnError(err, "Error while validating data service deployment")
 
-						_, _, config, err := pdslib.ValidateDataServiceVolumes(updatedDeployment, *resDep.Name, dataServiceDefaultResourceTemplateID, storageTemplateID, ns2)
+						customParams.SetParamsForServiceIdentityTest(params, false)
+						_, _, config, err := pdslib.ValidateDataServiceVolumes(updatedDeployment, *resDep.Name, dataServiceDefaultResourceTemplateID, storageTemplateID, ns2.Name)
 						log.FailOnError(err, "error on ValidateDataServiceVolumes method")
 						dash.VerifyFatal(int32(ds.ScaleReplicas), config.Spec.Nodes, "Validating replicas after scaling up of dataservice")
 					}
@@ -218,12 +241,629 @@ var _ = Describe("{ServiceIdentityNsLevel}", func() {
 					CleanupServiceIdentitiesAndIamRoles(siToBeCleaned, iamRolesToBeCleaned, actorId)
 					customParams.SetParamsForServiceIdentityTest(params, false)
 				})
+			}
+		})
+	})
+	JustAfterEach(func() {
+		defer EndTorpedoTest()
+		err := bkpClient.AWSStorageClient.DeleteBucket()
+		log.FailOnError(err, "Failed while deleting the bucket")
+	})
+})
+
+var _ = Describe("{ServiceIdentityTargetClusterLevel}", func() {
+
+	JustBeforeEach(func() {
+		StartTorpedoTest("ServiceIdentityTargetClusterLevel", "Create and Update Service Identity with 2 namespaces on different clusters and perform cross-cluster restore", pdsLabels, 0)
+
+		bkpClient, err = pdsbkp.InitializePdsBackup()
+		log.FailOnError(err, "Failed to initialize backup for pds.")
+		bkpTarget, err = bkpClient.CreateAwsS3BackupCredsAndTarget(tenantID, fmt.Sprintf("%v-aws", bkpTargetName), deploymentTargetID)
+		log.FailOnError(err, "Failed to create S3 backup target1.")
+		log.InfoD("AWS S3 target1 - %v created successfully", bkpTarget.GetName())
+		awsBkpTargets = append(awsBkpTargets, bkpTarget)
+
+		//Initializing the parameters required for workload generation
+		wkloadParams = pdsdriver.LoadGenParams{
+			LoadGenDepName: params.LoadGen.LoadGenDepName,
+			Namespace:      params.InfraToTest.Namespace,
+			NumOfRows:      params.LoadGen.NumOfRows,
+			Timeout:        params.LoadGen.Timeout,
+			Replicas:       params.LoadGen.Replicas,
+			TableName:      params.LoadGen.TableName,
+			Iterations:     params.LoadGen.Iterations,
+			FailOnError:    params.LoadGen.FailOnError,
+		}
+	})
+
+	It("Deploy Dataservices", func() {
+		var (
+			deploymentsToBeCleaned         []*pds.ModelsDeployment
+			restoredDeploymentsToBeCleaned []*pds.ModelsDeployment
+			deployments                    = make(map[PDSDataService]*pds.ModelsDeployment)
+			resDeployments                 = make(map[PDSDataService]*pds.ModelsDeployment)
+			depList                        []*pds.ModelsDeployment
+			deps                           []*pds.ModelsDeployment
+			dsVersions                     = make(map[string]map[string][]string)
+			nsRolesSrc                     []pds.ModelsBinding
+			nsRolesDesti                   []pds.ModelsBinding
+			iamRolesToBeCleanedinSrc       []string
+			siToBeCleanedinSrc             []string
+			iamRolesToBeCleanedinDest      []string
+			siToBeCleanedinDest            []string
+			binding1                       pds.ModelsBinding
+			binding2                       pds.ModelsBinding
+			nsID1                          []string
+			nsID2                          []string
+			serviceIdentityIDSrc           string
+			serviceIdentityIDDesti         string
+			destinationTargetID            string
+		)
+
+		Step("Deploy Data Services", func() {
+			backupSupportedDataServiceNameIDMap, err = bkpClient.GetAllBackupSupportedDataServices()
+			log.FailOnError(err, "Error while fetching the backup supported ds.")
+			log.FailOnError(err, "Failed to fetch destination Target cluster ID")
+			for _, ds := range params.DataServiceToTest {
+				_, supported := backupSupportedDataServiceNameIDMap[ds.Name]
+				if !supported {
+					log.InfoD("Data service: %v doesn't support backup, skipping...", ds.Name)
+					continue
+				}
+				log.InfoD("Create namespace ns1 and assign admin role to it on targetCluster 1")
+
+				log.FailOnError(err, "failed while setting set cluster path")
+
+				srcNS, _, err := targetCluster.CreatePDSNamespace("ns1-" + strconv.Itoa(rand.Int()))
+				namespaceName := srcNS.Name
+				log.FailOnError(err, "Error while creating namespace")
+				log.InfoD("Successfully created source namespace with PDS Label %v ", srcNS)
+				ns1Id1, err := targetCluster.GetnameSpaceID(namespaceName, deploymentTargetID)
+				nsID1 = append(nsID1, ns1Id1)
+				log.FailOnError(err, "Error while fetching namespaceID")
+				log.InfoD("srcNs fetched is %v ", nsID1)
+				ns1RoleName := "namespace-admin"
+
+				binding1.ResourceIds = nsID1
+				binding1.RoleName = &ns1RoleName
+
+				nsRolesSrc = append(nsRolesSrc, binding1)
+
+				actorId1, iamId1, err := pdslib.CreateSiAndIamRoleBindings(accountID, nsRolesSrc)
+				log.FailOnError(err, "Error while creating and fetching IAM Roles")
+				log.InfoD("Successfully created ServiceIdentity- %v and IAM Roles- %v ", actorId1, iamId1)
+				serviceIdentityIDSrc = actorId1
+
+				siToBeCleanedinSrc = append(siToBeCleanedinSrc, actorId1)
+				iamRolesToBeCleanedinSrc = append(iamRolesToBeCleanedinSrc, iamId1)
+
+				log.InfoD("Create namespace ns2 and assign admin role to it on targetCluster 2")
+				log.InfoD("setting source kubeconfig")
+				err = SetDestinationKubeConfig()
+				log.FailOnError(err, "failed while setting set cluster path")
+				destinationConfigPath, err := GetDestinationClusterConfigPath()
+				destinationClusterID, _ := targetCluster.GetClusterIDFromKubePath(destinationConfigPath)
+				destinationTargetID, err = targetCluster.GetDeploymentTargetID(destinationClusterID, tenantID)
+				log.InfoD("Destination cluster Target ID is- %v", destinationTargetID)
+				nsDesti, _, err := targetCluster.CreatePDSNamespace(namespaceName)
+				log.FailOnError(err, "Error while creating namespace")
+				log.InfoD("Successfully created namespace with PDS Label %v ", nsDesti)
+				ns2Id2, err := targetCluster.GetnameSpaceID(namespaceName, destinationTargetID)
+				nsID2 = append(nsID2, ns2Id2)
+				log.FailOnError(err, "Error while fetching namespaceID")
+				log.InfoD("nsDesti fetched is %v ", nsID2)
+				ns2RoleName := "namespace-admin"
+
+				binding2.ResourceIds = nsID2
+				binding2.RoleName = &ns2RoleName
+
+				nsRolesDesti = append(nsRolesDesti, binding2)
+
+				actorId2, iamId2, err := pdslib.CreateSiAndIamRoleBindings(accountID, nsRolesDesti)
+				log.FailOnError(err, "Error while creating and fetching IAM Roles")
+				log.InfoD("Successfully created ServiceIdentity- %v and IAM Roles- %v ", actorId2, iamId2)
+				serviceIdentityIDDesti = actorId2
+
+				siToBeCleanedinDest = append(siToBeCleanedinDest, actorId2)
+				iamRolesToBeCleanedinDest = append(iamRolesToBeCleanedinDest, iamId2)
+
+				log.InfoD("setting source kubeconfig")
+				err = SetSourceKubeConfig()
+				log.FailOnError(err, "failed while setting set cluster path")
+				resTempId, appConfigId, err := dsWithRbac.GetDataServiceDeploymentTemplateIDS(tenantID, ds)
+				log.FailOnError(err, "Error while fetching template and app-config ids")
+
+				log.FailOnError(err, "Error while fetching template and app-config ids")
+				dsId, err := dsTest.GetDataServiceID(ds.Name)
+				versionId, imageID, err := dsWithRbac.GetDSImageVersionToBeDeployed(false, ds, dsId)
+
+				components.ServiceIdentity.GenerateServiceTokenAndSetAuthContext(actorId1)
+				customParams.SetParamsForServiceIdentityTest(params, true)
+				log.InfoD("Successfully updated Infra params for Si test")
+
+				isDeploymentsDeleted = false
+				deployment, _, dataServiceVersionBuildMap, err = DeployandValidateDataServicesWithSiAndTls(ds, namespaceName, ns1Id1, projectID, resTempId, appConfigId, versionId, imageID, dsId, false)
+				log.FailOnError(err, "Error while deploying data services")
+				deploymentsToBeCleaned = append(deploymentsToBeCleaned, deployment)
+				log.FailOnError(err, "Error while deploying data services")
+				deployments[ds] = deployment
+				deps = append(deps, deployment)
+				depList = append(depList, deployment)
+
+				dsEntity = restoreBkp.DSEntity{
+					Deployment: deployment,
+				}
+				dsVersions[ds.Name] = dataServiceVersionBuildMap
+
+				//ToDo : Add workload generation for deps with RBAC roles on ns1
+
+				Step("Perform adhoc backup and validate them", func() {
+
+					log.Infof("Deployment ID: %v, backup target ID: %v", deployment.GetId(), bkpTarget.GetId())
+					err = bkpClient.TriggerAndValidateAdhocBackup(deployment.GetId(), bkpTarget.GetId(), "s3")
+					log.FailOnError(err, "Failed while performing adhoc backup")
+				})
+
+				Step("Perform cross restore with S1 on ns2 of cluster2", func() {
+					log.FailOnError(err, "failed while getting dest cluster path")
+					restoreTarget := tc.NewTargetCluster(destinationConfigPath)
+					restoreClient := restoreBkp.RestoreClient{
+						TenantId:             tenantID,
+						ProjectId:            projectID,
+						Components:           components,
+						Deployment:           deployment,
+						RestoreTargetCluster: restoreTarget,
+					}
+					// ListBackupJobsBelongToDeployment will be changed after BUG: DS-6679 will be fixed
+					customParams.SetParamsForServiceIdentityTest(params, false)
+					backupJobs, err := restoreClient.Components.BackupJob.ListBackupJobsBelongToDeployment(projectID, deployment.GetId())
+					log.FailOnError(err, "Error while fetching the backup jobs for the deployment: %v", deployment.GetClusterResourceName())
+					err = SetDestinationKubeConfig()
+					for _, backupJob := range backupJobs {
+						log.Infof("[Restoring] Details Backup job name- %v, Id- %v", backupJob.GetName(), backupJob.GetId())
+						pdsRestoreNsName, err := restoreClient.GetNameSpaceNameToRestore(backupJob.GetId(), destinationTargetID, namespaceName, true)
+						log.FailOnError(err, "unable to fetch namespace id to restore")
+						components.ServiceIdentity.GenerateServiceTokenAndSetAuthContext(actorId1)
+						customParams.SetParamsForServiceIdentityTest(params, true)
+						_, err = restoreClient.RestoreDataServiceWithRbac(destinationTargetID, backupJob.GetId(), pdsRestoreNsName, dsEntity, ns2Id2, true)
+						dash.VerifyFatal(err != nil, true, "Restore is failed as expected")
+
+					}
+				})
+
+				Step("Update IAM2 with ns1 of cluster1 as reader role", func() {
+					nsRolesDesti = nil
+					var newBinding pds.ModelsBinding
+					customParams.SetParamsForServiceIdentityTest(params, false)
+					newns1RoleName := "namespace-reader"
+					newBinding.ResourceIds = nsID1
+					newBinding.RoleName = &newns1RoleName
+					nsRolesDesti = append(nsRolesDesti, newBinding, binding2)
+					log.InfoD("Starting to update the IAM Roles for ns2")
+					resp, err := components.IamRoleBindings.UpdateIamRoleBindings(accountID, serviceIdentityIDDesti, nsRolesDesti)
+					log.InfoD("Updated IAM role Binding is- %v", resp.AccessPolicy)
+					log.FailOnError(err, "Failed while updating IAM Roles for ns2")
+				})
+
+				Step("Restore ds on ns2 of cluster2 to ns2 using updated ServiceIdentity2 (with ns1 as reader) token", func() {
+					log.FailOnError(err, "failed while getting dest cluster path")
+					restoreTarget := tc.NewTargetCluster(destinationConfigPath)
+					restoreClient := restoreBkp.RestoreClient{
+						TenantId:             tenantID,
+						ProjectId:            projectID,
+						Components:           components,
+						Deployment:           deployment,
+						RestoreTargetCluster: restoreTarget,
+					}
+					// ListBackupJobsBelongToDeployment will be changed after BUG: DS-6679 will be fixed
+
+					backupJobs, err := restoreClient.Components.BackupJob.ListBackupJobsBelongToDeployment(projectID, deployment.GetId())
+					log.FailOnError(err, "Error while fetching the backup jobs for the deployment: %v", deployment.GetClusterResourceName())
+					err = SetDestinationKubeConfig()
+					for _, backupJob := range backupJobs {
+						log.Infof("[Restoring] Details Backup job name- %v, Id- %v", backupJob.GetName(), backupJob.GetId())
+						pdsRestoreNsName, err := restoreClient.GetNameSpaceNameToRestore(backupJob.GetId(), destinationTargetID, namespaceName, true)
+						log.FailOnError(err, "unable to fetch namespace id to restore")
+						components.ServiceIdentity.GenerateServiceTokenAndSetAuthContext(actorId2)
+						customParams.SetParamsForServiceIdentityTest(params, true)
+						_, err = restoreClient.RestoreDataServiceWithRbac(destinationTargetID, backupJob.GetId(), pdsRestoreNsName, dsEntity, ns2Id2, false)
+						dash.VerifyFatal(err != nil, true, "Restore is failed as expected")
+
+					}
+				})
+				Step("Update IAM2 with ns1 of cluster1 as admin role", func() {
+					nsRolesDesti = nil
+					var newBinding2 pds.ModelsBinding
+					customParams.SetParamsForServiceIdentityTest(params, false)
+					newns1RoleName := "namespace-admin"
+					newBinding2.ResourceIds = nsID1
+					newBinding2.RoleName = &newns1RoleName
+					nsRolesDesti = append(nsRolesDesti, newBinding2, binding2)
+					log.InfoD("Starting to update the IAM Roles for ns2")
+					_, err := components.IamRoleBindings.UpdateIamRoleBindings(accountID, serviceIdentityIDDesti, nsRolesDesti)
+					log.FailOnError(err, "Failed while updating IAM Roles for ns2")
+				})
+				Step("Restore ds on ns2 of cluster2 to ns2 using updated ServiceIdentity2 (with ns1 as admin) token", func() {
+					log.FailOnError(err, "failed while getting dest cluster path")
+					restoreTarget := tc.NewTargetCluster(destinationConfigPath)
+					restoreClient := restoreBkp.RestoreClient{
+						TenantId:             tenantID,
+						ProjectId:            projectID,
+						Components:           components,
+						Deployment:           deployment,
+						RestoreTargetCluster: restoreTarget,
+					}
+					// ListBackupJobsBelongToDeployment will be changed after BUG: DS-6679 will be fixed
+
+					backupJobs, err := restoreClient.Components.BackupJob.ListBackupJobsBelongToDeployment(projectID, deployment.GetId())
+					log.FailOnError(err, "Error while fetching the backup jobs for the deployment: %v", deployment.GetClusterResourceName())
+					for _, backupJob := range backupJobs {
+						log.Infof("[Restoring] Details Backup job name- %v, Id- %v", backupJob.GetName(), backupJob.GetId())
+						pdsRestoreNsName, err := restoreClient.GetNameSpaceNameToRestore(backupJob.GetId(), destinationTargetID, namespaceName, true)
+						log.FailOnError(err, "unable to fetch namespace id to restore")
+						components.ServiceIdentity.GenerateServiceTokenAndSetAuthContext(actorId2)
+						customParams.SetParamsForServiceIdentityTest(params, true)
+						restoredModel, _ := restoreClient.RestoreDataServiceWithRbac(destinationTargetID, backupJob.GetId(), pdsRestoreNsName, dsEntity, ns2Id2, true)
+						log.FailOnError(err, "Failed during restore.")
+						restoredDeployment, err = restoreClient.Components.DataServiceDeployment.GetDeployment(restoredModel.GetDeploymentId())
+						resDeployments[ds] = restoredDeployment
+						log.FailOnError(err, fmt.Sprintf("Failed while fetching the restore data service instance: %v", restoredModel.GetClusterResourceName()))
+						restoredDeploymentsToBeCleaned = append(restoredDeploymentsToBeCleaned, restoredDeployment)
+						log.InfoD("Restored successfully. Details: Deployment- %v, Status - %v", restoredModel.GetClusterResourceName(), restoredModel.GetStatus())
+					}
+				})
+
+				//ToDo : Add workload generation for restored-deps with RBAC roles on ns2 of cluster2
+				Step("Perform adhoc backup of restored deployment and validate them", func() {
+					customParams.SetParamsForServiceIdentityTest(params, false)
+					log.Infof("Deployment ID: %v, backup target ID: %v", restoredDeployment.GetId(), bkpTarget.GetId())
+					err = bkpClient.TriggerAndValidateAdhocBackup(restoredDeployment.GetId(), bkpTarget.GetId(), "s3")
+					log.FailOnError(err, "Failed while performing adhoc backup")
+				})
+
+				Step("Update IAM1 with ns1 of cluster2 as admin role", func() {
+					err = SetSourceKubeConfig()
+					nsRolesSrc = nil
+					var newBinding1 pds.ModelsBinding
+					customParams.SetParamsForServiceIdentityTest(params, false)
+					newns1RoleName := "namespace-admin"
+
+					newBinding1.ResourceIds = nsID2
+					newBinding1.RoleName = &newns1RoleName
+					nsRolesSrc = append(nsRolesSrc, newBinding1, binding1)
+					log.InfoD("Starting to update the IAM Roles for ns2")
+					_, err := components.IamRoleBindings.UpdateIamRoleBindings(accountID, serviceIdentityIDSrc, nsRolesSrc)
+					log.FailOnError(err, "Failed while updating IAM Roles for ns2")
+				})
+
+				Step("Restore ds on ns2 of cluster2 to ns2 using updated ServiceIdentity1 (with ns2 as admin) token", func() {
+					log.FailOnError(err, "failed while getting dest cluster path")
+					restoreTarget := tc.NewTargetCluster(destinationConfigPath)
+					restoreClient := restoreBkp.RestoreClient{
+						TenantId:             tenantID,
+						ProjectId:            projectID,
+						Components:           components,
+						Deployment:           deployment,
+						RestoreTargetCluster: restoreTarget,
+					}
+					// ListBackupJobsBelongToDeployment will be changed after BUG: DS-6679 will be fixed
+
+					backupJobs, err := restoreClient.Components.BackupJob.ListBackupJobsBelongToDeployment(projectID, deployment.GetId())
+					log.FailOnError(err, "Error while fetching the backup jobs for the deployment: %v", deployment.GetClusterResourceName())
+					err = SetDestinationKubeConfig()
+					for _, backupJob := range backupJobs {
+						log.Infof("[Restoring] Details Backup job name- %v, Id- %v", backupJob.GetName(), backupJob.GetId())
+						pdsRestoreNsName, err := restoreClient.GetNameSpaceNameToRestore(backupJob.GetId(), destinationTargetID, namespaceName, true)
+						log.FailOnError(err, "unable to fetch namespace id to restore")
+						components.ServiceIdentity.GenerateServiceTokenAndSetAuthContext(actorId2)
+						customParams.SetParamsForServiceIdentityTest(params, true)
+						restoredModel, _ := restoreClient.RestoreDataServiceWithRbac(destinationTargetID, backupJob.GetId(), pdsRestoreNsName, dsEntity, ns2Id2, true)
+						log.FailOnError(err, "Failed during restore.")
+						restoredDeployment, err = restoreClient.Components.DataServiceDeployment.GetDeployment(restoredModel.GetDeploymentId())
+						resDeployments[ds] = restoredDeployment
+						log.FailOnError(err, fmt.Sprintf("Failed while fetching the restore data service instance: %v", restoredModel.GetClusterResourceName()))
+						restoredDeploymentsToBeCleaned = append(restoredDeploymentsToBeCleaned, restoredDeployment)
+						log.InfoD("Restored successfully. Details: Deployment- %v, Status - %v", restoredModel.GetClusterResourceName(), restoredModel.GetStatus())
+					}
+				})
+
+				Step("Delete Deployments", func() {
+					customParams.SetParamsForServiceIdentityTest(params, false)
+					CleanupDeployments(restoredDeploymentsToBeCleaned)
+					CleanupServiceIdentitiesAndIamRoles(siToBeCleanedinDest, iamRolesToBeCleanedinDest, actorId2)
+					err = SetSourceKubeConfig()
+					CleanupDeployments(deploymentsToBeCleaned)
+					CleanupServiceIdentitiesAndIamRoles(siToBeCleanedinSrc, iamRolesToBeCleanedinSrc, actorId1)
+
+				})
 
 			}
 
 		})
-		JustAfterEach(func() {
-			defer EndTorpedoTest()
+
+	})
+	JustAfterEach(func() {
+		defer EndTorpedoTest()
+		err := bkpClient.AWSStorageClient.DeleteBucket()
+		log.FailOnError(err, "Failed while deleting the bucket")
+	})
+})
+
+var _ = Describe("{ServiceIdentitySiDLevel}", func() {
+
+	JustBeforeEach(func() {
+		StartTorpedoTest("ServiceIdentitySiDLevel", "Create and Update N Service Identities with N namespaces with different roles ", pdsLabels, 0)
+		bkpClient, err = pdsbkp.InitializePdsBackup()
+		log.FailOnError(err, "Failed to initialize backup for pds.")
+		bkpTarget, err = bkpClient.CreateAwsS3BackupCredsAndTarget(tenantID, fmt.Sprintf("%v-aws", bkpTargetName), deploymentTargetID)
+		log.FailOnError(err, "Failed to create S3 backup target.")
+		log.InfoD("AWS S3 target - %v created successfully", bkpTarget.GetName())
+		awsBkpTargets = append(awsBkpTargets, bkpTarget)
+
+		//Initializing the parameters required for workload generation
+		wkloadParams = pdsdriver.LoadGenParams{
+			LoadGenDepName: params.LoadGen.LoadGenDepName,
+			Namespace:      params.InfraToTest.Namespace,
+			NumOfRows:      params.LoadGen.NumOfRows,
+			Timeout:        params.LoadGen.Timeout,
+			Replicas:       params.LoadGen.Replicas,
+			TableName:      params.LoadGen.TableName,
+			Iterations:     params.LoadGen.Iterations,
+			FailOnError:    params.LoadGen.FailOnError,
+		}
+	})
+
+	It("Deploy Dataservices", func() {
+		var (
+			deploymentsToBeCleaned []*pds.ModelsDeployment
+			deployments            = make(map[PDSDataService]*pds.ModelsDeployment)
+			resDeployments         = make(map[PDSDataService]*pds.ModelsDeployment)
+			depList                []*pds.ModelsDeployment
+			deps                   []*pds.ModelsDeployment
+			dsVersions             = make(map[string]map[string][]string)
+			nsAdminRoles           []pds.ModelsBinding
+			nsReaderRoles          []pds.ModelsBinding
+			iamRolesToBeCleaned    []string
+			siToBeCleaned          []string
+			bindingReader          pds.ModelsBinding
+			bindingAdmin           pds.ModelsBinding
+			nsID1                  []string
+			nsID2                  []string
+			resDepNamespaceID      []string
+			resDepNamespaceName    string
+			serviceIdentityID2     string
+		)
+
+		Step("Deploy Data Services", func() {
+			backupSupportedDataServiceNameIDMap, err = bkpClient.GetAllBackupSupportedDataServices()
+			log.FailOnError(err, "Error while fetching the backup supported ds.")
+			for _, ds := range params.DataServiceToTest {
+				_, supported := backupSupportedDataServiceNameIDMap[ds.Name]
+				if !supported {
+					log.InfoD("Data service: %v doesn't support backup, skipping...", ds.Name)
+					continue
+				}
+				ns1, _, err := targetCluster.CreatePDSNamespace("ns1-" + strconv.Itoa(rand.Int()))
+				log.FailOnError(err, "Error while creating namespace")
+				log.InfoD("Successfully created namespace with PDS Label %v ", ns1)
+				ns1Id1, err := targetCluster.GetnameSpaceID(ns1.Name, deploymentTargetID)
+				nsID1 = append(nsID1, ns1Id1)
+				log.FailOnError(err, "Error while fetching namespaceID")
+				log.InfoD("NamespaceID1 fetched is %v ", nsID1)
+				nsAdminRole := "namespace-admin"
+				nsReaderRole := "namespace-reader"
+
+				bindingAdmin.ResourceIds = nsID1
+				bindingAdmin.RoleName = &nsAdminRole
+
+				bindingReader.ResourceIds = nsID2
+				bindingReader.RoleName = &nsReaderRole
+
+				nsAdminRoles = append(nsAdminRoles, bindingAdmin)
+				nsReaderRoles = append(nsReaderRoles, bindingReader)
+
+				actorId1, iamId1, err := pdslib.CreateSiAndIamRoleBindings(accountID, nsAdminRoles)
+				log.FailOnError(err, "Error while creating and fetching IAM Roles")
+				log.InfoD("Successfully created ServiceIdentity- %v and IAM Roles- %v ", actorId1, iamId1)
+				iamRolesToBeCleaned = append(iamRolesToBeCleaned, iamId1)
+
+				actorId2, iamId2, err := pdslib.CreateSiAndIamRoleBindings(accountID, nsReaderRoles)
+				log.FailOnError(err, "Error while creating and fetching IAM Roles")
+				log.InfoD("Successfully created ServiceIdentity- %v and IAM Roles- %v ", actorId2, iamId2)
+				serviceIdentityID2 = actorId2
+				siToBeCleaned = append(siToBeCleaned, serviceIdentityID2)
+				iamRolesToBeCleaned = append(iamRolesToBeCleaned, iamId2)
+
+				resTempId, appConfigId, err := dsWithRbac.GetDataServiceDeploymentTemplateIDS(tenantID, ds)
+				log.FailOnError(err, "Error while fetching template and app-config ids")
+				dsId, err := dsTest.GetDataServiceID(ds.Name)
+				versionId, imageID, err := dsWithRbac.GetDSImageVersionToBeDeployed(false, ds, dsId)
+
+				components.ServiceIdentity.GenerateServiceTokenAndSetAuthContext(actorId1)
+				customParams.SetParamsForServiceIdentityTest(params, true)
+				log.InfoD("Successfully updated Infra params for Si test")
+
+				isDeploymentsDeleted = false
+				deployment, _, dataServiceVersionBuildMap, err = DeployandValidateDataServicesWithSiAndTls(ds, ns1.Name, ns1Id1, projectID, resTempId, appConfigId, versionId, imageID, dsId, false)
+				log.FailOnError(err, "Error while deploying data services")
+				deploymentsToBeCleaned = append(deploymentsToBeCleaned, deployment)
+				log.FailOnError(err, "Error while deploying data services")
+				deployments[ds] = deployment
+				deps = append(deps, deployment)
+				depList = append(depList, deployment)
+
+				dsEntity = restoreBkp.DSEntity{
+					Deployment: deployment,
+				}
+				dsVersions[ds.Name] = dataServiceVersionBuildMap
+
+				//ToDo : Add workload generation for deps with RBAC roles on ns1
+
+				Step("Delete ServiceIdentity 1", func() {
+					customParams.SetParamsForServiceIdentityTest(params, false)
+					_, err := components.ServiceIdentity.DeleteServiceIdentity(actorId1)
+					log.FailOnError(err, "Failed to delete service identity 1")
+				})
+				Step("Scale up the deployments with general token", func() {
+					log.InfoD("Starting to scale up the restore deployment")
+					for ds, deployment := range deployments {
+						log.InfoD("Scaling up DataService %v ", &deployment.Name)
+						dataServiceDefaultAppConfigID, err = controlPlane.GetAppConfTemplate(tenantID, ds.Name)
+						log.FailOnError(err, "Error while getting app configuration template")
+						dash.VerifyFatal(dataServiceDefaultAppConfigID != "", true, "Validating dataServiceDefaultAppConfigID")
+
+						dataServiceDefaultResourceTemplateID, err = controlPlane.GetResourceTemplate(tenantID, ds.Name)
+						log.FailOnError(err, "Error while getting resource setting template")
+						dash.VerifyFatal(dataServiceDefaultAppConfigID != "", true, "Validating dataServiceDefaultAppConfigID")
+
+						updatedDeployment, err := pdslib.UpdateDataServices(deployment.GetId(),
+							dataServiceDefaultAppConfigID, deployment.GetImageId(),
+							int32(ds.ScaleReplicas), dataServiceDefaultResourceTemplateID, ns1.Name)
+						log.FailOnError(err, "Error while updating dataservices")
+
+						err = dsTest.ValidateDataServiceDeployment(updatedDeployment, ns1.Name)
+						log.FailOnError(err, "Error while validating data service deployment")
+
+						_, _, config, err := pdslib.ValidateDataServiceVolumes(updatedDeployment, *deployment.Name, dataServiceDefaultResourceTemplateID, storageTemplateID, ns1.Name)
+						log.FailOnError(err, "error on ValidateDataServiceVolumes method")
+						dash.VerifyFatal(int32(ds.ScaleReplicas), config.Spec.Nodes, "Validating replicas after scaling up of dataservice")
+					}
+
+				})
+
+				Step("Perform adhoc backup and validate them", func() {
+
+					log.Infof("Deployment ID: %v, backup target ID: %v", deployment.GetId(), bkpTarget.GetId())
+					err = bkpClient.TriggerAndValidateAdhocBackup(deployment.GetId(), bkpTarget.GetId(), "s3")
+					log.FailOnError(err, "Failed while performing adhoc backup")
+				})
+
+				Step("Perform restore for the backup jobs to diff namespace with general token", func() {
+					ctx, err := GetSourceClusterConfigPath()
+					log.FailOnError(err, "failed while getting src cluster path")
+					restoreTarget := tc.NewTargetCluster(ctx)
+					restoreClient := restoreBkp.RestoreClient{
+						TenantId:             tenantID,
+						ProjectId:            projectID,
+						Components:           components,
+						Deployment:           deployment,
+						RestoreTargetCluster: restoreTarget,
+					}
+					backupJobs, err := restoreClient.Components.BackupJob.ListBackupJobsBelongToDeployment(projectID, deployment.GetId())
+					log.FailOnError(err, "Error while fetching the backup jobs for the deployment: %v", deployment.GetClusterResourceName())
+					for _, backupJob := range backupJobs {
+						log.Infof("[Restoring] Details Backup job name- %v, Id- %v", backupJob.GetName(), backupJob.GetId())
+						restoredModel, err := restoreClient.TriggerAndValidateRestore(backupJob.GetId(), params.InfraToTest.Namespace, dsEntity, false, true)
+						log.FailOnError(err, "Failed during restore.")
+						restoredDeployment, err = restoreClient.Components.DataServiceDeployment.GetDeployment(restoredModel.GetDeploymentId())
+						resDepNamespaceID = append(resDepNamespaceID, *restoredDeployment.NamespaceId)
+						log.FailOnError(err, fmt.Sprintf("Failed while fetching the restore data service instance: %v", restoredModel.GetClusterResourceName()))
+						resDeployments[ds] = restoredDeployment
+						restoredDeployments = append(restoredDeployments, restoredDeployment)
+						deploymentsToBeCleaned = append(deploymentsToBeCleaned, restoredDeployment)
+						log.InfoD("Restored successfully. Details: Deployment- %v, Status - %v", restoredModel.GetClusterResourceName(), restoredModel.GetStatus())
+					}
+				})
+
+				Step("Update IAM2 with newly created restore namespace", func() {
+					nsReaderRoles = nil
+					var (
+						newBinding1 pds.ModelsBinding
+						newBinding2 pds.ModelsBinding
+					)
+					newRoleName := "namespace-admin"
+					newBinding1.ResourceIds = nsID2
+					newBinding1.RoleName = &newRoleName
+					newBinding2.ResourceIds = resDepNamespaceID
+					newBinding2.RoleName = &newRoleName
+
+					nsReaderRoles := append(nsReaderRoles, newBinding1, newBinding2)
+					log.InfoD("Starting to update the IAM Roles for ns2")
+					_, err := components.IamRoleBindings.UpdateIamRoleBindings(accountID, serviceIdentityID2, nsReaderRoles)
+					log.FailOnError(err, "Failed while updating IAM Roles for ns2")
+				})
+
+				Step("Scale up the restored deployments with updated IAM2 Sitoken", func() {
+					log.InfoD("Starting to scale up the restore deployment")
+					for rds, resDep := range resDeployments {
+						resDepNamespaceName = *resDep.Namespace.Name
+						customParams.SetParamsForServiceIdentityTest(params, false)
+						log.InfoD("Scaling up DataService %v ", rds.Name)
+						dataServiceDefaultAppConfigID, err = controlPlane.GetAppConfTemplate(tenantID, rds.Name)
+						log.FailOnError(err, "Error while getting app configuration template")
+						dash.VerifyFatal(dataServiceDefaultAppConfigID != "", true, "Validating dataServiceDefaultAppConfigID")
+
+						dataServiceDefaultResourceTemplateID, err = controlPlane.GetResourceTemplate(tenantID, rds.Name)
+						log.FailOnError(err, "Error while getting resource setting template")
+						dash.VerifyFatal(dataServiceDefaultAppConfigID != "", true, "Validating dataServiceDefaultAppConfigID")
+
+						components.ServiceIdentity.GenerateServiceTokenAndSetAuthContext(actorId2)
+						customParams.SetParamsForServiceIdentityTest(params, true)
+
+						updatedDeployment, err := pdslib.UpdateDataServices(resDep.GetId(),
+							dataServiceDefaultAppConfigID, deployment.GetImageId(),
+							int32(ds.ScaleReplicas), dataServiceDefaultResourceTemplateID, resDepNamespaceName)
+						log.FailOnError(err, "Error while updating dataservices")
+						customParams.SetParamsForServiceIdentityTest(params, false)
+						log.InfoD("PDS RESTORE NAMESPACE IS- %v", resDepNamespaceName)
+						err = dsTest.ValidateDataServiceDeployment(updatedDeployment, resDepNamespaceName)
+						log.FailOnError(err, "Error while validating data service deployment")
+						_, _, config, err := pdslib.ValidateDataServiceVolumes(updatedDeployment, *resDep.Name, dataServiceDefaultResourceTemplateID, storageTemplateID, resDepNamespaceName)
+						log.FailOnError(err, "error on ValidateDataServiceVolumes method")
+						dash.VerifyFatal(int32(ds.ScaleReplicas), config.Spec.Nodes, "Validating replicas after scaling up of dataservice")
+					}
+
+				})
+
+				//ToDo: Run workloads on restored dep
+
+				Step("Perform adhoc backup of the restored Deployment and validate them", func() {
+
+					customParams.SetParamsForServiceIdentityTest(params, true)
+					log.Infof("Deployment ID: %v, backup target ID: %v", restoredDeployment.GetId(), bkpTarget.GetId())
+					err = bkpClient.TriggerAndValidateAdhocBackup(restoredDeployment.GetId(), bkpTarget.GetId(), "s3")
+					log.FailOnError(err, "Failed while performing adhoc backup")
+				})
+
+				Step("Perform restore again for the backup jobs to same ns with new admin role token", func() {
+					customParams.SetParamsForServiceIdentityTest(params, false)
+					ctx, err := GetSourceClusterConfigPath()
+					log.FailOnError(err, "failed while getting src cluster path")
+					restoreTarget := tc.NewTargetCluster(ctx)
+					restoreClient := restoreBkp.RestoreClient{
+						TenantId:             tenantID,
+						ProjectId:            projectID,
+						Components:           components,
+						Deployment:           restoredDeployment,
+						RestoreTargetCluster: restoreTarget,
+					}
+					backupJobs, err := restoreClient.Components.BackupJob.ListBackupJobsBelongToDeployment(projectID, restoredDeployment.GetId())
+					log.FailOnError(err, "Error while fetching the backup jobs for the deployment: %v", restoredDeployment.GetClusterResourceName())
+					for _, backupJob := range backupJobs {
+						log.Infof("[Restoring] Details Backup job name- %v, Id- %v", backupJob.GetName(), backupJob.GetId())
+						pdsRestoreNsName, err := restoreClient.GetNameSpaceNameToRestore(backupJob.GetId(), deploymentTargetID, resDepNamespaceName, true)
+						log.FailOnError(err, "unable to fetch namespace id to restore")
+						customParams.SetParamsForServiceIdentityTest(params, true)
+						restoredModel, _ := restoreClient.RestoreDataServiceWithRbac(deploymentTargetID, backupJob.GetId(), pdsRestoreNsName, dsEntity, resDepNamespaceID[0], true)
+						log.FailOnError(err, "Failed during restore.")
+						restoredDeployment2, err := restoreClient.Components.DataServiceDeployment.GetDeployment(restoredModel.GetDeploymentId())
+						resDeployments[ds] = restoredDeployment2
+						log.FailOnError(err, fmt.Sprintf("Failed while fetching the restore data service instance: %v", restoredModel.GetClusterResourceName()))
+						deploymentsToBeCleaned = append(deploymentsToBeCleaned, restoredDeployment2)
+						log.InfoD("Restored successfully. Details: Deployment- %v, Status - %v", restoredModel.GetClusterResourceName(), restoredModel.GetStatus())
+					}
+				})
+				Step("Delete Deployments", func() {
+					customParams.SetParamsForServiceIdentityTest(params, false)
+					CleanupDeployments(deploymentsToBeCleaned)
+					CleanupServiceIdentitiesAndIamRoles(siToBeCleaned, iamRolesToBeCleaned, actorId2)
+				})
+			}
 		})
+	})
+	JustAfterEach(func() {
+		defer EndTorpedoTest()
+		err := bkpClient.AWSStorageClient.DeleteBucket()
+		log.FailOnError(err, "Failed while deleting the bucket")
 	})
 })

--- a/tests/pds/pds_ds_rbac_test.go
+++ b/tests/pds/pds_ds_rbac_test.go
@@ -221,7 +221,7 @@ var _ = Describe("{ServiceIdentityNsLevel}", func() {
 						components.ServiceIdentity.GenerateServiceTokenAndSetAuthContext(actorId)
 						customParams.SetParamsForServiceIdentityTest(params, true)
 
-						updatedDeployment, err := pdslib.UpdateDataServices(resDep.GetId(),
+						updatedDeployment, err := dsTest.UpdateDataServices(resDep.GetId(),
 							dataServiceDefaultAppConfigID, deployment.GetImageId(),
 							int32(ds.ScaleReplicas), dataServiceDefaultResourceTemplateID, ns2.Name)
 						log.FailOnError(err, "Error while updating dataservices")
@@ -717,7 +717,7 @@ var _ = Describe("{ServiceIdentitySiDLevel}", func() {
 						log.FailOnError(err, "Error while getting resource setting template")
 						dash.VerifyFatal(dataServiceDefaultAppConfigID != "", true, "Validating dataServiceDefaultAppConfigID")
 
-						updatedDeployment, err := pdslib.UpdateDataServices(deployment.GetId(),
+						updatedDeployment, err := dsTest.UpdateDataServices(deployment.GetId(),
 							dataServiceDefaultAppConfigID, deployment.GetImageId(),
 							int32(ds.ScaleReplicas), dataServiceDefaultResourceTemplateID, ns1.Name)
 						log.FailOnError(err, "Error while updating dataservices")
@@ -804,7 +804,7 @@ var _ = Describe("{ServiceIdentitySiDLevel}", func() {
 						components.ServiceIdentity.GenerateServiceTokenAndSetAuthContext(actorId2)
 						customParams.SetParamsForServiceIdentityTest(params, true)
 
-						updatedDeployment, err := pdslib.UpdateDataServices(resDep.GetId(),
+						updatedDeployment, err := dsTest.UpdateDataServices(resDep.GetId(),
 							dataServiceDefaultAppConfigID, deployment.GetImageId(),
 							int32(ds.ScaleReplicas), dataServiceDefaultResourceTemplateID, pdsRestoreNsName)
 						log.FailOnError(err, "Error while updating dataservices")


### PR DESCRIPTION
Initial Commit for Service Identity feature automation.

Added supporting libraries and added the Auth-token context switch feature.
Added the first testcase as well, which performs the below steps -

Create Service Identity with PDS Admin User
IAM roles - for service id a. namespace-admin - ns1 b. namespace-reader - ns2
Deploy TLS Enabled PG on ns1 with service identity token
Validate the Deployment
Run Workloads
Take Backup
Restore to ns2 -> expect failure
Update IAM for ns2 with admin role
Restore again on ns2 -> restore shuould be successful
Scale up restored dep on ns2
Clear all created entities.

Bug reported - https://portworx.atlassian.net/browse/DS-6679
Aetos Link - https://aetos.pwx.purestorage.com/resultSet/testSetID/360375
Jenkins Log - https://jenkins.pwx.dev.purestorage.com/job/PDS/job/pds-branch-build-test/540/console

