### PR TITLE
PB-5628: Updating the Golang version and removing the copy porx from the Dockerfile (TaaS).

### DIFF
--- a/Dockerfile-taas
+++ b/Dockerfile-taas
@@ -1,4 +1,4 @@
-FROM golang:1.19.5-alpine AS build
+FROM golang:1.21.6-alpine AS build
 LABEL maintainer="avinash@portworx.com"
 ARG MAKE_TARGET
 
@@ -13,7 +13,6 @@ COPY Makefile Makefile
 COPY go.mod go.mod
 COPY go.sum go.sum
 COPY pkg pkg
-COPY porx porx
 COPY scripts scripts
 COPY drivers drivers
 COPY deployments deployments

--- a/Dockerfile-taas
+++ b/Dockerfile-taas
@@ -1,4 +1,4 @@
-FROM golang:1.21.6-alpine AS build
+FROM golang:1.19.5-alpine AS build
 LABEL maintainer="avinash@portworx.com"
 ARG MAKE_TARGET
 

--- a/Dockerfile-taas
+++ b/Dockerfile-taas
@@ -1,4 +1,4 @@
-FROM golang:1.19.5-alpine AS build
+FROM golang:1.21.6-alpine AS build
 LABEL maintainer="avinash@portworx.com"
 ARG MAKE_TARGET
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
  
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes # PB-5628
```
curl -X POST http://10.13.186.250:31319/taas/createns
{"message":"Namespace created successfully","namespace":"0ce3dd"}

root@ip-10-13-184-98:~# kubectl get svc
NAME         TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)          AGE
kubernetes   ClusterIP   10.233.0.1      <none>        443/TCP          123d
taas-serv    NodePort    10.233.22.120   <none>        8080:31319/TCP   36m
  

**Special notes for your reviewer**:

