### PR TITLE
Adding helper functions for Start, Stop and Restart Kubevirt VMs

### DIFF
--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -2722,16 +2722,6 @@ func (k *K8s) destroyCoreObject(spec interface{}, opts map[string]bool, app *spe
 		}
 
 		log.Infof("[%v] Destroyed AutopilotRule: %v", app.Key, obj.Name)
-	} else if obj, ok := spec.(*kubevirtv1.VirtualMachine); ok {
-		err := k8sKubevirt.DeleteVirtualMachine(obj.Name, obj.Namespace)
-		if err != nil {
-			return pods, &scheduler.ErrFailedToDestroyApp{
-				App:   app,
-				Cause: fmt.Sprintf("Failed to destroy VirtualMachine: %v. Err: %v", obj.Name, err),
-			}
-		}
-
-		log.Infof("[%v] Destroyed VirtualMachine: %v", app.Key, obj.Name)
 	}
 
 	return pods, nil
@@ -3296,6 +3286,20 @@ func (k *K8s) Destroy(ctx *scheduler.Context, opts map[string]bool) error {
 	for _, appSpec := range ctx.App.SpecList {
 		t := func() (interface{}, bool, error) {
 			err := k.destroyPodDisruptionBudgetObjects(appSpec, ctx.App)
+			if err != nil {
+				return nil, true, err
+			}
+			return nil, false, nil
+		}
+
+		if _, err := task.DoRetryWithTimeout(t, k8sDestroyTimeout, DefaultRetryInterval); err != nil {
+			return err
+		}
+	}
+
+	for _, appSpec := range ctx.App.SpecList {
+		t := func() (interface{}, bool, error) {
+			err := k.destroyVirtualMachineObjects(appSpec, ctx.App)
 			if err != nil {
 				return nil, true, err
 			}
@@ -5146,7 +5150,7 @@ func (k *K8s) createAdmissionRegistrationObjects(
 	return nil, nil
 }
 
-// createVirtualMachineObjects creates the kubevirt VirtualMachines using kubectl apply
+// createVirtualMachineObjects creates the kubevirt VirtualMachines
 func (k *K8s) createVirtualMachineObjects(
 	spec interface{},
 	ns *corev1.Namespace,
@@ -5220,6 +5224,24 @@ func (k *K8s) WaitForImageImportForVM(vmName string, namespace string, v kubevir
 		}
 	}
 	// TODO: For other Volume Source types like Data Volumes, validation logic should come here
+	return nil
+}
+
+// destroyVirtualMachineObjects deletes the kubevirt VirtualMachines
+func (k *K8s) destroyVirtualMachineObjects(
+	spec interface{},
+	app *spec.AppSpec,
+) error {
+	if obj, ok := spec.(*kubevirtv1.VirtualMachine); ok {
+		err := k8sKubevirt.DeleteVirtualMachine(obj.Name, obj.Namespace)
+		if err != nil {
+			return &scheduler.ErrFailedToDestroyApp{
+				App:   app,
+				Cause: fmt.Sprintf("Failed to destroy VirtualMachine: %v. Err: %v", obj.Name, err),
+			}
+		}
+		log.Infof("[%v] Destroyed VirtualMachine: %v", app.Key, obj.Name)
+	}
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/portworx/pds-api-go-client v0.0.0-20230831092707-4faacf005c6b
 	github.com/portworx/px-backup-api v1.2.2-0.20230904054048-eb1f23dd7431
-	github.com/portworx/sched-ops v1.20.4-rc1.0.20230926074552-5a61e22be0a4
+	github.com/portworx/sched-ops v1.20.4-rc1.0.20231013094113-8ca7856dbe86
 	github.com/portworx/talisman v1.1.3
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.63.0
 	github.com/prometheus/client_golang v1.14.0
@@ -78,7 +78,7 @@ require (
 	kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90 // indirect
 )
 
-require go.uber.org/multierr v1.7.0 // indirect
+require go.uber.org/multierr v1.7.0
 
 require (
 	cloud.google.com/go v0.110.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2878,8 +2878,8 @@ github.com/portworx/sched-ops v1.20.4-rc1.0.20230103234348-243afb3bb8aa/go.mod h
 github.com/portworx/sched-ops v1.20.4-rc1.0.20230207070155-2e0ef25efadd/go.mod h1:JbHASXqA/GXwFD4blS1DZkrxtS5llb98ViZgUerOtQA=
 github.com/portworx/sched-ops v1.20.4-rc1.0.20230207140221-24ec094deec4/go.mod h1:drIYh+6f/vh11dVmbpwFv3GIusQCSMThPX774U8ix7w=
 github.com/portworx/sched-ops v1.20.4-rc1.0.20230228105744-505c1a2d8203/go.mod h1:JbHASXqA/GXwFD4blS1DZkrxtS5llb98ViZgUerOtQA=
-github.com/portworx/sched-ops v1.20.4-rc1.0.20230926074552-5a61e22be0a4 h1:kNr7y+uCDDq5JQKrSrZvM7rOUIb5pS9jTyGk3zgpqP0=
-github.com/portworx/sched-ops v1.20.4-rc1.0.20230926074552-5a61e22be0a4/go.mod h1:BLCAKaIu63mxgQTBjC7Xtkgm2mlnYuu+yyQhTfknsiI=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20231013094113-8ca7856dbe86 h1:p1psRMXYwmnlEXHb8p0P7ew/QYVrNSfNkLoa0liEt90=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20231013094113-8ca7856dbe86/go.mod h1:wZnNzyY7B/cuWwYZ6XysdbwsXPC8DjfJ1YGg6MdyefU=
 github.com/portworx/talisman v0.0.0-20191007232806-837747f38224/go.mod h1:OjpMH9Uh5o9ntVGktm4FbjLNwubJ3ITih2OfYrAeWtA=
 github.com/portworx/talisman v0.0.0-20210302012732-8af4564777f7/go.mod h1:e8a6uFpSbOlRpZQlW9aXYogC+GWAo065G0RL9hDkD4Q=
 github.com/portworx/talisman v1.1.3 h1:XrDE0fs4UACgDGi5bvt04uePC+QbhbA5YXozGYg5tr8=

--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -5020,6 +5020,7 @@ func RemoveCloudCredentialOwnership(cloudCredentialName string, cloudCredentialU
 	return nil
 }
 
+// StartKubevirtVM starts the kubevirt VM and waits till the status is Running
 func StartKubevirtVM(name, namespace string) error {
 	k8sKubevirt := kubevirt.Instance()
 	vm, err := k8sKubevirt.GetVirtualMachine(name, namespace)
@@ -5045,6 +5046,7 @@ func StartKubevirtVM(name, namespace string) error {
 	return err
 }
 
+// StopKubevirtVM stops the kubevirt VM and waits till the status is Stopped
 func StopKubevirtVM(name, namespace string) error {
 	k8sKubevirt := kubevirt.Instance()
 	vm, err := k8sKubevirt.GetVirtualMachine(name, namespace)
@@ -5070,6 +5072,9 @@ func StopKubevirtVM(name, namespace string) error {
 	return err
 }
 
+// RestartKubevirtVM restarts the kubevirt VM
+// If VM is in stopped state it starts the VM
+// If VM is in started state it restarts the VM
 func RestartKubevirtVM(name, namespace string) error {
 	k8sKubevirt := kubevirt.Instance()
 	vm, err := k8sKubevirt.GetVirtualMachine(name, namespace)

--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -5036,7 +5036,7 @@ func StartKubevirtVM(name, namespace string) error {
 			return "", false, fmt.Errorf("unable to get virtual machine [%s] in namespace [%s]", name, namespace)
 		}
 		if vm.Status.PrintableStatus != kubevirtv1.VirtualMachineStatusRunning {
-			return "", true, fmt.Errorf("virtual machine [%s] in namespace [%s] is in %s state, expecting to be in %s state", name, namespace, vm.Status.PrintableStatus, kubevirtv1.VirtualMachineStatusRunning)
+			return "", true, fmt.Errorf("virtual machine [%s] in namespace [%s] is in %s state, waiting to be in %s state", name, namespace, vm.Status.PrintableStatus, kubevirtv1.VirtualMachineStatusRunning)
 		}
 		log.Infof("virtual machine [%s] in namespace [%s] is in %s state", name, namespace, vm.Status.PrintableStatus)
 		return "", false, nil
@@ -5061,7 +5061,7 @@ func StopKubevirtVM(name, namespace string) error {
 			return "", false, fmt.Errorf("unable to get virtual machine [%s] in namespace [%s]", name, namespace)
 		}
 		if vm.Status.PrintableStatus != kubevirtv1.VirtualMachineStatusStopped {
-			return "", true, fmt.Errorf("virtual machine [%s] in namespace [%s] is in %s state, expecting to be in %s state", name, namespace, vm.Status.PrintableStatus, kubevirtv1.VirtualMachineStatusStopped)
+			return "", true, fmt.Errorf("virtual machine [%s] in namespace [%s] is in %s state, waiting to be in %s state", name, namespace, vm.Status.PrintableStatus, kubevirtv1.VirtualMachineStatusStopped)
 		}
 		log.Infof("virtual machine [%s] in namespace [%s] is in %s state", name, namespace, vm.Status.PrintableStatus)
 		return "", false, nil
@@ -5092,7 +5092,7 @@ func RestartKubevirtVM(name, namespace string) error {
 			return err
 		}
 	default:
-		return fmt.Errorf("virtual machine [%s] in namespace [%s] is in %s state. It should be eitehr be started or stopped", name, namespace, vm.Status.PrintableStatus)
+		return fmt.Errorf("virtual machine [%s] in namespace [%s] is in %s state. It should be in running or stopped state", name, namespace, vm.Status.PrintableStatus)
 	}
 	return nil
 }

--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/portworx/torpedo/drivers/backup"
 	"github.com/portworx/torpedo/drivers/scheduler"
 	"github.com/portworx/torpedo/pkg/log"
+	kubevirtv1 "kubevirt.io/api/core/v1"
 	"strings"
 	"time"
 
@@ -143,6 +144,22 @@ var _ = Describe("{BasicBackupCreation}", func() {
 		Step("Validating applications", func() {
 			log.InfoD("Validating applications")
 			ValidateApplications(scheduledAppContexts)
+			for _, ctx := range scheduledAppContexts {
+				ns := ctx.App.NameSpace
+				for _, appSpec := range ctx.App.SpecList {
+					if obj, ok := appSpec.(*kubevirtv1.VirtualMachine); ok {
+						log.Infof("Stopping VM")
+						err := StopKubevirtVM(obj.Name, ns)
+						log.FailOnError(err, fmt.Sprintf("unable to stop vm %s in ns %s", obj.Name, ns))
+						log.Infof("Starting VM")
+						err = StartKubevirtVM(obj.Name, ns)
+						log.FailOnError(err, fmt.Sprintf("unable to stop vm %s in ns %s", obj.Name, ns))
+						log.Infof("Restarting VM")
+						err = RestartKubevirtVM(obj.Name, ns)
+						log.FailOnError(err, fmt.Sprintf("unable to stop vm %s in ns %s", obj.Name, ns))
+					}
+				}
+			}
 		})
 
 		Step("Creating rules for backup", func() {

--- a/tests/backup/backup_test.go
+++ b/tests/backup/backup_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/portworx/torpedo/drivers/backup"
 	"github.com/portworx/torpedo/drivers/scheduler"
 	"github.com/portworx/torpedo/pkg/log"
-	kubevirtv1 "kubevirt.io/api/core/v1"
 	"strings"
 	"time"
 
@@ -144,22 +143,6 @@ var _ = Describe("{BasicBackupCreation}", func() {
 		Step("Validating applications", func() {
 			log.InfoD("Validating applications")
 			ValidateApplications(scheduledAppContexts)
-			for _, ctx := range scheduledAppContexts {
-				ns := ctx.App.NameSpace
-				for _, appSpec := range ctx.App.SpecList {
-					if obj, ok := appSpec.(*kubevirtv1.VirtualMachine); ok {
-						log.Infof("Stopping VM")
-						err := StopKubevirtVM(obj.Name, ns)
-						log.FailOnError(err, fmt.Sprintf("unable to stop vm %s in ns %s", obj.Name, ns))
-						log.Infof("Starting VM")
-						err = StartKubevirtVM(obj.Name, ns)
-						log.FailOnError(err, fmt.Sprintf("unable to stop vm %s in ns %s", obj.Name, ns))
-						log.Infof("Restarting VM")
-						err = RestartKubevirtVM(obj.Name, ns)
-						log.FailOnError(err, fmt.Sprintf("unable to stop vm %s in ns %s", obj.Name, ns))
-					}
-				}
-			}
 		})
 
 		Step("Creating rules for backup", func() {

--- a/vendor/github.com/portworx/sched-ops/k8s/core/nodes.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/core/nodes.go
@@ -453,7 +453,7 @@ func (c *Client) GetReadyWindowsNodes() (*corev1.NodeList, error) {
 	return c.getTaggedNodes("kubernetes.io/os", "windows", true)
 }
 
-// GetNodesUsingVolume: Returns the list of nodes using a Pv.
+// GetNodesUsingVolume Returns the list of nodes using a Pv.
 func (c *Client) GetNodesUsingVolume(pvName string, readyNodesOnly bool) (*corev1.NodeList, error) {
 	allNodes, err := c.getTaggedNodes("", "", readyNodesOnly)
 	if err != nil {

--- a/vendor/github.com/portworx/sched-ops/k8s/kubevirt/virtualmachine.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/kubevirt/virtualmachine.go
@@ -76,8 +76,9 @@ func (c *Client) ValidateVirtualMachineRunning(name, namespace string, timeout, 
 	}
 
 	// Start the VirtualMachine if its not Started yet
-	if !*vm.Spec.Running {
-		if err = instance.StartVirtualMachine(vm); err != nil {
+	if vm.Status.PrintableStatus == kubevirtv1.VirtualMachineStatusStopped ||
+		vm.Status.PrintableStatus == kubevirtv1.VirtualMachineStatusStopping {
+		if err = c.StartVirtualMachine(vm); err != nil {
 			return fmt.Errorf("Failed to start VirtualMachine %v", err)
 		}
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1120,7 +1120,7 @@ github.com/portworx/pds-api-go-client/pds/v1alpha1
 github.com/portworx/px-backup-api/pkg/apis/v1
 github.com/portworx/px-backup-api/pkg/kubeauth
 github.com/portworx/px-backup-api/pkg/kubeauth/gcp
-# github.com/portworx/sched-ops v1.20.4-rc1.0.20230926074552-5a61e22be0a4
+# github.com/portworx/sched-ops v1.20.4-rc1.0.20231013094113-8ca7856dbe86
 ## explicit; go 1.19
 github.com/portworx/sched-ops/k8s/admissionregistration
 github.com/portworx/sched-ops/k8s/apiextensions


### PR DESCRIPTION
**What this PR does / why we need it**:

- [x] Moved the destroy virtual machine function outside the `destroyCoreObject` function
- [x] Created helper functions - `RestartKubevirtVM`, `StopKubevirtVM` and `StartKubevirtVM`

**Which issue(s) this PR fixes** (optional)
Closes #PA-1641

**Special notes for your reviewer**:
[Jenkins Run](https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/3007/)
