### PR TITLE
Collect pxb and stork logs for all the tests

### DIFF
--- a/tests/common.go
+++ b/tests/common.go
@@ -7180,7 +7180,7 @@ func EndPxBackupTorpedoTest(contexts []*scheduler.Context) {
 		AfterEachTest(contexts, CurrentTestRailTestCaseId, RunIdForSuite)
 	}
 	ginkgoTestDescr := ginkgo.CurrentGinkgoTestDescription()
-	log.Infof(">>>> FAILED TEST: %s", ginkgoTestDescr.FullTestText)
+	log.Infof(">>>> Collecting logs for testcase : %s", ginkgoTestDescr.FullTestText)
 	testCaseName := ginkgoTestDescr.FullTestText
 	matches := regexp.MustCompile(`\{([^}]+)\}`).FindStringSubmatch(ginkgoTestDescr.FullTestText)
 	if len(matches) > 1 {

--- a/tests/common.go
+++ b/tests/common.go
@@ -7180,24 +7180,22 @@ func EndPxBackupTorpedoTest(contexts []*scheduler.Context) {
 		AfterEachTest(contexts, CurrentTestRailTestCaseId, RunIdForSuite)
 	}
 	ginkgoTestDescr := ginkgo.CurrentGinkgoTestDescription()
-	if ginkgoTestDescr.Failed {
-		log.Infof(">>>> FAILED TEST: %s", ginkgoTestDescr.FullTestText)
-		testCaseName := ginkgoTestDescr.FullTestText
-		matches := regexp.MustCompile(`\{([^}]+)\}`).FindStringSubmatch(ginkgoTestDescr.FullTestText)
-		if len(matches) > 1 {
-			testCaseName = matches[1]
-		}
-		masterNode := node.GetMasterNodes()[0]
-		log.Infof("Creating a directory [%s] to store logs", pxbLogDirPath)
-		err := runCmd(fmt.Sprintf("mkdir -p %v", pxbLogDirPath), masterNode)
-		if err != nil {
-			log.Errorf("Error in creating a directory [%s] to store logs. Err: %v", pxbLogDirPath, err.Error())
-			return
-		}
-		collectStorkLogs(testCaseName)
-		collectPxBackupLogs(testCaseName)
-		compressSubDirectories(pxbLogDirPath)
+	log.Infof(">>>> FAILED TEST: %s", ginkgoTestDescr.FullTestText)
+	testCaseName := ginkgoTestDescr.FullTestText
+	matches := regexp.MustCompile(`\{([^}]+)\}`).FindStringSubmatch(ginkgoTestDescr.FullTestText)
+	if len(matches) > 1 {
+		testCaseName = matches[1]
 	}
+	masterNode := node.GetMasterNodes()[0]
+	log.Infof("Creating a directory [%s] to store logs", pxbLogDirPath)
+	err := runCmd(fmt.Sprintf("mkdir -p %v", pxbLogDirPath), masterNode)
+	if err != nil {
+		log.Errorf("Error in creating a directory [%s] to store logs. Err: %v", pxbLogDirPath, err.Error())
+		return
+	}
+	collectStorkLogs(testCaseName)
+	collectPxBackupLogs(testCaseName)
+	compressSubDirectories(pxbLogDirPath)
 }
 
 func CreateMultiVolumesAndAttach(wg *sync.WaitGroup, count int, nodeName string) (map[string]string, error) {

--- a/tests/common.go
+++ b/tests/common.go
@@ -7180,6 +7180,9 @@ func EndPxBackupTorpedoTest(contexts []*scheduler.Context) {
 		AfterEachTest(contexts, CurrentTestRailTestCaseId, RunIdForSuite)
 	}
 	ginkgoTestDescr := ginkgo.CurrentGinkgoTestDescription()
+	if ginkgoTestDescr.Failed {
+		log.Infof(">>>> FAILED TEST: %s", ginkgoTestDescr.FullTestText)
+	}
 	log.Infof(">>>> Collecting logs for testcase : %s", ginkgoTestDescr.FullTestText)
 	testCaseName := ginkgoTestDescr.FullTestText
 	matches := regexp.MustCompile(`\{([^}]+)\}`).FindStringSubmatch(ginkgoTestDescr.FullTestText)


### PR DESCRIPTION
**What this PR does / why we need it**:
Collect pxb and stork logs for all the tests irrespective of PASS or FAIL

Currectly. logs are getting collected only if the testcase fails
Logs do not get collected when the failure is seen in justaftereach

**Which issue(s) this PR fixes** (optional)
Closes #https://portworx.atlassian.net/browse/PB-5216

**Special notes for your reviewer**:
https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/3882/consoleFull
<img width="561" alt="Screenshot 2023-12-20 at 12 31 00 PM" src="https://github.com/portworx/torpedo/assets/121086405/8fb6ea52-18fc-487c-8f43-d1698e40d8e0">

