### PR TITLE
[Kubevirt] Changed logic to check for CDI image import success

### DIFF
--- a/drivers/scheduler/k8s/specs/kubevirt-vm-pvc/storage.yaml
+++ b/drivers/scheduler/k8s/specs/kubevirt-vm-pvc/storage.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: containerized-data-importer
   annotations:
-    cdi.kubevirt.io/storage.import.endpoint: "http://download.cirros-cloud.net/0.3.0/cirros-0.3.0-x86_64-disk.img"
+    cdi.kubevirt.io/storage.import.endpoint: "http://kubevirt-disk-registry.pwx.dev.purestorage.com/cirros-0.3.0-x86_64-disk.img"
 spec:
   storageClassName: kubevirt-sc
   accessModes:

--- a/vendor/github.com/portworx/sched-ops/k8s/kubevirt/virtualmachine.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/kubevirt/virtualmachine.go
@@ -75,7 +75,7 @@ func (c *Client) ValidateVirtualMachineRunning(name, namespace string, timeout, 
 	if err != nil {
 		return fmt.Errorf("failed to get Virtual Machine")
 	}
-
+	fmt.Printf("VM spec - %v", &vm.Spec)
 	// Start the VirtualMachine if its not Started yet
 	if !*vm.Spec.Running {
 		if err = instance.StartVirtualMachine(vm); err != nil {

--- a/vendor/github.com/portworx/sched-ops/k8s/kubevirt/virtualmachine.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/kubevirt/virtualmachine.go
@@ -67,10 +67,14 @@ func (c *Client) DeleteVirtualMachine(name, namespace string) error {
 // ValidateVirtualMachineRunning check if VirtualMachine is running, if not
 // start VirtualMachine and wait for it get started.
 func (c *Client) ValidateVirtualMachineRunning(name, namespace string, timeout, retryInterval time.Duration) error {
+	fmt.Printf("name - [%s] in namespace - [%s]")
 	if err := c.initClient(); err != nil {
 		return err
 	}
 	vm, err := c.GetVirtualMachine(name, namespace)
+	if vm == nil{
+		fmt.Printf("vm is nil")
+	}
 	if err != nil {
 		return fmt.Errorf("failed to get Virtual Machine")
 	}

--- a/vendor/github.com/portworx/sched-ops/k8s/kubevirt/virtualmachine.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/kubevirt/virtualmachine.go
@@ -67,14 +67,11 @@ func (c *Client) DeleteVirtualMachine(name, namespace string) error {
 // ValidateVirtualMachineRunning check if VirtualMachine is running, if not
 // start VirtualMachine and wait for it get started.
 func (c *Client) ValidateVirtualMachineRunning(name, namespace string, timeout, retryInterval time.Duration) error {
-	fmt.Printf("name - [%s] in namespace - [%s]")
+	fmt.Printf("name - [%s] in namespace - [%s]", name, namespace)
 	if err := c.initClient(); err != nil {
 		return err
 	}
 	vm, err := c.GetVirtualMachine(name, namespace)
-	if vm == nil{
-		fmt.Printf("vm is nil")
-	}
 	if err != nil {
 		return fmt.Errorf("failed to get Virtual Machine")
 	}

--- a/vendor/github.com/portworx/sched-ops/k8s/kubevirt/virtualmachine.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/kubevirt/virtualmachine.go
@@ -67,7 +67,6 @@ func (c *Client) DeleteVirtualMachine(name, namespace string) error {
 // ValidateVirtualMachineRunning check if VirtualMachine is running, if not
 // start VirtualMachine and wait for it get started.
 func (c *Client) ValidateVirtualMachineRunning(name, namespace string, timeout, retryInterval time.Duration) error {
-	fmt.Printf("name - [%s] in namespace - [%s]", name, namespace)
 	if err := c.initClient(); err != nil {
 		return err
 	}
@@ -75,7 +74,7 @@ func (c *Client) ValidateVirtualMachineRunning(name, namespace string, timeout, 
 	if err != nil {
 		return fmt.Errorf("failed to get Virtual Machine")
 	}
-	fmt.Printf("VM spec - %v", &vm.Spec)
+	
 	// Start the VirtualMachine if its not Started yet
 	if !*vm.Spec.Running {
 		if err = instance.StartVirtualMachine(vm); err != nil {

--- a/vendor/github.com/portworx/sched-ops/k8s/kubevirt/virtualmachine.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/kubevirt/virtualmachine.go
@@ -74,7 +74,7 @@ func (c *Client) ValidateVirtualMachineRunning(name, namespace string, timeout, 
 	if err != nil {
 		return fmt.Errorf("failed to get Virtual Machine")
 	}
-	
+
 	// Start the VirtualMachine if its not Started yet
 	if !*vm.Spec.Running {
 		if err = instance.StartVirtualMachine(vm); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

- [x] Changed the logic where we were waiting for the CDI importer to complete downloading the disk image based on the events. Now we will rely on the annotation `cdi.kubevirt.io/storage.condition.running.message` to display `Import Complete`
- [x] Changed the endpoint from where we were downloading the disk image from `download.cirros-cloud.net` to our own internal web server `kubevirt-disk-registry.pwx.dev.purestorage.com`

**Which issue(s) this PR fixes** (optional)
Closes #PA-1640

**Special notes for your reviewer**:
[Jenkins Run](https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/2978/parameters/)

