### PR TITLE
Fixed backup deletion wait logic.

### DIFF
--- a/tests/backup/backup_orphaned_test.go
+++ b/tests/backup/backup_orphaned_test.go
@@ -278,13 +278,6 @@ var _ = Describe("{DeleteSameNameObjectsByMultipleUsersFromAdmin}", func() {
 					log.FailOnError(err, "failed to delete backup %s of the user %s", backupName, user)
 				}
 			})
-			Step(fmt.Sprintf("Delete user %s restores from the admin", user), func() {
-				log.InfoD(fmt.Sprintf("Deleting user %s restores from the admin", user))
-				for restoreUid, restoreName := range userRestoreMap[user] {
-					err = DeleteRestoreWithUID(restoreName, restoreUid, orgID, ctx)
-					log.FailOnError(err, "failed to delete restore %s of the user %s", restoreName, user)
-				}
-			})
 			Step(fmt.Sprintf("Wait for the backups and backup schedule to be deleted"), func() {
 				log.InfoD("Waiting for the backups and backup schedule to be deleted")
 				nonAdminCtx, err := backup.GetNonAdminCtx(user, commonPassword)
@@ -334,6 +327,13 @@ var _ = Describe("{DeleteSameNameObjectsByMultipleUsersFromAdmin}", func() {
 					}(backupName)
 				}
 				wg.Wait()
+			})
+			Step(fmt.Sprintf("Delete user %s restores from the admin", user), func() {
+				log.InfoD(fmt.Sprintf("Deleting user %s restores from the admin", user))
+				for restoreUid, restoreName := range userRestoreMap[user] {
+					err = DeleteRestoreWithUID(restoreName, restoreUid, orgID, ctx)
+					log.FailOnError(err, "failed to delete restore %s of the user %s", restoreName, user)
+				}
 			})
 			Step(fmt.Sprintf("Delete user %s source and destination cluster from the admin", user), func() {
 				log.InfoD(fmt.Sprintf("Deleting user %s source and destination cluster from the admin", user))
@@ -997,7 +997,7 @@ var _ = Describe("{DeleteObjectsByMultipleUsersFromNewAdmin}", func() {
 				}
 				scheduleUid, err := Inst().Backup.GetBackupScheduleUID(nonAdminCtx, userScheduleNameMap[user], orgID)
 				log.FailOnError(err, "failed to fetch backup schedule %s uid of the user %s", userScheduleNameMap[user], user)
-				err = DeleteScheduleWithUID(userScheduleNameMap[user], scheduleUid, orgID, newAdminCtx)
+				err = DeleteScheduleWithUIDAndWait(userScheduleNameMap[user], scheduleUid, SourceClusterName, userClusterMap[user][SourceClusterName], orgID, newAdminCtx)
 				log.FailOnError(err, "failed to delete schedule %s of the user %s", userScheduleNameMap[user], user)
 			})
 			Step(fmt.Sprintf("Delete user %s backups from the admin", user), func() {
@@ -1007,6 +1007,8 @@ var _ = Describe("{DeleteObjectsByMultipleUsersFromNewAdmin}", func() {
 					log.FailOnError(err, "failed to fetch backup %s uid of the user %s", backupName, user)
 					_, err = DeleteBackupWithClusterUID(backupName, backupUid, SourceClusterName, userClusterMap[user][SourceClusterName], orgID, newAdminCtx)
 					log.FailOnError(err, "failed to delete backup %s of the user %s", backupName, user)
+					err = DeleteBackupAndWait(backupName, newAdminCtx)
+					log.FailOnError(err, fmt.Sprintf("waiting for backup [%s] deletion", backupName))
 				}
 			})
 			Step(fmt.Sprintf("Delete user %s restores from the admin", user), func() {
@@ -1016,56 +1018,7 @@ var _ = Describe("{DeleteObjectsByMultipleUsersFromNewAdmin}", func() {
 					log.FailOnError(err, "failed to delete restore %s of the user %s", restoreName, user)
 				}
 			})
-			Step(fmt.Sprintf("Wait for the backups and backup schedule to be deleted"), func() {
-				log.InfoD("Waiting for the backups and backup schedule to be deleted")
-				nonAdminCtx, err := backup.GetNonAdminCtx(user, commonPassword)
-				log.FailOnError(err, "failed to fetch user %s ctx", user)
-				clusterInspectReq := &api.ClusterInspectRequest{
-					OrgId:          orgID,
-					Name:           SourceClusterName,
-					Uid:            userClusterMap[user][SourceClusterName],
-					IncludeSecrets: true,
-				}
-				clusterResp, err := Inst().Backup.InspectCluster(nonAdminCtx, clusterInspectReq)
-				log.FailOnError(err, "failed to inspect cluster %s", SourceClusterName)
-				var wg sync.WaitGroup
-				namespace := "*"
-				wg.Add(1)
-				go func() {
-					defer GinkgoRecover()
-					defer wg.Done()
-					err = Inst().Backup.WaitForBackupScheduleDeletion(
-						nonAdminCtx,
-						userScheduleNameMap[user],
-						namespace,
-						orgID,
-						clusterResp.GetCluster(),
-						backupLocationDeleteTimeout,
-						backupLocationDeleteRetryTime,
-					)
-					log.FailOnError(err, "failed while waiting for backup schedule %s to be deleted for the user %s", userScheduleNameMap[user], user)
-					for schedulePolicyUID, schedulePolicyName := range userSchedulePolicyMap[user] {
-						schedulePolicyDeleteRequest := &api.SchedulePolicyDeleteRequest{
-							Name:  schedulePolicyName,
-							Uid:   schedulePolicyUID,
-							OrgId: orgID,
-						}
-						_, err = Inst().Backup.DeleteSchedulePolicy(newAdminCtx, schedulePolicyDeleteRequest)
-						log.FailOnError(err, "failed to delete schedule policy %s of the user %s", schedulePolicyName, user)
-						break
-					}
-				}()
-				for backupName := range userBackupMap[user] {
-					wg.Add(1)
-					go func(backupName string) {
-						defer GinkgoRecover()
-						defer wg.Done()
-						err = Inst().Backup.WaitForBackupDeletion(nonAdminCtx, backupName, orgID, backupDeleteTimeout, backupDeleteRetryTime)
-						log.FailOnError(err, "failed while waiting for backup %s to be deleted", backupName)
-					}(backupName)
-				}
-				wg.Wait()
-			})
+
 			Step(fmt.Sprintf("Delete user %s source and destination cluster from the admin", user), func() {
 				log.InfoD(fmt.Sprintf("Deleting user %s source and destination cluster from the admin", user))
 				for _, clusterName := range []string{SourceClusterName, destinationClusterName} {
@@ -1776,27 +1729,20 @@ var _ = Describe("{DeleteSharedBackupOfUserFromAdmin}", func() {
 			log.FailOnError(err, "failed to delete user %s", user1)
 		})
 		Step(fmt.Sprintf("Delete user %s backups from the admin", user1), func() {
+			var wg sync.WaitGroup
 			ctx, err := backup.GetAdminCtxFromSecret()
 			log.FailOnError(err, "Fetching px-central-admin ctx")
 			log.InfoD(fmt.Sprintf("Deleting user %s backups from the admin", user1))
-			for backupName := range userBackupMap[user1] {
-				backupUid, err := Inst().Backup.GetBackupUID(ctx, backupName, orgID)
-				log.FailOnError(err, "failed to fetch backup %s uid of the user %s", backupName, user1)
-				_, err = DeleteBackupWithClusterUID(backupName, backupUid, SourceClusterName, userClusterMap[user1][SourceClusterName], orgID, ctx)
-				log.FailOnError(err, "failed to delete backup %s of the user %s", backupName, user1)
-			}
-		})
-		Step(fmt.Sprintf("Wait for the backups to be deleted"), func() {
-			log.InfoD("Waiting for the backups to be deleted")
-			ctx, err := backup.GetAdminCtxFromSecret()
-			log.FailOnError(err, "Fetching px-central-admin ctx")
-			var wg sync.WaitGroup
 			for backupName := range userBackupMap[user1] {
 				wg.Add(1)
 				go func(backupName string) {
 					defer GinkgoRecover()
 					defer wg.Done()
-					err = Inst().Backup.WaitForBackupDeletion(ctx, backupName, orgID, backupDeleteTimeout, backupDeleteRetryTime)
+					backupUid, err := Inst().Backup.GetBackupUID(ctx, backupName, orgID)
+					log.FailOnError(err, "failed to fetch backup %s uid of the user %s", backupName, user1)
+					_, err = DeleteBackupWithClusterUID(backupName, backupUid, SourceClusterName, userClusterMap[user1][SourceClusterName], orgID, ctx)
+					log.FailOnError(err, "failed to delete backup %s of the user %s", backupName, user1)
+					err = DeleteBackupAndWait(backupName, ctx)
 					log.FailOnError(err, "failed while waiting for backup %s to be deleted", backupName)
 				}(backupName)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed backup deletion wait logic issue.

issue:
The wait for deletion is failing because as per current logic the backup is getting deleted before the script check for its deletion success.  This can be an intermittent failure based on the various factors it takes for backup deletion time.

Fix:

Made sure all test check wait for backup deletion immediately after backup delete instead of different step.

Tests Fixed.
DeleteObjectsByMultipleUsersFromNewAdmin,
DeleteSharedBackupOfUserFromAdmin,
DeleteSameNameObjectsByMultipleUsersFromAdmin

**Which issue(s) this PR fixes** (optional)
Closes #PB-5202

**Special notes for your reviewer**:
Test log:
s3:
https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/3780/

NFS:
https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/3786/
