### PR TITLE
DS-7699: Divert newman Results into a file from command line logs

### DIFF
--- a/drivers/postmanApiLoadDriver/newmanResults/sample.json
+++ b/drivers/postmanApiLoadDriver/newmanResults/sample.json
@@ -1,0 +1,1 @@
+{"newman":"results"}

--- a/drivers/postmanApiLoadDriver/postmanApi.go
+++ b/drivers/postmanApiLoadDriver/postmanApi.go
@@ -64,7 +64,8 @@ func ExecutePostmanCommandInTorpedoForPDS(postmanParams *PostmanDriver) (bool, e
 
 	iterations := postmanParams.Iteration
 	resultsPath, err := filepath.Abs(defaultResultsPath)
-	newmanCmd := "newman run " + collectionPath + " -n " + iterations + " --verbose" + " -r " + postmanParams.ResultType + " --reporter-json-export " + resultsPath + "/" + postmanParams.ResultsFileName
+	resultsFilePath := resultsPath + "/" + postmanParams.ResultsFileName
+	newmanCmd := "newman run " + collectionPath + " -n " + iterations + " --verbose" + " -r " + postmanParams.ResultType + " --reporter-json-export " + resultsFilePath
 	log.InfoD("Newman command formed is- [%v]", newmanCmd)
 	output, res, err := ExecuteCommandInShell(newmanCmd)
 	if err != nil {
@@ -74,6 +75,6 @@ func ExecutePostmanCommandInTorpedoForPDS(postmanParams *PostmanDriver) (bool, e
 	if strings.Contains(output, "failure") {
 		return false, fmt.Errorf("newman exited with a failure..[%v] Please check logs for more details", err)
 	}
-	log.InfoD("Postman execution is completed and the results are exported to filepath - [%v]", resultsPath)
+	log.InfoD("Postman execution is completed and the results are exported to filepath - [%v]", resultsFilePath)
 	return true, nil
 }

--- a/drivers/postmanApiLoadDriver/postmanApi.go
+++ b/drivers/postmanApiLoadDriver/postmanApi.go
@@ -74,5 +74,6 @@ func ExecutePostmanCommandInTorpedoForPDS(postmanParams *PostmanDriver) (bool, e
 	if strings.Contains(output, "failure") {
 		return false, fmt.Errorf("newman exited with a failure..[%v] Please check logs for more details", err)
 	}
+	log.InfoD("Postman execution is completed and the results are exported to filepath - [%v]", resultsPath)
 	return true, nil
 }

--- a/drivers/postmanApiLoadDriver/postmanApi.go
+++ b/drivers/postmanApiLoadDriver/postmanApi.go
@@ -24,13 +24,14 @@ type PostmanDriver struct {
 }
 
 // GetProjectNameToExecutePostman MAIN driver function which will decide which project to run
-func GetProjectNameToExecutePostman(projectName string, driver *PostmanDriver) {
+func GetProjectNameToExecutePostman(projectName string, driver *PostmanDriver) error {
 	if projectName == PxDataServices {
 		_, err := ExecutePostmanCommandInTorpedoForPDS(driver)
 		if err != nil {
-			log.FailOnError(err, "Postman execution failed.. Please check the logs manually.")
+			return fmt.Errorf("postman execution failed.. [%v] Please check the logs manually", err)
 		}
 	}
+	return nil
 	//ToDo: Add cases for other PX Projects
 }
 
@@ -57,7 +58,7 @@ func ExecuteCommandInShell(command string) (string, string, error) {
 func ExecutePostmanCommandInTorpedoForPDS(postmanParams *PostmanDriver) (bool, error) {
 	collectionPath, err := GetPostmanCollectionPath()
 	if err != nil {
-		log.FailOnError(err, "Postman Collection Json not found, Please create a Collection json manually and export to {%v} folder", defaultCollectionPath)
+		return false, fmt.Errorf("postman Collection Json not found [%v], Please create a Collection json manually and export to [%v] folder", err, defaultCollectionPath)
 	}
 	log.InfoD("Postman Collection found is- %v", collectionPath)
 
@@ -71,7 +72,7 @@ func ExecutePostmanCommandInTorpedoForPDS(postmanParams *PostmanDriver) (bool, e
 	}
 	log.InfoD("output from the newman execution is- %v", res)
 	if strings.Contains(output, "failure") {
-		log.FailOnError(err, "newman exited with a failure.. Please check logs for more details")
+		return false, fmt.Errorf("newman exited with a failure..[%v] Please check logs for more details", err)
 	}
 	return true, nil
 }

--- a/tests/pds/pds_postman_test.go
+++ b/tests/pds/pds_postman_test.go
@@ -5,6 +5,7 @@ import (
 	postmanLib "github.com/portworx/torpedo/drivers/postmanApiLoadDriver"
 	"github.com/portworx/torpedo/pkg/log"
 	. "github.com/portworx/torpedo/tests"
+	"time"
 )
 
 var _ = Describe("{RunPdsPostManApiLoadTests}", func() {
@@ -13,7 +14,7 @@ var _ = Describe("{RunPdsPostManApiLoadTests}", func() {
 	})
 	It("Deploy Dataservices", func() {
 		Step("Starting to execute Postman-Newman on PDS", func() {
-			var resultsFileName = "result_" + RandomString(5) + ".json"
+			var resultsFileName = "result_" + time.DateTime + ".json"
 			ctx, err := GetSourceClusterConfigPath()
 			log.FailOnError(err, "failed while getting dest cluster path")
 			postmanParams := postmanLib.PostmanDriver{

--- a/tests/pds/pds_postman_test.go
+++ b/tests/pds/pds_postman_test.go
@@ -13,16 +13,16 @@ var _ = Describe("{RunPdsPostManApiLoadTests}", func() {
 	})
 	It("Deploy Dataservices", func() {
 		Step("Starting to execute Postman-Newman on PDS", func() {
-			var resultsFileName = "postman_results"
+			var resultsFileName = "result_" + RandomString(5) + ".json"
 			ctx, err := GetSourceClusterConfigPath()
 			log.FailOnError(err, "failed while getting dest cluster path")
 			postmanParams := postmanLib.PostmanDriver{
 				ResultsFileName: resultsFileName,
-				ResultType:      "json, cli",
+				ResultType:      "cli,json",
+				Namespace:       params.InfraToTest.Namespace,
 				Iteration:       "2",
 				Kubeconfig:      ctx}
-			err = postmanLib.GetProjectNameToExecutePostman("pds", &postmanParams)
-			log.FailOnError(err, "Postman execution failed.. Please check the logs manually.")
+			postmanLib.GetProjectNameToExecutePostman("pds", &postmanParams)
 		})
 	})
 	JustAfterEach(func() {

--- a/tests/pds/pds_postman_test.go
+++ b/tests/pds/pds_postman_test.go
@@ -15,7 +15,9 @@ var _ = Describe("{RunPdsPostManApiLoadTests}", func() {
 	})
 	It("Deploy Dataservices", func() {
 		Step("Starting to execute Postman-Newman on PDS", func() {
-			var resultsFileName = "result_" + fmt.Sprint(time.Now().Unix()) + ".json"
+			currentTime := time.Now()
+			timeStamp := currentTime.Format("2006-01-02_15:04:05_MST")
+			resultsFileName := fmt.Sprintf("result_%s.json", timeStamp)
 			ctx, err := GetSourceClusterConfigPath()
 			log.FailOnError(err, "failed while getting dest cluster path")
 			postmanParams := postmanLib.PostmanDriver{

--- a/tests/pds/pds_postman_test.go
+++ b/tests/pds/pds_postman_test.go
@@ -14,7 +14,7 @@ var _ = Describe("{RunPdsPostManApiLoadTests}", func() {
 	})
 	It("Deploy Dataservices", func() {
 		Step("Starting to execute Postman-Newman on PDS", func() {
-			var resultsFileName = "result_" + string(time.Now().Unix()) + ".json"
+			var resultsFileName = "result_" + fmt.Sprint(time.Now().Unix()) + ".json"
 			ctx, err := GetSourceClusterConfigPath()
 			log.FailOnError(err, "failed while getting dest cluster path")
 			postmanParams := postmanLib.PostmanDriver{

--- a/tests/pds/pds_postman_test.go
+++ b/tests/pds/pds_postman_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"fmt"
 	. "github.com/onsi/ginkgo"
 	postmanLib "github.com/portworx/torpedo/drivers/postmanApiLoadDriver"
 	"github.com/portworx/torpedo/pkg/log"

--- a/tests/pds/pds_postman_test.go
+++ b/tests/pds/pds_postman_test.go
@@ -22,7 +22,8 @@ var _ = Describe("{RunPdsPostManApiLoadTests}", func() {
 				Namespace:       params.InfraToTest.Namespace,
 				Iteration:       "2",
 				Kubeconfig:      ctx}
-			postmanLib.GetProjectNameToExecutePostman("pds", &postmanParams)
+			err = postmanLib.GetProjectNameToExecutePostman("pds", &postmanParams)
+			log.FailOnError(err, "Postman-Newman Execution has failed due to- ")
 		})
 	})
 	JustAfterEach(func() {

--- a/tests/pds/pds_postman_test.go
+++ b/tests/pds/pds_postman_test.go
@@ -14,7 +14,7 @@ var _ = Describe("{RunPdsPostManApiLoadTests}", func() {
 	})
 	It("Deploy Dataservices", func() {
 		Step("Starting to execute Postman-Newman on PDS", func() {
-			var resultsFileName = "result_" + time.DateTime + ".json"
+			var resultsFileName = "result_" + string(time.Now().Unix()) + ".json"
 			ctx, err := GetSourceClusterConfigPath()
 			log.FailOnError(err, "failed while getting dest cluster path")
 			postmanParams := postmanLib.PostmanDriver{


### PR DESCRIPTION
This ticket takes the newman execution result logs into a json file and saves it into /newmanresults folder.

Aetos Run - https://aetos.pwx.purestorage.com/resultSet/testSetID/508538
Jenkins Logs - https://jenkins.pwx.dev.purestorage.com/job/PDS/job/pds-system-test/job/pds-bkp-restr-system-test/122/console