### PR TITLE
[Kubevirt] Added testcase for backup and restore with different kubevirt VM states

### DIFF
--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -346,6 +346,7 @@ func (k *K8s) AddNewNode(newNode corev1.Node) error {
 	if err := k.IsNodeReady(n); err != nil {
 		return err
 	}
+	log.Infof("AddNewNode - Adding node - %s", n.Name)
 	if err := node.AddNode(n); err != nil {
 		return err
 	}
@@ -449,6 +450,7 @@ func (k *K8s) RefreshNodeRegistry() error {
 	node.CleanupRegistry()
 
 	for _, n := range nodes.Items {
+		log.Infof("RefreshNodeRegistry - %s", n.GetName())
 		if err = k.AddNewNode(n); err != nil {
 			return err
 		}

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -1752,6 +1752,12 @@ func (k *K8s) GetUpdatedSpec(spec interface{}) (interface{}, error) {
 			return nil, err
 		}
 		return obj, nil
+	} else if specObj, ok := spec.(*kubevirtv1.VirtualMachine); ok {
+		obj, err := k8sKubevirt.GetVirtualMachine(specObj.Name, specObj.Namespace)
+		if err != nil {
+			return nil, err
+		}
+		return obj, nil
 	}
 
 	return nil, fmt.Errorf("unsupported object: %v", reflect.TypeOf(spec))

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -300,7 +300,6 @@ func (k *K8s) Init(schedOpts scheduler.InitOptions) error {
 	}
 
 	for _, n := range nodes.Items {
-		log.Infof("Init add nodes - %s", n.Name)
 		if err = k.AddNewNode(n); err != nil {
 			return err
 		}
@@ -346,7 +345,6 @@ func (k *K8s) AddNewNode(newNode corev1.Node) error {
 	if err := k.IsNodeReady(n); err != nil {
 		return err
 	}
-	log.Infof("AddNewNode - Adding node - %s", n.Name)
 	if err := node.AddNode(n); err != nil {
 		return err
 	}
@@ -450,7 +448,6 @@ func (k *K8s) RefreshNodeRegistry() error {
 	node.CleanupRegistry()
 
 	for _, n := range nodes.Items {
-		log.Infof("RefreshNodeRegistry - %s", n.GetName())
 		if err = k.AddNewNode(n); err != nil {
 			return err
 		}

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -300,6 +300,7 @@ func (k *K8s) Init(schedOpts scheduler.InitOptions) error {
 	}
 
 	for _, n := range nodes.Items {
+		log.Infof("Init add nodes - %s", n.Name)
 		if err = k.AddNewNode(n); err != nil {
 			return err
 		}

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -165,6 +165,8 @@ const (
 	cdiPvcRunningMessageAnnotationKey = "cdi.kubevirt.io/storage.condition.running.message"
 	cdiPvcImportEndpointAnnotationKey = "cdi.kubevirt.io/storage.import.endpoint"
 	cdiImportComplete                 = "Import Complete"
+	cdiImageImportTimeout             = 20 * time.Minute
+	cdiImageImportRetry               = 30 * time.Second
 )
 
 const (
@@ -5239,7 +5241,7 @@ func (k *K8s) WaitForImageImportForVM(vmName string, namespace string, v kubevir
 						cdiPvcRunningMessageAnnotationKey, pvcName, namespace, vmName)
 				}
 			}
-			_, err = task.DoRetryWithTimeout(t, 5*time.Minute, 30*time.Second)
+			_, err = task.DoRetryWithTimeout(t, cdiImageImportTimeout, cdiImageImportRetry)
 			if err != nil {
 				return err
 			}

--- a/drivers/scheduler/k8s/specs/kubevirt-multi-vm/pvc-cdi-app-ubuntu.yaml
+++ b/drivers/scheduler/k8s/specs/kubevirt-multi-vm/pvc-cdi-app-ubuntu.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: pvc-cdi-ubuntu
+  name: pvc-cdi-ubuntu-app
   labels:
     app: containerized-data-importer
   annotations:

--- a/drivers/scheduler/k8s/specs/kubevirt-multi-vm/svc-nodeport.yaml
+++ b/drivers/scheduler/k8s/specs/kubevirt-multi-vm/svc-nodeport.yaml
@@ -7,7 +7,6 @@ spec:
   externalTrafficPolicy: Cluster
   ports:
     - name: nodeport
-      nodePort: 30000
       port: 27017
       protocol: TCP
       targetPort: 22

--- a/drivers/scheduler/k8s/specs/kubevirt-multi-vm/vm-ubuntu-containerdisk-pvc.yaml
+++ b/drivers/scheduler/k8s/specs/kubevirt-multi-vm/vm-ubuntu-containerdisk-pvc.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: pvc-data-volume
+  name: pvc-data-volume-containerdisk
 spec:
   storageClassName: kubevirt-sc
   accessModes:
@@ -55,7 +55,7 @@ spec:
             image: docker.pwx.dev.purestorage.com/portworx/ubuntu-container-disk:20.0
         - name: datavolume
           dataVolume:
-            name: pvc-data-volume
+            name: pvc-data-volume-containerdisk
         - name: cloudinitvolume
           cloudInitNoCloud:
             userData: |-

--- a/drivers/scheduler/k8s/specs/kubevirt-multi-vm/vm-ubuntu-pvc-datavolume.yaml
+++ b/drivers/scheduler/k8s/specs/kubevirt-multi-vm/vm-ubuntu-pvc-datavolume.yaml
@@ -17,7 +17,7 @@ kind: VirtualMachine
 metadata:
   name: vm-ubuntu-pvc-datavolume
 spec:
-  running: false
+  running: true
   template:
     metadata:
       labels:
@@ -50,7 +50,7 @@ spec:
       volumes:
         - name: containervolume
           persistentVolumeClaim:
-            claimName: pvc-cdi-ubuntu
+            claimName: pvc-cdi-ubuntu-app
         - name: datavolume
           dataVolume:
             name: pvc-data-volume

--- a/drivers/volume/portworx/schedops/k8s-schedops.go
+++ b/drivers/volume/portworx/schedops/k8s-schedops.go
@@ -400,6 +400,7 @@ PodLoop:
 				}
 				symlinkPath = strings.TrimSpace(symlinkPath)
 				if symlinkPath != "" && symlinkPath != path {
+					log.Infof("symlinkPath - %s", symlinkPath)
 					paths = append(paths[:i], paths[i+1:]...)
 					paths = append(paths, symlinkPath)
 				}

--- a/drivers/volume/portworx/schedops/k8s-schedops.go
+++ b/drivers/volume/portworx/schedops/k8s-schedops.go
@@ -400,9 +400,8 @@ PodLoop:
 				}
 				symlinkPath = strings.TrimSpace(symlinkPath)
 				if symlinkPath != "" && symlinkPath != path {
-					log.Infof("symlinkPath - %s", symlinkPath)
-					paths = append(paths[:i], paths[i+1:]...)
-					paths = append(paths, symlinkPath)
+					log.Infof("Linked path found for [%s] -> [%s]", path, symlinkPath)
+					paths[i] = symlinkPath
 				}
 			}
 			log.Infof("container [%s] and paths [%v] after checking sym links", containerName, paths)

--- a/go.mod
+++ b/go.mod
@@ -143,7 +143,7 @@ require (
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
-	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 // indirect
+	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-errors/errors v1.4.1 // indirect
 	github.com/go-gorp/gorp/v3 v3.0.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/portworx/pds-api-go-client v0.0.0-20230831092707-4faacf005c6b
 	github.com/portworx/px-backup-api v1.2.2-0.20231011130438-812370c309e7
-	github.com/portworx/sched-ops v1.20.4-rc1.0.20231013094113-8ca7856dbe86
+	github.com/portworx/sched-ops v1.20.4-rc1.0.20231018042450-4c290674cb5a
 	github.com/portworx/talisman v1.1.3
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.63.0
 	github.com/prometheus/client_golang v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -2878,8 +2878,8 @@ github.com/portworx/sched-ops v1.20.4-rc1.0.20230103234348-243afb3bb8aa/go.mod h
 github.com/portworx/sched-ops v1.20.4-rc1.0.20230207070155-2e0ef25efadd/go.mod h1:JbHASXqA/GXwFD4blS1DZkrxtS5llb98ViZgUerOtQA=
 github.com/portworx/sched-ops v1.20.4-rc1.0.20230207140221-24ec094deec4/go.mod h1:drIYh+6f/vh11dVmbpwFv3GIusQCSMThPX774U8ix7w=
 github.com/portworx/sched-ops v1.20.4-rc1.0.20230228105744-505c1a2d8203/go.mod h1:JbHASXqA/GXwFD4blS1DZkrxtS5llb98ViZgUerOtQA=
-github.com/portworx/sched-ops v1.20.4-rc1.0.20231013094113-8ca7856dbe86 h1:p1psRMXYwmnlEXHb8p0P7ew/QYVrNSfNkLoa0liEt90=
-github.com/portworx/sched-ops v1.20.4-rc1.0.20231013094113-8ca7856dbe86/go.mod h1:wZnNzyY7B/cuWwYZ6XysdbwsXPC8DjfJ1YGg6MdyefU=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20231018042450-4c290674cb5a h1:a5YtCR/a0l13lcb/tDJCC9zFqJXz/Y4YZPZeMwkI3zg=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20231018042450-4c290674cb5a/go.mod h1:wZnNzyY7B/cuWwYZ6XysdbwsXPC8DjfJ1YGg6MdyefU=
 github.com/portworx/talisman v0.0.0-20191007232806-837747f38224/go.mod h1:OjpMH9Uh5o9ntVGktm4FbjLNwubJ3ITih2OfYrAeWtA=
 github.com/portworx/talisman v0.0.0-20210302012732-8af4564777f7/go.mod h1:e8a6uFpSbOlRpZQlW9aXYogC+GWAo065G0RL9hDkD4Q=
 github.com/portworx/talisman v1.1.3 h1:XrDE0fs4UACgDGi5bvt04uePC+QbhbA5YXozGYg5tr8=

--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -1931,7 +1931,7 @@ func ValidateRestore(ctx context.Context, restoreName string, orgID string, expe
 						if restoredObj.Status.Status != api.RestoreInfo_StatusInfo_Success /*Can this also be partialsuccess?*/ {
 							if restoredObj.Status.Status == api.RestoreInfo_StatusInfo_Retained {
 								if theRestore.ReplacePolicy != api.ReplacePolicy_Retain {
-									err := fmt.Errorf("object (name: [%s], kind: [%s], namespace: [%s]) was found in the restore [%s] (as expected by presence in expectedRestoredAppContext [%s]), but status was retained - [%s], with reason [%s], despite the replace policy being [%s]", name, kind, ns, restoreName, expectedRestoredAppContextNamespace, restoredObj.Status.Status, restoredObj.Status.Reason, theRestore.ReplacePolicy)
+									err := fmt.Errorf("object (name: [%s], kind: [%s], namespace: [%s]) was found in the restore [%s] (as expected by presence in expectedRestoredAppContext [%s]), but status was [Retained], with reason [%s], despite the replace policy being [%s]", name, kind, ns, restoreName, expectedRestoredAppContextNamespace, restoredObj.Status.Reason, theRestore.ReplacePolicy)
 									errors = append(errors, err)
 								}
 							} else {

--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -1931,7 +1931,7 @@ func ValidateRestore(ctx context.Context, restoreName string, orgID string, expe
 						if restoredObj.Status.Status != api.RestoreInfo_StatusInfo_Success /*Can this also be partialsuccess?*/ {
 							if restoredObj.Status.Status == api.RestoreInfo_StatusInfo_Retained {
 								if theRestore.ReplacePolicy != api.ReplacePolicy_Retain {
-									err := fmt.Errorf("object (name: [%s], kind: [%s], namespace: [%s]) was found in the restore [%s] (as expected by presence in expectedRestoredAppContext [%s]), but status was [Retained], with reason [%s], despite the replace policy being [%s]", name, kind, ns, restoreName, expectedRestoredAppContextNamespace, restoredObj.Status.Reason, theRestore.ReplacePolicy)
+									err := fmt.Errorf("object (name: [%s], kind: [%s], namespace: [%s]) was found in the restore [%s] (as expected by presence in expectedRestoredAppContext [%s]), but status was retained - [%s], with reason [%s], despite the replace policy being [%s]", name, kind, ns, restoreName, expectedRestoredAppContextNamespace, restoredObj.Status.Status, restoredObj.Status.Reason, theRestore.ReplacePolicy)
 									errors = append(errors, err)
 								}
 							} else {

--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -5306,6 +5306,7 @@ func StartAllVMsInNamespace(namespace string, waitForCompletion bool) error {
 	for _, vm := range vms.Items {
 		wg.Add(1)
 		go func(vm kubevirtv1.VirtualMachine) {
+			defer GinkgoRecover()
 			defer wg.Done()
 			err := StartKubevirtVM(vm.Name, namespace, waitForCompletion)
 			if err != nil {
@@ -5336,6 +5337,7 @@ func StopAllVMsInNamespace(namespace string, waitForCompletion bool) error {
 	for _, vm := range vms.Items {
 		wg.Add(1)
 		go func(vm kubevirtv1.VirtualMachine) {
+			defer GinkgoRecover()
 			defer wg.Done()
 			err := StopKubevirtVM(vm.Name, namespace, waitForCompletion)
 			if err != nil {
@@ -5366,6 +5368,7 @@ func RestartAllVMsInNamespace(namespace string, waitForCompletion bool) error {
 	for _, vm := range vms.Items {
 		wg.Add(1)
 		go func(vm kubevirtv1.VirtualMachine) {
+			defer GinkgoRecover()
 			defer wg.Done()
 			err := RestartKubevirtVM(vm.Name, namespace, waitForCompletion)
 			if err != nil {

--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -5331,6 +5331,7 @@ func StopAllVMsInNamespace(namespace string, waitForCompletion bool) error {
 	for _, vm := range vms.Items {
 		wg.Add(1)
 		go func(vm kubevirtv1.VirtualMachine) {
+			defer wg.Done()
 			err := StopKubevirtVM(vm.Name, namespace, waitForCompletion)
 			if err != nil {
 				mutex.Lock()

--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -5003,7 +5003,7 @@ func RemoveCloudCredentialOwnership(cloudCredentialName string, cloudCredentialU
 }
 
 // StartKubevirtVM starts the kubevirt VM and waits till the status is Running
-func StartKubevirtVM(name, namespace string) error {
+func StartKubevirtVM(name string, namespace string, waitForCompletion bool) error {
 	k8sKubevirt := kubevirt.Instance()
 	vm, err := k8sKubevirt.GetVirtualMachine(name, namespace)
 	if err != nil {
@@ -5013,23 +5013,26 @@ func StartKubevirtVM(name, namespace string) error {
 	if err != nil {
 		return err
 	}
-	t := func() (interface{}, bool, error) {
-		vm, err = k8sKubevirt.GetVirtualMachine(name, namespace)
-		if err != nil {
-			return "", false, fmt.Errorf("unable to get virtual machine [%s] in namespace [%s]", name, namespace)
+	if waitForCompletion {
+		t := func() (interface{}, bool, error) {
+			vm, err = k8sKubevirt.GetVirtualMachine(name, namespace)
+			if err != nil {
+				return "", false, fmt.Errorf("unable to get virtual machine [%s] in namespace [%s]", name, namespace)
+			}
+			if vm.Status.PrintableStatus != kubevirtv1.VirtualMachineStatusRunning {
+				return "", true, fmt.Errorf("virtual machine [%s] in namespace [%s] is in %s state, waiting to be in %s state", name, namespace, vm.Status.PrintableStatus, kubevirtv1.VirtualMachineStatusRunning)
+			}
+			log.Infof("virtual machine [%s] in namespace [%s] is in %s state", name, namespace, vm.Status.PrintableStatus)
+			return "", false, nil
 		}
-		if vm.Status.PrintableStatus != kubevirtv1.VirtualMachineStatusRunning {
-			return "", true, fmt.Errorf("virtual machine [%s] in namespace [%s] is in %s state, waiting to be in %s state", name, namespace, vm.Status.PrintableStatus, kubevirtv1.VirtualMachineStatusRunning)
-		}
-		log.Infof("virtual machine [%s] in namespace [%s] is in %s state", name, namespace, vm.Status.PrintableStatus)
-		return "", false, nil
+		_, err = DoRetryWithTimeoutWithGinkgoRecover(t, vmStartStopTimeout, vmStartStopRetryTime)
+		return err
 	}
-	_, err = DoRetryWithTimeoutWithGinkgoRecover(t, vmStartStopTimeout, vmStartStopRetryTime)
-	return err
+	return nil
 }
 
 // StopKubevirtVM stops the kubevirt VM and waits till the status is Stopped
-func StopKubevirtVM(name, namespace string) error {
+func StopKubevirtVM(name string, namespace string, waitForCompletion bool) error {
 	k8sKubevirt := kubevirt.Instance()
 	vm, err := k8sKubevirt.GetVirtualMachine(name, namespace)
 	if err != nil {
@@ -5039,25 +5042,28 @@ func StopKubevirtVM(name, namespace string) error {
 	if err != nil {
 		return err
 	}
-	t := func() (interface{}, bool, error) {
-		vm, err = k8sKubevirt.GetVirtualMachine(name, namespace)
-		if err != nil {
-			return "", false, fmt.Errorf("unable to get virtual machine [%s] in namespace [%s]", name, namespace)
+	if waitForCompletion {
+		t := func() (interface{}, bool, error) {
+			vm, err = k8sKubevirt.GetVirtualMachine(name, namespace)
+			if err != nil {
+				return "", false, fmt.Errorf("unable to get virtual machine [%s] in namespace [%s]", name, namespace)
+			}
+			if vm.Status.PrintableStatus != kubevirtv1.VirtualMachineStatusStopped {
+				return "", true, fmt.Errorf("virtual machine [%s] in namespace [%s] is in %s state, waiting to be in %s state", name, namespace, vm.Status.PrintableStatus, kubevirtv1.VirtualMachineStatusStopped)
+			}
+			log.Infof("virtual machine [%s] in namespace [%s] is in %s state", name, namespace, vm.Status.PrintableStatus)
+			return "", false, nil
 		}
-		if vm.Status.PrintableStatus != kubevirtv1.VirtualMachineStatusStopped {
-			return "", true, fmt.Errorf("virtual machine [%s] in namespace [%s] is in %s state, waiting to be in %s state", name, namespace, vm.Status.PrintableStatus, kubevirtv1.VirtualMachineStatusStopped)
-		}
-		log.Infof("virtual machine [%s] in namespace [%s] is in %s state", name, namespace, vm.Status.PrintableStatus)
-		return "", false, nil
+		_, err = DoRetryWithTimeoutWithGinkgoRecover(t, vmStartStopTimeout, vmStartStopRetryTime)
+		return err
 	}
-	_, err = DoRetryWithTimeoutWithGinkgoRecover(t, vmStartStopTimeout, vmStartStopRetryTime)
-	return err
+	return nil
 }
 
 // RestartKubevirtVM restarts the kubevirt VM
 // If VM is in stopped state it starts the VM
 // If VM is in started state it restarts the VM
-func RestartKubevirtVM(name, namespace string) error {
+func RestartKubevirtVM(name string, namespace string, waitForCompletion bool) error {
 	k8sKubevirt := kubevirt.Instance()
 	vm, err := k8sKubevirt.GetVirtualMachine(name, namespace)
 	if err != nil {
@@ -5065,16 +5071,16 @@ func RestartKubevirtVM(name, namespace string) error {
 	}
 	switch vm.Status.PrintableStatus {
 	case kubevirtv1.VirtualMachineStatusRunning:
-		err = StopKubevirtVM(name, namespace)
+		err = StopKubevirtVM(name, namespace, waitForCompletion)
 		if err != nil {
 			return err
 		}
-		err = StartKubevirtVM(name, namespace)
+		err = StartKubevirtVM(name, namespace, waitForCompletion)
 		if err != nil {
 			return err
 		}
 	case kubevirtv1.VirtualMachineStatusStopped:
-		err = StartKubevirtVM(name, namespace)
+		err = StartKubevirtVM(name, namespace, waitForCompletion)
 		if err != nil {
 			return err
 		}
@@ -5283,4 +5289,59 @@ func createBackupUntilIncrementalBackup(ctx context.Context, scheduledAppContext
 		}
 	}
 	return incrementalBackupName, nil
+}
+
+// StartAllVMsInNamespace starts all the Kubevirt VMs in the given namespace
+func StartAllVMsInNamespace(namespace string, waitForCompletion bool) error {
+	k8sKubevirt := kubevirt.Instance()
+	var wg sync.WaitGroup
+	errors := make([]string, 0)
+
+	vms, err := k8sKubevirt.ListVirtualMachines(namespace)
+	if err != nil {
+		return err
+	}
+	for _, vm := range vms.Items {
+		wg.Add(1)
+		go func(vm kubevirtv1.VirtualMachine) {
+			err := StartKubevirtVM(vm.Name, namespace, waitForCompletion)
+			if err != nil {
+				errors = append(errors, err.Error())
+			}
+		}(vm)
+	}
+	wg.Wait()
+	if len(errors) > 0 {
+		return fmt.Errorf("Errors generated while starting VMs in namespace [%s] -\n%s", namespace, strings.Join(errors, "}\n{"))
+	}
+	return nil
+}
+
+// StopAllVMsInNamespace stops all the Kubevirt VMs in the given namespace
+func StopAllVMsInNamespace(namespace string, waitForCompletion bool) error {
+	k8sKubevirt := kubevirt.Instance()
+	var wg sync.WaitGroup
+	errors := make([]string, 0)
+	var mutex sync.Mutex
+
+	vms, err := k8sKubevirt.ListVirtualMachines(namespace)
+	if err != nil {
+		return err
+	}
+	for _, vm := range vms.Items {
+		wg.Add(1)
+		go func(vm kubevirtv1.VirtualMachine) {
+			err := StopKubevirtVM(vm.Name, namespace, waitForCompletion)
+			if err != nil {
+				mutex.Lock()
+				defer mutex.Unlock()
+				errors = append(errors, err.Error())
+			}
+		}(vm)
+	}
+	wg.Wait()
+	if len(errors) > 0 {
+		return fmt.Errorf("Errors generated while stopping VMs in namespace [%s] -\n%s", namespace, strings.Join(errors, "}\n{"))
+	}
+	return nil
 }

--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -5022,7 +5022,7 @@ func StartKubevirtVM(name string, namespace string, waitForCompletion bool) erro
 			if vm.Status.PrintableStatus != kubevirtv1.VirtualMachineStatusRunning {
 				return "", true, fmt.Errorf("virtual machine [%s] in namespace [%s] is in %s state, waiting to be in %s state", name, namespace, vm.Status.PrintableStatus, kubevirtv1.VirtualMachineStatusRunning)
 			}
-			log.Infof("virtual machine [%s] in namespace [%s] is in %s state", name, namespace, vm.Status.PrintableStatus)
+			log.InfoD("virtual machine [%s] in namespace [%s] is in %s state", name, namespace, vm.Status.PrintableStatus)
 			return "", false, nil
 		}
 		_, err = DoRetryWithTimeoutWithGinkgoRecover(t, vmStartStopTimeout, vmStartStopRetryTime)
@@ -5051,7 +5051,7 @@ func StopKubevirtVM(name string, namespace string, waitForCompletion bool) error
 			if vm.Status.PrintableStatus != kubevirtv1.VirtualMachineStatusStopped {
 				return "", true, fmt.Errorf("virtual machine [%s] in namespace [%s] is in %s state, waiting to be in %s state", name, namespace, vm.Status.PrintableStatus, kubevirtv1.VirtualMachineStatusStopped)
 			}
-			log.Infof("virtual machine [%s] in namespace [%s] is in %s state", name, namespace, vm.Status.PrintableStatus)
+			log.InfoD("virtual machine [%s] in namespace [%s] is in %s state", name, namespace, vm.Status.PrintableStatus)
 			return "", false, nil
 		}
 		_, err = DoRetryWithTimeoutWithGinkgoRecover(t, vmStartStopTimeout, vmStartStopRetryTime)
@@ -5080,7 +5080,7 @@ func RestartKubevirtVM(name string, namespace string, waitForCompletion bool) er
 			if vm.Status.PrintableStatus != kubevirtv1.VirtualMachineStatusRunning {
 				return "", true, fmt.Errorf("virtual machine [%s] in namespace [%s] is in %s state, waiting to be in %s state", name, namespace, vm.Status.PrintableStatus, kubevirtv1.VirtualMachineStatusRunning)
 			}
-			log.Infof("virtual machine [%s] in namespace [%s] is in %s state", name, namespace, vm.Status.PrintableStatus)
+			log.InfoD("virtual machine [%s] in namespace [%s] is in %s state", name, namespace, vm.Status.PrintableStatus)
 			return "", false, nil
 		}
 		_, err = DoRetryWithTimeoutWithGinkgoRecover(t, vmStartStopTimeout, vmStartStopRetryTime)

--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -5017,7 +5017,7 @@ func StartKubevirtVM(name string, namespace string, waitForCompletion bool) erro
 		t := func() (interface{}, bool, error) {
 			vm, err = k8sKubevirt.GetVirtualMachine(name, namespace)
 			if err != nil {
-				return "", false, fmt.Errorf("unable to get virtual machine [%s] in namespace [%s]", name, namespace)
+				return "", false, fmt.Errorf("unable to get virtual machine [%s] in namespace [%s]\nerror - %s", name, namespace, err.Error())
 			}
 			if vm.Status.PrintableStatus != kubevirtv1.VirtualMachineStatusRunning {
 				return "", true, fmt.Errorf("virtual machine [%s] in namespace [%s] is in %s state, waiting to be in %s state", name, namespace, vm.Status.PrintableStatus, kubevirtv1.VirtualMachineStatusRunning)
@@ -5046,7 +5046,7 @@ func StopKubevirtVM(name string, namespace string, waitForCompletion bool) error
 		t := func() (interface{}, bool, error) {
 			vm, err = k8sKubevirt.GetVirtualMachine(name, namespace)
 			if err != nil {
-				return "", false, fmt.Errorf("unable to get virtual machine [%s] in namespace [%s]", name, namespace)
+				return "", false, fmt.Errorf("unable to get virtual machine [%s] in namespace [%s]\nerror - %s", name, namespace, err.Error())
 			}
 			if vm.Status.PrintableStatus != kubevirtv1.VirtualMachineStatusStopped {
 				return "", true, fmt.Errorf("virtual machine [%s] in namespace [%s] is in %s state, waiting to be in %s state", name, namespace, vm.Status.PrintableStatus, kubevirtv1.VirtualMachineStatusStopped)
@@ -5075,7 +5075,7 @@ func RestartKubevirtVM(name string, namespace string, waitForCompletion bool) er
 		t := func() (interface{}, bool, error) {
 			vm, err = k8sKubevirt.GetVirtualMachine(name, namespace)
 			if err != nil {
-				return "", false, fmt.Errorf("unable to get virtual machine [%s] in namespace [%s]", name, namespace)
+				return "", false, fmt.Errorf("unable to get virtual machine [%s] in namespace [%s]\nerror - %s", name, namespace, err.Error())
 			}
 			if vm.Status.PrintableStatus != kubevirtv1.VirtualMachineStatusRunning {
 				return "", true, fmt.Errorf("virtual machine [%s] in namespace [%s] is in %s state, waiting to be in %s state", name, namespace, vm.Status.PrintableStatus, kubevirtv1.VirtualMachineStatusRunning)

--- a/tests/backup/backup_kubevirt_test.go
+++ b/tests/backup/backup_kubevirt_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/portworx/torpedo/pkg/log"
 	. "github.com/portworx/torpedo/tests"
 	"sync"
+	"time"
 )
 
 // This testcase verifies backup and restore of Kubevirt VMs in different states like Running, Stopped, Restarting
@@ -118,7 +119,7 @@ var _ = Describe("{KubevirtVMBackupRestoreWithDifferentStates}", func() {
 			log.InfoD("Stopping VMs in a few namespaces")
 			namespaceToStopVMs := []string{scheduledAppContexts[0].ScheduleOptions.Namespace, scheduledAppContexts[1].ScheduleOptions.Namespace}
 			namespaceWithStoppedVM = append(namespaceWithStoppedVM, namespaceToStopVMs...)
-			log.InfoD("Stopping VMs in one of the namespaces - [%v]", namespaceWithStoppedVM)
+			log.InfoD("Stopping VMs in namespaces - [%v]", namespaceWithStoppedVM)
 			for _, n := range namespaceWithStoppedVM {
 				err := StopAllVMsInNamespace(n, true)
 				log.FailOnError(err, "Failed stopping the VMs in namespace - "+n)
@@ -259,6 +260,8 @@ var _ = Describe("{KubevirtVMBackupRestoreWithDifferentStates}", func() {
 				}(n)
 			}
 			wg.Wait()
+			err = backupSuccessCheck(backupWithVMRestart, orgID, maxWaitPeriodForBackupCompletionInMinutes*time.Minute, 30*time.Second, ctx)
+			log.FailOnError(err, "Failed while checking success of backup [%s]")
 		})
 
 		Step("Restoring backup taken when VMs were Restarting", func() {

--- a/tests/backup/backup_kubevirt_test.go
+++ b/tests/backup/backup_kubevirt_test.go
@@ -42,8 +42,7 @@ var _ = Describe("{KubevirtVMBackupRestoreWithDifferentStates}", func() {
 	)
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("KubevirtVMBackupRestoreWithDifferentStates", "Verify backup and restore of Kubevirt VMs in different states",
-			nil, 93011)
+		StartTorpedoTest("KubevirtVMBackupRestoreWithDifferentStates", "Verify backup and restore of Kubevirt VMs in different states", nil, 93011)
 
 		backupLocationMap = make(map[string]string)
 		labelSelectors = make(map[string]string)
@@ -66,7 +65,7 @@ var _ = Describe("{KubevirtVMBackupRestoreWithDifferentStates}", func() {
 		}
 	})
 
-	It("Basic Backup Creation", func() {
+	It("Verify backup and restore of Kubevirt VMs in different states", func() {
 		defer func() {
 			log.InfoD("switching to default context")
 			err := SetClusterContext("")
@@ -210,8 +209,8 @@ var _ = Describe("{KubevirtVMBackupRestoreWithDifferentStates}", func() {
 			backupWithVMMixed = fmt.Sprintf("%s-%s", "auto-backup-mixed", RandomString(6))
 			backupNames = append(backupNames, backupWithVMMixed)
 			log.InfoD("creating backup [%s] in cluster [%s] (%s), organization [%s], of namespace [%v], in backup location [%s]", backupWithVMMixed, SourceClusterName, sourceClusterUid, orgID, namespaces, backupLocationName)
-			err = CreateBackup(backupWithVMMixed, SourceClusterName, backupLocationName, backupLocationUID, namespaces,
-				nil, orgID, sourceClusterUid, "", "", "", "", ctx)
+			err = CreateBackupWithValidation(ctx, backupWithVMMixed, SourceClusterName, backupLocationName, backupLocationUID, scheduledAppContexts,
+				nil, orgID, sourceClusterUid, "", "", "", "")
 			dash.VerifyFatal(err, nil, fmt.Sprintf("Creation of backup [%s]", backupWithVMMixed))
 		})
 
@@ -295,8 +294,8 @@ var _ = Describe("{KubevirtVMBackupRestoreWithDifferentStates}", func() {
 			backupWithVMStopped = fmt.Sprintf("%s-%s", "auto-backup-stopped", RandomString(6))
 			backupNames = append(backupNames, backupWithVMStopped)
 			log.InfoD("creating backup [%s] in cluster [%s] (%s), organization [%s], of namespace [%v], in backup location [%s]", backupWithVMStopped, SourceClusterName, sourceClusterUid, orgID, namespaces, backupLocationName)
-			err = CreateBackup(backupWithVMStopped, SourceClusterName, backupLocationName, backupLocationUID, namespaces,
-				nil, orgID, sourceClusterUid, "", "", "", "", ctx)
+			err = CreateBackupWithValidation(ctx, backupWithVMStopped, SourceClusterName, backupLocationName, backupLocationUID, scheduledAppContexts,
+				nil, orgID, sourceClusterUid, "", "", "", "")
 			dash.VerifyFatal(err, nil, fmt.Sprintf("Creation of backup [%s]", backupWithVMStopped))
 		})
 

--- a/tests/backup/backup_kubevirt_test.go
+++ b/tests/backup/backup_kubevirt_test.go
@@ -36,6 +36,7 @@ var _ = Describe("{KubevirtVMBackupRestoreWithDifferentStates}", func() {
 
 		backupLocationMap = make(map[string]string)
 		labelSelectors = make(map[string]string)
+		restoreNameToAppContextMap = make(map[string]*scheduler.Context)
 		providers = getProviders()
 
 		log.InfoD("scheduling applications")

--- a/tests/backup/backup_kubevirt_test.go
+++ b/tests/backup/backup_kubevirt_test.go
@@ -373,15 +373,6 @@ var _ = Describe("{KubevirtVMBackupRestoreWithDifferentStates}", func() {
 		err = SetClusterContext("")
 		log.FailOnError(err, "failed to SetClusterContext to default cluster")
 
-		backupDriver := Inst().Backup
-		log.Info("Deleting backed up namespaces")
-		for _, backupName := range backupNames {
-			backupUID, err := backupDriver.GetBackupUID(ctx, backupName, orgID)
-			log.FailOnError(err, "Failed while trying to get backup UID for - %s", backupName)
-			backupDeleteResponse, err := DeleteBackup(backupName, backupUID, orgID, ctx)
-			log.FailOnError(err, "Backup [%s] could not be deleted", backupName)
-			dash.VerifyFatal(backupDeleteResponse.String(), "", fmt.Sprintf("Verifying [%s] backup deletion is successful", backupName))
-		}
 		log.Info("Deleting restored namespaces")
 		for _, restoreName := range restoreNames {
 			err = DeleteRestore(restoreName, orgID, ctx)

--- a/tests/backup/backup_kubevirt_test.go
+++ b/tests/backup/backup_kubevirt_test.go
@@ -136,7 +136,7 @@ var _ = Describe("{KubevirtVMBackupRestoreWithDifferentStates}", func() {
 			restoreNames = make([]string, 0)
 			for i, appCtx := range scheduledAppContexts {
 				restoreName := fmt.Sprintf("%s-%s-%v", "auto-restore", appCtx.ScheduleOptions.Namespace, RandomString(6))
-				restoreNames = append(backupNames, restoreName)
+				restoreNames = append(restoreNames, restoreName)
 				wg.Add(1)
 				go func(backupName string, appCtx *scheduler.Context, i int) {
 					defer GinkgoRecover()

--- a/tests/backup/backup_kubevirt_test.go
+++ b/tests/backup/backup_kubevirt_test.go
@@ -124,6 +124,7 @@ var _ = Describe("{KubevirtVMBackupRestoreWithDifferentStates}", func() {
 					dash.VerifyFatal(err, nil, fmt.Sprintf("Creation and Validation of backup [%s]", backupName))
 				}(backupName, appCtx)
 			}
+			wg.Wait()
 		})
 
 		Step("Restoring the backed up namespaces", func() {
@@ -145,6 +146,7 @@ var _ = Describe("{KubevirtVMBackupRestoreWithDifferentStates}", func() {
 					dash.VerifyFatal(err, nil, fmt.Sprintf("Creation and Validation of restore [%s]", restoreName))
 				}(restoreName, appCtx, i)
 			}
+			wg.Wait()
 		})
 	})
 

--- a/tests/backup/backup_kubevirt_test.go
+++ b/tests/backup/backup_kubevirt_test.go
@@ -1,0 +1,205 @@
+package tests
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	"github.com/pborman/uuid"
+	api "github.com/portworx/px-backup-api/pkg/apis/v1"
+	"github.com/portworx/torpedo/drivers/backup"
+	"github.com/portworx/torpedo/drivers/scheduler"
+	"github.com/portworx/torpedo/pkg/log"
+	. "github.com/portworx/torpedo/tests"
+	"sync"
+)
+
+// This testcase verifies backup and restore of Kubevirt VMs in different states like Running, Stopped, Restarting
+var _ = Describe("{KubevirtVMBackupRestoreWithDifferentStates}", func() {
+
+	var (
+		backupNames          []string
+		restoreNames         []string
+		scheduledAppContexts []*scheduler.Context
+		sourceClusterUid     string
+		cloudCredName        string
+		cloudCredUID         string
+		backupLocationUID    string
+		backupLocationName   string
+		backupLocationMap    map[string]string
+		labelSelectors       map[string]string
+		providers            []string
+	)
+
+	JustBeforeEach(func() {
+		StartTorpedoTest("KubevirtVMBackupRestoreWithDifferentStates", "Verify backup and restore of Kubevirt VMs in different states",
+			nil, 93011)
+
+		backupLocationMap = make(map[string]string)
+		labelSelectors = make(map[string]string)
+		providers = getProviders()
+
+		log.InfoD("scheduling applications")
+		scheduledAppContexts = make([]*scheduler.Context, 0)
+		for i := 0; i < 3; i++ {
+			taskName := fmt.Sprintf("%d-%d", 93011, i)
+			appContexts := ScheduleApplications(taskName)
+			for _, appCtx := range appContexts {
+				appCtx.ReadinessTimeout = appReadinessTimeout
+				scheduledAppContexts = append(scheduledAppContexts, appCtx)
+			}
+		}
+	})
+
+	It("Basic Backup Creation", func() {
+		defer func() {
+			log.InfoD("switching to default context")
+			err := SetClusterContext("")
+			log.FailOnError(err, "failed to SetClusterContext to default cluster")
+		}()
+
+		Step("Validating applications", func() {
+			log.InfoD("Validating applications")
+			ValidateApplications(scheduledAppContexts)
+		})
+
+		Step("Creating backup location and cloud setting", func() {
+			log.InfoD("Creating backup location and cloud setting")
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			for _, provider := range providers {
+				cloudCredName = fmt.Sprintf("%s-%s-%v", "cred", provider, RandomString(6))
+				backupLocationName = fmt.Sprintf("%s-%v", getGlobalBucketName(provider), RandomString(6))
+				cloudCredUID = uuid.New()
+				backupLocationUID = uuid.New()
+				backupLocationMap[backupLocationUID] = backupLocationName
+				err := CreateCloudCredential(provider, cloudCredName, cloudCredUID, orgID, ctx)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation of cloud credential named [%s] for org [%s] with [%s] as provider", cloudCredName, orgID, provider))
+				err = CreateBackupLocation(provider, backupLocationName, backupLocationUID, cloudCredName, cloudCredUID, getGlobalBucketName(provider), orgID, "")
+				dash.VerifyFatal(err, nil, "Creating backup location")
+			}
+		})
+
+		Step("Registering cluster for backup", func() {
+			log.InfoD("Registering cluster for backup")
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+
+			err = CreateApplicationClusters(orgID, "", "", ctx)
+			dash.VerifyFatal(err, nil, "Creating source and destination cluster")
+
+			clusterStatus, err := Inst().Backup.GetClusterStatus(orgID, SourceClusterName, ctx)
+			log.FailOnError(err, fmt.Sprintf("Fetching [%s] cluster status", SourceClusterName))
+			dash.VerifyFatal(clusterStatus, api.ClusterInfo_StatusInfo_Online, fmt.Sprintf("Verifying if [%s] cluster is online", SourceClusterName))
+
+			sourceClusterUid, err = Inst().Backup.GetClusterUID(ctx, orgID, SourceClusterName)
+			dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching [%s] cluster uid", SourceClusterName))
+
+			clusterStatus, err = Inst().Backup.GetClusterStatus(orgID, destinationClusterName, ctx)
+			log.FailOnError(err, fmt.Sprintf("Fetching [%s] cluster status", destinationClusterName))
+			dash.VerifyFatal(clusterStatus, api.ClusterInfo_StatusInfo_Online, fmt.Sprintf("Verifying if [%s] cluster is online", destinationClusterName))
+		})
+
+		Step("Changing the states of Kubevirt Virtual Machines", func() {
+			namespaceToStopVMs := scheduledAppContexts[1].ScheduleOptions.Namespace
+			err := StopAllVMsInNamespace(namespaceToStopVMs, true)
+			log.FailOnError(err, "Failed stopping the VMs in namespace - "+namespaceToStopVMs)
+
+		})
+
+		Step("Taking backup of application from source cluster", func() {
+			log.InfoD("Taking backup of applications")
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			var wg sync.WaitGroup
+
+			backupNames = make([]string, 0)
+			for _, appCtx := range scheduledAppContexts {
+				backupName := fmt.Sprintf("%s-%s-%v", "auto-backup", appCtx.ScheduleOptions.Namespace, RandomString(6))
+				backupNames = append(backupNames, backupName)
+				wg.Add(1)
+				go func(backupName string, appCtx *scheduler.Context) {
+					defer GinkgoRecover()
+					defer wg.Done()
+					log.InfoD("creating backup [%s] in source cluster [%s] (%s), organization [%s], of namespace [%s], in backup location [%s]", backupName, SourceClusterName, sourceClusterUid, orgID, appCtx.ScheduleOptions.Namespace, backupLocationName)
+					err := CreateBackupWithValidation(ctx, backupName, SourceClusterName, backupLocationName, backupLocationUID, []*scheduler.Context{appCtx}, labelSelectors, orgID, sourceClusterUid, "", "", "", "")
+					dash.VerifyFatal(err, nil, fmt.Sprintf("Creation and Validation of backup [%s]", backupName))
+				}(backupName, appCtx)
+			}
+		})
+
+		Step("Restoring the backed up namespaces", func() {
+			log.InfoD("Restoring the backed up namespaces")
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			var wg sync.WaitGroup
+
+			restoreNames = make([]string, 0)
+			for i, appCtx := range scheduledAppContexts {
+				restoreName := fmt.Sprintf("%s-%s-%v", "auto-restore", appCtx.ScheduleOptions.Namespace, RandomString(6))
+				restoreNames = append(backupNames, restoreName)
+				wg.Add(1)
+				go func(backupName string, appCtx *scheduler.Context, i int) {
+					defer GinkgoRecover()
+					defer wg.Done()
+					log.InfoD("Restoring [%s] namespace from the [%s] backup", appCtx.ScheduleOptions.Namespace, backupNames[i])
+					err = CreateRestoreWithValidation(ctx, restoreName, backupNames[i], make(map[string]string), make(map[string]string), destinationClusterName, orgID, []*scheduler.Context{appCtx})
+					dash.VerifyFatal(err, nil, fmt.Sprintf("Creation and Validation of restore [%s]", restoreName))
+				}(restoreName, appCtx, i)
+			}
+		})
+	})
+
+	JustAfterEach(func() {
+		defer EndPxBackupTorpedoTest(scheduledAppContexts)
+
+		defer func() {
+			log.InfoD("switching to default context")
+			err := SetClusterContext("")
+			log.FailOnError(err, "failed to SetClusterContext to default cluster")
+		}()
+
+		ctx, err := backup.GetAdminCtxFromSecret()
+		log.FailOnError(err, "Fetching px-central-admin ctx")
+		dash.VerifySafely(err, nil, "Deleting backup schedule policies")
+		opts := make(map[string]bool)
+		opts[SkipClusterScopedObjects] = true
+
+		log.Info("Destroying scheduled apps on source cluster")
+		DestroyApps(scheduledAppContexts, opts)
+
+		log.InfoD("switching to destination context")
+		err = SetDestinationKubeConfig()
+		log.FailOnError(err, "failed to switch to context to destination cluster")
+
+		log.InfoD("Destroying restored apps on destination clusters")
+		restoredAppContexts := make([]*scheduler.Context, 0)
+		for _, scheduledAppContext := range scheduledAppContexts {
+			restoredAppContext, err := CloneAppContextAndTransformWithMappings(scheduledAppContext, make(map[string]string), make(map[string]string), true)
+			if err != nil {
+				log.Errorf("TransformAppContextWithMappings: %v", err)
+				continue
+			}
+			restoredAppContexts = append(restoredAppContexts, restoredAppContext)
+		}
+		DestroyApps(restoredAppContexts, opts)
+
+		log.InfoD("switching to default context")
+		err = SetClusterContext("")
+		log.FailOnError(err, "failed to SetClusterContext to default cluster")
+
+		backupDriver := Inst().Backup
+		log.Info("Deleting backed up namespaces")
+		for _, backupName := range backupNames {
+			backupUID, err := backupDriver.GetBackupUID(ctx, backupName, orgID)
+			log.FailOnError(err, "Failed while trying to get backup UID for - %s", backupName)
+			backupDeleteResponse, err := DeleteBackup(backupName, backupUID, orgID, ctx)
+			log.FailOnError(err, "Backup [%s] could not be deleted", backupName)
+			dash.VerifyFatal(backupDeleteResponse.String(), "", fmt.Sprintf("Verifying [%s] backup deletion is successful", backupName))
+		}
+		log.Info("Deleting restored namespaces")
+		for _, restoreName := range restoreNames {
+			err = DeleteRestore(restoreName, orgID, ctx)
+			dash.VerifyFatal(err, nil, fmt.Sprintf("Deleting Restore [%s]", restoreName))
+		}
+		CleanupCloudSettingsAndClusters(backupLocationMap, cloudCredName, cloudCredUID, ctx)
+	})
+})

--- a/tests/backup/backup_kubevirt_test.go
+++ b/tests/backup/backup_kubevirt_test.go
@@ -261,7 +261,7 @@ var _ = Describe("{KubevirtVMBackupRestoreWithDifferentStates}", func() {
 			}
 			wg.Wait()
 			err = backupSuccessCheck(backupWithVMRestart, orgID, maxWaitPeriodForBackupCompletionInMinutes*time.Minute, 30*time.Second, ctx)
-			log.FailOnError(err, "Failed while checking success of backup [%s]")
+			log.FailOnError(err, "Failed while checking success of backup [%s]", backupWithVMRestart)
 		})
 
 		Step("Restoring backup taken when VMs were Restarting", func() {

--- a/tests/backup/backup_kubevirt_test.go
+++ b/tests/backup/backup_kubevirt_test.go
@@ -104,8 +104,9 @@ var _ = Describe("{KubevirtVMBackupRestoreWithDifferentStates}", func() {
 			dash.VerifyFatal(clusterStatus, api.ClusterInfo_StatusInfo_Online, fmt.Sprintf("Verifying if [%s] cluster is online", destinationClusterName))
 		})
 
-		Step("Changing the states of Kubevirt Virtual Machines", func() {
+		Step("Stopping VMs in one of the namespaces", func() {
 			namespaceToStopVMs := scheduledAppContexts[1].ScheduleOptions.Namespace
+			log.InfoD("Stopping VMs in one of the namespaces - [%s]", namespaceToStopVMs)
 			err := StopAllVMsInNamespace(namespaceToStopVMs, true)
 			log.FailOnError(err, "Failed stopping the VMs in namespace - "+namespaceToStopVMs)
 
@@ -183,8 +184,16 @@ var _ = Describe("{KubevirtVMBackupRestoreWithDifferentStates}", func() {
 			wg.Wait()
 		})
 
+		Step("Starting the VMs in the namespace where it was stopped", func() {
+			namespace := scheduledAppContexts[1].ScheduleOptions.Namespace
+			log.InfoD("Starting the VMs in the namespace [%s] where it was stopped", namespace)
+			err := StartAllVMsInNamespace(namespace, true)
+			log.FailOnError(err, "Failed stopping the VMs in namespace - "+namespace)
+
+		})
+
 		Step("Take backup of all namespaces when VMs are restarting", func() {
-			log.InfoD("Taking backup of applications")
+			log.InfoD("Take backup of all namespaces when VMs are restarting")
 			ctx, err := backup.GetAdminCtxFromSecret()
 			log.FailOnError(err, "Fetching px-central-admin ctx")
 			var wg sync.WaitGroup

--- a/tests/backup/backup_kubevirt_test.go
+++ b/tests/backup/backup_kubevirt_test.go
@@ -191,7 +191,6 @@ var _ = Describe("{KubevirtVMBackupRestoreWithDifferentStates}", func() {
 
 		ctx, err := backup.GetAdminCtxFromSecret()
 		log.FailOnError(err, "Fetching px-central-admin ctx")
-		dash.VerifySafely(err, nil, "Deleting backup schedule policies")
 		opts := make(map[string]bool)
 		opts[SkipClusterScopedObjects] = true
 

--- a/tests/common.go
+++ b/tests/common.go
@@ -2014,6 +2014,7 @@ func ValidateStoragePools(contexts []*scheduler.Context) {
 		nodes := node.GetWorkerNodes()
 		expect(nodes).NotTo(beEmpty())
 		for _, n := range nodes {
+			log.Infof("Worker nodes - %s", n.Name)
 			for id, sPool := range n.StoragePools {
 				if workloadSizeForPool, ok := workloadSizesByPool[sPool.Uuid]; ok {
 					n.StoragePools[id].WorkloadSize = workloadSizeForPool

--- a/tests/common.go
+++ b/tests/common.go
@@ -2014,7 +2014,6 @@ func ValidateStoragePools(contexts []*scheduler.Context) {
 		nodes := node.GetWorkerNodes()
 		expect(nodes).NotTo(beEmpty())
 		for _, n := range nodes {
-			log.Infof("Worker nodes - %s", n.Name)
 			for id, sPool := range n.StoragePools {
 				if workloadSizeForPool, ok := workloadSizesByPool[sPool.Uuid]; ok {
 					n.StoragePools[id].WorkloadSize = workloadSizeForPool

--- a/vendor/github.com/portworx/sched-ops/k8s/kubevirt/virtualmachine.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/kubevirt/virtualmachine.go
@@ -26,6 +26,8 @@ type VirtualMachineOps interface {
 	StartVirtualMachine(*kubevirtv1.VirtualMachine) error
 	// StopVirtualMachine Stop VirtualMachine
 	StopVirtualMachine(*kubevirtv1.VirtualMachine) error
+	// RestartVirtualMachine restarts VirtualMachine
+	RestartVirtualMachine(*kubevirtv1.VirtualMachine) error
 }
 
 // ListVirtualMachines List Kubevirt VirtualMachine in given namespace
@@ -120,4 +122,12 @@ func (c *Client) StopVirtualMachine(vm *kubevirtv1.VirtualMachine) error {
 	}
 
 	return c.kubevirt.VirtualMachine(vm.GetNamespace()).Stop(vm.GetName(), &kubevirtv1.StopOptions{})
+}
+
+// RestartVirtualMachine restarts VirtualMachine
+func (c *Client) RestartVirtualMachine(vm *kubevirtv1.VirtualMachine) error {
+	if err := c.initClient(); err != nil {
+		return err
+	}
+	return c.kubevirt.VirtualMachine(vm.GetNamespace()).Restart(vm.GetName(), &kubevirtv1.RestartOptions{})
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1120,7 +1120,7 @@ github.com/portworx/pds-api-go-client/pds/v1alpha1
 github.com/portworx/px-backup-api/pkg/apis/v1
 github.com/portworx/px-backup-api/pkg/kubeauth
 github.com/portworx/px-backup-api/pkg/kubeauth/gcp
-# github.com/portworx/sched-ops v1.20.4-rc1.0.20231013094113-8ca7856dbe86
+# github.com/portworx/sched-ops v1.20.4-rc1.0.20231018042450-4c290674cb5a
 ## explicit; go 1.19
 github.com/portworx/sched-ops/k8s/admissionregistration
 github.com/portworx/sched-ops/k8s/apiextensions


### PR DESCRIPTION
**What this PR does / why we need it**:

- [x] Added a new test `KubevirtVMBackupRestoreWithDifferentStates` which does multiple backup and restore operations while the Kubevirt VMs are in different states
- [x] Added a new parameter to the VM operation helper functions called - `waitForCompletion` which will wait till the desired state is reached
- [x] Added functions `StartAllVMsInNamespace`, `StopAllVMsInNamespace` and `RestartAllVMsInNamespace`

**Which issue(s) this PR fixes** (optional)
Closes #PA-1733

**Special notes for your reviewer**:
[Jenkins Vanilla S3 Run](https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/3071/)
[Jenkins Vanilla NFS Run](https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/3074/)

