### PR TITLE
Skipping CR cleanup validation in case of GKE

### DIFF
--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -6364,6 +6364,14 @@ func dumpMongodbCollectionOnConsole(kubeConfigFile string, collectionName string
 // validateCRCleanup validates CR cleanup created during backup or restore
 func validateCRCleanup(resourceInterface interface{},
 	ctx context.Context) error {
+
+	log.InfoD("Validating CR cleanup")
+
+	if GetClusterProviders()[0] == "gke" {
+		log.Infof("Skipping CR cleanup validation in case of GKE")
+		return nil
+	}
+
 	var allCRs []string
 	var err error
 	var getCRMethod func(string, *api.ClusterObject) ([]string, error)
@@ -6439,12 +6447,11 @@ func validateCRCleanup(resourceInterface interface{},
 			return nil, true, err
 		}
 
-		log.Infof("Validating CR cleanup")
 		log.InfoD("All CRs in [%s] are [%v]", currentAdminNamespace, allCRs)
 
 		for _, eachCR := range allCRs {
 			if strings.Contains(eachCR, resourceName) {
-				log.Infof("CR found for [%s] under [%s] namespace", allCRs, currentAdminNamespace)
+				log.InfoD("CR found for [%s] under [%s] namespace", allCRs, currentAdminNamespace)
 				return nil, true, fmt.Errorf("CR cleanup validation failed for - [%s]", resourceName)
 			}
 		}

--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -6367,6 +6367,7 @@ func validateCRCleanup(resourceInterface interface{},
 
 	log.InfoD("Validating CR cleanup")
 
+	// TODO : This needs to be removed in future once stork client is integrated for GKE in automation
 	if GetClusterProviders()[0] == "gke" {
 		log.Infof("Skipping CR cleanup validation in case of GKE")
 		return nil


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Skip CR cleanup validation in case of GKE

**Which issue(s) this PR fixes** (optional)
Closes #PB-5226

**Special notes for your reviewer**:
Jenkins Run: https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/basic-system-test/job/px/job/s3/job/gke-cloud-px-backup-stork-upgrade/22/execution/node/267/log/?consoleFull
