### PR TITLE
[PTX-21138] Fix ValidateCreateVolume

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -1262,8 +1262,8 @@ func (d *portworx) ValidateCreateVolume(volumeName string, params map[string]str
 		// DevicePath
 		// TODO: remove this retry once PWX-27773 is fixed
 		// It is noted that the DevicePath is intermittently empty.
-		// The check below validates the response by ensuring the device path is not empty
-		if vol.DevicePath == "" {
+		// This check ensures the device path is not empty for volumes, bypassing the check for snapshots
+		if vol.Source.Parent == "" && vol.DevicePath == "" {
 			return vol, true, fmt.Errorf("device path is not present for volume: %s", volumeName)
 		}
 

--- a/tests/testTriggers.go
+++ b/tests/testTriggers.go
@@ -707,7 +707,7 @@ func TriggerVolumeCreatePXRestart(contexts *[]*scheduler.Context, recordChan *ch
 		var err error
 
 		for vol, volPath := range createdVolIDs {
-			//TODO: remove this retry once PWX-27773 is fixed
+			// TODO: remove this retry once PWX-27773 is fixed
 			t := func() (interface{}, bool, error) {
 				cVol, err = Inst().V.InspectVolume(vol)
 				if err != nil {
@@ -717,7 +717,9 @@ func TriggerVolumeCreatePXRestart(contexts *[]*scheduler.Context, recordChan *ch
 				if !strings.Contains(cVol.DevicePath, "pxd/") {
 					return cVol, true, fmt.Errorf("path %s is not correct", cVol.DevicePath)
 				}
-				if cVol.DevicePath == "" {
+				// It is noted that the DevicePath is intermittently empty.
+				// This check ensures the device path is not empty for volumes, bypassing the check for snapshots
+				if cVol.Source.Parent == "" && cVol.DevicePath == "" {
 					return cVol, false, fmt.Errorf("device path is not present for volume: %s", vol)
 				}
 				return cVol, true, err


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR skips DevicePath check for snapshots in ValidateCreateVolume and TriggerVolumeCreatePXRestart.

**Which issue(s) this PR fixes** (optional)
Closes #PTX-21138

**Special notes for your reviewer**:
Please review the Jenkins build for the test case "SetupTeadDown" that schedules and destroys "mysql" app

https://jenkins.pwx.dev.purestorage.com/job/Users/job/Leela/job/tp-byoc/360/

Aetos Dashboard: https://aetos.pwx.purestorage.com/resultSet/testSetID/430270