### PR TITLE
PTX-21105 Fix/improve ProfileOnlyDiags test

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -99,7 +99,7 @@ const (
 	pxVersionsConfigmapName                   = "px-versions"
 	pureKey                                   = "backend"
 	pureBlockValue                            = "pure_block"
-	clusterIDFile                             = "/etc/pwx/cluster_uuid"
+	clusterUUIDFile                           = "/etc/pwx/cluster_uuid"
 	pxReleaseManifestURLEnvVarName            = "PX_RELEASE_MANIFEST_URL"
 	pxServiceLocalEndpoint                    = "portworx-service.kube-system.svc.cluster.local"
 	mountGrepVolume                           = "mount | grep %s"
@@ -137,7 +137,8 @@ const (
 	waitVolDriverToCrash              = 1 * time.Minute
 	waitDriverDownOnNodeRetryInterval = 2 * time.Second
 	asyncTimeout                      = 15 * time.Minute
-	timeToTryPreviousFolder           = 10 * time.Minute
+	validateDiagsOnS3RetryTimeout     = 60 * time.Minute
+	validateDiagsOnS3RetryInterval    = 30 * time.Second
 	validateStorageClusterTimeout     = 40 * time.Minute
 	expandStoragePoolTimeout          = 2 * time.Minute
 	volumeUpdateTimeout               = 2 * time.Minute
@@ -4043,58 +4044,67 @@ func (d *portworx) CollectDiags(n node.Node, config *torpedovolume.DiagRequestCo
 }
 
 func (d *portworx) ValidateDiagsOnS3(n node.Node, diagsFile string) error {
-	log.Info("Validating diags uploaded on S3")
+	log.Infof("Validating diags got uploaded to the s3 bucket for node [%s]", n.Name)
+
+	// Diag file to look for
+	if diagsFile == "" {
+		return fmt.Errorf("Empty diag file was passed, cannot continue with validation")
+	}
+	d.DiagsFile = diagsFile
+
 	opts := node.ConnectionOpts{
 		IgnoreError:     false,
 		TimeBeforeRetry: defaultRetryInterval,
 		Timeout:         defaultTimeout,
 		Sudo:            true,
 	}
-	clusterUUID, err := d.GetClusterID(n, opts)
+
+	// Get cluster UUID to determine the S3 folder to look for
+	clusterUUID, err := d.GetClusterUUID(n, opts)
 	if err != nil {
-		return err
+		return fmt.Errorf("Failed to get cluster UUID, Err: %v", err)
 	}
 
-	//// Check S3 bucket for diags
-	log.Debugf("Node name [%s]", n.Name)
-	if diagsFile != "" {
-		d.DiagsFile = diagsFile
-	}
+	// Check S3 bucket for diags
+	log.Debugf("Validating diag file [%s] got uploaded to the s3 bucket", d.DiagsFile)
 	start := time.Now()
 	for {
-		if time.Since(start) >= asyncTimeout {
-			return fmt.Errorf("waiting for async diags job timed out")
+		if time.Since(start) >= validateDiagsOnS3RetryTimeout {
+			return fmt.Errorf("waiting for async diags job timed out after [%v], failed to find diag file [%s] on s3 bucket", validateDiagsOnS3RetryTimeout, d.DiagsFile)
 		}
 		var objects []s3utils.Object
 		var err error
-		if time.Since(start) >= timeToTryPreviousFolder {
-			objects, err = s3utils.GetS3Objects(clusterUUID, n.Name, true)
-			if err != nil {
-				return fmt.Errorf("Failed to get g3 objects, Err: %v", err)
-			}
-		} else {
-			objects, err = s3utils.GetS3Objects(clusterUUID, n.Name, false)
-			if err != nil {
-				return fmt.Errorf("Failed to get g3 objects, Err: %v", err)
-			}
+
+		// Check latest s3 folder for diags
+		latestObjects, err := s3utils.GetS3Objects(clusterUUID, n.Name, false)
+		if err != nil {
+			return fmt.Errorf("Failed to get g3 objects from latest folder, Err: %v", err)
 		}
+		objects = append(objects, latestObjects...)
+
+		// Check previous s3 folder for diags, if exists, due to some race condition of how/when diags can occasionally be uploaded
+		previousObjects, err := s3utils.GetS3Objects(clusterUUID, n.Name, true)
+		if err != nil {
+			return fmt.Errorf("Failed to get g3 objects from previous folder, Err: %v", err)
+		}
+		objects = append(objects, previousObjects...)
+
 		for _, obj := range objects {
 			if strings.Contains(obj.Key, d.DiagsFile) {
-				log.Debugf("File validated on S3")
-				log.Debugf("Object Name is %s", obj.Key)
-				log.Debugf("Object Created on %s", obj.LastModified.String())
-				log.Debugf("Object Size %d", obj.Size)
+				log.Debugf("File validated on s3")
+				log.Debugf("Object Name is [%s]", obj.Key)
+				log.Debugf("Object Created on [%s]", obj.LastModified.String())
+				log.Debugf("Object Size [%d]", obj.Size)
 				return nil
-
 			}
 		}
-		log.Debugf("File [%s] not found in S3 yet, re-trying in 30s", d.DiagsFile)
-		time.Sleep(30 * time.Second)
+		log.Debugf("File [%s] not found in the s3 bucket yet, re-trying in [%v]", d.DiagsFile, validateDiagsOnS3RetryInterval)
+		time.Sleep(validateDiagsOnS3RetryInterval)
 	}
 }
 
-func (d *portworx) GetClusterID(n node.Node, opts node.ConnectionOpts) (string, error) {
-	out, err := d.nodeDriver.RunCommand(n, fmt.Sprintf("cat %s", clusterIDFile), opts)
+func (d *portworx) GetClusterUUID(n node.Node, opts node.ConnectionOpts) (string, error) {
+	out, err := d.nodeDriver.RunCommand(n, fmt.Sprintf("cat %s", clusterUUIDFile), opts)
 	if err != nil {
 		return "", fmt.Errorf("failed to get pxctl status, Err: %v", err)
 	}

--- a/tests/basic/telemetry_test.go
+++ b/tests/basic/telemetry_test.go
@@ -336,7 +336,7 @@ var _ = Describe("{ProfileOnlyDiags}", func() {
 						log.Infof("Found new profile diags [%s]", newDiags)
 						// Needs to contain both stack/heap
 						if strings.Contains(newDiags, ".heap") && strings.Contains(newDiags, ".stack") {
-							diagsFiles = strings.Split(newDiags, "\n")
+							diagsFiles = strings.Split(strings.TrimSpace(newDiags), "\n")
 							log.InfoD("Files found on node [%s] [%v]", currNode.Name, diagsFiles)
 							return nil, false, nil
 						}


### PR DESCRIPTION
Fix/improve ProfileOnlyDiags test

* Improved overall code readability
* Simplified and improved some methods/functions
* Enforced Telemetry check to fail test, if test is expecting to validate diags on s3
* Fixed the part where we looking for `[{ProfileOnlyDiags}] Validating diag file [.] on s3` file by trimming space from `newDiags` string
* Increase retry interval to wait for s3 diags and make it a `const`
* Looking for diags in latest and previous folders (if exist), in same loop to save time, due to race condition of how diags can be potentially uploaded
* Renamed func `GetClusterID()` to `GetClusterUUID()` as this is what we getting there
* Renamed func `collectAsyncDiags` to `collectDiagsSdk` 
* Improved some logging and errors to be more verbose
* Removed some commented blocks of code
* Some other minor improvements of code, comments and messages

