### PR TITLE
update BringUpLargePodsVerifyNoPanic tests for FA deployment

### DIFF
--- a/tests/basic/longevity_test.go
+++ b/tests/basic/longevity_test.go
@@ -26,7 +26,6 @@ const (
 	testTriggersConfigMap = "longevity-triggers"
 	configMapNS           = "default"
 	controlLoopSleepTime  = time.Second * 15
-	podDestroyTimeout     = 5 * time.Minute
 )
 
 var (
@@ -810,7 +809,7 @@ func SetTopologyLabelsOnNodes() ([]map[string]string, error) {
 	// Bouncing Back the PX pods on all nodes to restart Csi Registrar Container
 	log.Info("Bouncing back the PX pods after setting the Topology Labels on Nodes")
 
-	if err := deletePXPods(volumeDriverNamespace); err != nil {
+	if err := DeletePXPods(volumeDriverNamespace); err != nil {
 		return nil, fmt.Errorf("Failed to delete PX pods. Error:[%v]", err)
 	}
 
@@ -826,16 +825,6 @@ func SetTopologyLabelsOnNodes() ([]map[string]string, error) {
 	}
 
 	return topologyLabels, nil
-}
-
-// deletePXPods delete px pods
-func deletePXPods(nameSpace string) error {
-	pxLabel := make(map[string]string)
-	pxLabel["name"] = "portworx"
-	if err := core.Instance().DeletePodsByLabels(nameSpace, pxLabel, podDestroyTimeout); err != nil {
-		return err
-	}
-	return nil
 }
 
 func populateIntervals() {

--- a/tests/basic/podmetric_test.go
+++ b/tests/basic/podmetric_test.go
@@ -367,7 +367,7 @@ func updateStorageSpecRuntimeOpts(callhomeInterval string, meteringInterval stri
 	}
 
 	log.InfoD("Deleting PX pods for reloading the runtime Opts")
-	err = deletePXPods(storageSpec.Namespace)
+	err = DeletePXPods(storageSpec.Namespace)
 	if err != nil {
 		return err
 	}

--- a/tests/basic/pure_test.go
+++ b/tests/basic/pure_test.go
@@ -173,6 +173,10 @@ var _ = Describe("{BringUpLargePodsVerifyNoPanic}", func() {
 			e.x : --app-list nginx-fa-davol --provisioner csi --storage-driver pure
 		*/
 
+		//https://portworx.atlassian.net/browse/PWX-33551
+		err := UpdateDriverVariables(map[string]string{"PURE_REST_TIMEOUT": "60"}, map[string]string{"execution_timeout_sec": "180"})
+		log.FailOnError(err, "error update storage cluster spec with env variables")
+
 		var wg sync.WaitGroup
 		var terminate bool = false
 
@@ -313,7 +317,7 @@ var _ = Describe("{BringUpLargePodsVerifyNoPanic}", func() {
 			}
 			return nil, false, nil
 		}
-		_, err := task.DoRetryWithTimeout(waitForPodsRunning, 60*time.Minute, 10*time.Second)
+		_, err = task.DoRetryWithTimeout(waitForPodsRunning, 60*time.Minute, 10*time.Second)
 		log.FailOnError(err, "Error checking pool rebalance")
 
 		for _, eachVol := range allVolumes {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Automating https://portworx.atlassian.net/browse/PWX-33551
update BringUpLargePodsVerifyNoPanic tests for FA deployment. Update storage spec with 
environment variable 
env:
- name: PURE_REST_TIMEOUT
value: "60"

Run Time opts:  execution_timeout_sec=180

**Which issue(s) this PR fixes** (optional)
Closes #PTX-20614

**Special notes for your reviewer**:
spec after update:

   installSnapshotController: true
    env:
    - name: PURE_FLASHARRAY_SAN_TYPE
      value: ISCSI
    - name: REGISTRY_USER
      value: cnbuautomation800
    - name: REGISTRY_PASS
      value: dckr_pat_Wy3ndZPh3fwyJAUGZ4JmKN8EnyY
    - name: PURE_REST_TIMEOUT
      value: "60"


runtimeOptions:
      execution_timeout_sec: "180"
