### PR TITLE
TC automation[PTX-20641] RebootNodeWhileVolCreate

### DIFF
--- a/tests/basic/pure_test.go
+++ b/tests/basic/pure_test.go
@@ -629,7 +629,7 @@ var _ = Describe("{RebootNodeWhileVolCreate}", func() {
 		//Provisioner for pure apps
 		Provisioner := fmt.Sprintf("%v", portworx.PortworxCsi)
 		n := 3
-		NumberOfDeploymentsPerReboot := 15
+		NumberOfDeploymentsPerReboot := 8
 		//Reboot a random storage node n number of times
 		for i := 0; i < n; i++ {
 			// Step 1: Schedule applications

--- a/tests/basic/pure_test.go
+++ b/tests/basic/pure_test.go
@@ -623,25 +623,24 @@ var _ = Describe("{RebootNodeWhileVolCreate}", func() {
 	JustBeforeEach(func() {
 		StartTorpedoTest("RebootNodeWhileVolCreate", "Test creates multiple FADA volume and reboots a node while volume creation is in progress", nil, 72615025)
 	})
-	var contexts = make([]*scheduler.Context, 0)
-	var wg sync.WaitGroup
-	//Scheduling app with volume placement strategy
-	applist := Inst().AppList
-	//select a storage node to place volumes and restart
-	storageNodes := node.GetStorageNodes()
-	selectedNode := storageNodes[rand.Intn(len(storageNodes))]
-	var err error
-	defer func() {
-		Inst().AppList = applist
-		err = Inst().S.RemoveLabelOnNode(selectedNode, k8s.NodeType)
-		log.FailOnError(err, "error removing label on node [%s]", selectedNode.Name)
-	}()
-	Inst().AppList = []string{"nginx-fada-fastpath-vps"}
-	err = Inst().S.AddLabelOnNode(selectedNode, k8s.NodeType, k8s.FastpathNodeType)
-	log.FailOnError(err, fmt.Sprintf("Failed add label on node %s", selectedNode.Name))
-
 	It("schedules nginx fada volumes on (n) * (NumberOfDeploymentsPerReboot) different namespaces and reboots a different node after every NumberOfDeploymentsPerReboot have been queued to schedule", func() {
 		//Provisioner for pure apps
+		var contexts = make([]*scheduler.Context, 0)
+		var wg sync.WaitGroup
+		//Scheduling app with volume placement strategy
+		applist := Inst().AppList
+		//select a storage node to place volumes and restart
+		storageNodes := node.GetStorageNodes()
+		selectedNode := storageNodes[rand.Intn(len(storageNodes))]
+		var err error
+		defer func() {
+			Inst().AppList = applist
+			err = Inst().S.RemoveLabelOnNode(selectedNode, k8s.NodeType)
+			log.FailOnError(err, "error removing label on node [%s]", selectedNode.Name)
+		}()
+		Inst().AppList = []string{"nginx-fada-fastpath-vps"}
+		err = Inst().S.AddLabelOnNode(selectedNode, k8s.NodeType, k8s.FastpathNodeType)
+		log.FailOnError(err, fmt.Sprintf("Failed add label on node %s", selectedNode.Name))
 		Provisioner := fmt.Sprintf("%v", portworx.PortworxCsi)
 		n := 3
 		NumberOfDeploymentsPerReboot := 8

--- a/tests/basic/pure_test.go
+++ b/tests/basic/pure_test.go
@@ -642,7 +642,7 @@ var _ = Describe("{RebootNodeWhileVolCreate}", func() {
 
 	It("schedules nginx fada volumes on (n) * (NumberOfDeploymentsPerReboot) different namespaces and reboots a different node after every NumberOfDeploymentsPerReboot have been queued to schedule", func() {
 		//Provisioner for pure apps
-		Provisioner := fmt.Sprintf("%v", "csi")
+		Provisioner := fmt.Sprintf("%v", portworx.PortworxCsi)
 		n := 3
 		NumberOfDeploymentsPerReboot := 8
 		//Reboot a random storage node n number of times

--- a/tests/basic/pure_test.go
+++ b/tests/basic/pure_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+	"github.com/portworx/torpedo/pkg/units"
 
 	"math/rand"
 


### PR DESCRIPTION
What this PR does / why we need it:
This PR adds RebootNodeWhileVolCreate test case which checks no error occurs when storage node is rebooted while creation and deletion of FADA nginx apps PVC

Which issue(s) this PR fixes (optional)
Closes #PTX-20641

Special notes for your reviewer:
[aetos](https://aetos.pwx.purestorage.com/resultSet/testSetID/393536) 