### PR TITLE
Fix torpedo pod logs getting printed on console

### DIFF
--- a/deployments/deploy-pxb-cloud.sh
+++ b/deployments/deploy-pxb-cloud.sh
@@ -729,15 +729,25 @@ function describe_pod_then_exit {
   exit 1
 }
 
-for i in $(seq 1 900) ; do
-  printf .
-  state=`kubectl get pod torpedo | grep -v NAME | awk '{print $3}'`
+first_iteration=true
+
+for i in $(seq 1 900); do
+  echo "Iteration: $i"
+  state=$(kubectl get pod torpedo | grep -v NAME | awk '{print $3}')
+
   if [ "$state" == "Error" ]; then
     echo "Error: Torpedo finished with $state state"
     describe_pod_then_exit
   elif [ "$state" == "Running" ]; then
-    echo ""
-    kubectl logs -f torpedo
+    # For the first iteration, display all logs. Later, only from 1 minute ago
+    if [ "$first_iteration" = true ]; then
+      echo "Logs from first iteration"
+      kubectl logs -f torpedo
+      first_iteration=false
+    else
+      echo "Logs from iteration: $i"
+      kubectl logs -f --since=1m torpedo
+    fi
   elif [ "$state" == "Completed" ]; then
     echo "Success: Torpedo finished with $state state"
     exit 0

--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -747,45 +747,25 @@ function describe_pod_then_exit {
   exit 1
 }
 
-#for i in $(seq 1 900) ; do
-#  printf .
-#  state=`kubectl get pod torpedo | grep -v NAME | awk '{print $3}'`
-#  if [ "$state" == "Error" ]; then
-#    echo "Error: Torpedo finished with $state state"
-#    describe_pod_then_exit
-#  elif [ "$state" == "Running" ]; then
-#    echo ""
-#
-#    kubectl logs -f torpedo
-#  elif [ "$state" == "Completed" ]; then
-#    echo "Success: Torpedo finished with $state state"
-#    exit 0
-#  fi
-#
-#  sleep 1
-#done
-
 first_iteration=true
 
 for i in $(seq 1 900); do
-  printf .
+  echo -n "Iteration: $i"
   state=$(kubectl get pod torpedo | grep -v NAME | awk '{print $3}')
+
   if [ "$state" == "Error" ]; then
     echo "Error: Torpedo finished with $state state"
     describe_pod_then_exit
   elif [ "$state" == "Running" ]; then
-    echo ""
-
     # For the first iteration, display all logs. Later, only from 1 minute ago
     if [ "$first_iteration" = true ]; then
-      echo "logs from first iteration"
+      echo "Logs from first iteration"
       kubectl logs -f torpedo
       first_iteration=false
     else
-      echo -n "Iteration $i: "
+      echo -n "Logs from iteration: $i"
       kubectl logs -f --since=1m -f torpedo
     fi
-
   elif [ "$state" == "Completed" ]; then
     echo "Success: Torpedo finished with $state state"
     exit 0

--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -764,7 +764,7 @@ for i in $(seq 1 900); do
       first_iteration=false
     else
       echo -n "Logs from iteration: $i"
-      kubectl logs -f --since=1m -f torpedo
+      kubectl logs -f --since=1m torpedo
     fi
   elif [ "$state" == "Completed" ]; then
     echo "Success: Torpedo finished with $state state"

--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -750,7 +750,7 @@ function describe_pod_then_exit {
 first_iteration=true
 
 for i in $(seq 1 900); do
-  echo -n "Iteration: $i"
+  echo "Iteration: $i"
   state=$(kubectl get pod torpedo | grep -v NAME | awk '{print $3}')
 
   if [ "$state" == "Error" ]; then
@@ -763,7 +763,7 @@ for i in $(seq 1 900); do
       kubectl logs -f torpedo
       first_iteration=false
     else
-      echo -n "Logs from iteration: $i"
+      echo "Logs from iteration: $i"
       kubectl logs -f --since=1m torpedo
     fi
   elif [ "$state" == "Completed" ]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
We have been observing this from a very long time in long torpedo runs. The logs we get on the jenkins console is a result of `kubectl logs -f torpedo`
But for some reason this log stream exits after every 4 hours and the whole log is printed again.
The cumulative logs get printed on the console page and this is resulting in slowness while loading the jenkins console page and also crashing at times.
To fix this we will be getting only recent logs if `kubectl logs -f torpedo` exits during the first iteration by using `kubectl logs -f --since=1m -f torpedo`

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

