### PR TITLE
Skipping CR cleanup validation in case of Sync Backups

### DIFF
--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -6391,6 +6391,10 @@ func validateCRCleanup(resourceInterface interface{},
 		resourceName = currentObject.Name
 	}
 
+	// Below code is added to skip the CR cleanup validation in case of synced backup
+	// For synced backup the cluster name has uuid suffix which is not supported/handled
+	// While creating the cluster object
+
 	// Fetching all clusters
 	enumerateClusterRequest := &api.ClusterEnumerateRequest{
 		OrgId: orgID,
@@ -6406,7 +6410,7 @@ func validateCRCleanup(resourceInterface interface{},
 	}
 
 	if !isValidCluster {
-		log.Infof("%s is not a valid cluster for CR cleanup validation", clusterName)
+		log.Infof("%s looks to be a synced backup, skipping CR cleanup validation", clusterName)
 		return nil
 	}
 

--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -6364,8 +6364,6 @@ func dumpMongodbCollectionOnConsole(kubeConfigFile string, collectionName string
 // validateCRCleanup validates CR cleanup created during backup or restore
 func validateCRCleanup(resourceInterface interface{},
 	ctx context.Context) error {
-	log.InfoD("Inside validateCRCleanup")
-	log.Infof("Resource Interface - [%+v]", resourceInterface)
 	var allCRs []string
 	var err error
 	var getCRMethod func(string, *api.ClusterObject) ([]string, error)
@@ -6373,6 +6371,7 @@ func validateCRCleanup(resourceInterface interface{},
 	var resourceNamespaces []string
 	var resourceName string
 	var orgID string
+	var isValidCluster = false
 
 	if currentObject, ok := resourceInterface.(*api.BackupObject); ok {
 		// Creating object and variables from backup object
@@ -6390,6 +6389,25 @@ func validateCRCleanup(resourceInterface interface{},
 		}
 		orgID = currentObject.OrgId
 		resourceName = currentObject.Name
+	}
+
+	// Fetching all clusters
+	enumerateClusterRequest := &api.ClusterEnumerateRequest{
+		OrgId: orgID,
+	}
+	enumerateClusterResponse, err := Inst().Backup.EnumerateAllCluster(ctx, enumerateClusterRequest)
+
+	// Comparing cluster names to the name from backup inspect response
+	for _, clusterObj := range enumerateClusterResponse.GetClusters() {
+		if clusterObj.Name == clusterName {
+			isValidCluster = true
+			break
+		}
+	}
+
+	if !isValidCluster {
+		log.Infof("%s is not a valid cluster for CR cleanup validation", clusterName)
+		return nil
 	}
 
 	backupDriver := Inst().Backup


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Fix Backup/Restore CR validation for Sync Backup scenario

**Which issue(s) this PR fixes** (optional)
Closes #PB-522

**Special notes for your reviewer**:
Aetos: https://aetos.pwx.purestorage.com/resultSet/testSetID/472763
