### PR TITLE
Adding script to deploy grafana if enabled through env variable

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -4,6 +4,10 @@ if [ -z "${ENABLE_DASH}" ]; then
     ENABLE_DASH=true
 fi
 
+if [ -z "${ENABLE_GRAFANA}" ]; then
+    ENABLE_GRAFANA=false
+fi
+
 if [ -z "${DATA_INTEGRITY_VALIDATION_TESTS}" ]; then
     DATA_INTEGRITY_VALIDATION_TESTS=""
 fi
@@ -743,6 +747,8 @@ spec:
       value: "${PX_BACKUP_MONGODB_USERNAME}"
     - name: PX_BACKUP_MONGODB_PASSWORD
       value: "${PX_BACKUP_MONGODB_PASSWORD}"
+    - name: ENABLE_GRAFANA
+      value: "${ENABLE_GRAFANA}"
   volumes: [${VOLUMES}]
   restartPolicy: Never
   serviceAccountName: torpedo-account

--- a/deployments/setup_grafana.sh
+++ b/deployments/setup_grafana.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <namespace>"
+    exit 1
+fi
+
+namespace=$1
+
+# Download Grafana dashboard configuration files
+curl -O https://docs.portworx.com/samples/k8s/pxc/grafana-dashboard-config.yaml
+curl -O https://docs.portworx.com/samples/k8s/pxc/grafana-datasource.yaml
+
+# Create ConfigMaps for Grafana dashboards
+kubectl -n $namespace create configmap grafana-dashboard-config --from-file=grafana-dashboard-config.yaml
+kubectl -n $namespace create configmap grafana-source-config --from-file=grafana-datasource.yaml
+
+# Download Grafana dashboard JSON files
+curl "https://docs.portworx.com/samples/k8s/pxc/portworx-cluster-dashboard.json" -o portworx-cluster-dashboard.json && \
+curl "https://docs.portworx.com/samples/k8s/pxc/portworx-node-dashboard.json" -o portworx-node-dashboard.json && \
+curl "https://docs.portworx.com/samples/k8s/pxc/portworx-volume-dashboard.json" -o portworx-volume-dashboard.json && \
+curl "https://docs.portworx.com/samples/k8s/pxc/portworx-performance-dashboard.json" -o portworx-performance-dashboard.json && \
+curl "https://docs.portworx.com/samples/k8s/pxc/portworx-etcd-dashboard.json" -o portworx-etcd-dashboard.json
+
+# Create ConfigMap for Grafana dashboards
+kubectl -n $namespace create configmap grafana-dashboards \
+--from-file=portworx-cluster-dashboard.json \
+--from-file=portworx-performance-dashboard.json \
+--from-file=portworx-node-dashboard.json \
+--from-file=portworx-volume-dashboard.json \
+--from-file=portworx-etcd-dashboard.json
+
+# Download Grafana YAML file and replace namespace
+curl "https://docs.portworx.com/samples/k8s/pxc/grafana.yaml" -o grafana.yaml
+sed -i "s/namespace: kube-system/namespace: $namespace/" grafana.yaml
+
+# Apply Grafana YAML
+kubectl apply -f grafana.yaml
+
+# Create node-exporter DaemonSet
+cat >> node-exporter.yaml <<EOF
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: node-exporter
+  name: node-exporter
+  namespace: $namespace
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: exporter
+      app.kubernetes.io/name: node-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: exporter
+        app.kubernetes.io/name: node-exporter
+    spec:
+      containers:
+      - args:
+        - --path.sysfs=/host/sys
+        - --path.rootfs=/host/root
+        - --no-collector.wifi
+        - --no-collector.hwmon
+        - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
+        - --collector.netclass.ignored-devices=^(veth.*)$
+        name: node-exporter
+        image: prom/node-exporter
+        ports:
+          - containerPort: 9100
+            protocol: TCP
+        resources:
+          limits:
+            cpu: 250m
+            memory: 180Mi
+          requests:
+            cpu: 102m
+            memory: 180Mi
+        volumeMounts:
+        - mountPath: /host/sys
+          mountPropagation: HostToContainer
+          name: sys
+          readOnly: true
+        - mountPath: /host/root
+          mountPropagation: HostToContainer
+          name: root
+          readOnly: true
+      volumes:
+      - hostPath:
+          path: /sys
+        name: sys
+      - hostPath:
+          path: /
+        name: root
+EOF
+
+# Apply node-exporter DaemonSet
+kubectl apply -f node-exporter.yaml -n $namespace
+
+
+# Create node-exporter Service
+cat >> node-exportersvc.yaml <<EOF
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: node-exporter
+  namespace: $namespace
+  labels:
+    name: node-exporter
+spec:
+  selector:
+      app.kubernetes.io/component: exporter
+      app.kubernetes.io/name: node-exporter
+  ports:
+  - name: node-exporter
+    protocol: TCP
+    port: 9100
+    targetPort: 9100
+EOF
+
+# Apply node-exporter service
+kubectl apply -f node-exportersvc.yaml -n $namespace
+
+
+# Create node-exporter service monitor
+cat >> node-exporter-svcmonitor.yaml <<EOF
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: node-exporter
+  labels:
+    prometheus: portworx
+spec:
+  selector:
+    matchLabels:
+      name: node-exporter
+  endpoints:
+  - port: node-exporter
+EOF
+
+# Apply node-exporter service monitor
+kubectl apply -f node-exporter-svcmonitor.yaml -n $namespace
+
+
+echo "Grafana and Node-Exporter setup completed for namespace: $namespace"


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Adding script to deploy grafana if enabled through env variable
**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

Result:

https://jenkins.pwx.dev.purestorage.com/view/Leela-monitoring-jobs/job/Torpedo/job/tp-vsphere-cd-btrfs/42/console

```
00:29:05.470 2024-01-29 14:19:40 +0000:[INFO] [osutils.Chmod:#135] - mode +x changed on file /torpedo/deployments/setup_grafana.sh

00:29:05.470 2024-01-29 14:19:40 +0000:[DEBUG] [osutils.ExecTorpedoShell:#85] - Command /bin/sh -c /torpedo/deployments/setup_grafana.sh portworx 



00:29:05.976 configmap/grafana-dashboard-config created

00:29:06.025 configmap/grafana-source-config created


00:29:07.657 configmap/grafana-dashboards created


00:29:08.067 service/grafana created

00:29:08.078 deployment.apps/grafana created

00:29:08.238 daemonset.apps/node-exporter created

00:29:08.464 service/node-exporter created

00:29:08.618 servicemonitor.monitoring.coreos.com/node-exporter created

00:29:08.620 Grafana and Node-Exporter setup completed for namespace: portworx
```

![Capture-2024-01-29-195702](https://github.com/portworx/torpedo/assets/83946232/d0fff38f-2cd6-4744-a909-2ee98db41e41)
