### PR TITLE
PB-5488: Change logic to check is original backups are synced or not

### DIFF
--- a/tests/backup/backup_restore_basic_test.go
+++ b/tests/backup/backup_restore_basic_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -1297,7 +1298,14 @@ var _ = Describe("{BackupSyncBasicTest}", func() {
 			log.FailOnError(err, "Wait for BackupSync to complete")
 			fetchedBackupNames, err := GetAllBackupsAdmin()
 			log.FailOnError(err, "Getting a list of all backups")
-			dash.VerifyFatal(len(fetchedBackupNames), len(backupNames), "Comparing the expected and actual number of backups")
+
+			// Iterating through all backup and check if they are present in the fetched backup list or not
+			listOfFetchedBackups := strings.Join(fetchedBackupNames, "")
+			for _, backup := range backupNames {
+				re := regexp.MustCompile(fmt.Sprintf("%s-*", backup))
+				dash.VerifyFatal(re.MatchString(listOfFetchedBackups), true, fmt.Sprintf("Checking if backup [%s] was synced or not", backup))
+			}
+
 			var bkp *api.BackupObject
 			backupDriver := Inst().Backup
 			bkpEnumerateReq := &api.BackupEnumerateRequest{


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
- [x] Change logic to check is original backups are synced or not

Dashbaord URL: 
https://aetos.pwx.purestorage.com/resultSet/testSetID/531787
https://aetos.pwx.purestorage.com/resultSet/testSetID/531826


**Which issue(s) this PR fixes** (optional)
Closes #PB-5488

**Special notes for your reviewer**:

