### PR TITLE
Skip Anthos admin cluster upgrade if upgrade hops contains only one v…

### DIFF
--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -120,6 +120,8 @@ type InitOptions struct {
 	AnthosAdminWorkStationNodeIP string
 	// AnthosInstancePath needed for anthos scheduler
 	AnthosInstancePath string
+	// UpgradeHops needed for a scheduler like Anthos to decide whether to upgrade admin cluster
+	UpgradeHops string
 }
 
 // ScheduleOptions are options that callers to pass to influence the apps that get schduled

--- a/tests/common.go
+++ b/tests/common.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+
 	optest "github.com/libopenstorage/operator/pkg/util/test"
 	"github.com/portworx/sched-ops/k8s/operator"
 	"github.com/portworx/torpedo/drivers/scheduler/openshift"
@@ -510,6 +511,7 @@ func InitInstance() {
 		SecureApps:                       Inst().SecureAppList,
 		AnthosAdminWorkStationNodeIP:     Inst().AnthosAdminWorkStationNodeIP,
 		AnthosInstancePath:               Inst().AnthosInstPath,
+		UpgradeHops:                      Inst().SchedUpgradeHops,
 	})
 
 	log.FailOnError(err, "Error occured while Scheduler Driver Initialization")


### PR DESCRIPTION
…ersion

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
[Anthos] Skip Anthos admin cluster upgrade if upgrade hops contains only one version

**Which issue(s) this PR fixes** (optional)
Closes # PTX-21038

**Special notes for your reviewer**:
Minor changes
```
11:53:33 2023-11-09 19:53:46 +0000:[INFO] [anthos.(*anthos).Init:#210] - Skip admin cluster upgrade is: [true]
```
Upgrade without admin cluster upgrade: https://jenkins.pwx.dev.purestorage.com/job/Torpedo/job/tp-anthos-upgrade/265/console


