### PR TITLE
PWX-35134: Fixed faulty SCSI serials in volume path check

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -1800,7 +1800,7 @@ func GetSerialFromWWID(wwid string) (string, error) {
 		return strings.ToLower(fmt.Sprintf("%s%s", wwid[6:20], wwid[26:36])), nil
 	}
 	// SCSI
-	return strings.TrimPrefix(strings.ToLower(wwid), "36"+schedops.PureVolumeOUI), nil
+	return strings.TrimPrefix(strings.ToLower(wwid), fmt.Sprintf("36%s0", schedops.PureVolumeOUI)), nil
 }
 
 func parseLsblkOutput(out string) (map[string]pureLocalPathEntry, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This is one of those "I don't know how it worked before" things - we were not trimming off quite enough of the path so we ended up with the serial having an extra zero at the beginning. The bug reproed locally immediately and this fix prevented it on most nodes (I believe I had an unrelated issue as well, still investigating, but this is required for sure).

