### PR TITLE
Fixed Restore Delete issue.

### DIFF
--- a/tests/backup/backup_orphaned_test.go
+++ b/tests/backup/backup_orphaned_test.go
@@ -558,6 +558,13 @@ var _ = Describe("{DeleteUserBackupsAndRestoresOfDeletedAndInActiveClusterFromAd
 							log.FailOnError(fmt.Errorf(""), err.Error())
 						}
 					}
+					Step(fmt.Sprintf("Delete user %s restores from the admin", user), func() {
+						log.InfoD(fmt.Sprintf("Deleting user %s restores from the admin", user))
+						for restoreUid, restoreName := range userRestoreMap[user] {
+							err = DeleteRestoreWithUID(restoreName, restoreUid, BackupOrgID, ctx)
+							log.FailOnError(err, "failed to delete restore %s of the user %s", restoreName, user)
+						}
+					})
 				})
 				if i == 0 {
 					Step(fmt.Sprintf("Delete user %s source and destination cluster", user), func() {
@@ -656,13 +663,6 @@ var _ = Describe("{DeleteUserBackupsAndRestoresOfDeletedAndInActiveClusterFromAd
 						log.FailOnError(err, "failed to delete backup %s of the user %s", backupName, user)
 						err = Inst().Backup.WaitForBackupDeletion(ctx, backupName, BackupOrgID, BackupDeleteTimeout, BackupDeleteRetryTime)
 						log.FailOnError(err, fmt.Sprintf("failed waiting for user %s backup %s deletion", user, backupName))
-					}
-				})
-				Step(fmt.Sprintf("Delete user %s restores from the admin", user), func() {
-					log.InfoD(fmt.Sprintf("Deleting user %s restores from the admin", user))
-					for restoreUid, restoreName := range userRestoreMap[user] {
-						err = DeleteRestoreWithUID(restoreName, restoreUid, BackupOrgID, ctx)
-						log.FailOnError(err, "failed to delete restore %s of the user %s", restoreName, user)
 					}
 				})
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed Restore Delete issue with DeleteUserBackupsAndRestoresOfDeletedAndInActiveClusterFromAdmin, 
with 2.7.0 by default restores will be deleted when cluster is deleted. Hence moved delete restore code before cluster deletion.
https://portworx.atlassian.net/browse/PB-3175?focusedCommentId=278098
 

**Which issue(s) this PR fixes** (optional)
Closes #PB-5499

**Special notes for your reviewer**:
Tested with 2.6.0 :
https://jenkins.pwx.dev.purestorage.com/job/Users/job/Adilk/job/byoc-network/11/
Tested with 2.7.0 :
https://jenkins.pwx.dev.purestorage.com/job/Users/job/Adilk/job/byoc-network/13/
https://aetos.pwx.purestorage.com/resultSet/testSetID/532141