### PR TITLE
moved createBackupUntilIncrementalBackup to backup_helper.go

### DIFF
--- a/tests/backup/backup_delete_test.go
+++ b/tests/backup/backup_delete_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -18,96 +17,6 @@ import (
 	"github.com/portworx/torpedo/pkg/log"
 	. "github.com/portworx/torpedo/tests"
 )
-
-// createBackupUntilIncrementalBackup creates backup until incremental backups is created returns the name of the incremental backup created
-func createBackupUntilIncrementalBackup(ctx context.Context, scheduledAppContextToBackup *scheduler.Context, customBackupLocationName string, backupLocationUID string, labelSelectors map[string]string, orgID string, clusterUid string) (string, error) {
-	namespace := scheduledAppContextToBackup.ScheduleOptions.Namespace
-	incrementalBackupName := fmt.Sprintf("%s-%s-%v", "incremental-backup", namespace, time.Now().Unix())
-	err := CreateBackupWithValidation(ctx, incrementalBackupName, SourceClusterName, customBackupLocationName, backupLocationUID, []*scheduler.Context{scheduledAppContextToBackup}, labelSelectors, orgID, clusterUid, "", "", "", "")
-	if err != nil {
-		return "", fmt.Errorf("creation and validation of incremental backup [%s] creation", incrementalBackupName)
-	}
-
-	log.InfoD("Check if backups are incremental backups or not")
-	backupDriver := Inst().Backup
-	ctx, err = backup.GetAdminCtxFromSecret()
-	if err != nil {
-		return "", fmt.Errorf("fetching px-central-admin ctx")
-	}
-	bkpUid, err := backupDriver.GetBackupUID(ctx, incrementalBackupName, orgID)
-	if err != nil {
-		return "", fmt.Errorf("unable to fetch backup UID - %s", incrementalBackupName)
-	}
-
-	bkpInspectReq := &api.BackupInspectRequest{
-		Name:  incrementalBackupName,
-		OrgId: orgID,
-		Uid:   bkpUid,
-	}
-	bkpInspectResponse, err := backupDriver.InspectBackup(ctx, bkpInspectReq)
-	if err != nil {
-		return "", fmt.Errorf("unable to fetch backup - %s", incrementalBackupName)
-	}
-
-	for _, vol := range bkpInspectResponse.GetBackup().GetVolumes() {
-		backupId := vol.GetBackupId()
-		log.InfoD(fmt.Sprintf("Backup Name: %s; BackupID: %s", incrementalBackupName, backupId))
-		if strings.Contains(backupId, "incr") {
-			return incrementalBackupName, nil
-		} else {
-			// Attempting to take backups and checking if they are incremental or not
-			// as the original incremental backup which we took has taken a full backup this is mostly
-			// because CloudSnap is taking full backup instead of incremental backup as it's hitting one of
-			// the if else condition in CloudSnap which forces it to take full instead of incremental backup
-			log.InfoD("New backup wasn't an incremental backup hence recreating new backup")
-			listOfVolumes := make(map[string]bool)
-			noFailures := true
-			for maxBackupsBeforeIncremental := 0; maxBackupsBeforeIncremental < 8; maxBackupsBeforeIncremental++ {
-				log.InfoD(fmt.Sprintf("Recreate incremental backup iteration: %d", maxBackupsBeforeIncremental))
-				// Create a new incremental backups
-				incrementalBackupName = fmt.Sprintf("%s-%s-%v", "incremental-backup", namespace, time.Now().Unix())
-				err := CreateBackupWithValidation(ctx, incrementalBackupName, SourceClusterName, customBackupLocationName, backupLocationUID, []*scheduler.Context{scheduledAppContextToBackup}, labelSelectors, orgID, clusterUid, "", "", "", "")
-				if err != nil {
-					return "", fmt.Errorf("verifying incremental backup [%s] creation", incrementalBackupName)
-				}
-
-				// Check if they are incremental or not
-				bkpUid, err = backupDriver.GetBackupUID(ctx, incrementalBackupName, orgID)
-				if err != nil {
-					return "", fmt.Errorf("unable to fetch backup - %s", incrementalBackupName)
-				}
-				bkpInspectReq := &api.BackupInspectRequest{
-					Name:  incrementalBackupName,
-					OrgId: orgID,
-					Uid:   bkpUid,
-				}
-				bkpInspectResponse, err = backupDriver.InspectBackup(ctx, bkpInspectReq)
-				if err != nil {
-					return "", fmt.Errorf("unable to fetch backup - %s", incrementalBackupName)
-				}
-				for _, vol := range bkpInspectResponse.GetBackup().GetVolumes() {
-					backupId := vol.GetBackupId()
-					log.InfoD(fmt.Sprintf("Backup Name: %s; BackupID: %s", incrementalBackupName, backupId))
-					if !strings.Contains(backupId, "incr") {
-						listOfVolumes[backupId] = false
-					} else {
-						listOfVolumes[backupId] = true
-					}
-				}
-				for id, isIncremental := range listOfVolumes {
-					if !isIncremental {
-						log.InfoD(fmt.Sprintf("Backup %s wasn't a incremental backup", id))
-						noFailures = false
-					}
-				}
-				if noFailures {
-					break
-				}
-			}
-		}
-	}
-	return incrementalBackupName, nil
-}
 
 // IssueDeleteOfIncrementalBackupsAndRestore Issues delete of incremental backups in between and tries to restore from
 // the newest backup.

--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -3,7 +3,6 @@ package tests
 import (
 	"context"
 	"fmt"
-	"github.com/portworx/sched-ops/k8s/kubevirt"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -15,6 +14,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/portworx/sched-ops/k8s/kubevirt"
 
 	"github.com/portworx/torpedo/drivers/backup/portworx"
 
@@ -5215,4 +5216,90 @@ func compareNamespaceAge(oldNamespaceAge map[string]time.Time) error {
 		}
 	}
 	return nil
+}
+
+// createBackupUntilIncrementalBackup creates backup until incremental backups is created returns the name of the incremental backup created
+func createBackupUntilIncrementalBackup(ctx context.Context, scheduledAppContextToBackup *scheduler.Context, customBackupLocationName string, backupLocationUID string, labelSelectors map[string]string, orgID string, clusterUid string) (string, error) {
+	namespace := scheduledAppContextToBackup.ScheduleOptions.Namespace
+	incrementalBackupName := fmt.Sprintf("%s-%s-%v", "incremental-backup", namespace, time.Now().Unix())
+	err := CreateBackupWithValidation(ctx, incrementalBackupName, SourceClusterName, customBackupLocationName, backupLocationUID, []*scheduler.Context{scheduledAppContextToBackup}, labelSelectors, orgID, clusterUid, "", "", "", "")
+	if err != nil {
+		return "", fmt.Errorf("creation and validation of incremental backup [%s] creation: error [%v]", incrementalBackupName, err)
+	}
+
+	log.InfoD("Check if backups are incremental backups or not")
+	backupDriver := Inst().Backup
+	bkpUid, err := backupDriver.GetBackupUID(ctx, incrementalBackupName, orgID)
+	if err != nil {
+		return "", fmt.Errorf("unable to fetch backup UID - %s : error [%v]", incrementalBackupName, err)
+	}
+
+	bkpInspectReq := &api.BackupInspectRequest{
+		Name:  incrementalBackupName,
+		OrgId: orgID,
+		Uid:   bkpUid,
+	}
+	bkpInspectResponse, err := backupDriver.InspectBackup(ctx, bkpInspectReq)
+	if err != nil {
+		return "", fmt.Errorf("unable to fetch backup - %s : error [%v]", incrementalBackupName, err)
+	}
+
+	for _, vol := range bkpInspectResponse.GetBackup().GetVolumes() {
+		backupId := vol.GetBackupId()
+		log.InfoD(fmt.Sprintf("Backup Name: %s; BackupID: %s", incrementalBackupName, backupId))
+		if strings.Contains(backupId, "incr") {
+			return incrementalBackupName, nil
+		} else {
+			// Attempting to take backups and checking if they are incremental or not
+			// as the original incremental backup which we took has taken a full backup this is mostly
+			// because CloudSnap is taking full backup instead of incremental backup as it's hitting one of
+			// the if else condition in CloudSnap which forces it to take full instead of incremental backup
+			log.InfoD("New backup wasn't an incremental backup hence recreating new backup")
+			listOfVolumes := make(map[string]bool)
+			noFailures := true
+			for maxBackupsBeforeIncremental := 0; maxBackupsBeforeIncremental < 8; maxBackupsBeforeIncremental++ {
+				log.InfoD(fmt.Sprintf("Recreate incremental backup iteration: %d", maxBackupsBeforeIncremental))
+				// Create a new incremental backups
+				incrementalBackupName = fmt.Sprintf("%s-%v-%s-%v", "incremental-backup", maxBackupsBeforeIncremental, namespace, time.Now().Unix())
+				err := CreateBackupWithValidation(ctx, incrementalBackupName, SourceClusterName, customBackupLocationName, backupLocationUID, []*scheduler.Context{scheduledAppContextToBackup}, labelSelectors, orgID, clusterUid, "", "", "", "")
+				if err != nil {
+					return "", fmt.Errorf("verifying incremental backup [%s] creation : error [%v]", incrementalBackupName, err)
+				}
+
+				// Check if they are incremental or not
+				bkpUid, err = backupDriver.GetBackupUID(ctx, incrementalBackupName, orgID)
+				if err != nil {
+					return "", fmt.Errorf("unable to fetch backup - %s : error [%v]", incrementalBackupName, err)
+				}
+				bkpInspectReq := &api.BackupInspectRequest{
+					Name:  incrementalBackupName,
+					OrgId: orgID,
+					Uid:   bkpUid,
+				}
+				bkpInspectResponse, err = backupDriver.InspectBackup(ctx, bkpInspectReq)
+				if err != nil {
+					return "", fmt.Errorf("unable to fetch backup - %s : error [%v]", incrementalBackupName, err)
+				}
+				for _, vol := range bkpInspectResponse.GetBackup().GetVolumes() {
+					backupId := vol.GetBackupId()
+					log.InfoD(fmt.Sprintf("Backup Name: %s; BackupID: %s ", incrementalBackupName, backupId))
+					if !strings.Contains(backupId, "incr") {
+						listOfVolumes[backupId] = false
+					} else {
+						listOfVolumes[backupId] = true
+					}
+				}
+				for id, isIncremental := range listOfVolumes {
+					if !isIncremental {
+						log.InfoD(fmt.Sprintf("Backup %s wasn't a incremental backup", id))
+						noFailures = false
+					}
+				}
+				if noFailures {
+					break
+				}
+			}
+		}
+	}
+	return incrementalBackupName, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
moved createBackupUntilIncrementalBackup to backup_helper.go as the methods was not returning proper error message at tests 

**Which issue(s) this PR fixes** (optional)
Closes #PA-1740

**Special notes for your reviewer**:
Tested with the tests which use this method.
https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/3061/
https://aetos.pwx.purestorage.com/resultSet/testSetID/385408
