### PR TITLE
[PWX-35030]: T34542906: Newly set pool labels should persist post pool expand using add-disk

### DIFF
--- a/tests/basic/pool_function_test.go
+++ b/tests/basic/pool_function_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+	"reflect"
 	"regexp"
 	"strings"
 	"sync"
@@ -858,4 +859,62 @@ var _ = Describe("{PoolExpandAddDiskInMaintenanceMode}", func() {
 			verifyPoolSizeEqualOrLargerThanExpected(poolIDToResize, targetSizeGiB)
 		})
 	})
+})
+
+var _ = Describe("{CheckPoolLabelsAfterAddDisk}", func() {
+
+	var testrailID = 34542906
+	// testrailID corresponds to: https://portworx.testrail.net/index.php?/tests/view/34542906
+
+	BeforeEach(func() {
+		StartTorpedoTest("CheckPoolLabelsAfterAddDisk",
+			"Initiate pool expansion and Newly set pool labels should persist post pool expand add-disk operation", nil, testrailID)
+		contexts = scheduleApps()
+	})
+
+	JustBeforeEach(func() {
+		poolIDToResize = pickPoolToResize()
+		log.Infof("Picked pool %s to resize", poolIDToResize)
+		poolToResize = getStoragePool(poolIDToResize)
+		storageNode, err = GetNodeWithGivenPoolID(poolIDToResize)
+		log.FailOnError(err, "Failed to get node with given pool ID")
+	})
+
+	JustAfterEach(func() {
+		AfterEachTest(contexts)
+	})
+
+	AfterEach(func() {
+		appsValidateAndDestroy(contexts)
+		EndTorpedoTest()
+	})
+
+	It("Initiate pool expansion and Newly set pool labels should persist post pool expand add-disk operation", func() {
+		log.InfoD("set pool label, before pool expand")
+		labelBeforeExpand := poolToResize.Labels
+		poolLabelToUpdate := make(map[string]string)
+		poolLabelToUpdate["cust-type"] = "test-label"
+		// Update the pool label
+		err = Inst().V.UpdatePoolLabels(*storageNode, poolIDToResize, poolLabelToUpdate)
+		log.FailOnError(err, "Failed to update the label on the pool %s", poolIDToResize)
+
+		log.InfoD("expand pool using resize-disk")
+		originalSizeInBytes = poolToResize.TotalSize
+		targetSizeInBytes = originalSizeInBytes + 100*units.GiB
+		targetSizeGiB = targetSizeInBytes / units.GiB
+
+		log.InfoD("Current Size of the pool %s is %d GiB. Trying to expand to %v GiB with type add-disk",
+			poolIDToResize, poolToResize.TotalSize/units.GiB, targetSizeGiB)
+		triggerPoolExpansion(poolIDToResize, targetSizeGiB, api.SdkStoragePool_RESIZE_TYPE_ADD_DISK)
+
+		err = waitForOngoingPoolExpansionToComplete(poolIDToResize)
+		dash.VerifyFatal(err, nil, "Pool expansion does not result in error")
+		verifyPoolSizeEqualOrLargerThanExpected(poolIDToResize, targetSizeGiB)
+
+		log.InfoD("check pool label, after pool expand")
+		labelAfterExpand := poolToResize.Labels
+		result := reflect.DeepEqual(labelBeforeExpand, labelAfterExpand)
+		dash.VerifyFatal(result, true, "Check if labels changed after pool expand")
+	})
+
 })

--- a/tests/basic/pool_function_test.go
+++ b/tests/basic/pool_function_test.go
@@ -2,8 +2,8 @@ package tests
 
 import (
 	"fmt"
-	"reflect"
 	"github.com/portworx/torpedo/drivers/scheduler/k8s"
+	"reflect"
 	"regexp"
 	"strings"
 	"sync"
@@ -920,9 +920,8 @@ var _ = Describe("{StorageFullPoolExpansion}", func() {
 			log.FailOnError(err, fmt.Sprintf("Error getting PX status of node %s", selectedNode.Name))
 			dash.VerifySafely(*status, api.Status_STATUS_OK, fmt.Sprintf("validate PX status on node %s", selectedNode.Name))
 		})
-  })
+	})
 })
-     
 
 var _ = Describe("{PoolExpandTestLimits}", func() {
 	BeforeEach(func() {
@@ -1030,13 +1029,13 @@ var _ = Describe("{CheckPoolLabelsAfterAddDisk}", func() {
 	It("Initiate pool expansion and Newly set pool labels should persist post pool expand add-disk operation", func() {
 
 		labelBeforeExpand := poolToResize.Labels
+		poolInMaintenance := "STATUS_POOLMAINTENANCE"
 
 		stepLog = "set pool label, before pool expand"
 		Step(stepLog, func() {
 			log.InfoD(stepLog)
 			poolLabelToUpdate := make(map[string]string)
 			poolLabelToUpdate["cust-type"] = "test-label"
-			// Update the pool label
 			err = Inst().V.UpdatePoolLabels(*storageNode, poolIDToResize, poolLabelToUpdate)
 			log.FailOnError(err, "Failed to update the label on the pool %s", poolIDToResize)
 		})
@@ -1046,8 +1045,9 @@ var _ = Describe("{CheckPoolLabelsAfterAddDisk}", func() {
 			log.InfoD(stepLog)
 			log.InfoD(fmt.Sprintf("Entering pool maintenance mode on node %s", storageNode.Name))
 			err = Inst().V.EnterPoolMaintenance(*storageNode)
-			log.FailOnError(err, fmt.Sprintf("fail to enter node %s in maintenance mode", storageNode.Name))
+			log.FailOnError(err, fmt.Sprintf("failed to enter node %s in maintenance mode", storageNode.Name))
 			status, _ := Inst().V.GetNodeStatus(*storageNode)
+			dash.VerifyFatal(status.String(), poolInMaintenance, "Pool now in maintenance mode")
 			log.InfoD(fmt.Sprintf("Node %s status %s", storageNode.Name, status.String()))
 		})
 

--- a/tests/basic/pool_function_test.go
+++ b/tests/basic/pool_function_test.go
@@ -979,7 +979,7 @@ var _ = Describe("{CheckPoolLabelsAfterAddDisk}", func() {
 			log.FailOnError(err, "Failed to update the label on the pool %s", poolIDToResize)
 		})
 
-		stepLog = "Move node to maintenance mode"
+		stepLog = "Move pool to maintenance mode"
 		Step(stepLog, func() {
 			log.InfoD(stepLog)
 			log.InfoD(fmt.Sprintf("Entering pool maintenance mode on node %s", storageNode.Name))

--- a/tests/basic/pool_function_test.go
+++ b/tests/basic/pool_function_test.go
@@ -1089,8 +1089,6 @@ var _ = Describe("{CheckPoolLabelsAfterAddDisk}", func() {
 		poolToResize = getStoragePool(poolIDToResize)
 		storageNode, err = GetNodeWithGivenPoolID(poolIDToResize)
 		log.FailOnError(err, "Failed to get node with given pool ID")
-		// labelBeforeExpand := poolToResize.Labels
-
 	})
 
 	JustAfterEach(func() {
@@ -1123,7 +1121,6 @@ var _ = Describe("{CheckPoolLabelsAfterAddDisk}", func() {
 			err = Inst().V.EnterPoolMaintenance(*storageNode)
 			log.FailOnError(err, fmt.Sprintf("failed to enter node %s in maintenance mode", storageNode.Name))
 			status, _ := Inst().V.GetNodeStatus(*storageNode)
-			// dash.VerifyFatal(status.String(), poolInMaintenance, "Pool now in maintenance mode")
 			log.InfoD(fmt.Sprintf("Node %s status %s", storageNode.Name, status.String()))
 			err := WaitForPoolStatusToUpdate(*storageNode, expectedStatus)
 			dash.VerifyFatal(err, nil, "Pool now in maintenance mode")


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Automation test for Newly set pool labels should persist post pool expand using add-disk
**Which issue(s) this PR fixes** (optional)
Closes # PWX-35030

**Special notes for your reviewer**:
Testing link:- https://jenkins.pwx.dev.purestorage.com/user/ragsingh@purestorage.com/my-views/view/all/job/Users/job/Raghvendra/job/raghav_pxdv-7-dev/63

