### PR TITLE
PWX-33997, PWX-34074: Added checks around local Pure mapper paths

### DIFF
--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -7007,7 +7007,29 @@ func (k *K8s) snapshotAndVerify(size resource.Quantity, data, snapName, namespac
 			return fmt.Errorf("restored volume does NOT contain data from original volume: expected to contain '%s', got '%s'", data, string(fileContent))
 		}
 	}
-	log.Info("Validation complete")
+
+	log.Info("Validation complete, deleting restored pods")
+	err = clientset.CoreV1().Pods(namespace).Delete(context.TODO(), restoredPod.Name, metav1.DeleteOptions{})
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return fmt.Errorf("error deleting restored pod: %s", err)
+	}
+
+	// Wait for the pod to be actually gone
+	t := func() (interface{}, bool, error) {
+		var err error
+		if _, err = clientset.CoreV1().Pods(namespace).Get(context.TODO(), restoredPod.Name, metav1.GetOptions{}); err != nil {
+			if k8serrors.IsNotFound(err) {
+				return nil, false, nil // Pod is now successfully gone
+			}
+			return nil, true, fmt.Errorf("failed to check that pod %s in ns %s is gone. Err: %v", restoredPod.Name, restoredPod.Namespace, err)
+		}
+		return nil, true, fmt.Errorf("pod %s in ns %s still exists", restoredPod.Name, restoredPod.Namespace)
+	}
+
+	if _, err := task.DoRetryWithTimeout(t, time.Minute*2, DefaultRetryInterval); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -7067,7 +7089,29 @@ func (k *K8s) cloneAndVerify(size resource.Quantity, data, namespace, storageCla
 			return fmt.Errorf("cloned volume does NOT contain data from original volume: expected to contain '%s', got '%s'", data, string(fileContent))
 		}
 	}
-	log.Info("Validation complete")
+
+	log.Info("Validation complete, deleting restored pods")
+	err = clientset.CoreV1().Pods(namespace).Delete(context.TODO(), restoredPod.Name, metav1.DeleteOptions{})
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return fmt.Errorf("error deleting restored pod: %s", err)
+	}
+
+	// Wait for the pod to be actually gone
+	t := func() (interface{}, bool, error) {
+		var err error
+		if _, err = clientset.CoreV1().Pods(namespace).Get(context.TODO(), restoredPod.Name, metav1.GetOptions{}); err != nil {
+			if k8serrors.IsNotFound(err) {
+				return nil, false, nil // Pod is now successfully gone
+			}
+			return nil, true, fmt.Errorf("failed to check that pod %s in ns %s is gone. Err: %v", restoredPod.Name, restoredPod.Namespace, err)
+		}
+		return nil, true, fmt.Errorf("pod %s in ns %s still exists", restoredPod.Name, restoredPod.Namespace)
+	}
+
+	if _, err := task.DoRetryWithTimeout(t, time.Minute*2, DefaultRetryInterval); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -6996,7 +6996,7 @@ func (k *K8s) snapshotAndVerify(size resource.Quantity, data, snapName, namespac
 			return fmt.Errorf("error checking content of cloned PVC: %s. Output: %s", err, string(fileContent))
 		}
 		if data != fileContent {
-			return fmt.Errorf("Compared data of text file & data copied to device path is not same")
+			return fmt.Errorf("compared data of text file & data copied to device path is not same")
 		}
 	} else {
 		fileContent, err := k.readDataFromPod(restoredPod.Name, namespace, "/mnt/volume1/aaaa.txt")
@@ -7014,16 +7014,19 @@ func (k *K8s) snapshotAndVerify(size resource.Quantity, data, snapName, namespac
 		return fmt.Errorf("error deleting restored pod: %s", err)
 	}
 
-	// Wait for the pod to be actually gone
+	// Wait for the pod to be actually gone, checking by pod UID in case it gets recreated (deployment in the future?)
 	t := func() (interface{}, bool, error) {
-		var err error
-		if _, err = clientset.CoreV1().Pods(namespace).Get(context.TODO(), restoredPod.Name, metav1.GetOptions{}); err != nil {
-			if k8serrors.IsNotFound(err) {
-				return nil, false, nil // Pod is now successfully gone
-			}
-			return nil, true, fmt.Errorf("failed to check that pod %s in ns %s is gone. Err: %v", restoredPod.Name, restoredPod.Namespace, err)
+		existingPods, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			return nil, true, fmt.Errorf("failed to list pods in ns %s. Error: %v", namespace, err)
 		}
-		return nil, true, fmt.Errorf("pod %s in ns %s still exists", restoredPod.Name, restoredPod.Namespace)
+
+		for _, pod := range existingPods.Items {
+			if pod.UID == restoredPod.UID {
+				return nil, true, fmt.Errorf("pod %s in ns %s still exists", restoredPod.Name, restoredPod.Namespace)
+			}
+		}
+		return nil, false, nil // Pod is now successfully gone
 	}
 
 	if _, err := task.DoRetryWithTimeout(t, time.Minute*2, DefaultRetryInterval); err != nil {
@@ -7078,7 +7081,7 @@ func (k *K8s) cloneAndVerify(size resource.Quantity, data, namespace, storageCla
 			return fmt.Errorf("error checking content of cloned PVC: %s. Output: %s", err, string(fileContent))
 		}
 		if data != fileContent {
-			return fmt.Errorf("Compared data of text file & data copied to device path is not same")
+			return fmt.Errorf("compared data of text file & data copied to device path is not same")
 		}
 	} else {
 		fileContent, err := k.readDataFromPod(restoredPod.Name, namespace, "/mnt/volume1/aaaa.txt")

--- a/drivers/volume/common.go
+++ b/drivers/volume/common.go
@@ -399,6 +399,22 @@ func (d *DefaultDriver) ValidatePureVolumesNoReplicaSets(volumeName string, para
 	}
 }
 
+// InitializePureLocalVolumePaths sets the baseline for how many Pure devices are already attached to the node
+func (d *DefaultDriver) InitializePureLocalVolumePaths() error {
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "InitializePureLocalVolumePaths()",
+	}
+}
+
+// ValidatePureLocalVolumePaths checks that the given volumes all have the proper local paths present, *and that no other unexpected ones are present*
+func (d *DefaultDriver) ValidatePureLocalVolumePaths(volumes []*Volume) error {
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "ValidatePureLocalVolumePaths()",
+	}
+}
+
 // ValidateUpdateVolume validates if volume changes has been applied
 func (d *DefaultDriver) ValidateUpdateVolume(vol *Volume, params map[string]string) error {
 	return &errors.ErrNotSupported{

--- a/drivers/volume/common.go
+++ b/drivers/volume/common.go
@@ -408,7 +408,7 @@ func (d *DefaultDriver) InitializePureLocalVolumePaths() error {
 }
 
 // ValidatePureLocalVolumePaths checks that the given volumes all have the proper local paths present, *and that no other unexpected ones are present*
-func (d *DefaultDriver) ValidatePureLocalVolumePaths(volumes []*Volume) error {
+func (d *DefaultDriver) ValidatePureLocalVolumePaths() error {
 	return &errors.ErrNotSupported{
 		Type:      "Function",
 		Operation: "ValidatePureLocalVolumePaths()",

--- a/drivers/volume/portworx/schedops/k8s-schedops.go
+++ b/drivers/volume/portworx/schedops/k8s-schedops.go
@@ -66,10 +66,10 @@ const (
 	talismanImage               = "portworx/talisman:latest"
 	rancherControlPlaneLabelKey = "node-role.kubernetes.io/controlplane"
 
-	// pureVolumeOUI is used to identify if a mapper device is of Pure origin
+	// PureVolumeOUI is used to identify if a mapper device is of Pure origin
 	// (if it matches with /dev/mapper/.*24a937.*, it's a Pure volume, if it's some other format it's not)
-	pureVolumeOUI   = "24a937"
-	pureMapperRegex = "/dev/mapper/.*" + pureVolumeOUI + ".*"
+	PureVolumeOUI   = "24a937"
+	PureMapperRegex = "/dev/mapper/.*" + PureVolumeOUI + ".*"
 )
 
 const (
@@ -406,7 +406,7 @@ PodLoop:
 			}
 			log.Infof("container [%s] and paths [%v] after checking sym links", containerName, paths)
 			for _, path := range paths {
-				pxMountCheckRegex := regexp.MustCompile(fmt.Sprintf("^(/dev/pxd.+|pxfs.+|/dev/mapper/pxd-enc.+|%s.+|/dev/loop.+|\\d+\\.\\d+\\.\\d+\\.\\d+:/var/lib/osd/pxns.+|(.[A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4}]:/var/lib/osd/pxns.+|\\d+.\\d+.\\d+.\\d+:/px_[0-9A-Za-z]{8}-pvc.+) %s", pureMapperRegex, path))
+				pxMountCheckRegex := regexp.MustCompile(fmt.Sprintf("^(/dev/pxd.+|pxfs.+|/dev/mapper/pxd-enc.+|%s.+|/dev/loop.+|\\d+\\.\\d+\\.\\d+\\.\\d+:/var/lib/osd/pxns.+|(.[A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4}]:/var/lib/osd/pxns.+|\\d+.\\d+.\\d+.\\d+:/px_[0-9A-Za-z]{8}-pvc.+) %s", PureMapperRegex, path))
 				pxMountFound := false
 				for _, line := range mounts {
 					pxMounts := pxMountCheckRegex.FindStringSubmatch(line)

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -155,6 +155,12 @@ type Driver interface {
 	// ValidatePureVolumesNoReplicaSets validates pure volumes has no replicaset
 	ValidatePureVolumesNoReplicaSets(volumeName string, params map[string]string) error
 
+	// InitializePureLocalVolumePaths sets the baseline for how many Pure devices are already attached to the node
+	InitializePureLocalVolumePaths() error
+
+	// ValidatePureLocalVolumePaths checks that the given volumes all have the proper local paths present, *and that no other unexpected ones are present*
+	ValidatePureLocalVolumePaths(volumes []*Volume) error
+
 	// ValidateVolumeInPxctlList validates that the given volume appears in the output of `pxctl v l`
 	ValidateVolumeInPxctlList(name string) error
 

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -159,7 +159,7 @@ type Driver interface {
 	InitializePureLocalVolumePaths() error
 
 	// ValidatePureLocalVolumePaths checks that the given volumes all have the proper local paths present, *and that no other unexpected ones are present*
-	ValidatePureLocalVolumePaths(volumes []*Volume) error
+	ValidatePureLocalVolumePaths() error
 
 	// ValidateVolumeInPxctlList validates that the given volume appears in the output of `pxctl v l`
 	ValidateVolumeInPxctlList(name string) error

--- a/tests/basic/pure_test.go
+++ b/tests/basic/pure_test.go
@@ -90,6 +90,9 @@ var _ = Describe("{PureVolumeCRUDWithSDK}", func() {
 		Step("setup credential necessary for cloudsnap", createCloudsnapCredential)
 		contexts = make([]*scheduler.Context, 0)
 
+		err := Inst().V.InitializePureLocalVolumePaths() // Initialize our "baseline" of Pure devices, such as FACD devices or other local FA disks
+		Expect(err).NotTo(HaveOccurred(), "unexpected error taking Pure device baseline")
+
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
 			contexts = append(contexts, ScheduleApplications(fmt.Sprintf("purevolumestest-%d", i))...)
 		}
@@ -118,6 +121,9 @@ var _ = Describe("{PureVolumeCRUDWithPXCTL}", func() {
 	It("schedule pure volumes on applications, run CRUD, tear down", func() {
 		Step("setup credential necessary for cloudsnap", createCloudsnapCredential)
 		contexts = make([]*scheduler.Context, 0)
+
+		err := Inst().V.InitializePureLocalVolumePaths() // Initialize our "baseline" of Pure devices, such as FACD devices or other local FA disks
+		Expect(err).NotTo(HaveOccurred(), "unexpected error taking Pure device baseline")
 
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
 			contexts = append(contexts, ScheduleApplications(fmt.Sprintf("purevolumestest-%d", i))...)

--- a/tests/basic/pure_test.go
+++ b/tests/basic/pure_test.go
@@ -2,25 +2,20 @@ package tests
 
 import (
 	"fmt"
-	"github.com/portworx/torpedo/drivers/scheduler/spec"
-	"github.com/portworx/torpedo/pkg/units"
-	appsv1 "k8s.io/api/apps/v1"
+	"math/rand"
 	"sort"
 	"strconv"
-
-	"math/rand"
-
-	"github.com/portworx/torpedo/pkg/osutils"
-
-	"github.com/libopenstorage/openstorage/api"
-	"github.com/portworx/sched-ops/k8s/core"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/libopenstorage/openstorage/api"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/google/uuid"
+	"github.com/portworx/sched-ops/k8s/core"
 	"github.com/portworx/sched-ops/task"
 	"github.com/portworx/torpedo/drivers/volume"
 	"github.com/portworx/torpedo/drivers/volume/portworx"
@@ -30,7 +25,10 @@ import (
 	"github.com/portworx/torpedo/drivers/node"
 	"github.com/portworx/torpedo/drivers/scheduler"
 	"github.com/portworx/torpedo/drivers/scheduler/k8s"
+	"github.com/portworx/torpedo/drivers/scheduler/spec"
+	"github.com/portworx/torpedo/pkg/osutils"
 	"github.com/portworx/torpedo/pkg/pureutils"
+	"github.com/portworx/torpedo/pkg/units"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -84,10 +82,10 @@ var _ = Describe("{PureVolumeCRUDWithSDK}", func() {
 	var contexts []*scheduler.Context
 	JustBeforeEach(func() {
 		StartTorpedoTest("PureVolumeCRUDWithSDK", "Test pure volumes on applications, run CRUD", nil, 0)
+		Step("setup credential necessary for cloudsnap", createCloudsnapCredential)
 	})
 
 	It("schedule pure volumes on applications, run CRUD, tear down", func() {
-		Step("setup credential necessary for cloudsnap", createCloudsnapCredential)
 		contexts = make([]*scheduler.Context, 0)
 
 		err := Inst().V.InitializePureLocalVolumePaths() // Initialize our "baseline" of Pure devices, such as FACD devices or other local FA disks
@@ -103,10 +101,11 @@ var _ = Describe("{PureVolumeCRUDWithSDK}", func() {
 		for _, ctx := range contexts {
 			TearDownContext(ctx, opts)
 		}
-		Step("delete credential used for cloudsnap", deleteCloudsnapCredential)
 	})
 
 	JustAfterEach(func() {
+		Step("delete credential used for cloudsnap", deleteCloudsnapCredential)
+
 		defer EndTorpedoTest()
 		AfterEachTest(contexts)
 	})
@@ -117,9 +116,9 @@ var _ = Describe("{PureVolumeCRUDWithPXCTL}", func() {
 	var contexts []*scheduler.Context
 	JustBeforeEach(func() {
 		StartTorpedoTest("PureVolumeCRUDWithPXCTL", "Test pure volumes on applications, run CRUD using pxctl", nil, 0)
+		Step("setup credential necessary for cloudsnap", createCloudsnapCredential)
 	})
 	It("schedule pure volumes on applications, run CRUD, tear down", func() {
-		Step("setup credential necessary for cloudsnap", createCloudsnapCredential)
 		contexts = make([]*scheduler.Context, 0)
 
 		err := Inst().V.InitializePureLocalVolumePaths() // Initialize our "baseline" of Pure devices, such as FACD devices or other local FA disks
@@ -135,9 +134,10 @@ var _ = Describe("{PureVolumeCRUDWithPXCTL}", func() {
 		for _, ctx := range contexts {
 			TearDownContext(ctx, opts)
 		}
-		Step("delete credential used for cloudsnap", deleteCloudsnapCredential)
 	})
 	JustAfterEach(func() {
+		Step("delete credential used for cloudsnap", deleteCloudsnapCredential)
+
 		defer EndTorpedoTest()
 		AfterEachTest(contexts)
 	})

--- a/tests/common.go
+++ b/tests/common.go
@@ -1063,11 +1063,6 @@ func ValidatePureSnapshotsSDK(ctx *scheduler.Context, errChan ...*chan error) {
 			processError(err, errChan...)
 		})
 
-		Step("validate Pure local volume paths", func() {
-			err = Inst().V.ValidatePureLocalVolumePaths()
-			processError(err, errChan...)
-		})
-
 		var vols map[string]map[string]string
 		Step(fmt.Sprintf("get %s app's volume's custom parameters", ctx.App.Key), func() {
 			vols, err = Inst().S.GetVolumeParameters(ctx)
@@ -1105,6 +1100,11 @@ func ValidatePureSnapshotsSDK(ctx *scheduler.Context, errChan ...*chan error) {
 				}
 			})
 		}
+
+		Step("validate Pure local volume paths", func() {
+			err = Inst().V.ValidatePureLocalVolumePaths()
+			processError(err, errChan...)
+		})
 	})
 }
 

--- a/tests/common.go
+++ b/tests/common.go
@@ -1063,11 +1063,8 @@ func ValidatePureSnapshotsSDK(ctx *scheduler.Context, errChan ...*chan error) {
 			processError(err, errChan...)
 		})
 
-		Step(fmt.Sprintf("validate Pure local volume paths", ctx.App.Key), func() {
-			vols, err := Inst().S.GetVolumes(ctx)
-			processError(err, errChan...)
-
-			err = Inst().V.ValidatePureLocalVolumePaths(vols)
+		Step("validate Pure local volume paths", func() {
+			err = Inst().V.ValidatePureLocalVolumePaths()
 			processError(err, errChan...)
 		})
 
@@ -1196,11 +1193,8 @@ func ValidateResizePurePVC(ctx *scheduler.Context, errChan ...*chan error) {
 		// TODO: add more checks (is the PVC resized in the pod?), we currently only check that the
 		//       CSI resize succeeded.
 
-		Step(fmt.Sprintf("validate Pure local volume paths", ctx.App.Key), func() {
-			vols, err := Inst().S.GetVolumes(ctx)
-			processError(err, errChan...)
-
-			err = Inst().V.ValidatePureLocalVolumePaths(vols)
+		Step("validate Pure local volume paths", func() {
+			err = Inst().V.ValidatePureLocalVolumePaths()
 			processError(err, errChan...)
 		})
 	})
@@ -1344,7 +1338,7 @@ func ValidateCSIVolumeClone(ctx *scheduler.Context, errChan ...*chan error) {
 			err = Inst().S.CSICloneTest(ctx, request)
 			processError(err, errChan...)
 
-			err = Inst().V.ValidatePureLocalVolumePaths(vols)
+			err = Inst().V.ValidatePureLocalVolumePaths()
 			processError(err, errChan...)
 		}
 	})
@@ -1383,7 +1377,7 @@ func ValidatePureVolumeLargeNumOfClones(ctx *scheduler.Context, errChan ...*chan
 
 			// Note: the above only creates PVCs, it does not attach them to pods, so no extra care needs to be taken for local paths
 
-			err = Inst().V.ValidatePureLocalVolumePaths(vols)
+			err = Inst().V.ValidatePureLocalVolumePaths()
 			processError(err, errChan...)
 		}
 	})
@@ -5319,7 +5313,7 @@ func HaIncreaseRebootTargetNode(event *EventRecord, ctx *scheduler.Context, v *v
 						if restartPX {
 							action = "restart px on"
 						}
-						stepLog = fmt.Sprintf("%a target node %s while repl increase is in-progres", action,
+						stepLog = fmt.Sprintf("%s target node %s while repl increase is in-progres", action,
 							newReplNode.Hostname)
 						Step(stepLog,
 							func() {

--- a/tests/common.go
+++ b/tests/common.go
@@ -1063,6 +1063,14 @@ func ValidatePureSnapshotsSDK(ctx *scheduler.Context, errChan ...*chan error) {
 			processError(err, errChan...)
 		})
 
+		Step(fmt.Sprintf("validate Pure local volume paths", ctx.App.Key), func() {
+			vols, err := Inst().S.GetVolumes(ctx)
+			processError(err, errChan...)
+
+			err = Inst().V.ValidatePureLocalVolumePaths(vols)
+			processError(err, errChan...)
+		})
+
 		var vols map[string]map[string]string
 		Step(fmt.Sprintf("get %s app's volume's custom parameters", ctx.App.Key), func() {
 			vols, err = Inst().S.GetVolumeParameters(ctx)
@@ -1187,6 +1195,14 @@ func ValidateResizePurePVC(ctx *scheduler.Context, errChan ...*chan error) {
 
 		// TODO: add more checks (is the PVC resized in the pod?), we currently only check that the
 		//       CSI resize succeeded.
+
+		Step(fmt.Sprintf("validate Pure local volume paths", ctx.App.Key), func() {
+			vols, err := Inst().S.GetVolumes(ctx)
+			processError(err, errChan...)
+
+			err = Inst().V.ValidatePureLocalVolumePaths(vols)
+			processError(err, errChan...)
+		})
 	})
 }
 
@@ -1327,6 +1343,9 @@ func ValidateCSIVolumeClone(ctx *scheduler.Context, errChan ...*chan error) {
 
 			err = Inst().S.CSICloneTest(ctx, request)
 			processError(err, errChan...)
+
+			err = Inst().V.ValidatePureLocalVolumePaths(vols)
+			processError(err, errChan...)
 		}
 	})
 }
@@ -1360,6 +1379,11 @@ func ValidatePureVolumeLargeNumOfClones(ctx *scheduler.Context, errChan ...*chan
 				SnapshotclassName: snapShotClassName,
 			}
 			err = Inst().S.CSISnapshotAndRestoreMany(ctx, request)
+			processError(err, errChan...)
+
+			// Note: the above only creates PVCs, it does not attach them to pods, so no extra care needs to be taken for local paths
+
+			err = Inst().V.ValidatePureLocalVolumePaths(vols)
 			processError(err, errChan...)
 		}
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds two extra functions to the Volume driver interface:

1. First, it adds a method to set the "baseline" of what Pure devices are attached to each node. This way, if the node has an FA boot drive or is using FA cloud drives for example, we don't get confused over those drives and think they are extra.

2. Second, it adds a method to list all the local Pure mapper paths on each node (excluding baseline devices), and validate that they are all corresponding to a volume that should be attached on that node. It will then raise an error if any of the mapper paths left on the device should not be attached, or if some of the baseline devices are no longer present then we also raise an error as we may have accidentally touched a disk we weren't supposed to.

**Note**: This will encounter some issues with FACD failover tests, as it will then be a different mapper device than originally and will trigger the baseline device error. I have left todos for where we can improve this in the future.

**Testing notes**:
Ran locally on my own cluster fully through both Pure tests, and confirmed that a) the tests passed, and b) the checks that it was running were making sense and passing as well. I also confirmed with a few failures while testing that it does indeed catch volumes that should have been deleted but were not.

Confirmed the same above for FADA + FBDA, with multiple apps at once, and confirmed it still passes
