### PR TITLE
[PTX-21149] Fix ValidateCreateVolume

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -1259,14 +1259,6 @@ func (d *portworx) ValidateCreateVolume(volumeName string, params map[string]str
 			}
 		}
 
-		// DevicePath
-		// TODO: remove this retry once PWX-27773 is fixed
-		// It is noted that the DevicePath is intermittently empty.
-		// This check ensures the device path is not empty for volumes, bypassing the check for snapshots
-		if vol.Source.Parent == "" && vol.DevicePath == "" {
-			return vol, true, fmt.Errorf("device path is not present for volume: %s", volumeName)
-		}
-
 		return vol, false, nil
 	}
 

--- a/tests/testTriggers.go
+++ b/tests/testTriggers.go
@@ -717,9 +717,7 @@ func TriggerVolumeCreatePXRestart(contexts *[]*scheduler.Context, recordChan *ch
 				if !strings.Contains(cVol.DevicePath, "pxd/") {
 					return cVol, true, fmt.Errorf("path %s is not correct", cVol.DevicePath)
 				}
-				// It is noted that the DevicePath is intermittently empty.
-				// This check ensures the device path is not empty for volumes, bypassing the check for snapshots
-				if cVol.Source.Parent == "" && cVol.DevicePath == "" {
+				if cVol.DevicePath == "" {
 					return cVol, false, fmt.Errorf("device path is not present for volume: %s", vol)
 				}
 				return cVol, true, err


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR reverts the changes made in PR #1788 and PR #1892 to prevent job failures.

**Which issue(s) this PR fixes** (optional)
Closes #PTX-201149

**Special notes for your reviewer**:
Please review the Jenkins build for the test cases "SetupTeardown" and "AppScaleUpAndDown" with "elasticsearch" app

https://jenkins.pwx.dev.purestorage.com/job/Users/job/Leela/job/tp-byoc/368/

Aetos Dashboard: https://aetos.pwx.purestorage.com/resultSet/testSetID/430965