### PR TITLE
[Kubevirt] Fixed the test case ResizeVolumeOnScheduleBackup for Kubevirt App

### DIFF
--- a/drivers/scheduler/k8s/specs/kubevirt-multi-vm/vm-ubuntu-containerdisk-pvc.yaml
+++ b/drivers/scheduler/k8s/specs/kubevirt-multi-vm/vm-ubuntu-containerdisk-pvc.yaml
@@ -24,6 +24,7 @@ spec:
         kubevirt.io/size: small
         kubevirt.io/domain: ubuntu-bionic
         kubevirt-key: kubevirt-val
+        app: vm-ubuntu-containerdisk-pvc
     spec:
       domain:
         cpu:

--- a/drivers/scheduler/k8s/specs/kubevirt-multi-vm/vm-ubuntu-containerdisk.yaml
+++ b/drivers/scheduler/k8s/specs/kubevirt-multi-vm/vm-ubuntu-containerdisk.yaml
@@ -11,6 +11,7 @@ spec:
         kubevirt.io/size: small
         kubevirt.io/domain: vm-ubuntu-containerdisk
         kubevirt-key: kubevirt-val
+        app: vm-ubuntu-containerdisk
     spec:
       domain:
         cpu:

--- a/drivers/scheduler/k8s/specs/kubevirt-multi-vm/vm-ubuntu-pvc-datavolume.yaml
+++ b/drivers/scheduler/k8s/specs/kubevirt-multi-vm/vm-ubuntu-pvc-datavolume.yaml
@@ -23,6 +23,7 @@ spec:
       labels:
         kubevirt.io/domain: ubuntu-bionic
         kubevirt-key: kubevirt-val
+        app: vm-ubuntu-pvc-datavolume
     spec:
       domain:
         cpu:

--- a/drivers/scheduler/k8s/specs/kubevirt-multi-vm/vm-ubuntu-pvc.yaml
+++ b/drivers/scheduler/k8s/specs/kubevirt-multi-vm/vm-ubuntu-pvc.yaml
@@ -11,6 +11,7 @@ spec:
     metadata:
       labels:
         kubevirt.io/domain: vm-ubuntu-pvc
+        app: vm-ubuntu-pvc
     spec:
       domain:
         cpu:

--- a/drivers/scheduler/k8s/specs/kubevirt-vm-pvc/kubevirt-app.yaml
+++ b/drivers/scheduler/k8s/specs/kubevirt-vm-pvc/kubevirt-app.yaml
@@ -13,6 +13,7 @@ spec:
       creationTimestamp: null
       labels:
         kubevirt.io/domain: cirrosvm
+        app: kubevirt-vm-pvc
     spec:
       domain:
         cpu:

--- a/drivers/volume/portworx/schedops/k8s-schedops.go
+++ b/drivers/volume/portworx/schedops/k8s-schedops.go
@@ -321,7 +321,7 @@ func (k *k8sSchedOps) validateDevicesInPods(
 			return validatedDevicePods, err
 		}
 		log.Debugf("validating the devices in pod %s/%s", p.Namespace, p.Name)
-		containerPaths := getContainerPVCMountMap(*pod)
+		containerPaths := GetContainerPVCMountMap(*pod)
 		if len(containerPaths) == 0 {
 			return validatedDevicePods, fmt.Errorf("pod: [%s] %s does not have raw block devices.", pod.Namespace, pod.Name)
 		}
@@ -376,7 +376,7 @@ PodLoop:
 		}
 
 		log.Debugf("validating the mounts in pod %s/%s", p.Namespace, p.Name)
-		containerPaths := getContainerPVCMountMap(*pod)
+		containerPaths := GetContainerPVCMountMap(*pod)
 		skipHostMountCheck := false
 		for containerName, paths := range containerPaths {
 			log.Infof("container [%s] has paths [%v]", containerName, paths)
@@ -860,9 +860,9 @@ func (k *k8sSchedOps) GetRemotePXNodes(destKubeConfig string) ([]node.Node, erro
 	return remoteNodeList, nil
 }
 
-// getContainerPVCMountMap is a helper routine to return map of containers in the pod that
+// GetContainerPVCMountMap is a helper routine to return map of containers in the pod that
 // have a PVC. The values in the map are the mount paths of the PVC
-func getContainerPVCMountMap(pod corev1.Pod) map[string][]string {
+func GetContainerPVCMountMap(pod corev1.Pod) map[string][]string {
 	containerPaths := make(map[string][]string)
 
 	// Each pvc in a pod spec has a associated name (which is different from the actual PVC name).

--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -3666,6 +3666,7 @@ func GetAppLabelFromSpec(AppContextsMapping *scheduler.Context) (map[string]stri
 			labelMap = k8s.MergeMaps(labelMap, obj.Spec.Template.ObjectMeta.Labels)
 		}
 	}
+	log.Infof("labelMap - %+v", labelMap)
 	if len(labelMap) == 0 {
 		return nil, fmt.Errorf("unable to find the label for %s", AppContextsMapping.App.Key)
 	}

--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -985,11 +985,16 @@ func getSizeOfMountPoint(podName string, namespace string, kubeConfigFile string
 	if err != nil {
 		return 0, err
 	}
-	for _, line := range strings.SplitAfter(ret, "\n") {
+	log.Infof("ret-\n%s", ret)
+	log.Infof("volumeMount - %s", volumeMount)
+	for i, line := range strings.SplitAfter(ret, "\n") {
+		log.Infof("Line no. %d - %s", i, line)
 		if strings.Contains(line, volumeMount) {
+			log.Infof("Found in line - %s", line)
 			ret = strings.Fields(line)[3]
 		}
 	}
+	log.Infof("final ret-\n%s", ret)
 	number, err = strconv.Atoi(ret)
 	if err != nil {
 		return 0, err

--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -979,7 +979,7 @@ func CreateRestoreWithValidation(ctx context.Context, restoreName, backupName st
 	return
 }
 
-func getSizeOfMountPoint(podName string, namespace string, kubeConfigFile string, volumeMount string, containerNames ...string) (int, error) {
+func getSizeOfMountPoint(podName string, namespace string, kubeConfigFile string, volumeMount string, containerName ...string) (int, error) {
 	var number int
 	var str string
 	output, err := kubectlExec([]string{fmt.Sprintf("--kubeconfig=%v", kubeConfigFile), "exec", "-it", podName, "-n", namespace, "--", "/bin/df"})
@@ -995,7 +995,10 @@ func getSizeOfMountPoint(podName string, namespace string, kubeConfigFile string
 	if str == "" {
 		log.Infof("Could not find any mount points for the volume mount [%s] in the pod [%s] in namespace [%s] ", volumeMount, podName, namespace)
 		log.Infof("Trying to check if there is a sym link for [%s]", volumeMount)
-		symlinkPath, err := core.Instance().RunCommandInPod([]string{"readlink", "-f", volumeMount}, podName, containerNames[0], namespace)
+		if len(containerName) == 0 {
+			return number, err
+		}
+		symlinkPath, err := core.Instance().RunCommandInPod([]string{"readlink", "-f", volumeMount}, podName, containerName[0], namespace)
 		if err != nil {
 			return number, err
 		}

--- a/tests/backup/backup_portworx_test.go
+++ b/tests/backup/backup_portworx_test.go
@@ -776,7 +776,7 @@ var _ = Describe("{ResizeVolumeOnScheduleBackup}", func() {
 						for containerName, paths := range containerPaths {
 							log.Infof("container [%s] has paths [%v]", containerName, paths)
 							for _, path := range paths {
-								beforeSize, err = getSizeOfMountPoint(pod.GetName(), namespace, srcClusterConfigPath, path)
+								beforeSize, err = getSizeOfMountPoint(pod.GetName(), namespace, srcClusterConfigPath, path, containerName)
 								dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching the size of volume before resizing %v from pod %v", beforeSize, pod.GetName()))
 								volListBeforeSizeMap[path] = beforeSize
 							}
@@ -847,7 +847,7 @@ var _ = Describe("{ResizeVolumeOnScheduleBackup}", func() {
 						for containerName, paths := range containerPaths {
 							log.Infof("container [%s] has paths [%v]", containerName, paths)
 							for _, path := range paths {
-								afterSize, err := getSizeOfMountPoint(pod.GetName(), namespace, srcClusterConfigPath, path)
+								afterSize, err := getSizeOfMountPoint(pod.GetName(), namespace, srcClusterConfigPath, path, containerName)
 								dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching the size of volume ater resizing %v from pod %v", afterSize, pod.GetName()))
 								volListAfterSizeMap[path] = afterSize
 							}

--- a/tests/backup/backup_portworx_test.go
+++ b/tests/backup/backup_portworx_test.go
@@ -848,7 +848,7 @@ var _ = Describe("{ResizeVolumeOnScheduleBackup}", func() {
 							log.Infof("container [%s] has paths [%v]", containerName, paths)
 							for _, path := range paths {
 								afterSize, err := getSizeOfMountPoint(pod.GetName(), namespace, srcClusterConfigPath, path, containerName)
-								dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching the size of volume ater resizing %v from pod %v", afterSize, pod.GetName()))
+								dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching the size of volume after resizing %v from pod %v", afterSize, pod.GetName()))
 								volListAfterSizeMap[path] = afterSize
 							}
 						}

--- a/tests/backup/backup_portworx_test.go
+++ b/tests/backup/backup_portworx_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+	"github.com/portworx/torpedo/drivers/volume/portworx/schedops"
 	"sync"
 	"time"
 
@@ -664,7 +665,7 @@ var _ = Describe("{ResizeVolumeOnScheduleBackup}", func() {
 		restoreNames                []string
 		nextScheduleBackupName      string
 		volumeMounts                []string
-		podList                     []string
+		podList                     []v1.Pod
 	)
 	labelSelectors := make(map[string]string)
 	cloudCredUIDMap := make(map[string]string)
@@ -769,14 +770,16 @@ var _ = Describe("{ResizeVolumeOnScheduleBackup}", func() {
 					dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching the pod list"))
 					srcClusterConfigPath, err := GetSourceClusterConfigPath()
 					dash.VerifyFatal(err, nil, fmt.Sprintf("Getting kubeconfig path for source cluster %v", srcClusterConfigPath))
+					podList = pods.Items
 					for _, pod := range pods.Items {
-						volumeMounts, err := GetVolumeMounts(AppContextsMapping[namespace])
-						dash.VerifyFatal(err, nil, fmt.Sprintf("unable to get the mountpoints from the application spec %s", AppContextsMapping[namespace].App.Key))
-						for _, volumeMount := range volumeMounts {
-							beforeSize, err = getSizeOfMountPoint(pod.GetName(), namespace, srcClusterConfigPath, volumeMount)
-							dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching the size of volume before resizing %v from pod %v", beforeSize, pod.GetName()))
-							volListBeforeSizeMap[volumeMount] = beforeSize
-							podList = append(podList, pod.Name)
+						containerPaths := schedops.GetContainerPVCMountMap(pod)
+						for containerName, paths := range containerPaths {
+							log.Infof("container [%s] has paths [%v]", containerName, paths)
+							for _, path := range paths {
+								beforeSize, err = getSizeOfMountPoint(pod.GetName(), namespace, srcClusterConfigPath, path)
+								dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching the size of volume before resizing %v from pod %v", beforeSize, pod.GetName()))
+								volListBeforeSizeMap[path] = beforeSize
+							}
 						}
 					}
 				})
@@ -839,12 +842,15 @@ var _ = Describe("{ResizeVolumeOnScheduleBackup}", func() {
 					log.InfoD("Checking size of volume after resize")
 					srcClusterConfigPath, err := GetSourceClusterConfigPath()
 					dash.VerifyFatal(err, nil, fmt.Sprintf("Getting kubeconfig path for source cluster %v", srcClusterConfigPath))
-					for _, podName := range podList {
-						volumeMounts, err = GetVolumeMounts(AppContextsMapping[namespace])
-						for _, volumeMount := range volumeMounts {
-							afterSize, err := getSizeOfMountPoint(podName, namespace, srcClusterConfigPath, volumeMount)
-							dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching the size of volume ater resizing %v from pod %v", afterSize, podName))
-							volListAfterSizeMap[volumeMount] = afterSize
+					for _, pod := range podList {
+						containerPaths := schedops.GetContainerPVCMountMap(pod)
+						for containerName, paths := range containerPaths {
+							log.Infof("container [%s] has paths [%v]", containerName, paths)
+							for _, path := range paths {
+								afterSize, err := getSizeOfMountPoint(pod.GetName(), namespace, srcClusterConfigPath, path)
+								dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching the size of volume ater resizing %v from pod %v", afterSize, pod.GetName()))
+								volListAfterSizeMap[path] = afterSize
+							}
 						}
 					}
 					for _, volumeMount := range volumeMounts {


### PR DESCRIPTION
**What this PR does / why we need it**:

- [x] Fixed the test case ResizeVolumeOnScheduleBackup to work with all apps. Earlier it expected the app to have Deployment spec but Kubevirt apps may not have it
- [x] Used function `GetContainerPVCMountMap` to get volume mount points instead of `GetVolumeMounts`
- [x] Added label to kubevirt spec `app: kubevirt-vm-pvc`

**Which issue(s) this PR fixes** (optional)
Closes #PB-4698

**Special notes for your reviewer**:
[Jenkins run with kubevirt app](https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/3173/)
[Jenkins run with postgres](https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/3171)
[Jenkins run with mysql](https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/3172/)

