### PR TITLE
Changed nfs mount from master node to worker node

### DIFF
--- a/tests/common.go
+++ b/tests/common.go
@@ -5270,12 +5270,13 @@ func IsBackupLocationEmpty(provider, bucketName string) (bool, error) {
 }
 
 func IsNFSSubPathEmpty(subPath string) (bool, error) {
+	//TODO enhance the method to work with NFS server on cloud
 	// Get NFS share details from ENV variables.
 	creds := GetNfsInfoFromEnv()
 	mountDir := fmt.Sprintf("/tmp/nfsMount" + RandomString(4))
 
-	// Mount the NFS share to the master node.
-	masterNode := node.GetMasterNodes()[0]
+	// Mount the NFS share to the worker node.
+	masterNode := node.GetWorkerNodes()[0]
 	mountCmds := []string{
 		fmt.Sprintf("mkdir -p %s", mountDir),
 		fmt.Sprintf("mount -t nfs %s:%s %s", creds.NfsServerAddress, creds.NfsPath, mountDir),


### PR DESCRIPTION
**What this PR does / why we need it**:

Changed nfs mount from master node to worker node in isNfsSubpathEmpty.

**Which issue(s) this PR fixes** (optional)
Closes #PA-1696

**Special notes for your reviewer**:
Tested two test which uses this method.
https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/2984/