### PR TITLE
PWX-33944 

### DIFF
--- a/drivers/scheduler/k8s/specs/fio/pxd/px-storage-class.yaml
+++ b/drivers/scheduler/k8s/specs/fio/pxd/px-storage-class.yaml
@@ -8,7 +8,7 @@ parameters:
   {{ if .Repl }}
   repl: "{{ .Repl }}"
   {{ else }}
-  repl: "2"{{ end }}
+  repl: "1"{{ end }}
   priority_io: "high"
   {{ if .IoProfile }}
   io_profile: "{{ .IoProfile }}"
@@ -30,7 +30,7 @@ parameters:
   {{ if .Repl }}
   repl: "{{ .Repl }}"
   {{ else }}
-  repl: "2"{{ end }}
+  repl: "1"{{ end }}
   priority_io: "high"
   {{ if .IoProfile }}
   io_profile: "{{ .IoProfile }}"

--- a/drivers/scheduler/k8s/specs/fio/pxd/px-storage-class.yaml
+++ b/drivers/scheduler/k8s/specs/fio/pxd/px-storage-class.yaml
@@ -8,7 +8,7 @@ parameters:
   {{ if .Repl }}
   repl: "{{ .Repl }}"
   {{ else }}
-  repl: "1"{{ end }}
+  repl: "2"{{ end }}
   priority_io: "high"
   {{ if .IoProfile }}
   io_profile: "{{ .IoProfile }}"
@@ -30,7 +30,7 @@ parameters:
   {{ if .Repl }}
   repl: "{{ .Repl }}"
   {{ else }}
-  repl: "1"{{ end }}
+  repl: "2"{{ end }}
   priority_io: "high"
   {{ if .IoProfile }}
   io_profile: "{{ .IoProfile }}"

--- a/tests/basic/pool_function_test.go
+++ b/tests/basic/pool_function_test.go
@@ -885,7 +885,43 @@ var _ = Describe("{StorageFullPoolExpansion}", func() {
 		_ = Inst().S.RemoveLabelOnNode(*selectedNode, k8s.NodeType)
 	})
 
-	It(stepLog, func() {
+	It("Expand pool with add-disk type after pool is down due to storage full", func() {
+		// https://portworx.testrail.net/index.php?/cases/view/51280
+		StartTorpedoTest("StorageFullPoolExpandAddDiskType", "Expand pool with add-disk type after pool is down due to storage full", nil, 51280)
+		Step("Prepare a full pool to expand", func() {
+			err = WaitForPoolOffline(*selectedNode)
+			log.FailOnError(err, "Timed out waiting to load a pool and bring node %s storage down", selectedNode.Name)
+			poolsStatus, err := Inst().V.GetNodePoolsStatus(*selectedNode)
+			log.FailOnError(err, "error getting pool status on node %s", selectedNode.Name)
+			for i, s := range poolsStatus {
+				if s == "Offline" {
+					poolIDToResize = i
+					poolToResize, err = GetStoragePoolByUUID(poolIDToResize)
+					log.FailOnError(err, "error getting pool with UUID [%s]", poolIDToResize)
+					break
+				}
+			}
+		})
+
+		Step("Expand the full pool in type add-disk", func() {
+			targetSizeGiB = (poolToResize.TotalSize / units.GiB) * 2
+			log.InfoD("Current Size of the pool %s is %d, trying to expand it to double the size", poolToResize.Uuid, poolToResize.TotalSize/units.GiB)
+			err = Inst().V.ExpandPool(poolToResize.Uuid, api.SdkStoragePool_RESIZE_TYPE_ADD_DISK, targetSizeGiB, true)
+			dash.VerifyFatal(err, nil, "Pool expansion init should be successful.")
+		})
+
+		Step("Verify that pool expansion is successful", func() {
+			err = waitForOngoingPoolExpansionToComplete(poolToResize.Uuid)
+			log.FailOnError(err, fmt.Sprintf("Error waiting for pool %s resize", poolToResize.Uuid))
+			verifyPoolSizeEqualOrLargerThanExpected(poolIDToResize, targetSizeGiB)
+			status, err := Inst().V.GetNodeStatus(*selectedNode)
+			log.FailOnError(err, fmt.Sprintf("Error getting PX status of node %s", selectedNode.Name))
+			dash.VerifySafely(*status, api.Status_STATUS_OK, fmt.Sprintf("validate PX status on node %s", selectedNode.Name))
+		})
+	})
+
+	It("Expand pool with resize-disk type after pool is down due to storage full", func() {
+>>>>>>> 54e0028c7... remove unnecessary fmt
 		// https://portworx.testrail.net/index.php?/cases/view/51280
 		StartTorpedoTest("StorageFullPoolResize", "Feed a pool full, then expand the pool in type resize-disk", nil, 51280)
 		Step("Prepare a full pool to expand", func() {

--- a/tests/basic/pool_function_test.go
+++ b/tests/basic/pool_function_test.go
@@ -868,7 +868,7 @@ var _ = Describe("{StorageFullPoolExpansion}", func() {
 	)
 
 	BeforeEach(func() {
-		Inst().AppList = []string{"fio-fastpath-rep1"}
+		Inst().AppList = []string{"fio-fastpath-repl1"}
 		contexts = ScheduleApplications("storagefull-resize")
 		appList = Inst().AppList
 	})

--- a/tests/basic/pool_function_test.go
+++ b/tests/basic/pool_function_test.go
@@ -868,7 +868,7 @@ var _ = Describe("{StorageFullPoolExpansion}", func() {
 	)
 
 	BeforeEach(func() {
-		Inst().AppList = []string{"fio-fastpath"}
+		Inst().AppList = []string{"fio-fastpath-rep1"}
 		contexts = ScheduleApplications("storagefull-resize")
 		appList = Inst().AppList
 	})


### PR DESCRIPTION
This test is based on the https://github.com/portworx/torpedo/blob/acf4287ba1222d0385fdbadbc9366e2e80f202fd/tests/basic/storage_pool_test.go#L4630 

Main changes: 
* Use fio-fastpath-repl1 instead of `fio-fastpath` as the test app.`fio-fastpath` uses 5 replicas, which is excessive for this test. Using `fio-fastpath-repl1` reduces test run time and risk of failures due to infra issues.
* Removed the logic around introducing and managing a `secondReplNode`. This is confirmed feasible @lsrinivas-pure  
* Removed journal related logic. 
* Various test structure improvements  

Test passed at https://jenkins.pwx.dev.purestorage.com/job/pool-functional-0/8