### PR TITLE
PB-5348: Add mysql-ibm app to run mysql app with ibm block vpc

### DIFF
--- a/drivers/scheduler/k8s/specs/mysql-ibm/ibm/ibm-storage-class.yaml
+++ b/drivers/scheduler/k8s/specs/mysql-ibm/ibm/ibm-storage-class.yaml
@@ -1,0 +1,19 @@
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: mysql-sc
+parameters:
+  billingType: hourly
+  classVersion: "1"
+  csi.storage.k8s.io/fstype: ext4
+  encrypted: "false"
+  encryptionKey: ""
+  profile: 10iops-tier
+  region: ""
+  resourceGroup: ""
+  tags: ""
+  zone: ""
+provisioner: vpc.block.csi.ibm.io
+reclaimPolicy: Delete
+volumeBindingMode: Immediate

--- a/drivers/scheduler/k8s/specs/mysql-ibm/mysql-app.yaml
+++ b/drivers/scheduler/k8s/specs/mysql-ibm/mysql-app.yaml
@@ -1,0 +1,101 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  labels:
+    app: mysql
+spec:
+  ports:
+    - port: 3306
+  selector:
+    app: mysql
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql
+  labels:
+    app: mysql
+spec:
+  selector:
+    matchLabels:
+      app: mysql
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      containers:
+        - image: mysql:5.6
+          name: mysql
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: password
+          ports:
+            - containerPort: 3306
+          livenessProbe:
+            exec:
+              command: ["sh", "-c", "mysqladmin -u root -p$MYSQL_ROOT_PASSWORD ping"]
+            initialDelaySeconds: 70
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command: ["sh", "-c", "mysql -u root -p$MYSQL_ROOT_PASSWORD -e \"select 1\""]
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            timeoutSeconds: 5
+          volumeMounts:
+            - name: mysql-persistent-storage
+              mountPath: /var/lib/mysql
+            - mountPath: /var/lib/mysql-aggr
+              name: mysql-persistent-storage-aggr
+            - mountPath: /var/lib/mysql-seq
+              name: mysql-persistent-storage-seq
+      volumes:
+        - name: mysql-persistent-storage
+          persistentVolumeClaim:
+            claimName: mysql-data
+        - name: mysql-persistent-storage-aggr
+          persistentVolumeClaim:
+            claimName: mysql-data-aggr
+        - name: mysql-persistent-storage-seq
+          persistentVolumeClaim:
+            claimName: mysql-data-seq
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysqlslap
+  labels:
+    app: mysqlslap
+spec:
+  selector:
+    matchLabels:
+      app: mysqlslap
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: mysqlslap
+    spec:
+      containers:
+        - name: mysqlslap
+          image: adityadani/mysqlslap
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: password
+            - name: MYSQL_SERVICE_PORT
+              value: "3306"

--- a/drivers/scheduler/k8s/specs/mysql-ibm/mysql-storage.yaml
+++ b/drivers/scheduler/k8s/specs/mysql-ibm/mysql-storage.yaml
@@ -1,0 +1,37 @@
+
+##### Portworx persistent volume claim
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: mysql-data
+spec:
+  storageClassName: mysql-sc
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: mysql-data-seq
+spec:
+  storageClassName: mysql-sc
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: mysql-data-aggr
+spec:
+  storageClassName: mysql-sc
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi

--- a/tests/backup/backup_helper.go
+++ b/tests/backup/backup_helper.go
@@ -243,6 +243,18 @@ var (
 				},
 			},
 		},
+		"mysql-ibm": {
+			PreRule: backup.PreRule{
+				Rule: backup.RuleSpec{
+					ActionList: []string{"mysql --user=root --password=$MYSQL_ROOT_PASSWORD -Bse 'FLUSH TABLES WITH READ LOCK;system ${WAIT_CMD};'"}, PodSelectorList: []string{"app=mysql"}, Background: []string{"true"}, RunInSinglePod: []string{"false"}, Container: []string{},
+				},
+			},
+			PostRule: backup.PostRule{
+				Rule: backup.RuleSpec{
+					ActionList: []string{"mysql --user=root --password=$MYSQL_ROOT_PASSWORD -Bse 'FLUSH LOGS; UNLOCK TABLES;'"}, PodSelectorList: []string{"app=mysql"}, Background: []string{"false"}, RunInSinglePod: []string{"false"}, Container: []string{},
+				},
+			},
+		},
 		"postgres": {
 			PreRule: backup.PreRule{
 				Rule: backup.RuleSpec{


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
- [x] Add mysql-ibm app to run mysql app with ibm block vpc
- [x] Add `mysql-ibm` rule in `backup_helper.go` 

**Which issue(s) this PR fixes** (optional)
Closes #PB-5348

**Special notes for your reviewer**:

