### PR TITLE
[PWX-33950],[PWX-33962],[PWX-32868] Added automation test

### DIFF
--- a/tests/basic/pool_function_test.go
+++ b/tests/basic/pool_function_test.go
@@ -2,6 +2,9 @@ package tests
 
 import (
 	"fmt"
+	"regexp"
+
+	"github.com/google/uuid"
 	"github.com/libopenstorage/openstorage/api"
 	. "github.com/onsi/ginkgo"
 	"github.com/portworx/torpedo/drivers/node"
@@ -240,4 +243,148 @@ var _ = Describe("{PoolExpandWithPXRestart}", func() {
 			verifyPoolSizeEqualOrLargerThanExpected(poolIDToResize, targetSizeGiB)
 		})
 	})
+})
+
+var _ = Describe("{PoolExpandResizeInvalidPoolID}", func() {
+
+	BeforeEach(func() {
+		StartTorpedoTest("PoolExpandResizeInvalidPoolID",
+			"Initiate pool expansion using invalid Id", nil, testrailID)
+	})
+
+	AfterEach(func() {
+		EndTorpedoTest()
+	})
+
+	stepLog := "Resize with invalid pool ID"
+	log.InfoD(stepLog)
+	It(stepLog, func() {
+		// invalidPoolUUID Generation
+		invalidPoolUUID := uuid.New().String()
+
+		// Resize Pool with Invalid Pool ID
+		stepLog = fmt.Sprintf("Expanding pool on Node UUID [%s] using auto", invalidPoolUUID)
+		Step(stepLog, func() {
+			resizeErr := Inst().V.ExpandPool(invalidPoolUUID, api.SdkStoragePool_RESIZE_TYPE_AUTO, 100, true)
+			dash.VerifyFatal(resizeErr != nil, true, "Verify error occurs with invalid Pool UUID")
+			// Verify error on pool expansion failure
+			var errMatch error
+			re := regexp.MustCompile(fmt.Sprintf(".*failed to find storage pool with UID.*%s.*",
+				invalidPoolUUID))
+			if !re.MatchString(fmt.Sprintf("%v", resizeErr)) {
+				errMatch = fmt.Errorf("failed to verify failure using invalid PoolUUID [%v]", invalidPoolUUID)
+			}
+			dash.VerifyFatal(errMatch, nil, "Pool expand with invalid PoolUUID completed?")
+		})
+	})
+
+})
+
+var _ = Describe("{PoolExpandDiskAddAndVerifyFromOtherNode}", func() {
+
+	BeforeEach(func() {
+		StartTorpedoTest("PoolExpandDiskAddAndVerifyFromOtherNode",
+			"Initiate pool expansion and verify from other node", nil, testrailID)
+		contexts = scheduleApps()
+	})
+
+	JustBeforeEach(func() {
+		poolIDToResize = pickPoolToResize()
+		log.Infof("Picked pool %s to resize", poolIDToResize)
+		poolToBeResized = getStoragePool(poolIDToResize)
+		storageNode, err = GetNodeWithGivenPoolID(poolIDToResize)
+		log.FailOnError(err, "Failed to get node with given pool ID")
+	})
+
+	JustAfterEach(func() {
+		AfterEachTest(contexts)
+	})
+
+	AfterEach(func() {
+		appsValidateAndDestroy(contexts)
+		EndTorpedoTest()
+	})
+
+	stepLog := "should get the existing pool and expand it by adding a disk and verify from other node"
+	log.InfoD(stepLog)
+	It(stepLog, func() {
+		// get original total size
+		provisionStatus, err := GetClusterProvisionStatusOnSpecificNode(*storageNode)
+		var orignalTotalSize float64
+		for _, pstatus := range provisionStatus {
+			if pstatus.NodeUUID == storageNode.Id {
+				orignalTotalSize += pstatus.TotalSize
+			}
+		}
+
+		originalSizeInBytes = poolToBeResized.TotalSize
+		targetSizeInBytes = originalSizeInBytes + 100*units.GiB
+		targetSizeGiB = targetSizeInBytes / units.GiB
+
+		log.InfoD("Current Size of the pool %s is %d GiB. Trying to expand to %v GiB with type add-disk",
+			poolIDToResize, poolToBeResized.TotalSize/units.GiB, targetSizeGiB)
+		triggerPoolExpansion(poolIDToResize, targetSizeGiB, api.SdkStoragePool_RESIZE_TYPE_ADD_DISK)
+
+		Step("Ensure pool has been expanded to the expected size", func() {
+			err = waitForOngoingPoolExpansionToComplete(poolIDToResize)
+			dash.VerifyFatal(err, nil, "Pool expansion does not result in error")
+			verifyPoolSizeEqualOrLargerThanExpected(poolIDToResize, targetSizeGiB)
+		})
+
+		stNodes, err := GetStorageNodes()
+		log.FailOnError(err, "Unable to get the storage nodes")
+		var verifyNode node.Node
+		for _, node := range stNodes {
+			status, _ := IsPxRunningOnNode(&node)
+			if node.Id != storageNode.Id && status {
+				verifyNode = node
+				break
+			}
+		}
+
+		// get final total size
+		provisionStatus, err = GetClusterProvisionStatusOnSpecificNode(verifyNode)
+		var finalTotalSize float64
+		for _, pstatus := range provisionStatus {
+			if pstatus.NodeUUID == storageNode.Id {
+				finalTotalSize += pstatus.TotalSize
+			}
+		}
+		dash.VerifyFatal(finalTotalSize > orignalTotalSize, true, "Pool expansion failed, pool size is not greater than pool size before expansion")
+
+	})
+
+})
+
+var _ = Describe("{PoolExpansionDiskResizeInvalidSize}", func() {
+
+	BeforeEach(func() {
+		StartTorpedoTest("PoolExpansionDiskResizeInvalidSize",
+			"Initiate pool expansion using invalid expansion size", nil, testrailID)
+	})
+
+	AfterEach(func() {
+		EndTorpedoTest()
+	})
+
+	stepLog := "select a pool and expand it by 30000000 GiB with resize-disk type"
+	log.InfoD(stepLog)
+	It(stepLog, func() {
+		// pick pool to resize
+		pools, err := GetAllPoolsPresent()
+		log.FailOnError(err, "Unable to get the storage Pools")
+		pooltoPick := pools[0]
+
+		resizeErr := Inst().V.ExpandPool(pooltoPick, api.SdkStoragePool_RESIZE_TYPE_RESIZE_DISK, 30000000, true)
+		dash.VerifyFatal(resizeErr != nil, true, "Verify error occurs with invalid Pool expansion size")
+
+		// Verify error on pool expansion failure
+		var errMatch error
+		re := regexp.MustCompile(`.*cannot be expanded beyond maximum size.*`)
+		if !re.MatchString(fmt.Sprintf("%v", resizeErr)) {
+			errMatch = fmt.Errorf("failed to verify failure using invalid Pool size")
+		}
+		dash.VerifyFatal(errMatch, nil, "Pool expand with invalid PoolUUID completed?")
+	})
+
 })


### PR DESCRIPTION
Added automation tests for following use scenarios :-
Check the pool size from the other nodes after pool resize
Resize license limits enforced
Resize with invalid pool ID

[PWX-33950](https://portworx.atlassian.net/browse/PWX-33950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)
[PWX-33962](https://portworx.atlassian.net/browse/PWX-33962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)
[PWX-33963](https://portworx.atlassian.net/browse/PWX-33963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

Testing Done :-

Jenkins Passed job :- https://jenkins.pwx.dev.purestorage.com/job/Users/job/Rushikesh/job/rushi_pxdv-7-dev/13/

test results when run locally

INFO[2023-10-12 14:40:30] Verifying : Description : Test completed successfully ?
INFO[2023-10-12 14:40:30] Actual:PASS, Expected: PASS
INFO[2023-10-12 14:40:30] --------Test End------
INFO[2023-10-12 14:40:30] #Test: PoolExpandDiskAddAndVerifyFromOtherNode
INFO[2023-10-12 14:40:30] #Description: Initiate pool expansion and verify from other node
INFO[2023-10-12 14:40:30] ------------------------
INFO[2023-10-12 12:37:12] Verifying : Description : Pool expand with invalid PoolUUID completed?
INFO[2023-10-12 12:37:12] Actual:true, Expected: true
INFO[2023-10-12 12:37:12] Verifying : Description : Test completed successfully ?
INFO[2023-10-12 12:37:12] Actual:PASS, Expected: PASS
INFO[2023-10-12 12:37:12] --------Test End------
INFO[2023-10-12 12:37:12] #Test: PoolExpandResizeInvalidPoolID
INFO[2023-10-12 12:37:12] #Description: Initiate pool expansion using invalid Id
INFO[2023-10-12 12:37:12] ------------------------
INFO[2023-10-12 12:27:08] Verifying : Description : Verify error occurs with invalid Pool expansion size
INFO[2023-10-12 12:27:08] Actual:true, Expected: true
INFO[2023-10-12 12:27:08] Verifying : Description : Test completed successfully ?
INFO[2023-10-12 12:27:08] Actual:PASS, Expected: PASS
INFO[2023-10-12 12:27:08] --------Test End------
INFO[2023-10-12 12:27:08] #Test: PoolExpandDiskResizeResizeLimit
INFO[2023-10-12 12:27:08] #Description: Initiate pool expansion using invalid expansion size
INFO[2023-10-12 12:27:08] ------------------------