### PR TITLE
Kubevirt app deployment fixes

### DIFF
--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -5176,7 +5176,7 @@ func (k *K8s) createVirtualMachineObjects(
 						}
 						return "", true, fmt.Errorf("waiting for import to be completed for pvc [%s] in namespace [%s] for virtual machine [%s]", pvcName, ns.Name, obj.Name)
 					}
-					_, err := task.DoRetryWithTimeout(t, 5*time.Minute, 5*time.Second)
+					_, err := task.DoRetryWithTimeout(t, 5*time.Minute, 30*time.Second)
 					if err != nil {
 						return nil, err
 					}

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -5211,7 +5211,7 @@ func isPVCType(source kubevirtv1.VolumeSource) bool {
 		log.Infof("Field - %s", t.Field(i).Name)
 		fieldType := t.Field(i)
 
-		if fieldType.Type == reflect.TypeOf(kubevirtv1.PersistentVolumeClaimVolumeSource{}) {
+		if fieldType.Type == reflect.TypeOf(&kubevirtv1.PersistentVolumeClaimVolumeSource{}) {
 			log.Infof("returning true")
 			return true
 		}

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -5176,7 +5176,7 @@ func (k *K8s) createVirtualMachineObjects(
 						}
 						return "", true, fmt.Errorf("waiting for import to be completed for pvc [%s] in namespace [%s] for virtual machine [%s]", pvcName, ns.Name, obj.Name)
 					}
-					_, err := task.DoRetryWithTimeout(t, 5*time.Minute, 30*time.Second)
+					_, err := task.DoRetryWithTimeout(t, 5*time.Minute, 10*time.Second)
 					if err != nil {
 						return nil, err
 					}

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -5166,7 +5166,7 @@ func (k *K8s) createVirtualMachineObjects(
 						log.Infof("Events for pvc [%s] in namespace [%s] for virtual machine [%s] \n\n%v\n", pvcName, ns.Name, obj.Name, events)
 						for _, event := range events.Items {
 							if strings.Contains(event.Message, "Import Successful") {
-								pvc, err := k8sCore.GetPersistentVolumeClaim(pvcName, obj.GetNamespace())
+								pvc, err := k8sCore.GetPersistentVolumeClaim(pvcName, ns.Name)
 								if err != nil {
 									return "", false, err
 								}

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -5152,6 +5152,7 @@ func (k *K8s) createVirtualMachineObjects(
 		virtualMachineVolumes := obj.Spec.Template.Spec.Volumes
 		if len(virtualMachineVolumes) > 0 {
 			for _, v := range virtualMachineVolumes {
+				log.Infof("Volume dump - \n%v", v)
 				if isPVCType(v.VolumeSource) {
 					pvcName := v.VolumeSource.PersistentVolumeClaim.ClaimName
 					t := func() (interface{}, bool, error) {
@@ -5204,14 +5205,18 @@ func (k *K8s) createVirtualMachineObjects(
 func isPVCType(source kubevirtv1.VolumeSource) bool {
 	v := reflect.ValueOf(source)
 	t := v.Type()
+	log.Infof("Volume source - \n%v", source)
 
 	for i := 0; i < v.NumField(); i++ {
+		log.Infof("Field - %s", t.Field(i).Name)
 		fieldType := t.Field(i)
 
 		if fieldType.Type == reflect.TypeOf(kubevirtv1.PersistentVolumeClaimVolumeSource{}) {
+			log.Infof("returning true")
 			return true
 		}
 	}
+	log.Infof("returning false")
 	return false
 }
 

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -5176,7 +5176,7 @@ func (k *K8s) createVirtualMachineObjects(
 						}
 						return "", true, fmt.Errorf("waiting for import to be completed for pvc [%s] in namespace [%s] for virtual machine [%s]", pvcName, ns.Name, obj.Name)
 					}
-					_, err := task.DoRetryWithTimeout(t, 5*time.Minute, 10*time.Second)
+					_, err := task.DoRetryWithTimeout(t, 5*time.Minute, 5*time.Second)
 					if err != nil {
 						return nil, err
 					}

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -5153,7 +5153,8 @@ func (k *K8s) createVirtualMachineObjects(
 		if len(virtualMachineVolumes) > 0 {
 			for _, v := range virtualMachineVolumes {
 				log.Infof("Volume dump - \n%v", v)
-				if isPVCType(v.VolumeSource) {
+				pvcVolumeSource := v.VolumeSource.PersistentVolumeClaim
+				if pvcVolumeSource != nil {
 					pvcName := v.VolumeSource.PersistentVolumeClaim.ClaimName
 					t := func() (interface{}, bool, error) {
 						events, err := k8sCore.ListEvents(obj.Namespace, metav1.ListOptions{
@@ -5202,23 +5203,24 @@ func (k *K8s) createVirtualMachineObjects(
 	return nil, nil
 }
 
-func isPVCType(source kubevirtv1.VolumeSource) bool {
-	v := reflect.ValueOf(source)
-	t := v.Type()
-	log.Infof("Volume source - \n%v", source)
-
-	for i := 0; i < v.NumField(); i++ {
-		log.Infof("Field - %s", t.Field(i).Name)
-		fieldType := t.Field(i)
-
-		if fieldType.Type == reflect.TypeOf(&kubevirtv1.PersistentVolumeClaimVolumeSource{}) {
-			log.Infof("returning true")
-			return true
-		}
-	}
-	log.Infof("returning false")
-	return false
-}
+//func isPVCType(source kubevirtv1.VolumeSource) bool {
+//	return source.PersistentVolumeClaim.ClaimName != ""
+//	v := reflect.ValueOf(source)
+//	t := v.Type()
+//	log.Infof("Volume source - \n%v", source)
+//
+//	for i := 0; i < v.NumField(); i++ {
+//		log.Infof("Field - %s", t.Field(i).Name)
+//		fieldType := t.Field(i)
+//
+//		if fieldType.Type == reflect.TypeOf(&kubevirtv1.PersistentVolumeClaimVolumeSource{}) && !v.Field(i).IsNil() {
+//			log.Infof("returning true")
+//			return true
+//		}
+//	}
+//	log.Infof("returning false")
+//	return false
+//}
 
 // createCustomResourceObjects is used to create objects whose resource `kind` is defined by a CRD. NOTE: this is done using the `kubectl apply -f` command instead of the conventional method of using an api library
 func (k *K8s) createCustomResourceObjects(

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -5163,15 +5163,36 @@ func (k *K8s) createVirtualMachineObjects(
 						if err != nil {
 							return "", false, err
 						}
-						log.Infof("Events for pvc [%s] in namespace [%s] for virtual machine [%s] \n\n%v\n", pvcName, obj.Name, obj.Name, events)
+						log.Infof("Events for pvc [%s] in namespace [%s] for virtual machine [%s] \n\n%v\n", pvcName, obj.Namespace, obj.Name, events)
 						for _, event := range events.Items {
 							if strings.Contains(event.Message, "Import Successful") {
 								return "", false, nil
 							}
 						}
-						return "", true, fmt.Errorf("waiting for import to be completed for pvc [%s] in namespace [%s] for virtual machine [%s]", pvcName, obj.Name, obj.Name)
+						return "", true, fmt.Errorf("waiting for import to be completed for pvc [%s] in namespace [%s] for virtual machine [%s]", pvcName, obj.Namespace, obj.Name)
 					}
 					_, err := task.DoRetryWithTimeout(t, 5*time.Minute, 10*time.Second)
+					if err != nil {
+						return nil, err
+					}
+
+					importerPodCheck := func() (interface{}, bool, error) {
+						pods, err := k8sCore.GetPods(obj.Namespace, make(map[string]string, 0))
+						if err != nil {
+							return "", false, fmt.Errorf("error getting pods - %s", err.Error())
+						}
+						for _, p := range pods.Items {
+							log.Infof("Pods in ns [%s] is [%v]", obj.Namespace, p.Name)
+						}
+						for _, p := range pods.Items {
+							importerPodName := fmt.Sprintf("importer-%s", pvcName)
+							if strings.Contains(p.Name, importerPodName) {
+								return "", true, fmt.Errorf("importer pod [%s] is still running for pvc [%s] in namespace [%s] for virtual machine [%s]", p.Name, pvcName, obj.Namespace, obj.Name)
+							}
+						}
+						return "", false, nil
+					}
+					_, err = task.DoRetryWithTimeout(importerPodCheck, 5*time.Minute, 10*time.Second)
 					if err != nil {
 						return nil, err
 					}

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -5157,13 +5157,13 @@ func (k *K8s) createVirtualMachineObjects(
 				if pvcVolumeSource != nil {
 					pvcName := v.VolumeSource.PersistentVolumeClaim.ClaimName
 					t := func() (interface{}, bool, error) {
-						events, err := k8sCore.ListEvents(obj.Namespace, metav1.ListOptions{
+						events, err := k8sCore.ListEvents(ns.Name, metav1.ListOptions{
 							FieldSelector: fmt.Sprintf("involvedObject.kind=PersistentVolumeClaim,involvedObject.name=%s", pvcName),
 						})
 						if err != nil {
 							return "", false, err
 						}
-						log.Infof("Events for pvc [%s] in namespace [%s] for virtual machine [%s] \n\n%v\n", pvcName, obj.Namespace, obj.Name, events)
+						log.Infof("Events for pvc [%s] in namespace [%s] for virtual machine [%s] \n\n%v\n", pvcName, ns.Name, obj.Name, events)
 						for _, event := range events.Items {
 							if strings.Contains(event.Message, "Import Successful") {
 								pvc, err := k8sCore.GetPersistentVolumeClaim(pvcName, obj.GetNamespace())
@@ -5174,7 +5174,7 @@ func (k *K8s) createVirtualMachineObjects(
 								return "", false, nil
 							}
 						}
-						return "", true, fmt.Errorf("waiting for import to be completed for pvc [%s] in namespace [%s] for virtual machine [%s]", pvcName, obj.Namespace, obj.Name)
+						return "", true, fmt.Errorf("waiting for import to be completed for pvc [%s] in namespace [%s] for virtual machine [%s]", pvcName, ns.Name, obj.Name)
 					}
 					_, err := task.DoRetryWithTimeout(t, 5*time.Minute, 30*time.Second)
 					if err != nil {

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -5208,7 +5208,6 @@ func (k *K8s) createVirtualMachineObjects(
 		if obj.Namespace != "kube-system" {
 			obj.Namespace = ns.Name
 		}
-		time.Sleep(1 * time.Minute)
 		vm, err := k8sKubevirt.CreateVirtualMachine(obj)
 		if k8serrors.IsAlreadyExists(err) {
 			if vm, err = k8sKubevirt.GetVirtualMachine(obj.Name, obj.Namespace); err == nil {

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -5203,6 +5203,7 @@ func (k *K8s) createVirtualMachineObjects(
 		if obj.Namespace != "kube-system" {
 			obj.Namespace = ns.Name
 		}
+		time.Sleep(1 * time.Minute)
 		vm, err := k8sKubevirt.CreateVirtualMachine(obj)
 		if k8serrors.IsAlreadyExists(err) {
 			if vm, err = k8sKubevirt.GetVirtualMachine(obj.Name, obj.Namespace); err == nil {

--- a/drivers/scheduler/k8s/specs/kubevirt-simple-vm/kubevirt-app.yaml
+++ b/drivers/scheduler/k8s/specs/kubevirt-simple-vm/kubevirt-app.yaml
@@ -1,0 +1,39 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: testvm
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt.io/size: small
+        kubevirt.io/domain: testvm
+      annotations:
+        kubevirt.io/keep-launcher-alive-after-failure: "true"
+    spec:
+      domain:
+        devices:
+          disks:
+            - name: containerdisk
+              disk:
+                bus: virtio
+            - name: cloudinitdisk
+              disk:
+                bus: virtio
+          interfaces:
+            - name: default
+              masquerade: {}
+        resources:
+          requests:
+            memory: 64M
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/kubevirt/cirros-container-disk-demo
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userDataBase64: SGkuXG4=

--- a/drivers/scheduler/k8s/specs/kubevirt-vm-pvc/kubevirt-app.yaml
+++ b/drivers/scheduler/k8s/specs/kubevirt-vm-pvc/kubevirt-app.yaml
@@ -1,0 +1,44 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  creationTimestamp: 2018-07-04T15:03:08Z
+  generation: 1
+  labels:
+    kubevirt.io/os: linux
+  name: cirrosvm
+spec:
+  running: true
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        kubevirt.io/domain: cirrosvm
+    spec:
+      domain:
+        cpu:
+          cores: 2
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: disk0
+            - cdrom:
+                bus: sata
+                readonly: true
+              name: cloudinitdisk
+        machine:
+          type: q35
+        resources:
+          requests:
+            memory: 1024M
+      volumes:
+        - name: disk0
+          persistentVolumeClaim:
+            claimName: cirros-pvc
+        - cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              hostname: cirrosvm
+              ssh_pwauth: True
+              disable_root: false
+          name: cloudinitdisk

--- a/drivers/scheduler/k8s/specs/kubevirt-vm-pvc/pxd/px-storage-class.yaml
+++ b/drivers/scheduler/k8s/specs/kubevirt-vm-pvc/pxd/px-storage-class.yaml
@@ -1,0 +1,30 @@
+##### Portworx storage class
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    params/aggregation_level: Specifies the number of replication sets the volume
+      can be aggregated from
+    params/block_size: Block size
+    params/docs: https://docs.portworx.com/scheduler/kubernetes/dynamic-provisioning.html
+    params/fs: 'Filesystem to be laid out: none|xfs|ext4'
+    params/io_profile: 'IO Profile can be used to override the I/O algorithm Portworx
+      uses for the volumes: db|sequential|random|cms'
+    params/journal: Flag to indicate if you want to use journal device for the volume's
+      metadata. This will use the journal device that you used when installing Portworx.
+      It is recommended to use a journal device to absorb PX metadata writes
+    params/priority_io: 'IO Priority: low|medium|high'
+    params/repl: 'Replication factor for the volume: 1|2|3'
+    params/secure: 'Flag to create an encrypted volume: true|false'
+    params/shared: 'Flag to create a globally shared namespace volume which can be
+      used by multiple pods: true|false'
+    params/sticky: Flag to create sticky volumes that cannot be deleted until the
+      flag is disabled
+  name: kubevirt-sc
+parameters:
+  io_profile: db_remote
+  repl: "3"
+provisioner: kubernetes.io/portworx-volume
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+allowVolumeExpansion: true

--- a/drivers/scheduler/k8s/specs/kubevirt-vm-pvc/storage.yaml
+++ b/drivers/scheduler/k8s/specs/kubevirt-vm-pvc/storage.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "cirros-pvc"
+  labels:
+    app: containerized-data-importer
+  annotations:
+    cdi.kubevirt.io/storage.import.endpoint: "http://download.cirros-cloud.net/0.3.0/cirros-0.3.0-x86_64-disk.img"
+spec:
+  storageClassName: kubevirt-sc
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 2Gi

--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -291,7 +291,7 @@ var _ = Describe("{BasicBackupCreation}", func() {
 		opts[SkipClusterScopedObjects] = true
 
 		log.Info("Destroying scheduled apps on source cluster")
-		DestroyApps(scheduledAppContexts, opts)
+		//DestroyApps(scheduledAppContexts, opts)
 
 		log.InfoD("switching to destination context")
 		err = SetDestinationKubeConfig()
@@ -307,7 +307,7 @@ var _ = Describe("{BasicBackupCreation}", func() {
 			}
 			restoredAppContexts = append(restoredAppContexts, restoredAppContext)
 		}
-		DestroyApps(restoredAppContexts, opts)
+		//DestroyApps(restoredAppContexts, opts)
 
 		log.InfoD("switching to default context")
 		err = SetClusterContext("")

--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -291,7 +291,7 @@ var _ = Describe("{BasicBackupCreation}", func() {
 		opts[SkipClusterScopedObjects] = true
 
 		log.Info("Destroying scheduled apps on source cluster")
-		//DestroyApps(scheduledAppContexts, opts)
+		DestroyApps(scheduledAppContexts, opts)
 
 		log.InfoD("switching to destination context")
 		err = SetDestinationKubeConfig()
@@ -307,7 +307,7 @@ var _ = Describe("{BasicBackupCreation}", func() {
 			}
 			restoredAppContexts = append(restoredAppContexts, restoredAppContext)
 		}
-		//DestroyApps(restoredAppContexts, opts)
+		DestroyApps(restoredAppContexts, opts)
 
 		log.InfoD("switching to default context")
 		err = SetClusterContext("")

--- a/tests/common.go
+++ b/tests/common.go
@@ -2800,6 +2800,7 @@ func AfterEachTest(contexts []*scheduler.Context, ids ...int) {
 		DescribeNamespace(contexts)
 		testStatus = "Fail"
 	}
+	DescribeNamespace(contexts)
 	if len(ids) >= 1 {
 		driverVersion, err := Inst().V.GetDriverVersion()
 		if err != nil {

--- a/tests/common.go
+++ b/tests/common.go
@@ -2640,6 +2640,11 @@ func UpdateNamespace(in interface{}, namespaceMapping map[string]string) error {
 			}
 		}
 		return nil
+	} else if specObj, ok := in.(*kubevirtv1.VirtualMachine); ok {
+		if namespace, ok := namespaceMapping[specObj.GetNamespace()]; ok {
+			specObj.SetNamespace(namespace)
+		}
+		return nil
 	}
 
 	return fmt.Errorf("unsupported object while setting namespace: %v", reflect.TypeOf(in))

--- a/tests/common.go
+++ b/tests/common.go
@@ -2800,7 +2800,6 @@ func AfterEachTest(contexts []*scheduler.Context, ids ...int) {
 		DescribeNamespace(contexts)
 		testStatus = "Fail"
 	}
-	DescribeNamespace(contexts)
 	if len(ids) >= 1 {
 		driverVersion, err := Inst().V.GetDriverVersion()
 		if err != nil {

--- a/tests/common.go
+++ b/tests/common.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"go.uber.org/multierr"
+	kubevirtv1 "kubevirt.io/api/core/v1"
 	"math/rand"
 	"net/http"
 	"regexp"
@@ -2391,6 +2392,9 @@ func CloneSpec(spec interface{}) (interface{}, error) {
 	} else if specObj, ok := spec.(*apiextensionsv1beta1.CustomResourceDefinition); ok {
 		clone := *specObj
 		return &clone, nil
+	} else if specObj, ok := spec.(*kubevirtv1.VirtualMachine); ok {
+		clone := *specObj
+		return &clone, nil
 	} else if specObj, ok := spec.(*apiextensionsv1.CustomResourceDefinition); ok {
 		clone := *specObj
 		return &clone, nil
@@ -2726,6 +2730,8 @@ func GetSpecNameKindNamepace(specObj interface{}) (string, string, string, error
 	} else if obj, ok := specObj.(*storkapi.ResourceTransformation); ok {
 		return obj.GetName(), obj.GroupVersionKind().Kind, obj.GetNamespace(), nil
 	} else if obj, ok := specObj.(*admissionregistrationv1.ValidatingWebhookConfiguration); ok {
+		return obj.GetName(), obj.GroupVersionKind().Kind, obj.GetNamespace(), nil
+	} else if obj, ok := specObj.(*kubevirtv1.VirtualMachine); ok {
 		return obj.GetName(), obj.GroupVersionKind().Kind, obj.GetNamespace(), nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- [x] Created a separate function `createVirtualMachineObjects` to create Kubevirt VM
- [x] Added Virtual Machine details to be printed when `Describe` function is called
- [x] Added specs for `kubevirt-simple-vm` which creates a Kubevirt VM without any volumes. This creates volume in-memory
- [x] Added specs for `kubevirt-vm-pvc` which creates a Kubevirt VM with PVC as volume source
- [x] Made a small change in `validateMountsInPods`- In some cases the container path is sym linked to a local directory in the pod "/proc/mounts" contains this sym link path instead of the actual container path fetched. To make sure it doesn't fail in validation, we will be appending the sym link path to "paths" and removing the container path
- [x] Added Kubevirt VM type in `GetSpecNameKindNamepace`, `CloneSpec` and `UpdateNamespace`

**Which issue(s) this PR fixes** (optional)
Closes #PA-1638 #PA-1637

**Special notes for your reviewer**:
[Jenkins Run with simple VM](https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/2921)
[Jenkins Run with Px PVC based VM](https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/2919)

