### PR TITLE
Fixed cluster context switch for rke :PA-1773

### DIFF
--- a/tests/common.go
+++ b/tests/common.go
@@ -9,9 +9,9 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/portworx/torpedo/drivers/scheduler/openshift"
 	optest "github.com/libopenstorage/operator/pkg/util/test"
 	"github.com/portworx/sched-ops/k8s/operator"
+	"github.com/portworx/torpedo/drivers/scheduler/openshift"
 
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
@@ -2902,9 +2902,16 @@ func SetClusterContext(clusterConfigPath string) error {
 	// To update the rancher client for current cluster context
 	if os.Getenv("CLUSTER_PROVIDER") == drivers.ProviderRke {
 		if !strings.HasPrefix(clusterConfigPath, "/tmp/") {
-			return fmt.Errorf("clusterConfigPath cannot be an empty string for %s cluster provider", drivers.ProviderRke)
+			if clusterConfigPath == "" {
+				err = Inst().S.(*rke.Rancher).UpdateRancherClient("source-config")
+				if err != nil {
+					return fmt.Errorf("failed to update rancher client for default source cluster context with error: [%v]", err)
+				}
+				return nil
+			}
+			return fmt.Errorf("invalid clusterConfigPath: %s for %s cluster provider", clusterConfigPath, drivers.ProviderRke)
 		}
-		err := Inst().S.(*rke.Rancher).UpdateRancherClient(strings.Split(clusterConfigPath, "/tmp/")[1])
+		err = Inst().S.(*rke.Rancher).UpdateRancherClient(strings.Split(clusterConfigPath, "/tmp/")[1])
 		if err != nil {
 			return fmt.Errorf("failed to update rancher client for %s with error: [%v]", clusterConfigPath, err)
 		}


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
In method SetClusterContext , if the clusterConfigPath is empty, setting the context to source cluster
**Which issue(s) this PR fixes** (optional)
Closes #https://portworx.atlassian.net/browse/PA-1773

**Special notes for your reviewer**:
https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/basic-system-test/job/px/job/NFS/job/PX-Cloud-RKE-NFS/176/