### PR TITLE
SwapShareBackup : Fix' backup delete from user' issue in cleanup

### DIFF
--- a/tests/backup/backup_share_test.go
+++ b/tests/backup/backup_share_test.go
@@ -3975,6 +3975,7 @@ var _ = Describe("{SwapShareBackup}", func() {
 				}(userName, firstName, lastName, email)
 			}
 			wg.Wait()
+			log.Infof("List of users are %v", users)
 		})
 		Step(fmt.Sprintf("Adding Credentials and Registering Backup Location for %s and %s", users[0], users[1]), func() {
 			log.InfoD(fmt.Sprintf("Creating cloud credentials and backup location for %s and %s", users[0], users[1]))
@@ -4025,8 +4026,9 @@ var _ = Describe("{SwapShareBackup}", func() {
 
 				backupDriver := Inst().Backup
 				backupUID, err := backupDriver.GetBackupUID(ctx, backupName, orgID)
+				log.FailOnError(err, "Failed to get backup UID for backup %s for user %s", backupName, user)
 				backupUIDList = append(backupUIDList, backupUID)
-				log.FailOnError(err, "Failed getting backup uid for backup name %s", backupName)
+				log.Infof("Backup uid of backup: %s is %s for user %s", backupName, backupUID, user)
 			})
 		}
 		Step(fmt.Sprintf("Share backup with %s", users[1]), func() {
@@ -4089,13 +4091,6 @@ var _ = Describe("{SwapShareBackup}", func() {
 		opts[SkipClusterScopedObjects] = true
 		DestroyApps(scheduledAppContexts, opts)
 
-		Step("Delete all synced backups from the admin", func() {
-			log.InfoD("Delete all synced backups from the admin")
-			ctx, err := backup.GetAdminCtxFromSecret()
-			log.FailOnError(err, "Fetching px-central-admin ctx")
-			err = DeleteAllBackups(ctx, orgID)
-			log.FailOnError(err, "Delete all synced backups from the admin")
-		})
 		log.InfoD("Deleting all restores")
 		for _, userName := range users {
 			ctx, err := backup.GetNonAdminCtx(userName, commonPassword)
@@ -4108,7 +4103,7 @@ var _ = Describe("{SwapShareBackup}", func() {
 			}
 		}
 
-		log.InfoD("Delete all backups")
+		log.InfoD("Delete backups of users")
 		for i := numberOfUsers - 1; i >= 0; i-- {
 			ctx, err := backup.GetNonAdminCtx(users[i], commonPassword)
 			log.FailOnError(err, "Fetching non admin ctx")


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Deleting backups from user before deleting all backups from admin
**Which issue(s) this PR fixes** (optional)
Closes #
https://portworx.atlassian.net/browse/PA-1685
**Special notes for your reviewer**:
log : https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/2949/consoleFull
