### PR TITLE
Fixed error handling in CreateRestoreWithValidation function

### DIFF
--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -1460,7 +1460,7 @@ func (k *K8s) UpdateTasksID(ctx *scheduler.Context, id string) error {
 }
 
 // GetUpdatedSpec gets the updated spec of a K8s Object. Just `name`, and if required `namespace` must be specified on `spec` in order to GET the spec from K8s (if it exists).
-func (k *K8s) GetUpdatedSpec(spec interface{}) (interface{}, error) {
+func GetUpdatedSpec(spec interface{}) (interface{}, error) {
 	if specObj, ok := spec.(*appsapi.Deployment); ok {
 		dep, err := k8sApps.GetDeployment(specObj.Name, specObj.Namespace)
 		if err == nil {

--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -1680,12 +1680,7 @@ func ValidateBackup(ctx context.Context, backupName string, orgID string, schedu
 					continue volloop
 				}
 
-				sched, ok := Inst().S.(*k8s.K8s)
-				if !ok {
-					continue volloop
-				}
-
-				updatedSpec, err := sched.GetUpdatedSpec(pvcSpecObj)
+				updatedSpec, err := k8s.GetUpdatedSpec(pvcSpecObj)
 				if err != nil {
 					err := fmt.Errorf("unable to fetch updated version of PVC(name: [%s], namespace: [%s]) present in the context [%s]. Error: %v", pvcSpecObj.GetName(), pvcSpecObj.GetNamespace(), scheduledAppContextNamespace, err)
 					errors = append(errors, err)

--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -1951,16 +1951,11 @@ func ValidateRestore(ctx context.Context, restoreName string, orgID string, expe
 							}
 						}
 
-						if k8s, ok := Inst().S.(*k8s.K8s); ok {
-							_, err := k8s.GetUpdatedSpec(specObj)
-							if err == nil {
-								log.Infof("object (name: [%s], kind: [%s], namespace: [%s]) found in the restore [%s] was also present on the cluster/namespace [%s]", name, kind, ns, restoreName, expectedRestoredAppContextNamespace)
-							} else {
-								err := fmt.Errorf("prsence of object (name: [%s], kind: [%s], namespace: [%s]) found in the restore [%s] on the cluster/namespace [%s] could not be verified as scheduler is not K8s", name, kind, ns, restoreName, expectedRestoredAppContextNamespace)
-								errors = append(errors, err)
-							}
+						_, err := k8s.GetUpdatedSpec(specObj)
+						if err == nil {
+							log.Infof("object (name: [%s], kind: [%s], namespace: [%s]) found in the restore [%s] was also present on the cluster/namespace [%s]", name, kind, ns, restoreName, expectedRestoredAppContextNamespace)
 						} else {
-							err := fmt.Errorf("prsence of object (name: [%s], kind: [%s], namespace: [%s]) found in the restore [%s] on the cluster/namespace [%s] could not be verified as scheduler is not K8s", name, kind, ns, restoreName, expectedRestoredAppContextNamespace)
+							err := fmt.Errorf("presence of object (name: [%s], kind: [%s], namespace: [%s]) found in the restore [%s] on the cluster/namespace [%s] could not be verified as scheduler is not K8s", name, kind, ns, restoreName, expectedRestoredAppContextNamespace)
 							errors = append(errors, err)
 						}
 

--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -966,7 +966,7 @@ func CreateRestoreWithValidation(ctx context.Context, restoreName, backupName st
 		log.InfoD("Switching cluster context back to cluster path [%s]", originalClusterConfigPath)
 		err := SetClusterContext(originalClusterConfigPath)
 		if err != nil {
-			log.Errorf("Failed switching cluster context back to cluster path [%s].\nError - %s", originalClusterConfigPath, err.Error())
+			log.FailOnError(err, "Failed switching cluster context back to cluster path [%s]", originalClusterConfigPath)
 		}
 	}()
 	expectedRestoredAppContexts := make([]*scheduler.Context, 0)


### PR DESCRIPTION
**What this PR does / why we need it**:

- [x] `CreateRestoreWithValidation` function was never handling the error returned by `ValidateRestore` function. Fixed that by returning the proper error.
- [x] Removed the receiver type for `GetUpdatedSpec`
- [x] Added a case to handle the restored volume status in `ValidateRestore` if the status was `Retain` incase of in-place restore

**Which issue(s) this PR fixes** (optional)
Closes #PB-4759

**Special notes for your reviewer**:
[Successful Jenkins Run on RKE](https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/basic-system-test/job/px/job/s3/job/px-backup-system-test-rke/349/)
[Aetos link](https://aetos.pwx.purestorage.com/resultSet/testSetID/403906)
There is one failed test `MultipleProjectsAndNamespacesBackupAndRestore`
This has been failing from the beginning but we were unable to catch it because the `CreateRestoreWithValidation` function was not returning the error.
Created a ticket to track this and assigned it to @snigdha-px - https://portworx.atlassian.net/browse/PB-4760
