### PR TITLE
Revert "PTX-22246 Fix atupilot tests validation issues (#2067)"

### DIFF
--- a/drivers/scheduler/dcos/dcos.go
+++ b/drivers/scheduler/dcos/dcos.go
@@ -780,21 +780,11 @@ func (d *dcos) GetWorkloadSizeFromAppSpec(ctx *scheduler.Context) (uint64, error
 	return 0, nil
 }
 
-// GetAutopilotNamespace returns the autopilot namespace
 func (d *dcos) GetAutopilotNamespace() (string, error) {
 	// TODO implement this method
 	return "", &errors.ErrNotSupported{
 		Type:      "Function",
 		Operation: "GetAutopilotNamespace()",
-	}
-}
-
-// GetPortworxNamespace returns portworx namespace
-func (d *dcos) GetPortworxNamespace() (string, error) {
-	// TODO implement this method
-	return "", &errors.ErrNotSupported{
-		Type:      "Function",
-		Operation: "GetPortworxNamespace()",
 	}
 }
 

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -161,6 +161,7 @@ const (
 	SnapshotReadyTimeout             = 5 * time.Minute
 	numOfRestoredPVCForCloneManyTest = 500
 
+	autopilotDefaultNamespace         = "kube-system"
 	portworxServiceName               = "portworx-service"
 	resizeSupportedAnnotationKey      = "torpedo.io/resize-supported"
 	autopilotEnabledAnnotationKey     = "torpedo.io/autopilot-enabled"
@@ -3795,31 +3796,30 @@ func (k *K8s) ValidateVolumes(ctx *scheduler.Context, timeout, retryInterval tim
 					}
 				}
 			}
+
 			log.Infof("[%v] Validated PVC: %v, Namespace: %v", ctx.App.Key, obj.Name, obj.Namespace)
 
-			autopilotEnabledOnPvc := false
+			autopilotEnabled := false
 			if pvcAnnotationValue, ok := obj.Annotations[autopilotEnabledAnnotationKey]; ok {
-				autopilotEnabledOnPvc, err = strconv.ParseBool(pvcAnnotationValue)
+				autopilotEnabled, err = strconv.ParseBool(pvcAnnotationValue)
 				if err != nil {
 					return err
 				}
 			}
-
-			// Get autopilot namespace
-			autopilotNamespace, err := k.GetAutopilotNamespace()
-			if err != nil {
-				return fmt.Errorf("failed to get [autopilot] namespace, Err: %v", err)
-			}
-
 			autopilotLabels := make(map[string]string)
 			autopilotLabels["name"] = "autopilot"
-			autopilotPods, err := k8sCore.GetPods(autopilotNamespace, autopilotLabels)
+			autopilotPods, err := k8sCore.GetPods(autopilotDefaultNamespace, autopilotLabels)
 			if err != nil {
-				return fmt.Errorf("failed to get [autopilot] pods, Err: %v", err)
+				return err
 			}
-
-			autopilotEnabledOnPvc = autopilotEnabledOnPvc && !(len(autopilotPods.Items) == 0)
-			if autopilotEnabledOnPvc {
+			prometheusLabels := make(map[string]string)
+			prometheusLabels["app.kubernetes.io/name"] = "prometheus"
+			prometheusPods, err := k8sCore.GetPods(autopilotDefaultNamespace, prometheusLabels)
+			if err != nil {
+				return err
+			}
+			autopilotEnabled = autopilotEnabled && !(len(autopilotPods.Items) == 0) && !(len(prometheusPods.Items) == 0)
+			if autopilotEnabled {
 				listApRules, err := k8sAutopilot.ListAutopilotRules()
 				if err != nil {
 					return err
@@ -3836,7 +3836,7 @@ func (k *K8s) ValidateVolumes(ctx *scheduler.Context, timeout, retryInterval tim
 				}
 				log.Infof("[%v] Validated PVC: %v size based on Autopilot rules", ctx.App.Key, obj.Name)
 			} else {
-				log.Warnf("[%v] Autopilot is not enabled, PVC: %v size validation is not possible", ctx.App.Key, obj.Name)
+				log.Infof("[%v] Autopilot is not enabled, skipping PVC: %v size validation", ctx.App.Key, obj.Name)
 			}
 		} else if obj, ok := specObj.(*snapv1.VolumeSnapshot); ok {
 			if err := k8sExternalStorage.ValidateSnapshot(obj.Metadata.Name, obj.Metadata.Namespace, true, timeout,
@@ -6493,60 +6493,18 @@ func (k *K8s) addAnnotationsToPVC(pvc *corev1.PersistentVolumeClaim, annotations
 	}
 }
 
-// GetPortworxNamespace returns namespace where Portworx is deployed based on the portworx-service location
-func (k *K8s) GetPortworxNamespace() (string, error) {
+// GetAutopilotNamespace returns the autopilot namespace
+func (k *K8s) GetAutopilotNamespace() (string, error) {
 	allServices, err := k8sCore.ListServices("", metav1.ListOptions{})
 	if err != nil {
 		return "", err
 	}
-
-	var namespaces []string
 	for _, svc := range allServices.Items {
 		if svc.Name == portworxServiceName {
-			namespaces = append(namespaces, svc.Name)
+			return svc.Namespace, nil
 		}
 	}
-
-	if len(namespaces) > 0 {
-		// If portworx-service is deployed in 2 namespaces, return the none kube-system namespace
-		if len(namespaces) == 2 {
-			log.Debugf("Found [%s] service in 2 different namespaces %s", portworxServiceName, namespaces)
-			for _, namespace := range namespaces {
-				if namespace != "kube-system" {
-					log.Debugf("When Portworx deployed outside of [kube-system] namespace, it also creates [%s] service in the [kube-system ] namespace as well as in the namespace it is deployed in", portworxServiceName)
-					log.Debugf("Will assume Portworx is deployed in [%s] namespace", namespace)
-					return namespace, nil
-				}
-			}
-		}
-
-		// If portworx-service is deployed in more than 2 namespaces, something is wrong here
-		if len(namespaces) > 2 {
-			return "", fmt.Errorf("Portworx service [%s] is deployed in too many namespaces %s, something is wrong here", portworxServiceName, namespaces)
-		}
-
-		// portworx-service is deployed in kube-system if only 1 namesapce is found
-		return namespaces[0], nil
-	}
-
-	return "", fmt.Errorf("failed to determine which namespace Portowrx is deployed in, if deployed at all")
-}
-
-// GetAutopilotNamespace looks for StorageCluster object and returns the namespace of the object
-// If StorageCluster object is not found, will try to determine namespace by checking portworx-service location
-func (k *K8s) GetAutopilotNamespace() (string, error) {
-	stc, err := k8sOperator.ListStorageClusters("")
-	if err != nil {
-		return "", err
-	}
-	if len(stc.Items) > 0 {
-		log.Debugf("Found StorageCluster object, will assume Portworx and Autopilot are deployed in [%s] namespace", stc.Items[0].Namespace)
-		return stc.Items[0].Namespace, nil
-	}
-
-	// If StorageCluster object is not found, will try to determine namespace by checking portworx-service location
-	log.Debugf("Did not find any StorageCluster objects, will try to determine Portworx and Autopilot namespace based on [%s] service location", portworxServiceName)
-	return k.GetPortworxNamespace()
+	return autopilotDefaultNamespace, nil
 }
 
 // CreateAutopilotRule creates the AutopilotRule object

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -304,9 +304,6 @@ type Driver interface {
 	// GetAutopilotNamespace gets the Autopilot namespace
 	GetAutopilotNamespace() (string, error)
 
-	// GetPortworxNamespace gets the Portworx namespace
-	GetPortworxNamespace() (string, error)
-
 	// GetIOBandwidth gets container start and end time
 	GetIOBandwidth(string, string) (int, error)
 


### PR DESCRIPTION
This reverts commit b2e0eae88c836f4d36e70f65d50e01564f8f0d43.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
- [x] Revert "PTX-22246 Fix atupilot tests validation issues (#2067)" as it's causing pipeline failures in the non-px run  for px-backup pipelines with the below trace: 
```
14:07:54    [PANICKED] in [JustAfterEach] - /usr/local/go/src/runtime/panic.go:261 @ 02/11/24 08:37:54.07
14:07:54    << Timeline
14:07:54  
14:07:54    [FAILED] Unexpected error:
14:07:54        <*errors.errorString | 0xc000e9cf40>: 
14:07:54        failed to get [autopilot] namespace, Err: the server could not find the requested resource (get storageclusters.core.libopenstorage.org)
14:07:54        {
14:07:54            s: "failed to get [autopilot] namespace, Err: the server could not find the requested resource (get storageclusters.core.libopenstorage.org)",
14:07:54        }
14:07:54    occurred
14:07:54    In [It] at: /go/src/github.com/portworx/torpedo/pkg/log/log.go:334 @ 02/11/24 08:37:32.068
14:07:54  
14:07:54    Full Stack Trace
14:07:54      github.com/portworx/torpedo/pkg/log.FailOnError({0x8a77720, 0xc000e9cf40}, {0x80a0dcc?, 0xc002037000?}, {0x0?, 0x6 
```

**Which issue(s) this PR fixes** (optional)
Closes #PB-5626

**Special notes for your reviewer**:

