### PR TITLE
PB-4839: Add `postgres-csi` to `AppRuleMaster` array

### DIFF
--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -250,6 +250,13 @@ var (
 				},
 			},
 		},
+		"postgres-csi": {
+			PreRule: backup.PreRule{
+				Rule: backup.RuleSpec{
+					ActionList: []string{"PGPASSWORD=$POSTGRES_PASSWORD; psql -U \"$POSTGRES_USER\" -c \"CHECKPOINT\""}, PodSelectorList: []string{"app=postgres"}, Background: []string{"false"}, RunInSinglePod: []string{"false"}, Container: []string{},
+				},
+			},
+		},
 	}
 )
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Test case `VerifyRBACForAppUser` fails with the below nil pointer error due to postgres-csi not being present in `AppRuleMaster` array:
```
07:02:14  ------------------------------
07:02:14  •! Panic [62.777 seconds]
07:02:14  {VerifyRBACForAppUser}
07:02:14  /go/src/github.com/portworx/torpedo/tests/backup/backup_rbac_test.go:1263
07:02:14    To verify all the RBAC operations for an App-user [It]
07:02:14    /go/src/github.com/portworx/torpedo/tests/backup/backup_rbac_test.go:1303
07:02:14  
07:02:14    Test Panicked
07:02:14    runtime error: invalid memory address or nil pointer dereference
07:02:14    /usr/local/go/src/runtime/panic.go:260
07:02:14  
07:02:14    Full Stack Trace
07:02:14    github.com/portworx/torpedo/tests/backup.glob..func43.2.6()
07:02:14    	/go/src/github.com/portworx/torpedo/tests/backup/backup_rbac_test.go:1365 +0x11c
07:02:14    github.com/portworx/torpedo/tests/backup.glob..func43.2()
07:02:14    	/go/src/github.com/portworx/torpedo/tests/backup/backup_rbac_test.go:1360 +0x5e3
07:02:14    github.com/portworx/torpedo/tests/backup.TestBasic(0x0?)
07:02:14    	/go/src/github.com/portworx/torpedo/tests/backup/backup_basic_test.go:92 +0xb9
07:02:14    testing.tRunner(0xc000007860, 0x7bbe868)
07:02:14    	/usr/local/go/src/testing/testing.go:1446 +0x10b
07:02:14    created by testing.(*T).Run
07:02:14    	/usr/local/go/src/testing/testing.go:1493 +0x35f
```
- [x] Add `postgres-csi` to `AppRuleMaster` array


Dashboard URL: https://jenkins.pwx.dev.purestorage.com/blue/organizations/jenkins/portworx-backup%2Fsystem-tests%2Fbasic-system-test%2Fnonpx%2Fibm%2Fs3%2Fibm-s3-direct-kdmp/detail/ibm-s3-direct-kdmp/35/tests

**Which issue(s) this PR fixes** (optional)
Closes # PB-4839

**Special notes for your reviewer**:

