### PR TITLE
Assigning kube-system as debug pod namespace for non-px environments

### DIFF
--- a/drivers/node/ssh/ssh.go
+++ b/drivers/node/ssh/ssh.go
@@ -165,6 +165,10 @@ func (s *SSH) updateDriver() error {
 	if err != nil {
 		return err
 	}
+	if execPodNamespace == "" {
+		log.Warnf("Unable to find portworx namespace. Setting debug pod namespace to kube-system")
+		execPodNamespace = "kube-system"
+	}
 	s.execPodNamespace = execPodNamespace
 	log.InfoD("UpdateDriver: ssh driver's namespace (the 'portworx-service' namespace) is updated to [%s]", execPodNamespace)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
During node driver initialisation when we run torpedo on cloud clusters where the nodes are not accessible through SSH, we deploy a debug pod which will help us run commands on the node. This debug pod always assumes that Portworx is deployed and tries to get the Portworx namespace where we deploy the debug pod. But in case of non-px environments (which is needed for Px-Backup) there is no px installed and hence it kept failing with error
```
Error while creating debug daemonset. Err: an empty namespace may not be set during creation
```
Now we will deploy the debug pod in kube-system namespace if we dont find px namespace.

**Which issue(s) this PR fixes** (optional)
Closes #PB-4894

**Special notes for your reviewer**:
[Jenkins Run](https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/basic-system-test/job/nonpx/job/ibm/job/s3/job/ibm-s3-direct-kdmp/50/)

