### PR TITLE
Adding test for volume in detached state

### DIFF
--- a/drivers/scheduler/k8s/specs/aut-postgres-onlyvol/aut-postgres-storage.yaml
+++ b/drivers/scheduler/k8s/specs/aut-postgres-onlyvol/aut-postgres-storage.yaml
@@ -1,0 +1,29 @@
+##### Portworx storage class
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: px-postgres-sc
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  repl: "3"
+  priority_io: "high"
+allowVolumeExpansion: true
+---
+##### Portworx persistent volume claim
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: postgres-data
+  labels:
+    app: postgres
+  annotations:
+    volume.beta.kubernetes.io/storage-class: px-postgres-sc
+    torpedo.io/autopilot-enabled: "true"
+    torpedo.io/pvclabels-enabled: "true"
+    torpedo.io/pvcnodes-enabled: "true"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 8Gi


### PR DESCRIPTION
`docker run --rm -t -v `pwd`:`pwd`  -v `pwd`/spawn/k8s/clusterGroup0/kubeconfig:/tmp/kubeconfig -v `pwd`/deployments:/deployments -e KUBECONFIG=/tmp/kubeconfig -e FAIL_FAST=true -e TORPEDO_IMG=portworx/torpedo:PTX-20764 -e FOCUS_TESTS=AUTPVCVolDetached -e APP_LIST=aut-postgres-onlyvol -e VERBOSE=true -e TORPEDO_SSH_PASSWORD=Password1 -e SCALE_FACTOR=1 -e TEST_SUITE=bin/autopilot.test portworx/spawn:master deployments/deploy-ssh.sh`

https://aetos.pwx.purestorage.com/resultSet/testSetID/403082