### PR TITLE
Adding node validations during platform upgrade

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -660,6 +660,8 @@ spec:
       value: "${VSPHERE_PWD}"
     - name: VSPHERE_HOST_IP
       value: "${VSPHERE_HOST_IP}"
+    - name: VSPHERE_DATACENTER
+      value: "${VSPHERE_DATACENTER}"
     - name: IBMCLOUD_API_KEY
       value: "${IBMCLOUD_API_KEY}"
     - name: CONTROL_PLANE_URL

--- a/drivers/node/node_registry.go
+++ b/drivers/node/node_registry.go
@@ -91,7 +91,7 @@ func IsMasterNode(n Node) bool {
 func GetStorageDriverNodes() []Node {
 	var nodeList []Node
 	for _, n := range nodeRegistry {
-		if n.Type == TypeWorker && n.IsStorageDriverInstalled {
+		if n.IsStorageDriverInstalled {
 			nodeList = append(nodeList, n)
 		}
 	}

--- a/tests/basic/upgrade_cluster_test.go
+++ b/tests/basic/upgrade_cluster_test.go
@@ -2,9 +2,16 @@ package tests
 
 import (
 	"fmt"
+	ops_v1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
 	"github.com/portworx/sched-ops/k8s/core"
+	"github.com/portworx/sched-ops/k8s/operator"
+	"github.com/portworx/torpedo/drivers/node"
+	"github.com/portworx/torpedo/drivers/scheduler/openshift"
 	"github.com/portworx/torpedo/pkg/log"
+	v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"net/url"
+	"os/exec"
 	"strings"
 	"time"
 
@@ -12,7 +19,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/portworx/torpedo/drivers/scheduler"
 	. "github.com/portworx/torpedo/tests"
-	"k8s.io/api/core/v1"
 )
 
 var _ = Describe("{UpgradeCluster}", func() {
@@ -41,22 +47,29 @@ var _ = Describe("{UpgradeCluster}", func() {
 		stopSignal := make(chan struct{})
 		var mError error
 		go getClusterNodesInfo(stopSignal, &mError)
-		defer close(stopSignal)
+
+		defer func() {
+			close(stopSignal)
+		}()
 
 		for _, version := range versions {
+			if Inst().S.String() == openshift.SchedName && strings.Contains(version, "4.14") {
+				err = ocp414Prereq()
+				log.FailOnError(err, fmt.Sprintf("error running OCP pre-requisites for version:%s", version))
+			}
 			Step("start scheduler upgrade", func() {
 				err := Inst().S.UpgradeScheduler(version)
-				Expect(err).NotTo(HaveOccurred())
+				dash.VerifyFatal(err, nil, fmt.Sprintf("verify upgrade to %s is successful", version))
 			})
-
-			dash.VerifyFatal(mError, nil, "validate no parallel upgrade of nodes")
 
 			Step("validate storage components", func() {
-				u, err := url.Parse(fmt.Sprintf("%s/%s", Inst().StorageDriverUpgradeEndpointURL, Inst().StorageDriverUpgradeEndpointVersion))
-				Expect(err).NotTo(HaveOccurred())
+				urlToParse := fmt.Sprintf("%s/%s", Inst().StorageDriverUpgradeEndpointURL, Inst().StorageDriverUpgradeEndpointVersion)
+				u, err := url.Parse(urlToParse)
+				log.FailOnError(err, fmt.Sprintf("error parsing the url: %s", urlToParse))
 				err = Inst().V.ValidateDriver(u.String(), true)
-				Expect(err).NotTo(HaveOccurred())
+				dash.VerifyFatal(err, nil, fmt.Sprintf("verify volume driver after upgrade to %s", version))
 			})
+			dash.VerifyFatal(mError, nil, "validate no parallel upgrade of nodes")
 
 			Step("validate all apps after upgrade", func() {
 				ValidateApplications(contexts)
@@ -78,12 +91,30 @@ var _ = Describe("{UpgradeCluster}", func() {
 })
 
 func getClusterNodesInfo(stopSignal <-chan struct{}, mError *error) {
+	stNodes := node.GetStorageNodes()
 
-	masterNodeStatus := make(map[string]bool)
-	workerNodeStatus := make(map[string]bool)
+	nodeSchedulableStatus := make(map[string]string)
+	stNodeNames := make(map[string]bool)
+
+	for _, stNode := range stNodes {
+		stNodeNames[stNode.Name] = true
+	}
+
+	//Handling case where we have storageless node as kvdb node with dedicated kvdb device attached.
+	kvdbNodes, _ := GetAllKvdbNodes()
+	for _, kvdbNode := range kvdbNodes {
+		sNode, err := node.GetNodeDetailsByNodeID(kvdbNode.ID)
+		if err == nil {
+			stNodeNames[sNode.Name] = true
+		} else {
+			log.Errorf("got error while getting with id [%s]", kvdbNode.ID)
+		}
+	}
+
+	log.Infof("stnodes are %#v", stNodeNames)
 	itr := 1
 	for {
-		log.Infof("K8s node validation iteration: #%d", itr)
+		log.Infof("K8s node validation. iteration: #%d", itr)
 		select {
 		case <-stopSignal:
 			log.Infof("Exiting node validations routine")
@@ -91,41 +122,115 @@ func getClusterNodesInfo(stopSignal <-chan struct{}, mError *error) {
 		default:
 			nodeList, err := core.Instance().GetNodes()
 			if err != nil {
-				mError = &err
-				return
-			}
-			masterCount := 0
-			workerCount := 0
-			for _, k8sNode := range nodeList.Items {
-				if strings.Contains(k8sNode.Name, "master") {
-					masterNodeStatus[k8sNode.Name] = k8sNode.Spec.Unschedulable
-					if k8sNode.Spec.Unschedulable {
-						masterCount += 1
-					}
-				} else {
-					workerNodeStatus[k8sNode.Name] = k8sNode.Spec.Unschedulable
-					if k8sNode.Spec.Unschedulable {
-						workerCount += 1
-					}
-				}
-			}
-			log.Infof("Master Map status is %#v", masterNodeStatus)
-			log.Infof("Worker Map status is %#v", workerNodeStatus)
-			if masterCount > 1 || workerCount > 1 {
-				err = fmt.Errorf("multiple controlpnane or worker nodes are Unschedulable at same time,"+
-					"controlplane:%#v,worker:%#v", masterNodeStatus, workerNodeStatus)
-				mError = &err
+				log.Errorf("Got error : %s", err.Error())
+				*mError = err
 				return
 			}
 
-			itr++
-			time.Sleep(30 * time.Second)
+			nodeNotReadyeCount := 0
+			for _, k8sNode := range nodeList.Items {
+				for _, status := range k8sNode.Status.Conditions {
+					if status.Type == v1.NodeReady {
+						nodeSchedulableStatus[k8sNode.Name] = string(status.Status)
+						if status.Status != v1.ConditionTrue && stNodeNames[k8sNode.Name] {
+							nodeNotReadyeCount += 1
+						}
+						break
+					}
+				}
+
+			}
+			if nodeNotReadyeCount > 1 {
+				err = fmt.Errorf("multiple  nodes are Unschedulable at same time,"+
+					"node status:%#v", nodeSchedulableStatus)
+				log.Errorf("Got error : %s", err.Error())
+				log.Infof("Node Details: %#v", nodeList.Items)
+				output, err := Inst().N.RunCommand(stNodes[0], "pxctl status", node.ConnectionOpts{
+					IgnoreError:     false,
+					TimeBeforeRetry: defaultRetryInterval,
+					Timeout:         defaultTimeout,
+					Sudo:            true,
+				})
+				if err != nil {
+					log.Errorf("failed to get pxctl status, Err: %v", err)
+				}
+				log.Infof(output)
+				*mError = err
+				return
+			}
+		}
+		itr++
+		time.Sleep(30 * time.Second)
+	}
+}
+
+func ocp414Prereq() error {
+
+	stc, err := Inst().V.GetDriver()
+	if err != nil {
+		return err
+	}
+
+	log.Infof("is autopilot enabled?: %t", stc.Spec.Autopilot.Enabled)
+	if stc.Spec.Autopilot.Enabled {
+		if err = createClusterMonitoringConfig(); err != nil {
+			return err
+		}
+
+		if err = updatePrometheusAndAutopilot(stc); err != nil {
+			return err
 		}
 	}
 
+	return nil
+
 }
 
-func isNodeUpgradeInProgress(node v1.Node) bool {
-	log.Infof("Node [%s] Unschedulable status: %v ", node.Name, node.Spec.Unschedulable)
-	return node.Spec.Unschedulable
+func createClusterMonitoringConfig() error {
+	// Create configmap
+	ocpConfigmap := &v1.ConfigMap{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "cluster-monitoring-config",
+			Namespace: "openshift-monitoring",
+		},
+		Data: map[string]string{
+			"config.yaml": "enableUserWorkload: true",
+		},
+	}
+
+	_, err = core.Instance().CreateConfigMap(ocpConfigmap)
+
+	return err
+
+}
+
+func updatePrometheusAndAutopilot(stc *ops_v1.StorageCluster) error {
+	thanosQuerierHostCmd := `kubectl get route thanos-querier -n openshift-monitoring -o json | jq -r '.spec.host'`
+
+	var output []byte
+
+	output, err = exec.Command("sh", "-c", thanosQuerierHostCmd).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to get thanos querier host , Err: %v", err)
+	}
+	thanosQuerierHost := strings.TrimSpace(string(output))
+	log.Infof("Thanos Querier Host:%s", thanosQuerierHost)
+
+	if stc.Spec.Monitoring.Prometheus.Enabled {
+		stc.Spec.Monitoring.Prometheus.Enabled = false
+	}
+
+	dataProviders := stc.Spec.Autopilot.Providers
+
+	for _, dataProvider := range dataProviders {
+		if dataProvider.Type == "prometheus" {
+			dataProvider.Params["url"] = fmt.Sprintf("https://%s", thanosQuerierHost)
+		}
+
+	}
+	pxOperator := operator.Instance()
+	_, err = pxOperator.UpdateStorageCluster(stc)
+
+	return err
+
 }

--- a/tests/basic/upgrade_cluster_test.go
+++ b/tests/basic/upgrade_cluster_test.go
@@ -2,13 +2,17 @@ package tests
 
 import (
 	"fmt"
+	"github.com/portworx/sched-ops/k8s/core"
+	"github.com/portworx/torpedo/pkg/log"
 	"net/url"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/portworx/torpedo/drivers/scheduler"
 	. "github.com/portworx/torpedo/tests"
+	"k8s.io/api/core/v1"
 )
 
 var _ = Describe("{UpgradeCluster}", func() {
@@ -34,12 +38,18 @@ var _ = Describe("{UpgradeCluster}", func() {
 			versions = strings.Split(Inst().SchedUpgradeHops, ",")
 		}
 		Expect(versions).NotTo(BeEmpty())
+		stopSignal := make(chan struct{})
+		var mError error
+		go getClusterNodesInfo(stopSignal, &mError)
+		defer close(stopSignal)
 
 		for _, version := range versions {
 			Step("start scheduler upgrade", func() {
 				err := Inst().S.UpgradeScheduler(version)
 				Expect(err).NotTo(HaveOccurred())
 			})
+
+			dash.VerifyFatal(mError, nil, "validate no parallel upgrade of nodes")
 
 			Step("validate storage components", func() {
 				u, err := url.Parse(fmt.Sprintf("%s/%s", Inst().StorageDriverUpgradeEndpointURL, Inst().StorageDriverUpgradeEndpointVersion))
@@ -66,3 +76,56 @@ var _ = Describe("{UpgradeCluster}", func() {
 		AfterEachTest(contexts)
 	})
 })
+
+func getClusterNodesInfo(stopSignal <-chan struct{}, mError *error) {
+
+	masterNodeStatus := make(map[string]bool)
+	workerNodeStatus := make(map[string]bool)
+	itr := 1
+	for {
+		log.Infof("K8s node validation iteration: #%d", itr)
+		select {
+		case <-stopSignal:
+			log.Infof("Exiting node validations routine")
+			return
+		default:
+			nodeList, err := core.Instance().GetNodes()
+			if err != nil {
+				mError = &err
+				return
+			}
+			masterCount := 0
+			workerCount := 0
+			for _, k8sNode := range nodeList.Items {
+				if strings.Contains(k8sNode.Name, "master") {
+					masterNodeStatus[k8sNode.Name] = k8sNode.Spec.Unschedulable
+					if k8sNode.Spec.Unschedulable {
+						masterCount += 1
+					}
+				} else {
+					workerNodeStatus[k8sNode.Name] = k8sNode.Spec.Unschedulable
+					if k8sNode.Spec.Unschedulable {
+						workerCount += 1
+					}
+				}
+			}
+			log.Infof("Master Map status is %#v", masterNodeStatus)
+			log.Infof("Worker Map status is %#v", workerNodeStatus)
+			if masterCount > 1 || workerCount > 1 {
+				err = fmt.Errorf("multiple controlpnane or worker nodes are Unschedulable at same time,"+
+					"controlplane:%#v,worker:%#v", masterNodeStatus, workerNodeStatus)
+				mError = &err
+				return
+			}
+
+			itr++
+			time.Sleep(30 * time.Second)
+		}
+	}
+
+}
+
+func isNodeUpgradeInProgress(node v1.Node) bool {
+	log.Infof("Node [%s] Unschedulable status: %v ", node.Name, node.Spec.Unschedulable)
+	return node.Spec.Unschedulable
+}

--- a/tests/basic/upgrade_test.go
+++ b/tests/basic/upgrade_test.go
@@ -158,6 +158,9 @@ var _ = Describe("{UpgradeVolumeDriver}", func() {
 
 			var mError error
 			go doAppsValidation(contexts, stopSignal, &mError)
+			defer func() {
+				close(stopSignal)
+			}()
 
 			// Perform upgrade hops of volume driver based on a given list of upgradeEndpoints passed
 			for _, upgradeHop := range strings.Split(Inst().UpgradeStorageDriverEndpointList, ",") {
@@ -232,7 +235,6 @@ var _ = Describe("{UpgradeVolumeDriver}", func() {
 					break
 				}
 			}
-			close(stopSignal)
 			dash.VerifyFatal(mError, nil, "validate apps during PX upgrade")
 		})
 

--- a/tests/common.go
+++ b/tests/common.go
@@ -580,6 +580,16 @@ func InitInstance() {
 		t.Tags["px-version"] = pxVersion
 	}
 
+	output, err := Inst().N.RunCommand(node.GetStorageNodes()[0], "pxctl status", node.ConnectionOpts{
+		IgnoreError:     false,
+		TimeBeforeRetry: defaultRetryInterval,
+		Timeout:         defaultTimeout,
+		Sudo:            true,
+	})
+	if err != nil {
+		log.Errorf("failed to get pxctl status, Err: %v", err)
+	}
+	log.Infof(output)
 	ns, err := Inst().V.GetVolumeDriverNamespace()
 	log.FailOnError(err, "Error occured while getting volume driver namespace")
 	installGrafana(ns)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
- Fix for ocp upgrade to 4.14 
- Added logic for validating only one storage node is getting upgraded at a time in ocp
- Added VSPHERE_DATACENTER variable for vc which do not have default datacenters

**Which issue(s) this PR fixes** (optional)
Closes #PTX-22146

**Special notes for your reviewer**:

Result:
https://jenkins.pwx.dev.purestorage.com/job/Torpedo/view/OCP%20Jobs/job/tp-ocp-upgrade/533/console

please note job was failing due to another issue post upgrade

Non-ocp job regression 
https://jenkins.pwx.dev.purestorage.com/view/Leela-monitoring-jobs/job/Torpedo/job/tp-basic-sharedv4/813/console
