### PR TITLE
PB-4968: Fix issue with `LicensingCountBeforeAndAfterBackupPodRestart`

### DIFF
--- a/tests/backup/backup_license_test.go
+++ b/tests/backup/backup_license_test.go
@@ -315,7 +315,6 @@ var _ = Describe("{LicensingCountWithNodeLabelledBeforeClusterAddition}", func()
 	})
 })
 
-// LicensingCountBeforeAndAfterBackupPodRestart verifies the license count before and after the backup pods restart
 var _ = Describe("{LicensingCountBeforeAndAfterBackupPodRestart}", func() {
 	var (
 		pxbNamespace                  string
@@ -378,7 +377,9 @@ var _ = Describe("{LicensingCountBeforeAndAfterBackupPodRestart}", func() {
 		Step("Restart all the backup pod and wait for it to come up", func() {
 			pxbNamespace, err = backup.GetPxBackupNamespace()
 			log.FailOnError(err, "Getting px-backup namespace")
-			err = DeletePodWithLabelInNamespace(pxbNamespace, nil)
+			var labelselector = make(map[string]string)
+			labelselector["kdmp.portworx.com/driver-name"] = "kopiamaintenance"
+			err = DeletePodWithLabelInNamespace(pxbNamespace, labelselector, true)
 			dash.VerifyFatal(err, nil, "Restart all the backup pods")
 			log.InfoD("Validate if all the backup pods are up")
 			err = ValidateAllPodsInPxBackupNamespace()
@@ -407,7 +408,9 @@ var _ = Describe("{LicensingCountBeforeAndAfterBackupPodRestart}", func() {
 			log.FailOnError(err, "Switching context to source cluster failed")
 		})
 		Step("Restart all the backup pod again and wait for it to come up", func() {
-			err = DeletePodWithLabelInNamespace(pxbNamespace, nil)
+			var labelselector = make(map[string]string)
+			labelselector["kdmp.portworx.com/driver-name"] = "kopiamaintenance"
+			err = DeletePodWithLabelInNamespace(pxbNamespace, labelselector, true)
 			dash.VerifyFatal(err, nil, "Restart all the backup pods")
 			log.InfoD("Validate if all the backup pods are up")
 			err = ValidateAllPodsInPxBackupNamespace()

--- a/tests/backup/backup_resiliency_test.go
+++ b/tests/backup/backup_resiliency_test.go
@@ -315,7 +315,7 @@ var _ = Describe("{KillStorkWithBackupsAndRestoresInProgress}", func() {
 			log.InfoD("Kill stork when backup in progress")
 			pxNamespace, err := ssh.GetExecPodNamespace()
 			dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching PX namespace %s", pxNamespace))
-			err = DeletePodWithLabelInNamespace(pxNamespace, storkLabel)
+			err = DeletePodWithLabelInNamespace(pxNamespace, storkLabel, false)
 			dash.VerifyFatal(err, nil, fmt.Sprintf("Killing stork while backups %s is in progress", backupNames))
 		})
 
@@ -343,7 +343,7 @@ var _ = Describe("{KillStorkWithBackupsAndRestoresInProgress}", func() {
 			log.InfoD("Kill stork when restore in-progress")
 			pxNamespace, err := ssh.GetExecPodNamespace()
 			dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching PX namespace %s", pxNamespace))
-			err = DeletePodWithLabelInNamespace(pxNamespace, storkLabel)
+			err = DeletePodWithLabelInNamespace(pxNamespace, storkLabel, false)
 			dash.VerifyFatal(err, nil, "Killing stork while all the restores are in progress")
 		})
 		Step("Check if restore is successful when the stork restart happened", func() {
@@ -494,7 +494,7 @@ var _ = Describe("{RestartBackupPodDuringBackupSharing}", func() {
 			backupPodLabel["app"] = "px-backup"
 			pxbNamespace, err := backup.GetPxBackupNamespace()
 			dash.VerifyFatal(err, nil, "Getting px-backup namespace")
-			err = DeletePodWithLabelInNamespace(pxbNamespace, backupPodLabel)
+			err = DeletePodWithLabelInNamespace(pxbNamespace, backupPodLabel, false)
 			dash.VerifyFatal(err, nil, "Restart backup pod when backup sharing is in-progress")
 			err = ValidatePodByLabel(backupPodLabel, pxbNamespace, 5*time.Minute, 30*time.Second)
 			log.FailOnError(err, "Checking if px-backup pod is in running state")
@@ -548,7 +548,7 @@ var _ = Describe("{RestartBackupPodDuringBackupSharing}", func() {
 			mongoDBPodLabel["app.kubernetes.io/component"] = mongodbStatefulset
 			pxbNamespace, err := backup.GetPxBackupNamespace()
 			dash.VerifyFatal(err, nil, "Getting px-backup namespace")
-			err = DeletePodWithLabelInNamespace(pxbNamespace, mongoDBPodLabel)
+			err = DeletePodWithLabelInNamespace(pxbNamespace, mongoDBPodLabel, false)
 			dash.VerifyFatal(err, nil, "Restart mongo pod when backup sharing is in-progress")
 			err = IsMongoDBReady()
 			log.FailOnError(err, "Checking if mongo db pod is in running state")

--- a/tests/backup/backup_sse_test.go
+++ b/tests/backup/backup_sse_test.go
@@ -300,7 +300,7 @@ var _ = Describe("{CreateBackupAndRestoreForAllCombinationsOfSSES3AndDenyPolicy}
 				log.InfoD("Kill stork")
 				pxNamespace, err := ssh.GetExecPodNamespace()
 				dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching PX namespace %s", pxNamespace))
-				err = DeletePodWithLabelInNamespace(pxNamespace, storkLabel)
+				err = DeletePodWithLabelInNamespace(pxNamespace, storkLabel, false)
 				dash.VerifyFatal(err, nil, fmt.Sprintf("Killing stork after toggling SSE-S3 type"))
 			})
 			Step("Restart backup pod", func() {
@@ -309,7 +309,7 @@ var _ = Describe("{CreateBackupAndRestoreForAllCombinationsOfSSES3AndDenyPolicy}
 				backupPodLabel["app"] = "px-backup"
 				pxbNamespace, err := backup.GetPxBackupNamespace()
 				dash.VerifyFatal(err, nil, "Getting px-backup namespace")
-				err = DeletePodWithLabelInNamespace(pxbNamespace, backupPodLabel)
+				err = DeletePodWithLabelInNamespace(pxbNamespace, backupPodLabel, false)
 				dash.VerifyFatal(err, nil, "Restart backup pod")
 				err = ValidatePodByLabel(backupPodLabel, pxbNamespace, 5*time.Minute, 30*time.Second)
 				log.FailOnError(err, "Checking if px-backup pod is in running state")


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
While running the IBM jobs we saw testcase `LicensingCountBeforeAndAfterBackupPodRestart` fail intermittently with the below error:
```
error: pods "quick-maintenance-repo-6f03bd2-28337041-778fs" not found, Description: Restart all the backup pods
```
This is mostly because the `quick-maintenance-repo-6f03bd2-28337041-778fs` job pod is a short lived job pod and is deleted in some cases between the line 1480 and 1518.

**Which issue(s) this PR fixes** (optional)
Closes #PB-4968

**Special notes for your reviewer**:

