### PR TITLE
PA-1768: Refetch the list of pods before delete in `DeletePodWithLabelInNamespace()`

### DIFF
--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -1443,6 +1443,7 @@ func GetAllRestoresNonAdminCtx(ctx context.Context) ([]string, error) {
 func DeletePodWithLabelInNamespace(namespace string, label map[string]string) error {
 	var pods *corev1.PodList
 	var err error
+	// TODO: Revisit this function and remove the below code if not needed
 	podList := func() (interface{}, bool, error) {
 		pods, err = core.Instance().GetPods(namespace, label)
 		if err != nil {
@@ -1461,6 +1462,13 @@ func DeletePodWithLabelInNamespace(namespace string, label map[string]string) er
 	if err != nil {
 		return err
 	}
+
+	// fetch the newest set of pods post wait for pods to come up
+	pods, err = core.Instance().GetPods(namespace, label)
+	if err != nil {
+		return err
+	}
+
 	for _, pod := range pods.Items {
 		log.Infof("Deleting pod %s with label %v", pod.GetName(), label)
 		err = core.Instance().DeletePod(pod.GetName(), namespace, false)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->
**What this PR does / why we need it**:

LicensingCountBeforeAndAfterBackupPodRestart failed in [https://jenkins.pwx.dev.purestorage.com/blue/organizations/jenkins/portworx-backup%2Fsystem-tests%2Fupgrade-tests%2FPx-Backup-with-Stork-Upgrade%2FPx-Backup%2BStork-Upgrade-iks-non-px-csi/detail/Px-Backup Stork-Upgrade-iks-non-px-csi/13/tests/](https://jenkins.pwx.dev.purestorage.com/blue/organizations/jenkins/portworx-backup%2Fsystem-tests%2Fupgrade-tests%2FPx-Backup-with-Stork-Upgrade%2FPx-Backup%2BStork-Upgrade-iks-non-px-csi/detail/Px-Backup%20Stork-Upgrade-iks-non-px-csi/13/tests/) with 

```
s: "error: pods \"quick-maintenance-repo-367d103-28304281-qkj2x\" not found, Description: Restart all the backup pods"
```

This was mostly because the pods get remove after sometime and we just have 2 such pods running or in completed state at any given point below you can see that we had quick maintenance job which was in completed state but later it was removed as a new one ware created. In the current code what I see is that is that it waits for we have a `_, err = DoRetryWithTimeoutWithGinkgoRecover(podList, 5*time.Minute, 30*time.Second)` during which a new job pod instance is created and when we attempt to delete the older pod which is now removed it fails complaining not found. 
```
 [root@ip-10-13-11-25 ~]# kubectl get pods -n central quick-maintenance-repo-1e442df-28305721-q62zs 
NAME                                            READY   STATUS      RESTARTS   AGE
quick-maintenance-repo-1e442df-28305721-q62zs   0/1     Completed   0          81m

[root@ip-10-13-11-25 ~]# kubectl get pods -n central quick-maintenance-repo-1e442df-28305721-q62zs 
Error from server (NotFound): pods "quick-maintenance-repo-1e442df-28305721-q62zs" not found


[root@ip-10-13-11-25 ~]# kubectl get pods -n central 
NAME                                            READY   STATUS      RESTARTS      AGE
full-maintenance-repo-1e442df-28306081-4kqvz    0/1     Completed   0             143m
full-maintenance-repo-4709ba1-28306081-t9bb5    0/1     Completed   0             143m
nfs-backupsync-9gb62                            0/1     Completed   0             14h
px-backup-5fbfc7576f-fvcb2                      1/1     Running     0             37h
pxc-backup-mongodb-0                            1/1     Running     0             37h
pxc-backup-mongodb-1                            1/1     Running     2 (37h ago)   37h
pxc-backup-mongodb-2                            1/1     Running     0             37h
pxcentral-apiserver-75695bcd85-952xh            1/1     Running     0             37h
pxcentral-backend-585b67b6d4-gnqfh              1/1     Running     0             37h
pxcentral-frontend-999c699f4-vvkvk              1/1     Running     0             37h
pxcentral-keycloak-0                            1/1     Running     0             37h
pxcentral-keycloak-postgresql-0                 1/1     Running     0             37h
pxcentral-lh-middleware-747bcc9dcd-kf74x        1/1     Running     0             37h
pxcentral-mysql-0                               1/1     Running     0             37h
pxcentral-post-install-hook-nldsg               0/1     Completed   0             37h
quick-maintenance-repo-1e442df-28306081-h2795   0/1     Completed   0             143m
quick-maintenance-repo-4709ba1-28306081-mswv7   0/1     Completed   0             143m
```


- [x] Add code to refetch list of pods before delete call

**Which issue(s) this PR fixes** (optional)
Closes # PA-1768

**Special notes for your reviewer**:

