### PR TITLE
PWX-33942: restart px after expansion

### DIFF
--- a/tests/basic/common.go
+++ b/tests/basic/common.go
@@ -17,7 +17,7 @@ const (
 
 var contexts []*scheduler.Context
 var poolIDToResize string
-var poolToBeResized *api.StoragePool
+var poolToResize *api.StoragePool
 var isJournalEnabled bool
 var bufferSizeInGB uint64
 var targetSizeInBytes uint64

--- a/tests/basic/pool_function_test.go
+++ b/tests/basic/pool_function_test.go
@@ -31,7 +31,7 @@ var _ = Describe("{PoolExpandMultipleTimes}", func() {
 	JustBeforeEach(func() {
 		poolIDToResize = pickPoolToResize()
 		log.Infof("Picked pool %s to resize", poolIDToResize)
-		poolToBeResized = getStoragePool(poolIDToResize)
+		poolToResize = getStoragePool(poolIDToResize)
 	})
 
 	JustAfterEach(func() {
@@ -102,12 +102,12 @@ var _ = Describe("{PoolExpandSmoky}", func() {
 	It("Select a pool and expand it by 100 GiB with add-disk type. ", func() {
 		StartTorpedoTest("PoolExpandDiskAdd",
 			"Validate storage pool expansion with type=add-disk", nil, 0)
-		originalSizeInBytes = poolToBeResized.TotalSize
+		originalSizeInBytes = poolToResize.TotalSize
 		targetSizeInBytes = originalSizeInBytes + 100*units.GiB
 		targetSizeGiB = targetSizeInBytes / units.GiB
 
 		log.InfoD("Current Size of the pool %s is %d GiB. Trying to expand to %v GiB with type add-disk",
-			poolIDToResize, poolToBeResized.TotalSize/units.GiB, targetSizeGiB)
+			poolIDToResize, poolToResize.TotalSize/units.GiB, targetSizeGiB)
 		triggerPoolExpansion(poolIDToResize, targetSizeGiB, api.SdkStoragePool_RESIZE_TYPE_ADD_DISK)
 		resizeErr := waitForOngoingPoolExpansionToComplete(poolIDToResize)
 		dash.VerifyFatal(resizeErr, nil, "Pool expansion does not result in error")
@@ -117,12 +117,12 @@ var _ = Describe("{PoolExpandSmoky}", func() {
 	It("Select a pool and expand it by 100 GiB with resize-disk type. ", func() {
 		StartTorpedoTest("PoolExpandDiskResize",
 			"Validate storage pool expansion with type=resize-disk", nil, 0)
-		originalSizeInBytes = poolToBeResized.TotalSize
+		originalSizeInBytes = poolToResize.TotalSize
 		targetSizeInBytes = originalSizeInBytes + 100*units.GiB
 		targetSizeGiB = targetSizeInBytes / units.GiB
 
 		log.InfoD("Current Size of the pool %s is %d GiB. Trying to expand to %v GiB with type resize-disk",
-			poolIDToResize, poolToBeResized.TotalSize/units.GiB, targetSizeGiB)
+			poolIDToResize, poolToResize.TotalSize/units.GiB, targetSizeGiB)
 		triggerPoolExpansion(poolIDToResize, targetSizeGiB, api.SdkStoragePool_RESIZE_TYPE_RESIZE_DISK)
 		resizeErr := waitForOngoingPoolExpansionToComplete(poolIDToResize)
 		dash.VerifyFatal(resizeErr, nil, "Pool expansion does not result in error")
@@ -132,12 +132,12 @@ var _ = Describe("{PoolExpandSmoky}", func() {
 	It("Select a pool and expand it by 100 GiB with auto type. ", func() {
 		StartTorpedoTest("PoolExpandDiskAuto",
 			"Validate storage pool expansion with type=auto ", nil, 0)
-		originalSizeInBytes = poolToBeResized.TotalSize
+		originalSizeInBytes = poolToResize.TotalSize
 		targetSizeInBytes = originalSizeInBytes + 100*units.GiB
 		targetSizeGiB = targetSizeInBytes / units.GiB
 
 		log.InfoD("Current Size of the pool %s is %d GiB. Trying to expand to %v GiB with type auto",
-			poolIDToResize, poolToBeResized.TotalSize/units.GiB, targetSizeGiB)
+			poolIDToResize, poolToResize.TotalSize/units.GiB, targetSizeGiB)
 		triggerPoolExpansion(poolIDToResize, targetSizeGiB, api.SdkStoragePool_RESIZE_TYPE_AUTO)
 		resizeErr := waitForOngoingPoolExpansionToComplete(poolIDToResize)
 		dash.VerifyFatal(resizeErr, nil, "Pool expansion does not result in error")
@@ -153,7 +153,7 @@ var _ = Describe("{PoolExpandWithReboot}", func() {
 	JustBeforeEach(func() {
 		poolIDToResize = pickPoolToResize()
 		log.Infof("Picked pool %s to resize", poolIDToResize)
-		poolToBeResized = getStoragePool(poolIDToResize)
+		poolToResize = getStoragePool(poolIDToResize)
 		storageNode, err = GetNodeWithGivenPoolID(poolIDToResize)
 		log.FailOnError(err, "Failed to get node with given pool ID")
 	})
@@ -171,11 +171,11 @@ var _ = Describe("{PoolExpandWithReboot}", func() {
 		StartTorpedoTest("PoolExpandDiskAddWithReboot", "Initiate pool expansion using add-disk and reboot node", nil, 51309)
 		runID = testrailuttils.AddRunsToMilestone(testrailID)
 		Step("Select a pool that has I/O and expand it by 100 GiB with add-disk type. ", func() {
-			originalSizeInBytes = poolToBeResized.TotalSize
+			originalSizeInBytes = poolToResize.TotalSize
 			targetSizeInBytes = originalSizeInBytes + 100*units.GiB
 			targetSizeGiB = targetSizeInBytes / units.GiB
 			log.InfoD("Current Size of the pool %s is %d GiB. Trying to expand to %v GiB with type add-disk",
-				poolIDToResize, poolToBeResized.TotalSize/units.GiB, targetSizeGiB)
+				poolIDToResize, poolToResize.TotalSize/units.GiB, targetSizeGiB)
 			triggerPoolExpansion(poolIDToResize, targetSizeGiB, api.SdkStoragePool_RESIZE_TYPE_ADD_DISK)
 		})
 
@@ -202,7 +202,7 @@ var _ = Describe("{PoolExpandWithPXRestart}", func() {
 	JustBeforeEach(func() {
 		poolIDToResize = pickPoolToResize()
 		log.Infof("Picked pool %s to resize", poolIDToResize)
-		poolToBeResized = getStoragePool(poolIDToResize)
+		poolToResize = getStoragePool(poolIDToResize)
 		storageNode, err = GetNodeWithGivenPoolID(poolIDToResize)
 		log.FailOnError(err, "Failed to get node with given pool ID")
 	})
@@ -216,16 +216,47 @@ var _ = Describe("{PoolExpandWithPXRestart}", func() {
 		EndTorpedoTest()
 	})
 
+	It("Restart PX after pool expansion", func() {
+		StartTorpedoTest("RestartAfterPoolExpansion",
+			"Restart PX after pool expansion", nil, testrailID)
+
+		Step("Select a pool that has I/O and expand it by 100 GiB with add-disk type. ", func() {
+			originalSizeInBytes = poolToResize.TotalSize
+			targetSizeInBytes = originalSizeInBytes + 100*units.GiB
+			targetSizeGiB = targetSizeInBytes / units.GiB
+			log.InfoD("Current Size of the pool %s is %d GiB. Trying to expand to %v GiB with type add-disk",
+				poolIDToResize, poolToResize.TotalSize/units.GiB, targetSizeGiB)
+			triggerPoolExpansion(poolIDToResize, targetSizeGiB, api.SdkStoragePool_RESIZE_TYPE_ADD_DISK)
+		})
+
+		Step("Wait for expansion to finish and restart PX", func() {
+			resizeErr := waitForOngoingPoolExpansionToComplete(poolIDToResize)
+			dash.VerifyFatal(resizeErr, nil, "Pool expansion does not result in error")
+			log.FailOnError(Inst().V.RestartDriver(*storageNode, nil),
+				fmt.Sprintf("Error restarting px on node [%s]", storageNode.Name))
+			log.FailOnError(Inst().V.WaitDriverUpOnNode(*storageNode, addDriveUpTimeOut),
+				fmt.Sprintf("Timed out waiting for px to come up on node [%s]", storageNode.Name))
+		})
+
+		Step("Ensure pool is up and running", func() {
+			// Ensure pool is up and running
+			poolToResize = getStoragePool(poolIDToResize)
+			// Ensure poolToResize is not nil
+			dash.VerifyFatal(poolToResize != nil, true, "Pool is up and running after restart")
+			verifyPoolSizeEqualOrLargerThanExpected(poolIDToResize, targetSizeGiB)
+		})
+	})
+
 	It("Initiate pool expansion using add-drive and restart PX", func() {
 		StartTorpedoTest("PoolExpandAddDiskAndPXRestart",
 			"Initiate pool expansion using add-drive and restart PX", nil, testrailID)
 
 		Step("Select a pool that has I/O and expand it by 100 GiB with add-disk type. ", func() {
-			originalSizeInBytes = poolToBeResized.TotalSize
+			originalSizeInBytes = poolToResize.TotalSize
 			targetSizeInBytes = originalSizeInBytes + 100*units.GiB
 			targetSizeGiB = targetSizeInBytes / units.GiB
 			log.InfoD("Current Size of the pool %s is %d GiB. Trying to expand to %v GiB with type add-disk",
-				poolIDToResize, poolToBeResized.TotalSize/units.GiB, targetSizeGiB)
+				poolIDToResize, poolToResize.TotalSize/units.GiB, targetSizeGiB)
 			triggerPoolExpansion(poolIDToResize, targetSizeGiB, api.SdkStoragePool_RESIZE_TYPE_ADD_DISK)
 		})
 

--- a/tests/basic/pool_function_test.go
+++ b/tests/basic/pool_function_test.go
@@ -47,13 +47,13 @@ var _ = Describe("{PoolExpandMultipleTimes}", func() {
 		StartTorpedoTest("PoolExpandDiskAdd3Times",
 			"Validate storage pool expansion 3 times with type=add-disk", nil, 0)
 		for i := 0; i < 3; i++ {
-			poolToBeResized = getStoragePool(poolIDToResize)
-			originalSizeInBytes = poolToBeResized.TotalSize
+			poolToResize = getStoragePool(poolIDToResize)
+			originalSizeInBytes = poolToResize.TotalSize
 			targetSizeInBytes = originalSizeInBytes + 100*units.GiB
 			targetSizeGiB = targetSizeInBytes / units.GiB
 
 			log.InfoD("Current Size of pool %s is %d GiB. Expand to %v GiB with type add-disk...",
-				poolIDToResize, poolToBeResized.TotalSize/units.GiB, targetSizeGiB)
+				poolIDToResize, poolToResize.TotalSize/units.GiB, targetSizeGiB)
 			triggerPoolExpansion(poolIDToResize, targetSizeGiB, api.SdkStoragePool_RESIZE_TYPE_ADD_DISK)
 			resizeErr := waitForOngoingPoolExpansionToComplete(poolIDToResize)
 			dash.VerifyFatal(resizeErr, nil, "Pool expansion does not result in error")
@@ -65,12 +65,12 @@ var _ = Describe("{PoolExpandMultipleTimes}", func() {
 		StartTorpedoTest("PoolExpandDiskResize3Times",
 			"Validate storage pool expansion with type=resize-disk", nil, 0)
 		for i := 0; i < 3; i++ {
-			originalSizeInBytes = poolToBeResized.TotalSize
+			originalSizeInBytes = poolToResize.TotalSize
 			targetSizeInBytes = originalSizeInBytes + 100*units.GiB
 			targetSizeGiB = targetSizeInBytes / units.GiB
 
 			log.InfoD("Current Size of pool %s is %d GiB. Expand to %v GiB with type resize-disk...",
-				poolIDToResize, poolToBeResized.TotalSize/units.GiB, targetSizeGiB)
+				poolIDToResize, poolToResize.TotalSize/units.GiB, targetSizeGiB)
 			triggerPoolExpansion(poolIDToResize, targetSizeGiB, api.SdkStoragePool_RESIZE_TYPE_RESIZE_DISK)
 			resizeErr := waitForOngoingPoolExpansionToComplete(poolIDToResize)
 			dash.VerifyFatal(resizeErr, nil, "Pool expansion does not result in error")
@@ -87,7 +87,7 @@ var _ = Describe("{PoolExpandSmoky}", func() {
 	JustBeforeEach(func() {
 		poolIDToResize = pickPoolToResize()
 		log.Infof("Picked pool %s to resize", poolIDToResize)
-		poolToBeResized = getStoragePool(poolIDToResize)
+		poolToResize = getStoragePool(poolIDToResize)
 	})
 
 	JustAfterEach(func() {
@@ -329,7 +329,7 @@ var _ = Describe("{PoolExpandDiskAddAndVerifyFromOtherNode}", func() {
 	JustBeforeEach(func() {
 		poolIDToResize = pickPoolToResize()
 		log.Infof("Picked pool %s to resize", poolIDToResize)
-		poolToBeResized = getStoragePool(poolIDToResize)
+		poolToResize = getStoragePool(poolIDToResize)
 		storageNode, err = GetNodeWithGivenPoolID(poolIDToResize)
 		log.FailOnError(err, "Failed to get node with given pool ID")
 	})
@@ -355,12 +355,12 @@ var _ = Describe("{PoolExpandDiskAddAndVerifyFromOtherNode}", func() {
 			}
 		}
 
-		originalSizeInBytes = poolToBeResized.TotalSize
+		originalSizeInBytes = poolToResize.TotalSize
 		targetSizeInBytes = originalSizeInBytes + 100*units.GiB
 		targetSizeGiB = targetSizeInBytes / units.GiB
 
 		log.InfoD("Current Size of the pool %s is %d GiB. Trying to expand to %v GiB with type add-disk",
-			poolIDToResize, poolToBeResized.TotalSize/units.GiB, targetSizeGiB)
+			poolIDToResize, poolToResize.TotalSize/units.GiB, targetSizeGiB)
 		triggerPoolExpansion(poolIDToResize, targetSizeGiB, api.SdkStoragePool_RESIZE_TYPE_ADD_DISK)
 
 		Step("Ensure pool has been expanded to the expected size", func() {
@@ -451,9 +451,9 @@ var _ = Describe("{PoolExpandResizeWithSameSize}", func() {
 		pools, err := GetAllPoolsPresent()
 		log.FailOnError(err, "Unable to get the storage Pools")
 		pooltoPick := pools[0]
-		poolToBeResized = getStoragePool(pooltoPick)
+		poolToResize = getStoragePool(pooltoPick)
 
-		originalSizeGiB := poolToBeResized.TotalSize / units.GiB
+		originalSizeGiB := poolToResize.TotalSize / units.GiB
 		targetSizeGiB = originalSizeGiB
 		resizeErr := Inst().V.ExpandPool(pooltoPick, api.SdkStoragePool_RESIZE_TYPE_RESIZE_DISK, targetSizeGiB, true)
 		dash.VerifyFatal(resizeErr != nil, true, "Verify error occurs with same pool size")
@@ -482,7 +482,7 @@ var _ = Describe("{PoolExpandWhileResizeDiskInProgress}", func() {
 	JustBeforeEach(func() {
 		poolIDToResize = pickPoolToResize()
 		log.Infof("Picked pool %s to resize", poolIDToResize)
-		poolToBeResized = getStoragePool(poolIDToResize)
+		poolToResize = getStoragePool(poolIDToResize)
 		storageNode, err = GetNodeWithGivenPoolID(poolIDToResize)
 		log.FailOnError(err, "Failed to get node with given pool ID")
 	})
@@ -500,12 +500,12 @@ var _ = Describe("{PoolExpandWhileResizeDiskInProgress}", func() {
 	It(stepLog, func() {
 		log.InfoD(stepLog)
 
-		originalSizeInBytes = poolToBeResized.TotalSize
+		originalSizeInBytes = poolToResize.TotalSize
 		targetSizeInBytes = originalSizeInBytes + 100*units.GiB
 		targetSizeGiB = targetSizeInBytes / units.GiB
 
 		log.InfoD("Current Size of the pool %s is %d GiB. Trying to expand to %v GiB with type resize-disk",
-			poolIDToResize, poolToBeResized.TotalSize/units.GiB, targetSizeGiB)
+			poolIDToResize, poolToResize.TotalSize/units.GiB, targetSizeGiB)
 		triggerPoolExpansion(poolIDToResize, targetSizeGiB, api.SdkStoragePool_RESIZE_TYPE_RESIZE_DISK)
 
 		// we are using pxctl command direclty as we dont want retries and Inst().V.ExpandPool does not returns required error

--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -37,7 +37,7 @@ var _ = Describe("{StoragePoolExpandDiskResize}", func() {
 
 	JustBeforeEach(func() {
 		poolIDToResize = pickPoolToResize()
-		poolToBeResized = getStoragePool(poolIDToResize)
+		poolToResize = getStoragePool(poolIDToResize)
 		isJournalEnabled, _ = IsJournalEnabled()
 		bufferSizeInGB = uint64(0)
 		if isJournalEnabled {
@@ -48,12 +48,12 @@ var _ = Describe("{StoragePoolExpandDiskResize}", func() {
 	testName = "StoragePoolExpandDiskResize"
 	testDescription = "Validate storage pool expansion using resize-disk option"
 	It("select a pool that has I/O and expand it by 100 GiB with resize-disk type. ", func() {
-		originalSizeInBytes = poolToBeResized.TotalSize
+		originalSizeInBytes = poolToResize.TotalSize
 		targetSizeInBytes = originalSizeInBytes + 100*units.GiB // getDesiredSize(originalSizeInBytes)
 		targetSizeGiB := targetSizeInBytes / units.GiB
 
 		log.InfoD("Current size of pool %s is %d GiB. Trying to expand to %v GiB",
-			poolIDToResize, poolToBeResized.TotalSize/units.GiB, targetSizeGiB)
+			poolIDToResize, poolToResize.TotalSize/units.GiB, targetSizeGiB)
 		triggerPoolExpansion(poolIDToResize, targetSizeGiB+bufferSizeInGB, api.SdkStoragePool_RESIZE_TYPE_RESIZE_DISK)
 		resizeErr := waitForOngoingPoolExpansionToComplete(poolIDToResize)
 		dash.VerifyFatal(resizeErr, nil, "Pool expansion does not result in error")
@@ -699,9 +699,9 @@ var _ = Describe("{AddNewPoolWhileRebalance}", func() {
 			}
 		}
 		log.Infof("selected node %s, pool %s", nodeSelected.Name, poolIDToResize)
-		poolToBeResized, err = GetStoragePoolByUUID(poolIDToResize)
+		poolToResize, err = GetStoragePoolByUUID(poolIDToResize)
 		log.FailOnError(err, fmt.Sprintf("unable to get pool using UUID and vol %+v", volSelected))
-		currentTotalPoolSize = poolToBeResized.TotalSize / units.GiB
+		currentTotalPoolSize = poolToResize.TotalSize / units.GiB
 		pools, err = Inst().V.ListStoragePools(metav1.LabelSelector{})
 		log.FailOnError(err, "error getting storage pools")
 		existingPoolsCount := len(pools)
@@ -741,7 +741,7 @@ var _ = Describe("{AddNewPoolWhileRebalance}", func() {
 		stepLog = fmt.Sprintf("Verify that pool %s can be expanded", poolIDToResize)
 		Step(stepLog, func() {
 			log.InfoD(stepLog)
-			isPoolHealthy, err := poolResizeIsInProgress(poolToBeResized)
+			isPoolHealthy, err := poolResizeIsInProgress(poolToResize)
 			log.FailOnError(err, fmt.Sprintf("pool [%s] cannot be expanded due to error: %v", poolIDToResize, err))
 			dash.VerifyFatal(isPoolHealthy, true, "Verify pool before expansion")
 		})


### PR DESCRIPTION
Added new test case "Restart PX after pool expansion" in pool_functional_test.go
Renamed poolToBeResized -> poolToResize

Successful test run at 
https://jenkins.pwx.dev.purestorage.com/job/Users/job/alyu/job/pxdv-7-dev/77/console