### PR TITLE
TC to remove .json files from NFS backup location and perform restore operation

### DIFF
--- a/tests/backup/backup_nfs_test.go
+++ b/tests/backup/backup_nfs_test.go
@@ -377,7 +377,7 @@ var _ = Describe("{RemoveJSONFilesFromNFSBackupLocation}", func() {
 			newRestoreName := fmt.Sprintf("%s-%s", restoreNamePrefix, newBackupName)
 			appContextsToBackup := FilterAppContextsByNamespace(scheduledAppContexts, appNamespaces)
 			err = CreateRestoreWithValidation(ctx, newRestoreName, newBackupName, make(map[string]string), make(map[string]string), destinationClusterName, orgID, appContextsToBackup)
-			dash.VerifyFatal(err, true, fmt.Sprintf("Verifying if the restore [%s] is successful.", newRestoreName))
+			dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying if the restore [%s] is successful.", newRestoreName))
 			restoreNames = append(restoreNames, newRestoreName)
 		})
 	})


### PR DESCRIPTION
Added a new TC **RemoveJSONFilesFromNFSBackupLocation** against the task https://portworx.atlassian.net/browse/PB-5251
Testrail: https://portworx.testrail.net/index.php?/cases/view/86098

This TC deals with removing the .json files from the NFS backup location and then validating if the restore fail.

Helper function added: DeleteJSONFilesFromNFSLocation

**Which issue(s) this PR fixes** (optional)
Closes #PB-5251

**Special notes for your reviewer**:
Vanilla-NFS:
https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/3961/

