### PR TITLE
adding specs and test to validate proxy volumes

### DIFF
--- a/drivers/scheduler/k8s/specs/nginx-proxy-deployment/px-nginx-app.yaml
+++ b/drivers/scheduler/k8s/specs/nginx-proxy-deployment/px-nginx-app.yaml
@@ -1,0 +1,29 @@
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: bitnami/nginx
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        - name: nginx-persistent-storage
+          mountPath: /usr/share/nginx/html
+      volumes:
+      - name: nginx-persistent-storage
+        persistentVolumeClaim:
+          claimName: nfs-data
+

--- a/drivers/scheduler/k8s/specs/nginx-proxy-deployment/px-nginx-storage.yaml
+++ b/drivers/scheduler/k8s/specs/nginx-proxy-deployment/px-nginx-storage.yaml
@@ -1,0 +1,16 @@
+
+##### Persistent volume claim ,  sc portworx-proxy-volume-volume is created in test NFSProxyVolumeValidation with dynamic nfs endpoint
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: nfs-data
+  labels:
+    app: nginx
+spec:
+  storageClassName: portworx-proxy-volume-volume
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -3617,8 +3617,8 @@ func (d *portworx) DecommissionNode(n *node.Node) error {
 func (d *portworx) RejoinNode(n *node.Node) error {
 	opts := node.ConnectionOpts{
 		IgnoreError:     false,
-		TimeBeforeRetry: defaultRetryInterval,
-		Timeout:         defaultTimeout,
+		TimeBeforeRetry: podUpRetryInterval,
+		Timeout:         10 * time.Minute,
 	}
 
 	if _, err := d.nodeDriver.RunCommand(*n, fmt.Sprintf("%s sv node-wipe --all", d.getPxctlPath(*n)), opts); err != nil {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
adding specs and test to validate proxy volumes
**Which issue(s) this PR fixes** (optional)
Closes #PTX-21024

**Special notes for your reviewer**:
Result : https://aetos.pwx.purestorage.com/resultSet/testSetID/417613
https://jenkins.pwx.dev.purestorage.com/job/Users/job/Leela/job/leela-torpedo-only/251/console

```
kubectl get sc portworx-proxy-volume-volume -o yaml
allowVolumeExpansion: true
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  creationTimestamp: "2023-11-08T13:08:16Z"
  name: portworx-proxy-volume-volume
  resourceVersion: "3079853"
  uid: fc6da43d-600a-4ded-93b3-3896c3c8f2ce
parameters:
  io_profile: none
  mount_options: vers=4.0
  proxy_endpoint: nfs://10.13.164.185
  proxy_nfs_exportpath: /exports/testnfsexportdir
  repl: "1"
provisioner: kubernetes.io/portworx-volume
reclaimPolicy: Delete
volumeBindingMode: Immediate
```
```
kubectl -n nginx-proxy-deployment-purevolumestest-0-11-08-13h07m48s get pvc
NAME       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                   AGE
nfs-data   Bound    pvc-45319e7e-6bfa-4361-8e99-f102d96db02e   10Gi       RWX            portworx-proxy-volume-volume   10m
```
```
[root@ip-10-13-162-6 ~]# pxctl v i 712781848016895375
	Volume          	 :  712781848016895375
	Name            	 :  pvc-45319e7e-6bfa-4361-8e99-f102d96db02e
	Size            	 :  10 GiB
	Format          	 :  none
	HA              	 :  1
	IO Priority     	 :  LOW
	Creation time   	 :  Nov 8 13:08:16 UTC 2023
	Shared          	 :  no
	Proxy	         :
		  Type           : nfs
		  Endpoint       : 10.13.164.185
		  ExportPath     : /exports/testnfsexportdir
	Status          	 :  up
	State           	 :  Consumed from 10.13.164.185
	Last Attached   	 :  Jan 1 00:00:00 UTC 1970
	Labels          	 :  proxy_nfs_exportpath=/exports/testnfsexportdir,pvc=nfs-data,repl=1,app=nginx,io_profile=none,mount_options=vers=4.0,namespace=nginx-proxy-deployment-purevolumestest-0-11-08-13h07m48s,proxy_endpoint=nfs://10.13.164.185
	Mount Options          	 :  vers=4.0,actimeo=60,proto=tcp,retrans=11,soft,timeo=80
	Configured Mount Options :  vers=4.0
	Volume consumers	 :
		- Name           : nginx-65457c785b-7xjwj (9e8e943d-27a1-43d7-b400-e37bcfa519b2) (Pod)
		  Namespace      : nginx-proxy-deployment-purevolumestest-0-11-08-13h07m48s
		  Running on     : ip-10-13-162-6.pwx.purestorage.com
		  Controlled by  : nginx-65457c785b (ReplicaSet)
		- Name           : nginx-65457c785b-clfvt (40693cd9-b46b-4dee-b04c-0d59cabe18d0) (Pod)
		  Namespace      : nginx-proxy-deployment-purevolumestest-0-11-08-13h07m48s
		  Running on     : ip-10-13-161-174.pwx.purestorage.com
		  Controlled by  : nginx-65457c785b (ReplicaSet)
		- Name           : nginx-65457c785b-lv47c (d87ff29a-2186-4a55-9aa3-88aa6c7e891a) (Pod)
		  Namespace      : nginx-proxy-deployment-purevolumestest-0-11-08-13h07m48s
		  Running on     : ip-10-13-171-42.pwx.purestorage.com
		  Controlled by  : nginx-65457c785b (ReplicaSet)
```