### PR TITLE
Added helper methods for (.snapshot) exclude system tests

### DIFF
--- a/drivers/volume/portworx/schedops/k8s-schedops.go
+++ b/drivers/volume/portworx/schedops/k8s-schedops.go
@@ -24,6 +24,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/version"
@@ -896,8 +897,8 @@ func GetContainerPVCMountMap(pod corev1.Pod) map[string][]string {
 }
 
 // GetContainerPVCMountMapWithSC fetches storage class along with mount paths for containers using PVCs
-func GetContainerPVCMountMapWithSC(pod corev1.Pod) (map[string]string, error) {
-	scMountPathsMap := make(map[string]string)
+func GetContainerPVCMountMapWithSC(pod corev1.Pod) (map[string]*storagev1.StorageClass, error) {
+	scMountPathsMap := make(map[string]*storagev1.StorageClass)
 	pvcNamesInSpec := make(map[string]string)
 	for _, v := range pod.Spec.Volumes {
 		if v.PersistentVolumeClaim != nil {
@@ -916,7 +917,7 @@ func GetContainerPVCMountMapWithSC(pod corev1.Pod) (map[string]string, error) {
 				if err != nil {
 					return nil, err
 				}
-				scMountPathsMap[cMount.MountPath] = storageClass.Name
+				scMountPathsMap[cMount.MountPath] = storageClass
 			}
 		}
 
@@ -930,7 +931,7 @@ func GetContainerPVCMountMapWithSC(pod corev1.Pod) (map[string]string, error) {
 				if err != nil {
 					return nil, err
 				}
-				scMountPathsMap[cDevice.DevicePath] = storageClass.Name
+				scMountPathsMap[cDevice.DevicePath] = storageClass
 			}
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/portworx/pds-api-go-client v0.0.0-20231102112445-993d38984eae
 	github.com/portworx/px-backup-api v1.2.2-0.20231011130438-812370c309e7
-	github.com/portworx/sched-ops v1.20.4-rc1.0.20231109202231-f601f9891b01
+	github.com/portworx/sched-ops v1.20.4-rc1.0.20231212125252-c5df9b72ebe8
 	github.com/portworx/talisman v1.1.3
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.63.0
 	github.com/prometheus/client_golang v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -2895,8 +2895,8 @@ github.com/portworx/sched-ops v1.20.4-rc1.0.20230103234348-243afb3bb8aa/go.mod h
 github.com/portworx/sched-ops v1.20.4-rc1.0.20230207070155-2e0ef25efadd/go.mod h1:JbHASXqA/GXwFD4blS1DZkrxtS5llb98ViZgUerOtQA=
 github.com/portworx/sched-ops v1.20.4-rc1.0.20230207140221-24ec094deec4/go.mod h1:drIYh+6f/vh11dVmbpwFv3GIusQCSMThPX774U8ix7w=
 github.com/portworx/sched-ops v1.20.4-rc1.0.20230228105744-505c1a2d8203/go.mod h1:JbHASXqA/GXwFD4blS1DZkrxtS5llb98ViZgUerOtQA=
-github.com/portworx/sched-ops v1.20.4-rc1.0.20231109202231-f601f9891b01 h1:uSw5PzEaz60Nhpdf3cvn9gzbOsgkDvCteYqodadPbok=
-github.com/portworx/sched-ops v1.20.4-rc1.0.20231109202231-f601f9891b01/go.mod h1:wZnNzyY7B/cuWwYZ6XysdbwsXPC8DjfJ1YGg6MdyefU=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20231212125252-c5df9b72ebe8 h1:Ys0LM3q8SJRLDljnNCvWmmo6vuMf2bFrxSlI5t2UhGQ=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20231212125252-c5df9b72ebe8/go.mod h1:wZnNzyY7B/cuWwYZ6XysdbwsXPC8DjfJ1YGg6MdyefU=
 github.com/portworx/talisman v0.0.0-20191007232806-837747f38224/go.mod h1:OjpMH9Uh5o9ntVGktm4FbjLNwubJ3ITih2OfYrAeWtA=
 github.com/portworx/talisman v0.0.0-20210302012732-8af4564777f7/go.mod h1:e8a6uFpSbOlRpZQlW9aXYogC+GWAo065G0RL9hDkD4Q=
 github.com/portworx/talisman v1.1.3 h1:XrDE0fs4UACgDGi5bvt04uePC+QbhbA5YXozGYg5tr8=

--- a/tests/backup/backup_kdmp_test.go
+++ b/tests/backup/backup_kdmp_test.go
@@ -527,11 +527,11 @@ var _ = Describe("{ExcludeDirectoryFileBackup}", func() {
 						for _, mountPath := range mountPaths {
 							excludeFileDirList := make([]string, 0)
 							log.Infof(fmt.Sprintf("Fetch some random directories from created list %v", dirListMountMap[mountPath]))
-							randomDirs, err := GetRandomSubset(dirListMountMap[mountPath], 10)
+							randomDirs, err := GetRandomSubset(dirListMountMap[mountPath], 100)
 							dash.VerifyFatal(err, nil, fmt.Sprintf("Getting random directories from the list"))
 							log.Infof(fmt.Sprintf("the list of directories randomly selected from mountPath- %v : %v", mountPath, randomDirs))
 							log.Infof(fmt.Sprintf("Fetch some random files from created list %v", fileListMountMap[mountPath]))
-							randomFiles, err := GetRandomSubset(fileListMountMap[mountPath], 100)
+							randomFiles, err := GetRandomSubset(fileListMountMap[mountPath], 500)
 							dash.VerifyFatal(err, nil, fmt.Sprintf("Getting random files from the list"))
 							log.Infof(fmt.Sprintf("the list of files randomly selected from mountPath- %v : %v", mountPath, randomFiles))
 							excludeFileDirList = append(excludeFileDirList, randomDirs...)

--- a/tests/backup/backup_kdmp_test.go
+++ b/tests/backup/backup_kdmp_test.go
@@ -1,0 +1,722 @@
+package tests
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/pborman/uuid"
+
+	api "github.com/portworx/px-backup-api/pkg/apis/v1"
+	"github.com/portworx/sched-ops/k8s/core"
+	"github.com/portworx/torpedo/drivers/backup"
+	"github.com/portworx/torpedo/drivers/scheduler"
+	"github.com/portworx/torpedo/drivers/volume/portworx/schedops"
+	"github.com/portworx/torpedo/pkg/log"
+	. "github.com/portworx/torpedo/tests"
+)
+
+var _ = Describe("{ExcludeDirectoryFileBackup}", func() {
+	var (
+		backupName           string
+		scheduledAppContexts []*scheduler.Context
+		AppContextsMapping   map[string]*scheduler.Context
+		namespace            string
+		bkpNamespaces        []string
+		backupNames          []string
+		restoreNames         []string
+		scheduleNames        []string
+
+		clusterUid        string
+		clusterStatus     api.ClusterInfo_StatusInfo_Status
+		restoreName       string
+		cloudCredName     string
+		cloudCredUID      string
+		backupLocationUID string
+		bkpLocationName   string
+
+		numDeployments int
+
+		providers         []string
+		backupLocationMap map[string]string
+		labelSelectors    map[string]string
+
+		storageClassExcludeFileDirMap map[string][]string
+		mountPathExcludeFileDirMap    map[string][]string
+		existingFileDirMountPathMap   map[string][]string
+		podMountPathMap               map[string][]string
+		fileListMountMap              map[string][]string
+		dirListMountMap               map[string][]string
+		masterDirFileList             map[string][]string
+		scMountPathMap                map[string]string
+		backupNamespaceMap            map[string]string
+		formattedFileString           string
+		fileList                      []string
+		dirList                       []string
+		preRuleName                   string
+		postRuleName                  string
+		preRuleUid                    string
+		postRuleUid                   string
+		periodicSchedulePolicyName    string
+		periodicSchedulePolicyUid     string
+		mutex                         sync.Mutex
+		restoredNamespaces            []string
+		wg                            sync.WaitGroup
+	)
+	JustBeforeEach(func() {
+		backupNames = make([]string, 0)
+		restoreNames = make([]string, 0)
+		//scheduleNames = make([]string, 0)
+		bkpNamespaces = make([]string, 0)
+		restoredNamespaces = make([]string, 0)
+		backupLocationMap = make(map[string]string)
+		labelSelectors = make(map[string]string)
+		AppContextsMapping = make(map[string]*scheduler.Context)
+		storageClassExcludeFileDirMap = make(map[string][]string)
+		mountPathExcludeFileDirMap = make(map[string][]string)
+		existingFileDirMountPathMap = make(map[string][]string)
+		podMountPathMap = make(map[string][]string)
+		fileListMountMap = make(map[string][]string)
+		masterDirFileList = make(map[string][]string)
+		scheduleNames = make([]string, 0)
+		dirListMountMap = make(map[string][]string)
+		scMountPathMap = make(map[string]string)
+		backupNamespaceMap = make(map[string]string)
+		numDeployments = 1
+		providers = getProviders()
+
+		StartPxBackupTorpedoTest("ExcludeDirectoryFileBackup", "Excludes mentioned directories or files from backed-up apps and restores them", nil, 0, Ak, Q4FY24)
+
+		log.InfoD(fmt.Sprintf("App list %v", Inst().AppList))
+		scheduledAppContexts = make([]*scheduler.Context, 0)
+		log.InfoD("Starting to deploy applications")
+		for i := 0; i < numDeployments; i++ {
+			log.InfoD(fmt.Sprintf("Iteration %v of deploying applications", i))
+			taskName := fmt.Sprintf("%s-%d", taskNamePrefix, i)
+			appContexts := ScheduleApplications(taskName)
+			for _, ctx := range appContexts {
+				ctx.ReadinessTimeout = appReadinessTimeout
+				namespace = GetAppNamespace(ctx, taskName)
+				scheduledAppContexts = append(scheduledAppContexts, ctx)
+				AppContextsMapping[namespace] = ctx
+				bkpNamespaces = append(bkpNamespaces, namespace)
+			}
+		}
+
+	})
+	It("Excludes directories or files From a Backup", func() {
+
+		Step("Validating deployed applications", func() {
+			log.InfoD("Validating deployed applications")
+			ValidateApplications(scheduledAppContexts)
+		})
+
+		Step("Getting mountpath and associated stoargeClass for containers in deployed application", func() {
+			log.InfoD("Getting mountpath associated stoargeClass for containers in deployed application")
+			for _, namespace := range bkpNamespaces {
+				pods, err := core.Instance().GetPods(namespace, nil)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("getting pods from namespace [%s] ", namespace))
+				for _, pod := range pods.Items {
+					containerMountPathList := make([]string, 0)
+					containerPaths := schedops.GetContainerPVCMountMap(pod)
+					for containerName, paths := range containerPaths {
+						log.Infof(fmt.Sprintf("containerName:%s,paths: %s ", containerName, paths))
+						containerMountPathList = append(containerMountPathList, paths...)
+					}
+					if len(containerMountPathList) > 0 {
+						podMountPathMap[pod.Name] = containerMountPathList
+						log.Infof(fmt.Sprintf("the list of mountPath within pod [%v] are [%v]", pod.Name, containerMountPathList))
+					}
+					scMountPathMap, err = schedops.GetContainerPVCMountMapWithSC(pod)
+					dash.VerifyFatal(err, nil, fmt.Sprintf("getting storage class and mountpath mapping for pod [%s] ", pod.Name))
+				}
+			}
+		})
+
+		Step("Fetch the existing directories and files within mountPath before writing files and directories", func() {
+			log.InfoD("Fetch the existing directories and files within mountPath before writing files and directories")
+			for _, namespace := range bkpNamespaces {
+				pods, err := core.Instance().GetPods(namespace, nil)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("getting pods from namespace [%s] ", namespace))
+				for _, pod := range pods.Items {
+					if len(podMountPathMap[pod.Name]) > 0 {
+						existingFileDirList := make([]string, 0)
+						for _, mountPath := range podMountPathMap[pod.Name] {
+							log.Infof(fmt.Sprintf("Fetch the existing directories and files within mountPath [%s] before writing files and directories", mountPath))
+							existingFileList, existingDirList, err := FetchFilesAndDirectoriesFromPod(pod, mountPath, nil)
+							existingFileDirList = append(existingFileDirList, existingFileList...)
+							existingFileDirList = append(existingFileDirList, existingDirList...)
+							existingFileDirMountPathMap[mountPath] = existingFileDirList
+							dash.VerifyFatal(err, nil, fmt.Sprintf("fetching files and directory from mountpath [%s] for pod [%s]", mountPath, pod.Name))
+						}
+					}
+				}
+			}
+		})
+
+		Step("Create nested directories and files into container mountPath for applications", func() {
+			log.InfoD("Create nested directories and files into container mountPath for applications")
+			for _, namespace := range bkpNamespaces {
+				pods, err := core.Instance().GetPods(namespace, nil)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("getting pods from namespace [%s] ", namespace))
+				for _, pod := range pods.Items {
+					if len(podMountPathMap[pod.Name]) > 0 {
+						for _, mountPath := range podMountPathMap[pod.Name] {
+							scName := scMountPathMap[mountPath]
+							DirectoryConfig := PodDirectoryConfig{
+								BasePath:          mountPath,
+								Depth:             100,
+								Levels:            1,
+								FilesPerDirectory: 100,
+							}
+							log.Infof(fmt.Sprintf("creating nested directories and files within mountPath [%s] with depth [%d] , level [%d] and FilesPerDirectory [%d]", DirectoryConfig.BasePath, DirectoryConfig.Depth, DirectoryConfig.Levels, DirectoryConfig.FilesPerDirectory))
+							err = CreateNestedDirectoriesWithFilesInPod(pod, DirectoryConfig)
+							dash.VerifyFatal(err, nil, fmt.Sprintf("creating nested directories and files at mountpath [%v] for pod [%v] in namespace [%v]", mountPath, pod.Name, pod.Namespace))
+							log.Infof(fmt.Sprintf("Fetching files and directories from path [%s] by excluding existing directories", DirectoryConfig.BasePath))
+							fileList, dirList, err = FetchFilesAndDirectoriesFromPod(pod, mountPath, existingFileDirMountPathMap[mountPath])
+							dash.VerifyFatal(err, nil, fmt.Sprintf("fetching files and directory from mountpath [%s] for pod [%s]", mountPath, pod.Name))
+							log.Infof(fmt.Sprintf("the list of files created in mountPath [%v] for pod [%v]: %v", mountPath, pod.Name, fileList))
+							log.Infof(fmt.Sprintf("the list of directories created in mountPath [%v] for pod [%v]: %v", mountPath, pod.Name, dirList))
+							fileListMountMap[mountPath] = fileList
+							dirListMountMap[mountPath] = dirList
+							masterDirFileList[mountPath] = append(masterDirFileList[mountPath], fileList...)
+							masterDirFileList[mountPath] = append(masterDirFileList[mountPath], dirList...)
+							log.Infof(fmt.Sprintf("creating files within mountPath [%s] with extensions", mountPath))
+							fileConfig := PodDirectoryConfig{
+								BasePath:          mountPath,
+								FilesPerDirectory: 1,
+								FileName:          "test.yaml",
+							}
+							err = CreateFilesInPodDirectory(pod, fileConfig)
+							dash.VerifyFatal(err, nil, fmt.Sprintf("creating files within mountPath [%s] with extensions and add to exclude list", mountPath))
+							storageClassExcludeFileDirMap[scName] = append(storageClassExcludeFileDirMap[scName], fileConfig.FileName)
+							mountPathExcludeFileDirMap[mountPath] = append(mountPathExcludeFileDirMap[mountPath], fileConfig.FileName)
+							log.Infof(fmt.Sprintf("creating file within mountPath [%s] with hidden type", mountPath))
+							fileConfig = PodDirectoryConfig{
+								BasePath:          mountPath,
+								FilesPerDirectory: 1,
+								FileName:          ".snapshot",
+							}
+							err = CreateFilesInPodDirectory(pod, fileConfig)
+							dash.VerifyFatal(err, nil, fmt.Sprintf("creating files within mountPath [%s] with hidden type and add to exclude list", mountPath))
+							storageClassExcludeFileDirMap[scName] = append(storageClassExcludeFileDirMap[scName], fileConfig.FileName)
+							mountPathExcludeFileDirMap[mountPath] = append(mountPathExcludeFileDirMap[mountPath], fileConfig.FileName)
+							log.Infof(fmt.Sprintf("creating file within mountPath [%s] with valid special chars ", mountPath))
+							fileConfig = PodDirectoryConfig{
+								BasePath:          mountPath,
+								FilesPerDirectory: 1,
+								FileName:          "myn@meisunkn*wn",
+							}
+							err = CreateFilesInPodDirectory(pod, fileConfig)
+							dash.VerifyFatal(err, nil, fmt.Sprintf("creating files within mountPath [%s] valid special chars and add to exclude list", mountPath))
+							storageClassExcludeFileDirMap[scName] = append(storageClassExcludeFileDirMap[scName], fileConfig.FileName)
+							mountPathExcludeFileDirMap[mountPath] = append(mountPathExcludeFileDirMap[mountPath], fileConfig.FileName)
+
+							log.Infof(fmt.Sprintf("creating file within mountPath [%s] with maximum name length (255 characters)", mountPath))
+							fileConfig = PodDirectoryConfig{
+								BasePath:          mountPath,
+								FilesPerDirectory: 1,
+								FileName:          "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopq.txt",
+							}
+							err = CreateFilesInPodDirectory(pod, fileConfig)
+							dash.VerifyFatal(err, nil, fmt.Sprintf("creating files within mountPath [%s] with maximum name length (255 characters and add to exclude list)", mountPath))
+							storageClassExcludeFileDirMap[scName] = append(storageClassExcludeFileDirMap[scName], fileConfig.FileName)
+							mountPathExcludeFileDirMap[mountPath] = append(mountPathExcludeFileDirMap[mountPath], fileConfig.FileName)
+
+						}
+					}
+				}
+			}
+		})
+		Step("Update KDMP config map on source cluster by formatting storage class name and random files and directories as a string", func() {
+			log.InfoD("Update KDMP config map on source cluster by formatting storage class name and random files and directories as a string")
+			for _, namespace := range bkpNamespaces {
+				pods, err := core.Instance().GetPods(namespace, nil)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("getting pods from namespace [%s] ", namespace))
+				for _, pod := range pods.Items {
+					if len(podMountPathMap[pod.Name]) > 0 {
+						for _, mountPath := range podMountPathMap[pod.Name] {
+							excludeFileDirList := make([]string, 0)
+							log.Infof(fmt.Sprintf("Fetch some random directories from created list %v", dirListMountMap[mountPath]))
+							randomDirs, err := GetRandomSubset(dirListMountMap[mountPath], 2)
+							dash.VerifyFatal(err, nil, fmt.Sprintf("Getting random directories from the list"))
+							log.Infof(fmt.Sprintf("the list of directories randomly selected from mountPath- %v : %v", mountPath, randomDirs))
+							log.Infof(fmt.Sprintf("Fetch some random files from created list %v", fileListMountMap[mountPath]))
+							randomFiles, err := GetRandomSubset(fileListMountMap[mountPath], 2)
+							dash.VerifyFatal(err, nil, fmt.Sprintf("Getting random files from the list"))
+							log.Infof(fmt.Sprintf("the list of files randomly selected from mountPath- %v : %v", mountPath, randomFiles))
+							excludeFileDirList = append(excludeFileDirList, randomDirs...)
+							excludeFileDirList = append(excludeFileDirList, randomFiles...)
+							scName := scMountPathMap[mountPath]
+							storageClassExcludeFileDirMap[scName] = append(storageClassExcludeFileDirMap[scName], excludeFileDirList...)
+							mountPathExcludeFileDirMap[mountPath] = append(mountPathExcludeFileDirMap[mountPath], excludeFileDirList...)
+						}
+					}
+				}
+			}
+			log.Infof(fmt.Sprintf("create formatted string with storage class name and exclude file and directories list [%v]", storageClassExcludeFileDirMap))
+			formattedFileString = GenerateStorageClassFormattedString(storageClassExcludeFileDirMap)
+			err := UpdateKDMPConfigMap("KDMP_EXCLUDE_FILE_LIST", formattedFileString)
+			dash.VerifyFatal(err, nil, fmt.Sprintf("updating KDMP config map"))
+		})
+
+		Step("Creating backup location and cloud setting", func() {
+			log.InfoD("Creating backup location and cloud setting")
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			for _, provider := range providers {
+				cloudCredName = fmt.Sprintf("%s-%s-%v", "cred", provider, time.Now().Unix())
+				bkpLocationName = fmt.Sprintf("%s-%s-bl", provider, getGlobalBucketName(provider))
+				cloudCredUID = uuid.New()
+				backupLocationUID = uuid.New()
+				backupLocationMap[backupLocationUID] = bkpLocationName
+				err := CreateCloudCredential(provider, cloudCredName, cloudCredUID, orgID, ctx)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation of cloud credential named [%s] for org [%s] with [%s] as provider", cloudCredName, orgID, provider))
+				err = CreateBackupLocation(provider, bkpLocationName, backupLocationUID, cloudCredName, cloudCredUID, getGlobalBucketName(provider), orgID, "", true)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Creating backup location %s", bkpLocationName))
+			}
+		})
+		Step("Registering cluster for backup", func() {
+			log.InfoD("Registering cluster for backup")
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			err = CreateApplicationClusters(orgID, "", "", ctx)
+			dash.VerifyFatal(err, nil, "Creating source and destination cluster")
+			clusterStatus, err = Inst().Backup.GetClusterStatus(orgID, SourceClusterName, ctx)
+			log.FailOnError(err, fmt.Sprintf("Fetching [%s] cluster status", SourceClusterName))
+			dash.VerifyFatal(clusterStatus, api.ClusterInfo_StatusInfo_Online, fmt.Sprintf("Verifying if [%s] cluster is online", SourceClusterName))
+			clusterUid, err = Inst().Backup.GetClusterUID(ctx, orgID, SourceClusterName)
+			dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching [%s] cluster uid", SourceClusterName))
+		})
+
+		Step(fmt.Sprintf("Verify creation of pre and post exec rules for applications "), func() {
+			log.InfoD("Verify creation of pre and post exec rules for applications ")
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			preRuleName, postRuleName, err = CreateRuleForBackupWithMultipleApplications(orgID, Inst().AppList, ctx)
+			dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation of pre and post exec rules for applications from px-admin"))
+			if preRuleName != "" {
+				preRuleUid, err = Inst().Backup.GetRuleUid(orgID, ctx, preRuleName)
+				log.FailOnError(err, "Fetching pre backup rule [%s] uid", preRuleName)
+				log.Infof("Pre backup rule [%s] uid: [%s]", preRuleName, preRuleUid)
+			}
+			if postRuleName != "" {
+				postRuleUid, err = Inst().Backup.GetRuleUid(orgID, ctx, postRuleName)
+				log.FailOnError(err, "Fetching post backup rule [%s] uid", postRuleName)
+				log.Infof("Post backup rule [%s] uid: [%s]", postRuleName, postRuleUid)
+			}
+		})
+
+		Step(fmt.Sprintf("Create schedule policy for backup schedules"), func() {
+			log.InfoD("Create schedule policy for backup schedules")
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			periodicSchedulePolicyName = fmt.Sprintf("%s-%s", "periodic", RandomString(5))
+			periodicSchedulePolicyUid = uuid.New()
+			periodicSchedulePolicyInterval := int64(15)
+			err = CreateBackupScheduleIntervalPolicy(5, periodicSchedulePolicyInterval, 5, periodicSchedulePolicyName, periodicSchedulePolicyUid, orgID, ctx)
+			dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation of periodic schedule policy of interval [%v] minutes named [%s] ", periodicSchedulePolicyInterval, periodicSchedulePolicyName))
+
+		})
+
+		Step("Taking manual backup of namespaces with rules", func() {
+			log.InfoD(fmt.Sprintf("Taking manual backup of namespaces with rules"))
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			for _, namespace := range bkpNamespaces {
+				backupName = fmt.Sprintf("%s-%v", BackupNamePrefix, time.Now().Unix())
+				appContextsToBackup := FilterAppContextsByNamespace(scheduledAppContexts, []string{namespace})
+				err = CreateBackupWithValidation(ctx, backupName, SourceClusterName, bkpLocationName, backupLocationUID, appContextsToBackup, labelSelectors, orgID, clusterUid, preRuleName, preRuleUid, postRuleName, postRuleUid)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Creation and Validation of backup [%s]", backupName))
+				backupNames = append(backupNames, backupName)
+				backupNamespaceMap[backupName] = namespace
+			}
+		})
+
+		Step("Taking schedule backup of namespaces with rules", func() {
+			log.InfoD(fmt.Sprintf("Taking schedule backup of namespaces with rules"))
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			for _, namespace := range bkpNamespaces {
+				scheduleName := fmt.Sprintf("%s-schedule-with-rules-%s", BackupNamePrefix, RandomString(4))
+				log.InfoD("Creating a schedule backup of namespace [%s] without pre and post exec rules", namespace)
+				appContextsToBackup := FilterAppContextsByNamespace(scheduledAppContexts, []string{namespace})
+				scheduleBackupName, err := CreateScheduleBackupWithValidation(ctx, scheduleName, SourceClusterName, bkpLocationName, backupLocationUID, appContextsToBackup,
+					labelSelectors, orgID, "", "", "", "", periodicSchedulePolicyName, periodicSchedulePolicyUid)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation of backup [%s]", scheduleBackupName))
+				err = suspendBackupSchedule(scheduleName, periodicSchedulePolicyName, orgID, ctx)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Suspending Backup Schedule [%s] ", scheduleName))
+				backupNames = append(backupNames, scheduleBackupName)
+				scheduleNames = append(scheduleNames, scheduleName)
+				backupNamespaceMap[scheduleBackupName] = namespace
+			}
+		})
+
+		Step("Taking restore of backups created", func() {
+			log.InfoD("Taking restore of backups created")
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+
+			restoreSingleNSBackupInVariousWaysTask := func(index int, backupName string) {
+				restoreConfigs := []struct {
+					namePrefix          string
+					namespaceMapping    map[string]string
+					storageClassMapping map[string]string
+					replacePolicy       ReplacePolicyType
+				}{
+					{
+						"test-custom-restore-single-ns",
+						map[string]string{backupNamespaceMap[backupName]: fmt.Sprintf("custom1-%s-%d", backupNamespaceMap[backupName], index)},
+						make(map[string]string, 0),
+						ReplacePolicyRetain,
+					},
+					{
+						"test-replace-restore-single-ns",
+						map[string]string{backupNamespaceMap[backupName]: fmt.Sprintf("custom1-rep-%s-%d", backupNamespaceMap[backupName], index)},
+						make(map[string]string, 0),
+						ReplacePolicyDelete,
+					},
+				}
+				for _, config := range restoreConfigs {
+					restoreName := fmt.Sprintf("%s-%s", config.namePrefix, RandomString(4))
+					log.InfoD("Restoring backup [%s] in cluster [%s] with restore [%s] and namespace mapping %v", backupName, destinationClusterName, restoreName, config.namespaceMapping)
+					if config.replacePolicy == ReplacePolicyRetain {
+						appContextsToBackup := FilterAppContextsByNamespace(scheduledAppContexts, []string{backupNamespaceMap[backupName]})
+						restoredNamespaces = append(restoredNamespaces, config.namespaceMapping[backupNamespaceMap[backupName]])
+						err = CreateRestoreWithValidation(ctx, restoreName, backupName, config.namespaceMapping, config.storageClassMapping, destinationClusterName, orgID, appContextsToBackup)
+					} else if config.replacePolicy == ReplacePolicyDelete {
+						restoredNamespaces = append(restoredNamespaces, config.namespaceMapping[backupNamespaceMap[backupName]])
+						err = CreateRestoreWithReplacePolicy(restoreName, backupName, config.namespaceMapping, destinationClusterName, orgID, ctx, config.storageClassMapping, config.replacePolicy)
+					}
+					dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying restoration [%s] of single namespace backup [%s] in cluster", restoreName, backupName))
+					restoreNames = SafeAppend(&mutex, restoreNames, restoreName).([]string)
+				}
+			}
+			_ = TaskHandler(backupNames, restoreSingleNSBackupInVariousWaysTask, Sequential)
+		})
+
+		Step("List files and directories from the mount path after restore and verify excluded items are not present,iteration 1", func() {
+			log.InfoD("List files and directories from the mount path after restore and verify excluded items are not present,iteration 1")
+
+			defer func() {
+				err := SetSourceKubeConfig()
+				log.FailOnError(err, "Unable to switch context to source cluster [%s]", SourceClusterName)
+			}()
+
+			err := SetDestinationKubeConfig()
+			log.FailOnError(err, "Switching context to destination cluster failed")
+
+			for _, restoredNamespace := range restoredNamespaces {
+				pods, err := core.Instance().GetPods(restoredNamespace, nil)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("getting pods from namespace [%s] ", restoredNamespace))
+				for _, pod := range pods.Items {
+					log.Infof(fmt.Sprintf("verfiying the files and directories for pod [%s] in restored namespace [%s] ", pod.Name, restoredNamespace))
+					containerMountPathList := make([]string, 0)
+					containerPaths := schedops.GetContainerPVCMountMap(pod)
+					if len(containerPaths) > 0 {
+						for containerName, paths := range containerPaths {
+							log.Infof(fmt.Sprintf("containerName:%s,paths: %s ", containerName, paths))
+							containerMountPathList = append(containerMountPathList, paths...)
+						}
+
+						log.Infof(fmt.Sprintf("the list of mountPath within pod [%v] are [%v]", pod.Name, containerMountPathList))
+						for _, containerMountPath := range containerMountPathList {
+							restoredCombinedList := make([]string, 0)
+							fileList, dirList, err := FetchFilesAndDirectoriesFromPod(pod, containerMountPath, existingFileDirMountPathMap[containerMountPath])
+							dash.VerifyFatal(err, nil, fmt.Sprintf("fetching files and directory from mountpath [%s] for pod [%s]", containerMountPath, pod.Name))
+							log.Infof(fmt.Sprintf("The list of files created in mountPath [%v] for pod [%v]: %v", containerMountPath, pod.Name, fileList))
+							log.Infof(fmt.Sprintf("The list of directories created in mountPath [%v] for pod [%v]: %v", containerMountPath, pod.Name, dirList))
+							restoredCombinedList = append(restoredCombinedList, fileList...)
+							restoredCombinedList = append(restoredCombinedList, dirList...)
+							log.Infof(fmt.Sprintf("the list of combined directories and files after restore: %v", restoredCombinedList))
+							for _, item := range mountPathExcludeFileDirMap[containerMountPath] {
+								if item != "" {
+									if !IsPresent(restoredCombinedList, item) {
+										log.Infof(fmt.Sprintf("the item file/directory [%s] is not present in the mountPath[%s] for pod [%s] in namespace [%s]", item, containerMountPath, pod.Name, restoredNamespace))
+									} else {
+										err := fmt.Errorf("the item file/directory[%s] is still present in mountPath [%s] for pod [%s] in namespace [%s]", item, containerMountPath, pod.Name, restoredNamespace)
+										dash.VerifyFatal(err, nil, fmt.Sprintf("%v", err))
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		})
+
+		Step("Create second iteration of nested directories and files into container mountPath for applications", func() {
+			log.InfoD("Create second iteration of  nested directories and files into container mountPath for applications")
+			for _, namespace := range bkpNamespaces {
+				pods, err := core.Instance().GetPods(namespace, nil)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("getting pods from namespace [%s] ", namespace))
+				for _, pod := range pods.Items {
+					if len(podMountPathMap[pod.Name]) > 0 {
+						for _, mountPath := range podMountPathMap[pod.Name] {
+							// Creating a PodDirectoryConfig object with test values
+							DirectoryConfig := PodDirectoryConfig{
+								BasePath:          mountPath,
+								Depth:             20,
+								Levels:            2,
+								FilesPerDirectory: 50,
+							}
+							log.Infof(fmt.Sprintf("creating nested directories and files within mountPath [%s] with depth [%d] , level [%d] and FilesPerDirectory [%d]", DirectoryConfig.BasePath, DirectoryConfig.Depth, DirectoryConfig.Levels, DirectoryConfig.FilesPerDirectory))
+							err = CreateNestedDirectoriesWithFilesInPod(pod, DirectoryConfig)
+							dash.VerifyFatal(err, nil, fmt.Sprintf("creating nested directories and files at mountpath [%v] for pod [%v] in namespace [%v]", mountPath, pod.Name, pod.Namespace))
+							log.Infof(fmt.Sprintf("Fetching files and directories from path [%s] by excluding existing directories", DirectoryConfig.BasePath))
+							fileList, dirList, err := FetchFilesAndDirectoriesFromPod(pod, mountPath, append(existingFileDirMountPathMap[mountPath], masterDirFileList[mountPath]...))
+							dash.VerifyFatal(err, nil, fmt.Sprintf("fetching files and directory from mountpath [%s] for pod [%s]", mountPath, pod.Name))
+							log.Infof(fmt.Sprintf("the list of files created in mountPath [%v] for pod [%v]: %v", mountPath, pod.Name, fileList))
+							log.Infof(fmt.Sprintf("the list of directories created in mountPath [%v] for pod [%v]: %v", mountPath, pod.Name, dirList))
+							fileListMountMap[mountPath] = fileList
+							dirListMountMap[mountPath] = dirList
+							masterDirFileList[mountPath] = append(masterDirFileList[mountPath], fileList...)
+							masterDirFileList[mountPath] = append(masterDirFileList[mountPath], dirList...)
+						}
+					}
+				}
+			}
+		})
+
+		Step("Update KDMP config map by selecting random files and directories from the second iternation", func() {
+			log.InfoD("Update KDMP config map by selecting random files and directories from the second iternation")
+			for _, namespace := range bkpNamespaces {
+				pods, err := core.Instance().GetPods(namespace, nil)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("getting pods from namespace [%s] ", namespace))
+				for _, pod := range pods.Items {
+					if len(podMountPathMap[pod.Name]) > 0 {
+						for _, mountPath := range podMountPathMap[pod.Name] {
+							excludeFileDirList := make([]string, 0)
+							log.Infof(fmt.Sprintf("Fetch some random directories from created list %v", dirListMountMap[mountPath]))
+							randomDirs, err := GetRandomSubset(dirListMountMap[mountPath], 10)
+							dash.VerifyFatal(err, nil, fmt.Sprintf("Getting random directories from the list"))
+							log.Infof(fmt.Sprintf("the list of directories randomly selected from mountPath- %v : %v", mountPath, randomDirs))
+							log.Infof(fmt.Sprintf("Fetch some random files from created list %v", fileListMountMap[mountPath]))
+							randomFiles, err := GetRandomSubset(fileListMountMap[mountPath], 5)
+							dash.VerifyFatal(err, nil, fmt.Sprintf("Getting random files from the list"))
+							log.Infof(fmt.Sprintf("the list of files randomly selected from mountPath- %v : %v", mountPath, randomFiles))
+							excludeFileDirList = append(excludeFileDirList, randomDirs...)
+							excludeFileDirList = append(excludeFileDirList, randomFiles...)
+							scName := scMountPathMap[mountPath]
+							storageClassExcludeFileDirMap[scName] = append(storageClassExcludeFileDirMap[scName], excludeFileDirList...)
+							mountPathExcludeFileDirMap[mountPath] = append(mountPathExcludeFileDirMap[mountPath], excludeFileDirList...)
+						}
+					}
+				}
+			}
+			log.Infof(fmt.Sprintf("create new formatted string with storage class name and exclude file ,directories list [%v]", storageClassExcludeFileDirMap))
+			formattedFileString = GenerateStorageClassFormattedString(storageClassExcludeFileDirMap)
+			err := UpdateKDMPConfigMap("KDMP_EXCLUDE_FILE_LIST", formattedFileString)
+			dash.VerifyFatal(err, nil, fmt.Sprintf("updating KDMP config map"))
+		})
+
+		Step("Taking manual backup of namespaces with rules ,iteration 2", func() {
+			log.InfoD(fmt.Sprintf("Taking manual backup of namespaces with rules, iteration 2"))
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			backupNames := make([]string, 0)
+			for _, namespace := range bkpNamespaces {
+				backupName = fmt.Sprintf("%s-%v", BackupNamePrefix, time.Now().Unix())
+				appContextsToBackup := FilterAppContextsByNamespace(scheduledAppContexts, []string{namespace})
+				err = CreateBackupWithValidation(ctx, backupName, SourceClusterName, bkpLocationName, backupLocationUID, appContextsToBackup, labelSelectors, orgID, clusterUid, preRuleName, preRuleUid, postRuleName, postRuleUid)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Creation and Validation of backup [%s]", backupName))
+				backupNames = append(backupNames, backupName)
+				backupNamespaceMap[backupName] = namespace
+			}
+		})
+
+		Step("Taking restore of backups after ,iteration 2", func() {
+			log.InfoD("Taking restore of backups after ,iteration 2")
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			restoredNamespaces = make([]string, 0)
+			for _, backupName := range backupNames {
+				appContextsToBackup := FilterAppContextsByNamespace(scheduledAppContexts, []string{backupNamespaceMap[backupName]})
+				restoreName = fmt.Sprintf("%s-%v", RestoreNamePrefix, time.Now().Unix())
+				restoreNamespace := "custom2-" + backupNamespaceMap[backupName]
+				namespaceMapping := map[string]string{backupNamespaceMap[backupName]: restoreNamespace}
+				restoredNamespaces = append(restoredNamespaces, restoreNamespace)
+				err = CreateRestoreWithValidation(ctx, restoreName, backupName, namespaceMapping, make(map[string]string), destinationClusterName, orgID, appContextsToBackup)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Creating restore [%s]", restoreName))
+				restoreNames = append(restoreNames, restoreName)
+			}
+		})
+
+		Step("List files and directories from the mount path after restore and verify excluded items are not present ,iteration 2", func() {
+			log.InfoD("List files and directories from the mount path after restore and verify excluded items are not present ,iteration 2")
+
+			defer func() {
+				err := SetSourceKubeConfig()
+				log.FailOnError(err, "Unable to switch context to source cluster [%s]", SourceClusterName)
+			}()
+
+			err := SetDestinationKubeConfig()
+			log.FailOnError(err, "Switching context to destination cluster failed")
+
+			for _, restoredNamespace := range restoredNamespaces {
+				pods, err := core.Instance().GetPods(restoredNamespace, nil)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("getting pods from namespace [%s] ", restoredNamespace))
+				for _, pod := range pods.Items {
+					log.Infof(fmt.Sprintf("verfiying the files and directories for pod [%s] in restored namespace [%s] ", pod.Name, restoredNamespace))
+					containerMountPathList := make([]string, 0)
+					containerPaths := schedops.GetContainerPVCMountMap(pod)
+					if len(containerPaths) > 0 {
+						for containerName, paths := range containerPaths {
+							log.Infof(fmt.Sprintf("containerName:%s,paths: %s ", containerName, paths))
+							containerMountPathList = append(containerMountPathList, paths...)
+						}
+
+						log.Infof(fmt.Sprintf("the list of mountPath within pod [%v] are [%v]", pod.Name, containerMountPathList))
+						for _, containerMountPath := range containerMountPathList {
+							restoredCombinedList := make([]string, 0)
+							fileList, dirList, err := FetchFilesAndDirectoriesFromPod(pod, containerMountPath, existingFileDirMountPathMap[containerMountPath])
+							dash.VerifyFatal(err, nil, fmt.Sprintf("fetching files and directory from mountpath [%s] for pod [%s]", containerMountPath, pod.Name))
+							log.Infof(fmt.Sprintf("The list of files created in mountPath [%v] for pod [%v]: %v", containerMountPath, pod.Name, fileList))
+							log.Infof(fmt.Sprintf("The list of directories created in mountPath [%v] for pod [%v]: %v", containerMountPath, pod.Name, dirList))
+							restoredCombinedList = append(restoredCombinedList, fileList...)
+							restoredCombinedList = append(restoredCombinedList, dirList...)
+							log.Infof(fmt.Sprintf("the list of combined directories and files after restore: %v", restoredCombinedList))
+							for _, item := range mountPathExcludeFileDirMap[containerMountPath] {
+								if item != "" {
+									if !IsPresent(restoredCombinedList, item) {
+										log.Infof(fmt.Sprintf("the item(file/directory) [%s] is not present in the mountPath[%s] for pod [%s] in namespace [%s]", item, containerMountPath, pod.Name, restoredNamespace))
+									} else {
+										err := fmt.Errorf("the item(file/directory) [%s] is still present in mountPath [%s] for pod [%s] in namespace [%s]", item, containerMountPath, pod.Name, restoredNamespace)
+										dash.VerifyFatal(err, nil, fmt.Sprintf("%v", err))
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		})
+
+		Step("Update KDMP config map to not exclude any files or directories", func() {
+			log.InfoD("Update KDMP config map to not exclude any files or directories")
+			log.Infof(fmt.Sprintf("upating KDMP_EXCLUDE_FILE_LIST to nil"))
+			formattedFileString = ""
+			err := UpdateKDMPConfigMap("KDMP_EXCLUDE_FILE_LIST", formattedFileString)
+			dash.VerifyFatal(err, nil, fmt.Sprintf("updating KDMP config map"))
+		})
+
+		Step("Taking manual backup of namespaces with rules without excluding any files or directories", func() {
+			log.InfoD(fmt.Sprintf("Taking manual backup of namespaces with rules without excluding any files or directories"))
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			backupNames = make([]string, 0)
+			for _, namespace := range bkpNamespaces {
+				backupName = fmt.Sprintf("%s-%v", BackupNamePrefix, time.Now().Unix())
+				appContextsToBackup := FilterAppContextsByNamespace(scheduledAppContexts, []string{namespace})
+				err = CreateBackupWithValidation(ctx, backupName, SourceClusterName, bkpLocationName, backupLocationUID, appContextsToBackup, labelSelectors, orgID, clusterUid, preRuleName, preRuleUid, postRuleName, postRuleUid)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Creation and Validation of backup [%s]", backupName))
+				backupNames = append(backupNames, backupName)
+				backupNamespaceMap[backupName] = namespace
+			}
+		})
+
+		Step("Taking restore of backups without excluding any files or directories", func() {
+			log.InfoD("Taking restore of backups without excluding any files or directories")
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			restoredNamespaces = make([]string, 0)
+			for _, backupName := range backupNames {
+				appContextsToBackup := FilterAppContextsByNamespace(scheduledAppContexts, []string{backupNamespaceMap[backupName]})
+				restoreName = fmt.Sprintf("%s-%v", RestoreNamePrefix, time.Now().Unix())
+				restoreNamespace := "custom3-" + backupNamespaceMap[backupName]
+				namespaceMapping := map[string]string{backupNamespaceMap[backupName]: restoreNamespace}
+				restoredNamespaces = append(restoredNamespaces, restoreNamespace)
+				err = CreateRestoreWithValidation(ctx, restoreName, backupName, namespaceMapping, make(map[string]string), destinationClusterName, orgID, appContextsToBackup)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Creating restore [%s]", restoreName))
+				restoreNames = append(restoreNames, restoreName)
+			}
+		})
+
+		Step("List files and directories from the mount path after restore and verify all files and directories are present", func() {
+			log.InfoD("List files and directories from the mount path after restore and verify all files and directories are present")
+
+			defer func() {
+				err := SetSourceKubeConfig()
+				log.FailOnError(err, "Unable to switch context to source cluster [%s]", SourceClusterName)
+			}()
+
+			err := SetDestinationKubeConfig()
+			log.FailOnError(err, "Switching context to destination cluster failed")
+
+			for _, restoredNamespace := range restoredNamespaces {
+				pods, err := core.Instance().GetPods(restoredNamespace, nil)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("getting pods from namespace [%s] ", restoredNamespace))
+				for _, pod := range pods.Items {
+					log.Infof(fmt.Sprintf("verfiying all the files and directories created above for pod [%s] in restored namespace [%s] ", pod.Name, restoredNamespace))
+					containerMountPathList := make([]string, 0)
+					containerPaths := schedops.GetContainerPVCMountMap(pod)
+					if len(containerPaths) > 0 {
+						for containerName, paths := range containerPaths {
+							log.Infof(fmt.Sprintf("containerName:%s,paths: %s ", containerName, paths))
+							containerMountPathList = append(containerMountPathList, paths...)
+						}
+
+						log.Infof(fmt.Sprintf("the list of mountPath within pod [%v] are [%v]", pod.Name, containerMountPathList))
+						for _, containerMountPath := range containerMountPathList {
+							restoredCombinedList := make([]string, 0)
+							fileList, dirList, err := FetchFilesAndDirectoriesFromPod(pod, containerMountPath, existingFileDirMountPathMap[containerMountPath])
+							dash.VerifyFatal(err, nil, fmt.Sprintf("fetching files and directory from mountpath [%s] for pod [%s]", containerMountPath, pod.Name))
+							log.Infof(fmt.Sprintf("The list of files created in mountPath [%v] for pod [%v]: %v", containerMountPath, pod.Name, fileList))
+							log.Infof(fmt.Sprintf("The list of directories created in mountPath [%v] for pod [%v]: %v", containerMountPath, pod.Name, dirList))
+							restoredCombinedList = append(restoredCombinedList, fileList...)
+							restoredCombinedList = append(restoredCombinedList, dirList...)
+							log.Infof(fmt.Sprintf("the list of combined directories and files after restore: %v", restoredCombinedList))
+							for _, item := range masterDirFileList[containerMountPath] {
+								if item != "" {
+									if !IsPresent(restoredCombinedList, item) {
+										err := fmt.Errorf("item(file/directory) [%s] is not present in mountPath [%s] for pod [%s] in namespace [%s]", item, containerMountPath, pod.Name, restoredNamespace)
+										dash.VerifyFatal(err, nil, fmt.Sprintf("%v", err))
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		})
+
+	})
+	JustAfterEach(func() {
+		defer EndPxBackupTorpedoTest(scheduledAppContexts)
+		ctx, err := backup.GetAdminCtxFromSecret()
+		log.FailOnError(err, "Fetching px-central-admin ctx")
+
+		opts := make(map[string]bool)
+		opts[SkipClusterScopedObjects] = true
+		log.InfoD("Deleting deployed applications")
+		DestroyApps(scheduledAppContexts, opts)
+
+		backupNames, err := GetAllBackupsAdmin()
+		dash.VerifySafely(err, nil, fmt.Sprintf("Fetching all backups for admin"))
+		for _, backupName := range backupNames {
+			wg.Add(1)
+			go func(backupName string) {
+				defer GinkgoRecover()
+				defer wg.Done()
+				backupUid, err := Inst().Backup.GetBackupUID(ctx, backupName, orgID)
+				_, err = DeleteBackup(backupName, backupUid, orgID, ctx)
+				log.FailOnError(err, "Failed to delete the backup %s ", backupName)
+				err = DeleteBackupAndWait(backupName, ctx)
+				log.FailOnError(err, fmt.Sprintf("waiting for backup [%s] deletion", backupName))
+			}(backupName)
+		}
+		wg.Wait()
+		for _, restoreName := range restoreNames {
+			err = DeleteRestore(restoreName, orgID, ctx)
+			dash.VerifySafely(err, nil, fmt.Sprintf("Deleting restore [%s]", restoreName))
+		}
+
+		for _, scheduleName := range scheduleNames {
+			err = DeleteSchedule(scheduleName, SourceClusterName, orgID, ctx)
+			dash.VerifySafely(err, nil, fmt.Sprintf("Deleting schedule [%s]", scheduleName))
+		}
+
+		CleanupCloudSettingsAndClusters(backupLocationMap, cloudCredName, cloudCredUID, ctx)
+	})
+})

--- a/tests/common.go
+++ b/tests/common.go
@@ -10048,3 +10048,18 @@ func GetKubevirtVersionToUpgrade() string {
 	}
 	return LatestKubevirtVersion
 }
+
+// GetRandomSubset generates a random subset of elements from a given list.
+func GetRandomSubset(elements []string, subsetSize int) ([]string, error) {
+	if subsetSize > len(elements) {
+		return nil, fmt.Errorf("subset size exceeds the length of the input list")
+	}
+
+	shuffledElements := make([]string, len(elements))
+	copy(shuffledElements, elements)
+	rand.Shuffle(len(shuffledElements), func(i, j int) {
+		shuffledElements[i], shuffledElements[j] = shuffledElements[j], shuffledElements[i]
+	})
+
+	return shuffledElements[:subsetSize], nil
+}

--- a/vendor/github.com/portworx/sched-ops/k8s/kubevirt/virtualmachine.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/kubevirt/virtualmachine.go
@@ -15,6 +15,8 @@ type VirtualMachineOps interface {
 	CreateVirtualMachine(*kubevirtv1.VirtualMachine) (*kubevirtv1.VirtualMachine, error)
 	// ListVirtualMachines List Kubevirt VirtualMachine in given namespace
 	ListVirtualMachines(namespace string) (*kubevirtv1.VirtualMachineList, error)
+	// BatchListVirtualMachines List Kubevirt VirtualMachine in given namespace in batches
+	BatchListVirtualMachines(namespace string, listOptions *k8smetav1.ListOptions) (*kubevirtv1.VirtualMachineList, error)
 	// ValidateVirtualMachineRunning check if VirtualMachine is running, if not
 	// start VirtualMachine and wait for it get started.
 	ValidateVirtualMachineRunning(string, string, time.Duration, time.Duration) error
@@ -28,6 +30,16 @@ type VirtualMachineOps interface {
 	StopVirtualMachine(*kubevirtv1.VirtualMachine) error
 	// RestartVirtualMachine restarts VirtualMachine
 	RestartVirtualMachine(*kubevirtv1.VirtualMachine) error
+	// GetVMDataVolumes returns DataVolumes used by the VM
+	GetVMDataVolumes(vm *kubevirtv1.VirtualMachine) []string
+	// GetVMPersistentVolumeClaims returns persistentVolumeClaim names used by the VMs
+	GetVMPersistentVolumeClaims(vm *kubevirtv1.VirtualMachine) []string
+	// GetVMSecrets returns references to secrets in all supported formats of VM configs
+	GetVMSecrets(vm *kubevirtv1.VirtualMachine) []string
+	// GetVMConfigMaps returns ConfigMaps referenced in the VirtualMachine.
+	GetVMConfigMaps(*kubevirtv1.VirtualMachine) []string
+	//IsVirtualMachineRunning returns true if virtualMachine is in running state
+	IsVirtualMachineRunning(*kubevirtv1.VirtualMachine) bool
 }
 
 // ListVirtualMachines List Kubevirt VirtualMachine in given namespace
@@ -37,6 +49,15 @@ func (c *Client) ListVirtualMachines(namespace string) (*kubevirtv1.VirtualMachi
 	}
 
 	return c.kubevirt.VirtualMachine(namespace).List(&k8smetav1.ListOptions{})
+}
+
+// BatchListVirtualMachines List Kubevirt VirtualMachine in given namespace
+func (c *Client) BatchListVirtualMachines(namespace string, listOptions *k8smetav1.ListOptions) (*kubevirtv1.VirtualMachineList, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	return c.kubevirt.VirtualMachine(namespace).List(listOptions)
 }
 
 // CreateVirtualMachine calls VirtualMachine create client method
@@ -130,4 +151,102 @@ func (c *Client) RestartVirtualMachine(vm *kubevirtv1.VirtualMachine) error {
 		return err
 	}
 	return c.kubevirt.VirtualMachine(vm.GetNamespace()).Restart(vm.GetName(), &kubevirtv1.RestartOptions{})
+}
+
+// IsVirtualMachineRunning returns true if virtualMachine is in running state
+func (c *Client) IsVirtualMachineRunning(vm *kubevirtv1.VirtualMachine) bool {
+	if err := c.initClient(); err != nil {
+		return false
+	}
+	if vm.Status.PrintableStatus == kubevirtv1.VirtualMachineStatusRunning {
+		return true
+	}
+	return false
+
+}
+
+// GetVMDataVolumes returns DataVolumes used by the VM
+func (c *Client) GetVMDataVolumes(vm *kubevirtv1.VirtualMachine) []string {
+	volList := vm.Spec.Template.Spec.Volumes
+	dvList := make([]string, 0)
+	for _, vol := range volList {
+		if vol.VolumeSource.DataVolume != nil {
+			dvList = append(dvList, vol.VolumeSource.DataVolume.Name)
+		}
+	}
+	return dvList
+}
+
+// GetVMPersistentVolumeClaims returns persistentVolumeClaim names used by the VMs
+func (c *Client) GetVMPersistentVolumeClaims(vm *kubevirtv1.VirtualMachine) []string {
+	volList := vm.Spec.Template.Spec.Volumes
+	PVCList := make([]string, 0)
+	for _, vol := range volList {
+		if vol.VolumeSource.PersistentVolumeClaim != nil {
+			PVCList = append(PVCList, vol.VolumeSource.PersistentVolumeClaim.ClaimName)
+		}
+	}
+	return PVCList
+}
+
+// GetVMSecrets returns references to secrets in all supported formats of VM configs
+func (c *Client) GetVMSecrets(vm *kubevirtv1.VirtualMachine) []string {
+	volList := vm.Spec.Template.Spec.Volumes
+	secretList := make([]string, 0)
+	for _, vol := range volList {
+		// secret as VolumeType
+		if vol.VolumeSource.Secret != nil {
+			secretList = append(secretList, vol.Secret.SecretName)
+		}
+		// Secret reference as sysprep
+		if vol.VolumeSource.Sysprep != nil {
+			if vol.VolumeSource.Sysprep.Secret != nil {
+				secretList = append(secretList, vol.VolumeSource.Sysprep.Secret.Name)
+			}
+		}
+		if vol.VolumeSource.CloudInitNoCloud != nil {
+			cloudInitNoCloud := vol.VolumeSource.CloudInitNoCloud
+			// secret as NetworkDataSecretRef
+			if cloudInitNoCloud.NetworkDataSecretRef != nil {
+				secretList = append(secretList, cloudInitNoCloud.NetworkDataSecretRef.Name)
+			}
+			// secret as UserDataSecretRef
+			if cloudInitNoCloud.UserDataSecretRef != nil {
+				secretList = append(secretList, cloudInitNoCloud.UserDataSecretRef.Name)
+			}
+		}
+		if vol.VolumeSource.CloudInitConfigDrive != nil {
+			cloudInitConfigDrive := vol.VolumeSource.CloudInitConfigDrive
+			// Secret from configDrive for NetworkData
+			if cloudInitConfigDrive.NetworkDataSecretRef != nil {
+				secretList = append(secretList, cloudInitConfigDrive.NetworkDataSecretRef.Name)
+			}
+			// Secret from confifDrive aka Ignition
+			if cloudInitConfigDrive.UserDataSecretRef != nil {
+				secretList = append(secretList, cloudInitConfigDrive.UserDataSecretRef.Name)
+			}
+
+		}
+	}
+	return secretList
+}
+
+// GetVMConfigMaps returns ConfigMaps referenced in the VirtualMachine.
+func (c *Client) GetVMConfigMaps(vm *kubevirtv1.VirtualMachine) []string {
+	volList := vm.Spec.Template.Spec.Volumes
+	configMaps := make([]string, 0)
+	for _, vol := range volList {
+		// ConfigMap as volumeType
+		if vol.ConfigMap != nil {
+			configMaps = append(configMaps, vol.ConfigMap.Name)
+		}
+		// configMap reference in sysprep
+		if vol.VolumeSource.Sysprep != nil {
+			if vol.VolumeSource.Sysprep.ConfigMap != nil {
+				configMaps = append(configMaps, vol.VolumeSource.Sysprep.ConfigMap.Name)
+			}
+		}
+
+	}
+	return configMaps
 }

--- a/vendor/github.com/portworx/sched-ops/k8s/storage/storageclass.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/storage/storageclass.go
@@ -10,9 +10,12 @@ import (
 
 // ScOps is an interface to perform k8s storage class operations
 type ScOps interface {
+	// GetAllStorageClasses returns all storageClasses
+	// Added this function since GetStorageClasses method was failing to list the Storage Classes when an empty label selector is passed
+	GetAllStorageClasses() (*storagev1.StorageClassList, error)
 	// GetStorageClasses returns all storageClasses that match given optional label selector
 	GetStorageClasses(labelSelector map[string]string) (*storagev1.StorageClassList, error)
-	// GetStorageClass returns the storage class for the give namme
+	// GetStorageClass returns the storage class for the give name
 	GetStorageClass(name string) (*storagev1.StorageClass, error)
 	// GetDefaultStorageClasses returns all storageClasses that are set as default
 	GetDefaultStorageClasses() (*storagev1.StorageClassList, error)
@@ -127,4 +130,13 @@ func (c *Client) AnnotateStorageClassAsDefault(name string) error {
 		return err
 	}
 	return nil
+}
+
+// GetAllStorageClasses returns all storageClasses
+// Added this function since GetStorageClasses method was failing to list the Storage Classes when an empty label selector is passed
+func (c *Client) GetAllStorageClasses() (*storagev1.StorageClassList, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.storage.StorageClasses().List(context.TODO(), metav1.ListOptions{})
 }

--- a/vendor/github.com/portworx/sched-ops/k8s/storage/storageclass.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/storage/storageclass.go
@@ -10,6 +10,8 @@ import (
 
 // ScOps is an interface to perform k8s storage class operations
 type ScOps interface {
+	// GetAllStorageClasses returns all storageClasses.
+	GetAllStorageClasses() (*storagev1.StorageClassList, error)
 	// GetStorageClasses returns all storageClasses that match given optional label selector
 	GetStorageClasses(labelSelector map[string]string) (*storagev1.StorageClassList, error)
 	// GetStorageClass returns the storage class for the give namme
@@ -33,6 +35,14 @@ type ScOps interface {
 const (
 	defaultStorageclassAnnotationKey = "storageclass.kubernetes.io/is-default-class"
 )
+
+// GetAllStorageClasses returns all storageClasses.
+func (c *Client) GetAllStorageClasses() (*storagev1.StorageClassList, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.storage.StorageClasses().List(context.TODO(), metav1.ListOptions{})
+}
 
 // GetStorageClasses returns all storageClasses that match given optional label selector
 func (c *Client) GetStorageClasses(labelSelector map[string]string) (*storagev1.StorageClassList, error) {

--- a/vendor/github.com/portworx/sched-ops/k8s/storage/storageclass.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/storage/storageclass.go
@@ -10,8 +10,6 @@ import (
 
 // ScOps is an interface to perform k8s storage class operations
 type ScOps interface {
-	// GetAllStorageClasses returns all storageClasses.
-	GetAllStorageClasses() (*storagev1.StorageClassList, error)
 	// GetStorageClasses returns all storageClasses that match given optional label selector
 	GetStorageClasses(labelSelector map[string]string) (*storagev1.StorageClassList, error)
 	// GetStorageClass returns the storage class for the give namme
@@ -35,14 +33,6 @@ type ScOps interface {
 const (
 	defaultStorageclassAnnotationKey = "storageclass.kubernetes.io/is-default-class"
 )
-
-// GetAllStorageClasses returns all storageClasses.
-func (c *Client) GetAllStorageClasses() (*storagev1.StorageClassList, error) {
-	if err := c.initClient(); err != nil {
-		return nil, err
-	}
-	return c.storage.StorageClasses().List(context.TODO(), metav1.ListOptions{})
-}
 
 // GetStorageClasses returns all storageClasses that match given optional label selector
 func (c *Client) GetStorageClasses(labelSelector map[string]string) (*storagev1.StorageClassList, error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1166,7 +1166,7 @@ github.com/portworx/pds-api-go-client/pds/v1alpha1
 github.com/portworx/px-backup-api/pkg/apis/v1
 github.com/portworx/px-backup-api/pkg/kubeauth
 github.com/portworx/px-backup-api/pkg/kubeauth/gcp
-# github.com/portworx/sched-ops v1.20.4-rc1.0.20231109202231-f601f9891b01
+# github.com/portworx/sched-ops v1.20.4-rc1.0.20231212125252-c5df9b72ebe8
 ## explicit; go 1.19
 github.com/portworx/sched-ops/k8s/admissionregistration
 github.com/portworx/sched-ops/k8s/apiextensions


### PR DESCRIPTION
**What this PR does / why we need it**:
Added Following helper methods for automating system tests related to (.snapshot) directory fix going in stork 23.9.1. 
Added new system test **ExcludeDirectoryFileBackup.**

**In backup_helper.go.**
FetchFilesAndDirectoriesFromPod
generateStorageClassFormattedString
getRandomSubset
CreateFilesInPodDirectory
createDirectoryInPod
CreateDirectoryStructureInPod
CreateNestedDirectoriesWithFilesInPod
UpdateKDMPConfigMap

**in k8s-schedops.go**
GetContainerPVCMountMapWithSC


**Which issue(s) this PR fixes** (optional)
Closes #PB-4916
PB-4917
PB-4918
PB-5004
PB-4919
**Special notes for your reviewer**:


Tested log:

https://jenkins.pwx.dev.purestorage.com/job/Users/job/Adilk/job/kdmp-byoc/2/consoleFull

100*100 , 10k files.  Total 30k files after second iterations.
https://jenkins.pwx.dev.purestorage.com/job/Users/job/Adilk/job/kdmp-byoc/4/consoleFull
