### PR TITLE
Adding data integrity validation for PX upgrade test

### DIFF
--- a/drivers/pds/lib/utils.go
+++ b/drivers/pds/lib/utils.go
@@ -2993,7 +2993,7 @@ func ExpandAndValidatePxPool(context []*scheduler.Context) error {
 		expectedSizeWithJournal = expectedSizeWithJournal - 3
 	}
 	log.InfoD("Current Size of the pool %s is %d", poolIDToResize, poolToBeResized.TotalSize/units.GiB)
-	err = tests.Inst().V.ExpandPool(poolIDToResize, api.SdkStoragePool_RESIZE_TYPE_ADD_DISK, expectedSize, false)
+	err = tests.Inst().V.ExpandPool(poolIDToResize, api.SdkStoragePool_RESIZE_TYPE_ADD_DISK, expectedSize, true)
 	resizeErr := WaitForPoolToBeResized(expectedSize, poolIDToResize, isjournal)
 	if resizeErr != nil {
 		log.FailOnError(resizeErr, fmt.Sprintf("Failed to resize pool with ID-  %s", poolIDToResize))

--- a/tests/basic/upgrade_test.go
+++ b/tests/basic/upgrade_test.go
@@ -193,6 +193,8 @@ var _ = Describe("{UpgradeVolumeDriver}", func() {
 
 				// Validate Apps after volume driver upgrade
 				ValidateApplications(contexts)
+				err = ValidateDataIntegrity(&contexts)
+				log.FailOnError(err, "data integrity validation failed after upgrade")
 			}
 		})
 

--- a/tests/basic/upgrade_test.go
+++ b/tests/basic/upgrade_test.go
@@ -2,6 +2,10 @@ package tests
 
 import (
 	"fmt"
+	"go.uber.org/multierr"
+	"golang.org/x/sync/errgroup"
+	"math/rand"
+	"strconv"
 	"strings"
 	"time"
 
@@ -153,6 +157,32 @@ var _ = Describe("{UpgradeVolumeDriver}", func() {
 
 			// Perform upgrade hops of volume driver based on a given list of upgradeEndpoints passed
 			for _, upgradeHop := range strings.Split(Inst().UpgradeStorageDriverEndpointList, ",") {
+				var volName string
+				var attachedNode *node.Node
+				fioJobName := "upg_vol"
+				log.Infof(upgradeHop)
+
+				n := storageNodes[rand.Intn(numOfNodes)]
+
+				if Inst().N.IsUsingSSH() {
+
+					volName = fmt.Sprintf("vol-%s", time.Now().Format("01-02-15h04m05s"))
+					volId, err := Inst().V.CreateVolume(volName, 53687091200, 3)
+					log.FailOnError(err, "error creating vol-1")
+					log.Infof("created vol %s", volId)
+					out, err := Inst().V.AttachVolume(volId)
+					log.FailOnError(err, "error attaching vol-1")
+					log.Infof("attached vol %s", out)
+					attachedNode, err = GetNodeForGivenVolumeName(volName)
+
+					log.FailOnError(err, fmt.Sprintf("error getting  attached node fro volume %s", volName))
+
+					err = writeFIOData(volName, fioJobName, *attachedNode)
+					log.FailOnError(err, fmt.Sprintf("error running fio command on node %s", n.Name))
+				}
+
+				done := make(chan bool)
+				eg := errgroup.Group{}
 				currPXVersion, err := Inst().V.GetDriverVersionOnNode(storageNodes[0])
 				if err != nil {
 					log.Warnf("error getting driver version, Err: %v", err)
@@ -160,6 +190,33 @@ var _ = Describe("{UpgradeVolumeDriver}", func() {
 				timeBeforeUpgrade = time.Now()
 				isDmthinBeforeUpgrade, errDmthinCheck := IsDMthin()
 				dash.VerifyFatal(errDmthinCheck, nil, "verified is setup dmthin before upgrade? ")
+
+				//validating the apps during the PX upgrade
+				eg.Go(func() error {
+
+					var mError error
+					for {
+						select {
+						case <-done:
+							return nil
+						default:
+							for _, ctx := range contexts {
+								errorChan := make(chan error, len(contexts))
+								ValidateContext(ctx, &errorChan)
+								for err := range errorChan {
+									mError = multierr.Append(mError, err)
+								}
+							}
+
+							if mError != nil {
+								return mError
+							}
+							time.Sleep(30 * time.Second)
+						}
+					}
+
+				})
+
 				err = Inst().V.UpgradeDriver(upgradeHop)
 				timeAfterUpgrade = time.Now()
 				dash.VerifyFatal(err, nil, "Volume driver upgrade successful?")
@@ -190,11 +247,20 @@ var _ = Describe("{UpgradeVolumeDriver}", func() {
 				statsData["duration"] = fmt.Sprintf("%d mins", durationInMins)
 				statsData["status"] = upgradeStatus
 				dash.UpdateStats("px-upgrade-stats", "px-enterprise", "upgrade", majorVersion, statsData)
+				//end the apps validation loop
+				done <- true
+
+				if err = eg.Wait(); err != nil {
+					dash.VerifyFatal(err, nil, "validate apps status during upgrade")
+				}
+
+				if attachedNode != nil {
+					err = readFIOData(volName, fioJobName, *attachedNode)
+					log.FailOnError(err, fmt.Sprintf("error while reading fio data on node %s", attachedNode.Name))
+				}
 
 				// Validate Apps after volume driver upgrade
 				ValidateApplications(contexts)
-				err = ValidateDataIntegrity(&contexts)
-				log.FailOnError(err, "data integrity validation failed after upgrade")
 			}
 		})
 
@@ -213,6 +279,84 @@ var _ = Describe("{UpgradeVolumeDriver}", func() {
 		AfterEachTest(contexts)
 	})
 })
+
+func writeFIOData(volName, fioJobName string, n node.Node) error {
+	mountPath := fmt.Sprintf("/var/lib/osd/mounts/%s", volName)
+	creatDir := fmt.Sprintf("mkdir %s", mountPath)
+
+	cmdConnectionOpts := node.ConnectionOpts{
+		Timeout:         15 * time.Second,
+		TimeBeforeRetry: 5 * time.Second,
+		Sudo:            true,
+	}
+
+	log.Infof("Running command %s on %s", creatDir, n.Name)
+	_, err := Inst().N.RunCommandWithNoRetry(n, creatDir, cmdConnectionOpts)
+
+	if err != nil {
+		return err
+	}
+
+	mountCmd := fmt.Sprintf("pxctl host mount --path %s %s", mountPath, volName)
+	log.Infof("Running command %s on %s", mountCmd, n.Name)
+	_, err = Inst().N.RunCommandWithNoRetry(n, mountCmd, cmdConnectionOpts)
+
+	if err != nil {
+		return err
+	}
+
+	writeCmd := fmt.Sprintf("fio --name=%s --ioengine=libaio --rw=write --bs=4k --numjobs=1 --size=5G --iodepth=256 --directory=%s --output=/tmp/vol_write.log --verify=meta --direct=1 --randrepeat=1 --verify_pattern=0xbeddacef --end_fsync=1", fioJobName, mountPath)
+
+	log.Infof("Running command %s on %s", writeCmd, n.Name)
+	_, err = Inst().N.RunCommandWithNoRetry(n, writeCmd, cmdConnectionOpts)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+
+}
+
+func readFIOData(volName, fioJobName string, n node.Node) error {
+	mountPath := fmt.Sprintf("/var/lib/osd/mounts/%s", volName)
+
+	cmdConnectionOpts := node.ConnectionOpts{
+		Timeout:         15 * time.Second,
+		TimeBeforeRetry: 5 * time.Second,
+		Sudo:            true,
+	}
+
+	readCmd := fmt.Sprintf("fio --name=%s --ioengine=libaio --rw=read --bs=4k --numjobs=1 --size=5G --iodepth=256 --directory=%s --output=/tmp/vol_read.log --do_verify=1 --verify=meta --direct=1 --randrepeat=1 --verify_pattern=0xbeddacef --end_fsync=1", fioJobName, mountPath)
+
+	log.Infof("Running command %s on %s", readCmd, n.Name)
+	_, err = Inst().N.RunCommandWithNoRetry(n, readCmd, cmdConnectionOpts)
+
+	if err != nil {
+		return err
+	}
+
+	validationCmd := "cat /tmp/vol_write.log | grep \"error\\|bad magic header\" | wc -l"
+	log.Infof("Running command %s on %s", validationCmd, n.Name)
+	out, err := Inst().N.RunCommandWithNoRetry(n, validationCmd, cmdConnectionOpts)
+
+	if err != nil {
+		return err
+	}
+
+	out = strings.TrimSpace(out)
+	errCount, err := strconv.Atoi(out)
+	if err != nil {
+		return err
+	}
+
+	if errCount > 0 {
+		return fmt.Errorf("error reading fio data after upgrade")
+	}
+
+	return nil
+
+}
 
 // UpgradeVolumeDriverFromCatalog test performs upgrade hops of volume driver based on a given list of upgradeEndpoints from marketplace
 var _ = Describe("{UpgradeVolumeDriverFromCatalog}", func() {

--- a/tests/common.go
+++ b/tests/common.go
@@ -8112,7 +8112,10 @@ func DeleteGivenPoolInNode(stNode node.Node, poolIDToDelete string, retry bool) 
 	if err := Inst().V.DeletePool(stNode, poolIDToDelete, retry); err != nil {
 		return err
 	}
-	if err := ExitPoolMaintenance(stNode); err != nil {
+
+	err = ExitPoolMaintenance(stNode)
+
+	if err != nil && !strings.Contains(err.Error(), "not in pool maintenance mode") {
 		return err
 	}
 	return nil
@@ -10198,4 +10201,44 @@ func DeleteAllNamespacesCreatedByTestCase() error {
 		}
 	}
 	return nil
+}
+
+func GetNodeForGivenVolumeName(volName string) (*node.Node, error) {
+
+	t := func() (interface{}, bool, error) {
+		pxVol, err := Inst().V.InspectVolume(volName)
+		if err != nil {
+			log.Warnf("Failed to inspect volume [%s], Err: %v", volName, err)
+			return nil, false, err
+		}
+
+		for _, n := range node.GetStorageDriverNodes() {
+			ok, err := Inst().V.IsVolumeAttachedOnNode(pxVol, n)
+			if err != nil {
+				return nil, false, err
+			}
+			if ok {
+				return &n, false, err
+			}
+		}
+
+		// Snapshots may not be attached to a node
+		if pxVol.Source.Parent != "" {
+			return nil, false, nil
+		}
+
+		return nil, true, fmt.Errorf("volume [%s] is not attached on any node", volName)
+	}
+
+	n, err := task.DoRetryWithTimeout(t, 1*time.Minute, 10*time.Second)
+	if err != nil {
+		return nil, err
+	}
+
+	if n != nil {
+		attachedNode := n.(*node.Node)
+		return attachedNode, nil
+	}
+
+	return nil, fmt.Errorf("no attached node found for vol [%s]", volName)
 }

--- a/tests/common.go
+++ b/tests/common.go
@@ -9100,7 +9100,7 @@ outer:
 				}
 				return "", false, fmt.Errorf("volume %s is in %s state cannot proceed further", v.ID, replicationStatus)
 			}
-			_, mError = task.DoRetryWithTimeout(t, 60*time.Minute, 1*time.Minute)
+			_, mError = task.DoRetryWithTimeout(t, 120*time.Minute, 2*time.Minute)
 			if mError != nil {
 				return mError
 			}


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
- Added a change to validate apps while px upgrades is in-progress
- Added logic to write data before upgrade and validate it post upgrade
- Minor fixes for pool tests

**Which issue(s) this PR fixes** (optional)
Closes #PTX-21685

**Special notes for your reviewer**:

result

```
2024-01-17 16:48:31 +0530:[DEBUG] [{UpgradeVolumeDriver}] [portworx.(*portworx).IsVolumeAttachedOnNode:#2411] - Volume [375740877748323337] attached on [10.13.207.126] checking for node [e77e37f9-fa63-4328-b75d-ca4913142413]
2024-01-17 16:48:31 +0530:[INFO] [{UpgradeVolumeDriver}] [basic.writeFIOData:#291] - Running command mkdir /var/lib/osd/mounts/vol-01-17-16h48m03s on ip-10-13-207-126.pwx.purestorage.com
2024-01-17 16:48:34 +0530:[INFO] [{UpgradeVolumeDriver}] [basic.writeFIOData:#299] - Running command pxctl host mount --path /var/lib/osd/mounts/vol-01-17-16h48m03s vol-01-17-16h48m03s on ip-10-13-207-126.pwx.purestorage.com
2024-01-17 16:48:37 +0530:[INFO] [{UpgradeVolumeDriver}] [basic.writeFIOData:#308] - Running command fio --name=upg_vol --ioengine=libaio --rw=write --bs=4k --numjobs=1 --size=5G --iodepth=256 --directory=/var/lib/osd/mounts/vol-01-17-16h48m03s --output=/tmp/vol_write.log --verify=meta --direct=1 --randrepeat=1 --verify_pattern=0xbeddacef --end_fsync=1 on ip-10-13-207-126.pwx.purestorage.com
2024-01-17 16:49:39 +0530:[INFO] [{UpgradeVolumeDriver}] [basic.readFIOData:#330] - Running command fio --name=upg_vol --ioengine=libaio --rw=read --bs=4k --numjobs=1 --size=5G --iodepth=256 --directory=/var/lib/osd/mounts/vol-01-17-16h48m03s --output=/tmp/vol_read.log --do_verify=1 --verify=meta --direct=1 --randrepeat=1 --verify_pattern=0xbeddacef --end_fsync=1 on ip-10-13-207-126.pwx.purestorage.com
2024-01-17 16:49:56 +0530:[INFO] [{UpgradeVolumeDriver}] [basic.readFIOData:#338] - Running command cat /tmp/vol_write.log | grep "error\|bad magic header" | wc -l on ip-10-13-207-126.pwx.purestorage.com
STEP: Destroy apps
2024-01-17 16:50:00 +0530:[INFO] [{UpgradeVolumeDriver}] Destroy apps
INFO[2024-01-17 16:50:00] Verifying : Description : Test completed successfully ?
INFO[2024-01-17 16:50:00] Actual:PASS, Expected: PASS
INFO[2024-01-17 16:50:01] --------Test End------
INFO[2024-01-17 16:50:01] #Test: UpgradeVolumeDriver
INFO[2024-01-17 16:50:01] #Description: Validating volume driver upgrade
INFO[2024-01-17 16:50:01] ------------------------

• [SLOW TEST:122.382 seconds]
{UpgradeVolumeDriver}
```
