### PR TITLE
PTX-15936 Bumped elasticsearch version to 7.2.0

### DIFF
--- a/drivers/scheduler/k8s/specs/elasticsearch/px-elasticdata-app.yaml
+++ b/drivers/scheduler/k8s/specs/elasticsearch/px-elasticdata-app.yaml
@@ -80,7 +80,7 @@ spec:
             add:
               - IPC_LOCK
               - SYS_RESOURCE
-        image: docker.elastic.co/elasticsearch/elasticsearch:6.5.0
+        image: docker.elastic.co/elasticsearch/elasticsearch:7.2.0
         imagePullPolicy: IfNotPresent
         env:
         - name: ES_JAVA_OPTS


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Bumped elasticsearch version to 7.2.0 as it fails in k8s 1.26.0 using containerd

**Which issue(s) this PR fixes** (optional)
Closes https://portworx.atlassian.net/browse/PTX-15936

**Special notes for your reviewer**:
Tested in the matrix k8s job: https://jenkins.pwx.dev.purestorage.com/job/Torpedo/job/tp-k8s-matrix-op-csi/801/
