### PR TITLE
DS-6810: Automate TestCase4- Bringdown the Master node in DB

### DIFF
--- a/drivers/pds/api/dataServiceDeployment.go
+++ b/drivers/pds/api/dataServiceDeployment.go
@@ -171,6 +171,7 @@ func (ds *DataServiceDeployment) UpdateDeployment(deploymentID string, appConfig
 		NodeCount:                          &nodeCount,
 		ResourceSettingsTemplateId:         &resourceTemplateID,
 	}
+	log.InfoD("Starting to update the deployment ... ")
 	dsModel, res, err := dsClient.ApiDeploymentsIdPut(ctx, deploymentID).Body(createRequest).Execute()
 	if err != nil && res.StatusCode != status.StatusOK {
 		return nil, fmt.Errorf("Error when calling `ApiDeploymentsIdPut`: %v\n.Full HTTP response: %v", err, res)

--- a/drivers/pds/lib/resiliency_utils.go
+++ b/drivers/pds/lib/resiliency_utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	tc "github.com/portworx/torpedo/drivers/pds/targetcluster"
 	"math/rand"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -24,25 +25,27 @@ import (
 )
 
 const (
-	PdsDeploymentControllerManagerPod = "pds-deployment-controller-manager"
-	PdsAgentPod                       = "pds-agent"
-	PdsTeleportPod                    = "pds-teleport"
-	PdsBackupControllerPod            = "pds-backup-controller-manager"
-	PdsTargetControllerPod            = "pds-operator-target-controller-manager"
-	ActiveNodeRebootDuringDeployment  = "active-node-reboot-during-deployment"
-	KillDeploymentControllerPod       = "kill-deployment-controller-pod-during-deployment"
-	RestartPxDuringDSScaleUp          = "restart-portworx-during-ds-scaleup"
-	RebootNodesDuringDeployment       = "reboot-multiple-nodes-during-deployment"
-	KillAgentPodDuringDeployment      = "kill-agent-pod-during-deployment"
-	RestartAppDuringResourceUpdate    = "restart-app-during-resource-update"
-	UpdateTemplate                    = "medium"
-	RebootNodeDuringAppVersionUpdate  = "reboot-node-during-app-version-update"
-	KillTeleportPodDuringDeployment   = "kill-teleport-pod-during-deployment"
-	RestoreDSDuringPXPoolExpansion    = "restore-ds-during-px-pool-expansion"
-	RestoreDSDuringKVDBFailOver       = "restore-ds-during-kvdb-fail-over"
-	RestoreDuringAllNodesReboot       = "restore-ds-during-node-reboot"
-	poolResizeTimeout                 = time.Minute * 120
-	retryTimeout                      = time.Minute * 2
+	PdsDeploymentControllerManagerPod   = "pds-deployment-controller-manager"
+	PdsAgentPod                         = "pds-agent"
+	PdsTeleportPod                      = "pds-teleport"
+	PdsBackupControllerPod              = "pds-backup-controller-manager"
+	PdsTargetControllerPod              = "pds-operator-target-controller-manager"
+	ActiveNodeRebootDuringDeployment    = "active-node-reboot-during-deployment"
+	KillDeploymentControllerPod         = "kill-deployment-controller-pod-during-deployment"
+	RestartPxDuringDSScaleUp            = "restart-portworx-during-ds-scaleup"
+	RebootNodesDuringDeployment         = "reboot-multiple-nodes-during-deployment"
+	KillAgentPodDuringDeployment        = "kill-agent-pod-during-deployment"
+	RestartAppDuringResourceUpdate      = "restart-app-during-resource-update"
+	UpdateTemplate                      = "Medium"
+	RebootNodeDuringAppVersionUpdate    = "reboot-node-during-app-version-update"
+	KillTeleportPodDuringDeployment     = "kill-teleport-pod-during-deployment"
+	RestoreDSDuringPXPoolExpansion      = "restore-ds-during-px-pool-expansion"
+	RestoreDSDuringKVDBFailOver         = "restore-ds-during-kvdb-fail-over"
+	RestoreDuringAllNodesReboot         = "restore-ds-during-node-reboot"
+	StopPXDuringStorageResize           = "stop-px-during-storage-resize"
+	KillDbMasterNodeDuringStorageResize = "kill-db-master-node-during-storage-resize"
+	poolResizeTimeout                   = time.Minute * 120
+	retryTimeout                        = time.Minute * 2
 )
 
 // PDS vars
@@ -221,6 +224,24 @@ func InduceFailureAfterWaitingForCondition(deployment *pds.ModelsDeployment, nam
 			InduceFailure(FailureType.Type, namespace)
 		}
 		ExecuteInParallel(func1, func2)
+	case StopPXDuringStorageResize:
+		log.InfoD("Entering to resize of the Data service Volume, while PX on volume node is stopped")
+		func1 := func() {
+			ResizeDataserviceStorage(deployment, namespace, UpdateTemplate)
+		}
+		func2 := func() {
+			InduceFailure(FailureType.Type, namespace)
+		}
+		ExecuteInParallel(func1, func2)
+	case KillDbMasterNodeDuringStorageResize:
+		log.InfoD("Entering to resize of the Data service Volume, while PX on volume node is stopped")
+		func1 := func() {
+			ResizeDataserviceStorage(deployment, namespace, UpdateTemplate)
+		}
+		func2 := func() {
+			InduceFailure(FailureType.Type, namespace)
+		}
+		ExecuteInParallel(func1, func2)
 	}
 
 	var aggregatedError error
@@ -335,6 +356,63 @@ func RestoreAndValidateConfiguration(ns string, deployment *pds.ModelsDeployment
 		DynamicDeployments = append(DynamicDeployments, restoredDeployment)
 		RestoredDeployments = append(RestoredDeployments, restoredDeployment)
 		log.InfoD("Restored successfully. Details: Deployment- %v", restoredDeployment.GetClusterResourceName())
+	}
+	return true, nil
+}
+
+func ResizeDataserviceStorage(deployment *pds.ModelsDeployment, namespace string, resourceTemplate string) (bool, error) {
+	log.Debugf("I HAVE ENTERED INTO UpdateDeploymentResourceConfig")
+	var (
+		resourceTemplateId string
+		cpuLimits          int64
+		initialCapacity    string
+		updatedCapacity    string
+	)
+	initialCapacity = *deployment.Resources.StorageRequest
+	log.InfoD("Initial volume storage size is : %v", initialCapacity)
+	resourceTemplates, err := components.ResourceSettingsTemplate.ListTemplates(*deployment.TenantId)
+	if err != nil {
+		if ResiliencyFlag {
+			CapturedErrors <- err
+		}
+		return false, err
+	}
+	for _, template := range resourceTemplates {
+		log.Debugf("template - %v", template.GetName())
+		if template.GetDataServiceId() == deployment.GetDataServiceId() && strings.ToLower(template.GetName()) == strings.ToLower(resourceTemplate) {
+			cpuLimits, _ = strconv.ParseInt(template.GetCpuLimit(), 10, 64)
+			log.Debugf("CpuLimit - %v, %T", cpuLimits, cpuLimits)
+			resourceTemplateId = template.GetId()
+		}
+	}
+	if resourceTemplateId == "" {
+		return false, fmt.Errorf("resource template - {%v} , not found", resourceTemplate)
+	}
+	if appConfigTemplateID == "" {
+		appConfigTemplateID, err = controlplane.GetAppConfTemplate(*deployment.TenantId, *deployment.Name)
+		log.FailOnError(err, "Error while fetching AppConfigID")
+	}
+	log.Infof("Deployment details: Ds id- %v, appConfigTemplateID - %v, imageId - %v, Node count -%v, resourceTemplateId- %v ", deployment.GetId(),
+		appConfigTemplateID, deployment.GetImageId(), deployment.GetNodeCount(), resourceTemplateId)
+	updatedDeployment, err := components.DataServiceDeployment.UpdateDeployment(deployment.GetId(),
+		appConfigTemplateID, deployment.GetImageId(), deployment.GetNodeCount(), resourceTemplateId, nil)
+	if err != nil {
+		CapturedErrors <- err
+		return false, err
+	}
+	if ResiliencyFlag {
+		ResiliencyCondition <- true
+	}
+	log.InfoD("Resiliency Condition is met, now proceeding to validate if storage size is increased.")
+	err = dataservice.ValidateDataServiceDeployment(updatedDeployment, namespace)
+	log.FailOnError(err, "Error while validating dataservices")
+	log.InfoD("Data-service: %v is up and healthy", updatedDeployment.Name)
+	updatedCapacity = updatedDeployment.Resources.GetStorageRequest()
+	if updatedCapacity > initialCapacity {
+		log.InfoD("Initial PVC Capacity is- %v and Updated PVC Capacity is- %v", initialCapacity, updatedCapacity)
+		log.InfoD("Storage is Successfully increased to  [%v]", updatedCapacity)
+	} else {
+		log.FailOnError(err, "Failed to verify Storage Resize at PV/PVC level")
 	}
 	return true, nil
 }

--- a/drivers/pds/lib/utils.go
+++ b/drivers/pds/lib/utils.go
@@ -3022,3 +3022,65 @@ func CreateSiAndIamRoleBindings(accountID string, nsRoles []pds.ModelsBinding) (
 	log.InfoD("Successfully created for IAM Roles- %v", iamId)
 	return actorId, iamId, nil
 }
+
+func StopPXDuringStorageIncrease(ns string, deployment *pds.ModelsDeployment) error {
+	// Get StatefulSet Object
+	var ss *v1.StatefulSet
+	var testError error
+
+	//Waiting till pod have a node assigned
+	var pods []corev1.Pod
+	var nodesToStopPx []node.Node
+	var nodeToRestartPX node.Node
+	var nodeName string
+	var podName string
+	err = wait.Poll(resiliencyInterval, timeOut, func() (bool, error) {
+		ss, testError = k8sApps.GetStatefulSet(deployment.GetClusterResourceName(), ns)
+		if testError != nil {
+			CapturedErrors <- testError
+			return false, testError
+		}
+		// Get Pods of this StatefulSet
+		pods, testError = k8sApps.GetStatefulSetPods(ss)
+		if testError != nil {
+			CapturedErrors <- testError
+			return false, testError
+		}
+		// Check if the new Pod have a node assigned or it's in a window where it's just coming up
+		podCount := 0
+		for _, pod := range pods {
+			log.Infof("Nodename of pod %v is :%v:", pod.Name, pod.Spec.NodeName)
+			if pod.Spec.NodeName == "" || pod.Spec.NodeName == " " {
+				log.Infof("Pod %v still does not have a node assigned. Retrying in 5 seconds", pod.Name)
+				return false, nil
+			} else {
+				podCount += 1
+				log.Debugf("No of pods that has node assigned: %d", podCount)
+			}
+			if int32(podCount) == *ss.Spec.Replicas {
+				log.Debugf("Expected pod %v has node %v assigned", pod.Name, pod.Spec.NodeName)
+				nodeName = pod.Spec.NodeName
+				podName = pod.Name
+				return true, nil
+			}
+		}
+		return true, nil
+	})
+	nodeToRestartPX, testError = node.GetNodeByName(nodeName)
+	if testError != nil {
+		CapturedErrors <- testError
+		return testError
+	}
+
+	log.InfoD("Going ahead and stopping PX the node %v as there is an "+
+		"application pod %v that's coming up on this node", nodeName, podName)
+	nodesToStopPx = append(nodesToStopPx, nodeToRestartPX)
+	testError = tests.Inst().V.StopDriver(nodesToStopPx, true, nil)
+	if testError != nil {
+		CapturedErrors <- testError
+		return testError
+	}
+
+	log.InfoD("PX stopped successfully on node %v", podName)
+	return testError
+}

--- a/tests/pds/pds_common.go
+++ b/tests/pds/pds_common.go
@@ -57,37 +57,39 @@ type TestParams struct {
 }
 
 const (
-	pdsNamespace                     = "pds-system"
-	deploymentName                   = "qa"
-	envDeployAllDataService          = "DEPLOY_ALL_DATASERVICE"
-	postgresql                       = "PostgreSQL"
-	cassandra                        = "Cassandra"
-	elasticSearch                    = "Elasticsearch"
-	couchbase                        = "Couchbase"
-	redis                            = "Redis"
-	rabbitmq                         = "RabbitMQ"
-	mongodb                          = "MongoDB"
-	mysql                            = "MySQL"
-	kafka                            = "Kafka"
-	zookeeper                        = "ZooKeeper"
-	consul                           = "Consul"
-	pdsNamespaceLabel                = "pds.portworx.com/available"
-	timeOut                          = 30 * time.Minute
-	maxtimeInterval                  = 30 * time.Second
-	timeInterval                     = 1 * time.Second
-	ActiveNodeRebootDuringDeployment = "active-node-reboot-during-deployment"
-	RebootNodeDuringAppVersionUpdate = "reboot-node-during-app-version-update"
-	KillDeploymentControllerPod      = "kill-deployment-controller-pod-during-deployment"
-	RestartPxDuringDSScaleUp         = "restart-portworx-during-ds-scaleup"
-	RestartAppDuringResourceUpdate   = "restart-app-during-resource-update"
-	BackUpCRD                        = "backups.pds.io"
-	DeploymentCRD                    = "deployments.pds.io"
-	RebootNodesDuringDeployment      = "reboot-multiple-nodes-during-deployment"
-	KillAgentPodDuringDeployment     = "kill-agent-pod-during-deployment"
-	KillTeleportPodDuringDeployment  = "kill-teleport-pod-during-deployment"
-	RestoreDSDuringPXPoolExpansion   = "restore-ds-during-px-pool-expansion"
-	RestoreDSDuringKVDBFailOver      = "restore-ds-during-kvdb-fail-over"
-	RestoreDuringAllNodesReboot      = "restore-ds-during-node-reboot"
+	pdsNamespace                        = "pds-system"
+	deploymentName                      = "qa"
+	envDeployAllDataService             = "DEPLOY_ALL_DATASERVICE"
+	postgresql                          = "PostgreSQL"
+	cassandra                           = "Cassandra"
+	elasticSearch                       = "Elasticsearch"
+	couchbase                           = "Couchbase"
+	redis                               = "Redis"
+	rabbitmq                            = "RabbitMQ"
+	mongodb                             = "MongoDB"
+	mysql                               = "MySQL"
+	kafka                               = "Kafka"
+	zookeeper                           = "ZooKeeper"
+	consul                              = "Consul"
+	pdsNamespaceLabel                   = "pds.portworx.com/available"
+	timeOut                             = 30 * time.Minute
+	maxtimeInterval                     = 30 * time.Second
+	timeInterval                        = 1 * time.Second
+	ActiveNodeRebootDuringDeployment    = "active-node-reboot-during-deployment"
+	RebootNodeDuringAppVersionUpdate    = "reboot-node-during-app-version-update"
+	KillDeploymentControllerPod         = "kill-deployment-controller-pod-during-deployment"
+	RestartPxDuringDSScaleUp            = "restart-portworx-during-ds-scaleup"
+	RestartAppDuringResourceUpdate      = "restart-app-during-resource-update"
+	BackUpCRD                           = "backups.pds.io"
+	DeploymentCRD                       = "deployments.pds.io"
+	RebootNodesDuringDeployment         = "reboot-multiple-nodes-during-deployment"
+	KillAgentPodDuringDeployment        = "kill-agent-pod-during-deployment"
+	KillTeleportPodDuringDeployment     = "kill-teleport-pod-during-deployment"
+	RestoreDSDuringPXPoolExpansion      = "restore-ds-during-px-pool-expansion"
+	RestoreDSDuringKVDBFailOver         = "restore-ds-during-kvdb-fail-over"
+	StopPXDuringStorageResize           = "stop-px-during-storage-resize"
+	KillDbMasterNodeDuringStorageResize = "kill-db-master-node-during-storage-resize"
+	RestoreDuringAllNodesReboot         = "restore-ds-during-node-reboot"
 )
 
 var (
@@ -579,6 +581,25 @@ func GetDbMasterNode(namespace string, dsName string, deployment *pds.ModelsDepl
 		return "", false
 	}
 	return dbMaster, true
+}
+
+func KillDbMasterNodeDuringStorageIncrease(dsName string, nsName string, deployment *pds.ModelsDeployment, sourceTarget *targetcluster.TargetCluster) error {
+	log.Debugf("I HAVE ENTERED INTO KILL FUNC")
+	dbMaster, _ := GetDbMasterNode(nsName, dsName, deployment, sourceTarget)
+	log.InfoD("dbMaster Node is %v-", dbMaster)
+	log.FailOnError(err, "Failed while fetching db master node.")
+
+	err = sourceTarget.DeleteK8sPods(dbMaster, nsName)
+	log.FailOnError(err, "Failed while deleting db master pod.")
+	err = dsTest.ValidateDataServiceDeployment(deployment, nsName)
+	log.FailOnError(err, "Failed while validating the deployment pods, post pod deletion.")
+	log.InfoD("DB MasterNode- [%v] Successfully killed", dbMaster)
+	newDbMaster, _ := GetDbMasterNode(nsName, dsName, deployment, sourceTarget)
+	if dbMaster == newDbMaster {
+		log.FailOnError(fmt.Errorf("leader node is not reassigned"), fmt.Sprintf("Leader pod %v", dbMaster))
+	}
+	log.InfoD("New DB MasterNode- [%v] is created.", newDbMaster)
+	return nil
 }
 
 // ValidateDepConfigPostStorageIncrease Verifies the storage and other config values after storage resize

--- a/tests/pds/pds_resiliency_test.go
+++ b/tests/pds/pds_resiliency_test.go
@@ -1563,3 +1563,85 @@ var _ = Describe("{RestoreDSDuringKVDBFailOver}", func() {
 		log.FailOnError(err, "Failed while deleting the bucket")
 	})
 })
+var _ = Describe("{KillDbMasterNodeDuringStorageResize}", func() {
+	JustBeforeEach(func() {
+		StartTorpedoTest("KillDbMasterNodeDuringStorageResize", "Kill DB Master node during application's storage is resized", pdsLabels, 0)
+		pdslib.MarkResiliencyTC(true)
+
+		wkloadParams = pdsdriver.LoadGenParams{
+			LoadGenDepName: params.LoadGen.LoadGenDepName,
+			Namespace:      params.InfraToTest.Namespace,
+			NumOfRows:      params.LoadGen.NumOfRows,
+			Timeout:        params.LoadGen.Timeout,
+			Replicas:       params.LoadGen.Replicas,
+			TableName:      "wltestingnew",
+			Iterations:     params.LoadGen.Iterations,
+			FailOnError:    params.LoadGen.FailOnError,
+		}
+	})
+
+	It("Deploy Dataservices and Restart PX During App scaleup", func() {
+		var deployments = make(map[PDSDataService]*pds.ModelsDeployment)
+		//var generateWorkloads = make(map[string]string)
+		var wlDeploymentsToBeCleaned []*v1.Deployment
+
+		Step("Deploy Data Services", func() {
+			for _, ds := range params.DataServiceToTest {
+				Step("Deploy and validate data service", func() {
+					isDeploymentsDeleted = false
+					deployment, _, _, err = DeployandValidateDataServices(ds, params.InfraToTest.Namespace, tenantID, projectID)
+					log.FailOnError(err, "Error while deploying data services")
+					deployments[ds] = deployment
+				})
+			}
+		})
+
+		//defer func() {
+		//	for _, newDeployment := range deployments {
+		//		Step("Delete created deployments")
+		//		resp, err := pdslib.DeleteDeployment(newDeployment.GetId())
+		//		log.FailOnError(err, "Error while deleting data services")
+		//		dash.VerifyFatal(resp.StatusCode, http.StatusAccepted, "validating the status response")
+		//		err = pdslib.DeletePvandPVCs(*newDeployment.ClusterResourceName, false)
+		//		log.FailOnError(err, "Error while deleting PV and PVCs")
+		//	}
+		//}()
+
+		Step("Kill DB Master node during application's storage is resized", func() {
+			for ds, deployment := range deployments {
+				ctx, err := GetSourceClusterConfigPath()
+				sourceTarget = tc.NewTargetCluster(ctx)
+				failuretype := pdslib.TypeOfFailure{
+					Type: KillDbMasterNodeDuringStorageResize,
+					Method: func() error {
+						return KillDbMasterNodeDuringStorageIncrease(ds.Name, namespace, deployment, sourceTarget)
+					},
+				}
+				pdslib.DefineFailureType(failuretype)
+				//Kill DB Master Node during storage size Increase by updating the DS from "small" to "medium" template
+				err = pdslib.InduceFailureAfterWaitingForCondition(deployment, namespace, int32(ds.ScaleReplicas))
+				log.FailOnError(err, fmt.Sprintf("Error happened while stopping px for data service %v", *deployment.ClusterResourceName))
+			}
+		})
+		Step("Running Workloads", func() {
+
+			for _, deployment := range deployments {
+				ckSum2, wlDep, err := dsTest.InsertDataAndReturnChecksum(deployment, wkloadParams)
+				log.FailOnError(err, "Error while Running workloads-%v", wlDep)
+				log.Debugf("Checksum for the deployment %s is %s", *deployment.ClusterResourceName, ckSum2)
+				wlDeploymentsToBeCleaned = append(wlDeploymentsToBeCleaned, wlDep)
+			}
+		})
+		Step("Clean up workload deployments", func() {
+			for _, wlDep := range wlDeploymentsToBeCleaned {
+				err := k8sApps.DeleteDeployment(wlDep.Name, wlDep.Namespace)
+				log.FailOnError(err, "Failed while deleting the workload deployment")
+			}
+
+		})
+	})
+	JustAfterEach(func() {
+		EndTorpedoTest()
+
+	})
+})


### PR DESCRIPTION
Added Resiliency testcase for storage size increase festure.

Testcase added - 
T1. Automate TestCase4- Bringdown the Master node in DB

Steps - 

1.Deploy PG Data Service (minimum 3 pod deployment)

2.Start Running PG Bench. Wait for the data to settle

3.Shutdown master node and then trigger Storage increase

4.Verify Storage increase has happened successfully on remaining Nodes

5.Bring Up Master Node

6.Verify storage increase on the master node

T2. Automate Testcase3- Have a replica factor of 2, Increase storage size and stop Px on data Service Node and Replica Node

Steps -

1. Deploy a Data Service with Volume Replication factor 2

2. Increase the storage size

3. Stop Px on the Node where the volume is during storage expansion

4. Once the DS Recovers Verify storage size

5. Now stop the px service on the node where the voluem replica is present

6.Verify DS is not affected during or after the node comes back up

Expected Results-

Volume expansion should happen seamlessly and Both primary and replica volume should be same size

