### PR TITLE
Adding ML workload to Torpedo

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -725,6 +725,8 @@ spec:
       value: "${VCLUSTER_PARALLEL_APPS}"
     - name: VCLUSTER_TOTAL_ITERATIONS
       value: "${VCLUSTER_TOTAL_ITERATIONS}"
+    - name: NUM_ML_WORKLOADS
+      value: "${NUM_ML_WORKLOADS}"
     - name: KUBEVIRT_UPGRADE_VERSION
       value: "${KUBEVIRT_UPGRADE_VERSION}"
     - name: PX_BACKUP_MONGODB_USERNAME

--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -727,6 +727,8 @@ spec:
       value: "${VCLUSTER_TOTAL_ITERATIONS}"
     - name: NUM_ML_WORKLOADS
       value: "${NUM_ML_WORKLOADS}"
+    - name: ML_WORKLOAD_RUNTIME
+      value: "${ML_WORKLOAD_RUNTIME}"
     - name: KUBEVIRT_UPGRADE_VERSION
       value: "${KUBEVIRT_UPGRADE_VERSION}"
     - name: PX_BACKUP_MONGODB_USERNAME

--- a/drivers/scheduler/k8s/specs/ml-workload-continuous-training/continuous_retraining.yaml
+++ b/drivers/scheduler/k8s/specs/ml-workload-continuous-training/continuous_retraining.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: continuous-retraining
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: continuous-retraining
+  template:
+    metadata:
+      labels:
+        app: continuous-retraining
+    spec:
+      containers:
+        - name: ml-workload
+          image: portworx/ml-workload:rent-prediction
+          command: ["/bin/bash", "-c"]
+          args: ["while true; do python retrain.py; sleep 300; done"]
+          volumeMounts:
+            - name: ml-shared-data
+              mountPath: "/mnt/data"
+      volumes:
+        - name: ml-shared-data
+          persistentVolumeClaim:
+            claimName: ml-workload-pvc

--- a/drivers/scheduler/k8s/specs/ml-workload-preprocess-rwx/ml-workload-pvc.yaml
+++ b/drivers/scheduler/k8s/specs/ml-workload-preprocess-rwx/ml-workload-pvc.yaml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: ml-workload-pvc
+spec:
+  storageClassName: ml-workload-sc
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 100Gi

--- a/drivers/scheduler/k8s/specs/ml-workload-preprocess-rwx/preprocess_and_training.yaml
+++ b/drivers/scheduler/k8s/specs/ml-workload-preprocess-rwx/preprocess_and_training.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: preprocessing-and-training
+spec:
+  containers:
+    - name: ml-workload
+      image: portworx/ml-workload:rent-prediction
+      command: ["/bin/bash", "-c"]
+      args: ["python preprocess.py && python first_training.py && sleep 6000"]
+      volumeMounts:
+        - name: ml-shared-data
+          mountPath: "/mnt/data"
+  volumes:
+    - name: ml-shared-data
+      persistentVolumeClaim:
+        claimName: ml-workload-pvc
+  restartPolicy: Never

--- a/drivers/scheduler/k8s/specs/ml-workload-preprocess-rwx/pxd/sc.yaml
+++ b/drivers/scheduler/k8s/specs/ml-workload-preprocess-rwx/pxd/sc.yaml
@@ -1,0 +1,12 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: ml-workload-sc
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  priority_io: "high"
+  io_profile: "db_remote"
+  repl: "3"
+  sharedv4: "true"
+  sharedv4_svc_type: ""
+allowVolumeExpansion: true

--- a/drivers/scheduler/k8s/specs/ml-workload-rwx/query-ml-workload.yaml
+++ b/drivers/scheduler/k8s/specs/ml-workload-rwx/query-ml-workload.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: querying-app-1
+spec:
+  replicas: 1
+  selector:
+    matchlabels:
+      app: querying-app-1
+  template:
+    metadata:
+      labels:
+        app: querying-app-1
+    spec:
+      containers:
+      - name: ml-workload
+        image: portworx/ml-workload:rent-prediction
+        command:
+        - /bin/bash
+        - -c
+        args:
+        - python query.py && sleep 300
+        env:
+        - name: OUTPUT_FILE
+          value: query_output_1.csv
+        volumeMounts:
+        - name: ml-shared-data
+          mountPath: /mnt/data
+      volumes:
+      - name: ml-shared-data
+        persistentVolumeClaim:
+          claimName: ml-workload-pvc

--- a/drivers/scheduler/k8s/specs/ml-workload-rwx/query-ml-workload.yaml
+++ b/drivers/scheduler/k8s/specs/ml-workload-rwx/query-ml-workload.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   replicas: 1
   selector:
-    matchlabels:
+    matchLabels:
       app: querying-app-1
   template:
     metadata:

--- a/drivers/scheduler/k8s/specs/ml-workload-rwx/query-ml-workload.yaml
+++ b/drivers/scheduler/k8s/specs/ml-workload-rwx/query-ml-workload.yaml
@@ -4,22 +4,13 @@ metadata:
   name: querying-app-1
 spec:
   replicas: 1
-  selector:
-    matchLabels:
-      app: querying-app-1
   template:
-    metadata:
-      labels:
-        app: querying-app-1
     spec:
       containers:
       - name: ml-workload
         image: portworx/ml-workload:rent-prediction
-        command:
-        - /bin/bash
-        - -c
-        args:
-        - python query.py && sleep 300
+        command: ["/bin/bash", "-c"]
+        args: ["python query.py && sleep 300"]
         env:
         - name: OUTPUT_FILE
           value: query_output_1.csv

--- a/tests/basic/sharedv4_svc_test.go
+++ b/tests/basic/sharedv4_svc_test.go
@@ -1320,25 +1320,9 @@ var _ = Describe("{CreateMlWorkloadOnSharedv4Svc}", func() {
 	prereqContexts := make([]*scheduler.Context, 0)
 	taskName := "prepare-ml-workload"
 	totalMlDeps := 5
-	totalMlWorkloads := ReadEnvVariable("NUM_ML_WORKLOADS")
-	if totalMlWorkloads != "" {
-		var err error
-		totalMlDeps, err = strconv.Atoi(totalMlWorkloads)
-		if err != nil {
-			log.Errorf("Failed to convert value %v to int with error: %v", totalMlWorkloads, err)
-			totalMlDeps = 5
-		}
-	}
 	totalRunTime := 5
-	mlWorkloadRuntime := ReadEnvVariable("ML_WORKLOAD_RUNTIME")
-	if mlWorkloadRuntime != "" {
-		var err error
-		totalRunTime, err = strconv.Atoi(mlWorkloadRuntime)
-		if err != nil {
-			log.Errorf("Failed to convert value %v to int with error: %v", mlWorkloadRuntime, err)
-			totalRunTime = 5
-		}
-	}
+	log.Infof("Original App list : %v", Inst().AppList)
+	orig_app_list := Inst().AppList
 	JustBeforeEach(func() {
 		StartTorpedoTest("CreateMlWorkloadOnSharedv4Svc", "Create multiple pods coming and going and trying to edit/read a model on same volume", nil, 0)
 		// Runs Preprocess Workload to prepare the model
@@ -1347,6 +1331,25 @@ var _ = Describe("{CreateMlWorkloadOnSharedv4Svc}", func() {
 		// Runs Continuous Retraining module
 		Inst().AppList = []string{"ml-workload-continuous-training"}
 		prereqContexts = append(prereqContexts, ScheduleApplicationsOnNamespace(ns, taskName)...)
+		// Read Test Parameters
+		totalMlWorkloads := ReadEnvVariable("NUM_ML_WORKLOADS")
+		if totalMlWorkloads != "" {
+			var err error
+			totalMlDeps, err = strconv.Atoi(totalMlWorkloads)
+			if err != nil {
+				log.Errorf("Failed to convert value %v to int with error: %v", totalMlWorkloads, err)
+				totalMlDeps = 5
+			}
+		}
+		mlWorkloadRuntime := ReadEnvVariable("ML_WORKLOAD_RUNTIME")
+		if mlWorkloadRuntime != "" {
+			var err error
+			totalRunTime, err = strconv.Atoi(mlWorkloadRuntime)
+			if err != nil {
+				log.Errorf("Failed to convert value %v to int with error: %v", mlWorkloadRuntime, err)
+				totalRunTime = 5
+			}
+		}
 	})
 	It("Create Multiple ML Apps going and reading from the Model created. Continuous Retraining Module is already running", func() {
 		// Defining deployment of querying ML Workload apps. This is necessary otherwise Torpedo
@@ -1450,6 +1453,8 @@ var _ = Describe("{CreateMlWorkloadOnSharedv4Svc}", func() {
 		for _, ctx := range prereqContexts {
 			TearDownContext(ctx, opts)
 		}
+		Inst().AppList = orig_app_list
+		log.Infof("Restored original App list : %v", Inst().AppList)
 	})
 })
 

--- a/tests/basic/sharedv4_svc_test.go
+++ b/tests/basic/sharedv4_svc_test.go
@@ -1322,7 +1322,7 @@ var _ = Describe("{CreateMlWorkloadOnSharedv4Svc}", func() {
 	totalMlDeps := 5
 	totalRunTime := 5
 	log.Infof("Original App list : %v", Inst().AppList)
-	orig_app_list := Inst().AppList
+	origAppList := Inst().AppList
 	JustBeforeEach(func() {
 		StartTorpedoTest("CreateMlWorkloadOnSharedv4Svc", "Create multiple pods coming and going and trying to edit/read a model on same volume", nil, 0)
 		// Runs Preprocess Workload to prepare the model
@@ -1453,7 +1453,7 @@ var _ = Describe("{CreateMlWorkloadOnSharedv4Svc}", func() {
 		for _, ctx := range prereqContexts {
 			TearDownContext(ctx, opts)
 		}
-		Inst().AppList = orig_app_list
+		Inst().AppList = origAppList
 		log.Infof("Restored original App list : %v", Inst().AppList)
 	})
 })

--- a/tests/basic/sharedv4_svc_test.go
+++ b/tests/basic/sharedv4_svc_test.go
@@ -1319,12 +1319,13 @@ var _ = Describe("{CreateMlWorkloadOnSharedv4Svc}", func() {
 	appContexts := make([]*scheduler.Context, 0)
 	prereqContexts := make([]*scheduler.Context, 0)
 	taskName := "prepare-ml-workload"
+	var origAppList []string
 	totalMlDeps := 5
 	totalRunTime := 5
-	log.Infof("Original App list : %v", Inst().AppList)
-	origAppList := Inst().AppList
 	JustBeforeEach(func() {
 		StartTorpedoTest("CreateMlWorkloadOnSharedv4Svc", "Create multiple pods coming and going and trying to edit/read a model on same volume", nil, 0)
+		log.Infof("Original App list : %v", Inst().AppList)
+		origAppList = Inst().AppList
 		// Runs Preprocess Workload to prepare the model
 		Inst().AppList = []string{"ml-workload-preprocess-rwx"}
 		prereqContexts = append(prereqContexts, ScheduleApplicationsOnNamespace(ns, taskName)...)

--- a/tests/basic/sharedv4_svc_test.go
+++ b/tests/basic/sharedv4_svc_test.go
@@ -1385,7 +1385,7 @@ var _ = Describe("{CreateMlWorkloadOnSharedv4Svc}", func() {
 					}
 				}
 			}
-			opFilePath := filepath.Join("/specs", "ml-workload-rwx", "query-ml-workload.yaml")
+			opFilePath := filepath.Join(currentDir, "..", "drivers", "scheduler", "k8s", "specs", "ml-workload-rwx", "query-ml-workload.yaml")
 			modifiedData, err := yaml.Marshal(&deployment)
 			log.FailOnError(err, fmt.Sprintf("Error Marshaling back to Yaml File: %v", filePath))
 			err = os.WriteFile(opFilePath, modifiedData, 0644)

--- a/tests/basic/sharedv4_svc_test.go
+++ b/tests/basic/sharedv4_svc_test.go
@@ -1375,6 +1375,8 @@ var _ = Describe("{CreateMlWorkloadOnSharedv4Svc}", func() {
 			log.FailOnError(err, fmt.Sprintf("Error Unmarshaling Yaml File: %v", filePath))
 			appName := fmt.Sprintf("querying-app-%d", i)
 			deployment.Metadata.Name = appName
+			deployment.Spec.Selector.MatchLabels = map[string]string{"app": appName}
+			deployment.Spec.Template.Metadata.Labels = map[string]string{"app": appName}
 			for j := range deployment.Spec.Template.Spec.Containers {
 				for k := range deployment.Spec.Template.Spec.Containers[j].Env {
 					if deployment.Spec.Template.Spec.Containers[j].Env[k].Name == "OUTPUT_FILE" {

--- a/tests/basic/sharedv4_svc_test.go
+++ b/tests/basic/sharedv4_svc_test.go
@@ -1366,7 +1366,7 @@ var _ = Describe("{CreateMlWorkloadOnSharedv4Svc}", func() {
 		}
 		currentDir, err := os.Getwd()
 		log.FailOnError(err, "Failed to find current directory")
-		filePath := filepath.Join(currentDir, "..", "..", "drivers", "scheduler", "k8s", "specs", "ml-workload-rwx", "query-ml-workload.yaml")
+		filePath := filepath.Join(currentDir, "..", "drivers", "scheduler", "k8s", "specs", "ml-workload-rwx", "query-ml-workload.yaml")
 		for i := 1; i <= 20; i++ {
 			data, err := os.ReadFile(filePath)
 			log.FailOnError(err, fmt.Sprintf("Error Reading Yaml File: %v", filePath))


### PR DESCRIPTION
This test runs a ML Workload that predicts Housing rents. 

- It contains one pod that preprocesses model and prepares training data. 
- One pod runs continuously and keeps on retraining the model every 5 mins.
- The other workload (query-app) pods that are deployments run once every 5 mins and read the model, do some prediction and writes their predictions to shared volume on which model is saved. 
- Retraining pod picks this data up and again retrains the model. 
- This is a simple feed-forward neural network model.

We can tune the number of workload pods with NUM_ML_WORKLOADS env variable for this test. We can let the workload run for specific amount of time with ML_WORKLOAD_RUNTIME env variable. 

Jenkins Run: https://jenkins.pwx.dev.purestorage.com/job/Users/job/Dhruv/job/dhruv-local-test/7