### PR TITLE
Fixing node decomm test for storageless node

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -3498,15 +3498,22 @@ func (d *portworx) DecommissionNode(n *node.Node) error {
 		}
 	}
 
-	if err := d.EnterMaintenance(*n); err != nil {
-		return &ErrFailedToDecommissionNode{
-			Node:  n.Name,
-			Cause: fmt.Sprintf("Failed to enter maintenence mode on node [%s], Err: %v", n.Name, err),
+	err := d.EnterMaintenance(*n)
+	//check for storageless node
+	if err != nil && len(n.StoragePools) == 0 {
+		log.Infof("validating status for storageless node [%s]", n.Name)
+		stNode, nodeStatusErr := d.GetDriverNode(n)
+		if nodeStatusErr != nil {
+			return nodeStatusErr
+		}
+		if stNode.Status == api.Status_STATUS_OFFLINE {
+			//setting nil as OFFLINE status is expected for storageless nodes
+			err = nil
 		}
 	}
-
-	log.Infof("Waiting for a minute for node [%s] to transition to maintenance mode", n.Name)
-	time.Sleep(1 * time.Minute)
+	if err != nil {
+		return err
+	}
 
 	nodeResp, err := d.getNodeManager().Inspect(d.getContext(), &api.SdkNodeInspectRequest{NodeId: n.VolDriverNodeID})
 	if err != nil {
@@ -3522,7 +3529,7 @@ func (d *portworx) DecommissionNode(n *node.Node) error {
 		if err != nil {
 			return false, true, fmt.Errorf("failed getting node [%s] status", n.Name)
 		}
-		if stNode.Status == api.Status_STATUS_MAINTENANCE {
+		if stNode.Status == api.Status_STATUS_MAINTENANCE || stNode.Status == api.Status_STATUS_OFFLINE {
 			return true, false, nil
 		}
 		return false, true, fmt.Errorf("waiting for node [%s] to be in maintenence mode, current Status: %v", n.Name, stNode.Status)

--- a/tests/basic/node_decommission_test.go
+++ b/tests/basic/node_decommission_test.go
@@ -97,6 +97,7 @@ var _ = Describe("{DecommissionNode}", func() {
 				stepLog = fmt.Sprintf("check if node %s was decommissioned", nodeToDecommission.Name)
 				Step(stepLog, func() {
 					log.InfoD(stepLog)
+					result := false
 					t := func() (interface{}, bool, error) {
 						status, err := Inst().V.GetNodeStatus(nodeToDecommission)
 						if err != nil {
@@ -109,7 +110,10 @@ var _ = Describe("{DecommissionNode}", func() {
 					}
 					decommissioned, err := task.DoRetryWithTimeout(t, defaultTimeout, defaultRetryInterval)
 					log.FailOnError(err, "Failed to get decommissioned node status")
-					dash.VerifyFatal(decommissioned.(bool), true, fmt.Sprintf("Validate node [%s] is decommissioned", nodeToDecommission.Name))
+					result = decommissioned.(bool)
+
+					dash.VerifyFatal(result, true, fmt.Sprintf("Validate node [%s] is decommissioned", nodeToDecommission.Name))
+
 				})
 			})
 			stepLog = fmt.Sprintf("Rejoin node %s", nodeToDecommission.Name)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
- Fix for storageless node decomm test
- Fix for pool add disk when kernal version is less than 5.9
**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
Results:
Decomm : https://aetos.pwx.purestorage.com/resultSet/testSetID/421193
Add Disk : https://aetos.pwx.purestorage.com/resultSet/testSetID/420628
