### PR TITLE
Adding helper function to SSH into a Kubevirt VM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,9 @@ WORKDIR /go/src/github.com/portworx/torpedo
 # Install docker
 RUN apk add --update --no-cache docker
 
+# Install openssh and sshpass
+RUN apk add --no-cache openssh sshpass
+
 # Install dependancy for OCP 4.14 CLI
 RUN apk --update add gcompat
 

--- a/drivers/scheduler/k8s/specs/kubevirt-cirros-container-disk/svc-nodeport.yaml
+++ b/drivers/scheduler/k8s/specs/kubevirt-cirros-container-disk/svc-nodeport.yaml
@@ -1,8 +1,7 @@
----
 apiVersion: v1
 kind: Service
 metadata:
-  name: kubevirt-svc-nodeport
+  name: nodeport
 spec:
   externalTrafficPolicy: Cluster
   ports:
@@ -11,5 +10,5 @@ spec:
       protocol: TCP
       targetPort: 22
   selector:
-    app: vm-ubuntu-pvc
+    special: key
   type: NodePort

--- a/drivers/scheduler/k8s/specs/kubevirt-cirros-container-disk/vm-cirros.yaml
+++ b/drivers/scheduler/k8s/specs/kubevirt-cirros-container-disk/vm-cirros.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: vm-cirros-containerdisk
+spec:
+  running: true
+  template:
+    metadata:
+      name: vmi-ephemeral
+      labels:
+        special: key
+        username: cirros
+    spec:
+      domain:
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+        resources:
+          requests:
+            memory: 64M
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: kubevirt/cirros-registry-disk-demo:latest

--- a/drivers/scheduler/k8s/specs/kubevirt-dv-app/kubevirt-dv-app.yaml
+++ b/drivers/scheduler/k8s/specs/kubevirt-dv-app/kubevirt-dv-app.yaml
@@ -5,7 +5,7 @@ metadata:
     kubevirt.io/vm: ubuntu-vm-dvtemplate
   name: ubuntu-vm-dvtemplate
 spec:
-  running: false
+  running: true
   template:
     metadata:
       labels:

--- a/drivers/scheduler/k8s/specs/kubevirt-multi-vm/vm-ubuntu-pvc.yaml
+++ b/drivers/scheduler/k8s/specs/kubevirt-multi-vm/vm-ubuntu-pvc.yaml
@@ -4,6 +4,7 @@ kind: VirtualMachine
 metadata:
   labels:
     kubevirt.io/os: linux
+    app: vm-ubuntu-pvc
   name: vm-ubuntu-pvc
 spec:
   running: true

--- a/drivers/scheduler/k8s/specs/kubevirt-vm-pvc/kubevirt-app.yaml
+++ b/drivers/scheduler/k8s/specs/kubevirt-vm-pvc/kubevirt-app.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         kubevirt.io/domain: cirrosvm
         app: kubevirt-vm-pvc
+        username: cirros
     spec:
       domain:
         cpu:

--- a/drivers/scheduler/k8s/specs/kubevirt-vm-pvc/service.yaml
+++ b/drivers/scheduler/k8s/specs/kubevirt-vm-pvc/service.yaml
@@ -1,8 +1,7 @@
----
 apiVersion: v1
 kind: Service
 metadata:
-  name: kubevirt-svc-nodeport
+  name: nodeport
 spec:
   externalTrafficPolicy: Cluster
   ports:
@@ -11,5 +10,5 @@ spec:
       protocol: TCP
       targetPort: 22
   selector:
-    app: vm-ubuntu-pvc
+    app: kubevirt-vm-pvc
   type: NodePort

--- a/tests/backup/backup_kubevirt_test.go
+++ b/tests/backup/backup_kubevirt_test.go
@@ -669,3 +669,48 @@ var _ = Describe("{KubevirtUpgradeTest}", func() {
 		CleanupCloudSettingsAndClusters(backupLocationMap, cloudCredName, cloudCredUID, ctx)
 	})
 })
+
+var _ = Describe("{KubevirtVMSshTest}", func() {
+	var (
+		scheduledAppContexts []*scheduler.Context
+	)
+	JustBeforeEach(func() {
+		StartPxBackupTorpedoTest("KubevirtVMSshTest", "Verify SSH to kubevirt VM", nil, 0, Mkoppal, Q1FY25)
+
+		log.InfoD("scheduling applications")
+		scheduledAppContexts = make([]*scheduler.Context, 0)
+		for i := 0; i < Inst().GlobalScaleFactor; i++ {
+			taskName := fmt.Sprintf("%d-%d", 93013, i)
+			appContexts := ScheduleApplications(taskName)
+			for _, appCtx := range appContexts {
+				appCtx.ReadinessTimeout = AppReadinessTimeout
+				scheduledAppContexts = append(scheduledAppContexts, appCtx)
+			}
+		}
+	})
+
+	It("Verify backup and restore of Kubevirt VMs in different states", func() {
+
+		Step("Validating applications", func() {
+			log.InfoD("Validating applications")
+			ValidateApplications(scheduledAppContexts)
+		})
+
+		Step("SSH into the kubevirt VM", func() {
+			log.Infof("Sleeping...")
+			//time.Sleep(1 * time.Minute)
+			ctx, err := backup.GetAdminCtxFromSecret()
+			vms, err := GetAllVMsInNamespace(scheduledAppContexts[0].ScheduleOptions.Namespace)
+			if err != nil {
+				return
+			}
+			for _, vm := range vms {
+				log.Infof("Running command for VM [%s]", vm.Name)
+				output, err := RunCmdInVM(vm, "uname -a", ctx)
+				log.InfoD("Output of command in step - [%s]", output)
+				log.FailOnError(err, "Failed to run command in VM")
+			}
+
+		})
+	})
+})

--- a/tests/backup/backup_kubevirt_test.go
+++ b/tests/backup/backup_kubevirt_test.go
@@ -697,8 +697,6 @@ var _ = Describe("{KubevirtVMSshTest}", func() {
 		})
 
 		Step("SSH into the kubevirt VM", func() {
-			log.Infof("Sleeping...")
-			//time.Sleep(1 * time.Minute)
 			ctx, err := backup.GetAdminCtxFromSecret()
 			vms, err := GetAllVMsInNamespace(scheduledAppContexts[0].ScheduleOptions.Namespace)
 			if err != nil {

--- a/tests/backup_helper.go
+++ b/tests/backup_helper.go
@@ -129,6 +129,8 @@ const (
 	MultiAppNfsPodDeploymentNamespace         = "kube-system"
 	backupScheduleDeleteTimeout               = 60 * time.Minute
 	backupScheduleDeleteRetryTime             = 30 * time.Second
+	sshPodName                                = "ssh-pod"
+	sshPodNamespace                           = "ssh-pod-namespace"
 )
 
 var (
@@ -5983,6 +5985,188 @@ func RestartAllVMsInNamespace(namespace string, waitForCompletion bool) error {
 		return fmt.Errorf("Errors generated while restarting VMs in namespace [%s] -\n%s", namespace, strings.Join(errors, "}\n{"))
 	}
 	return nil
+}
+
+// GetAllVMsInNamespace returns all the Kubevirt VMs in the given namespace
+func GetAllVMsInNamespace(namespace string) ([]kubevirtv1.VirtualMachine, error) {
+	k8sKubevirt := kubevirt.Instance()
+	vms, err := k8sKubevirt.ListVirtualMachines(namespace)
+	if err != nil {
+		return nil, err
+	}
+	return vms.Items, nil
+
+}
+
+// RunCmdInVM runs a command in the VM by SSHing into it
+func RunCmdInVM(vm kubevirtv1.VirtualMachine, cmd string, ctx context1.Context) (string, error) {
+	// Kubevirt client
+	k8sKubevirt := kubevirt.Instance()
+
+	// Getting IP of the VM
+	vmInstance, err := k8sKubevirt.GetVirtualMachineInstance(ctx, vm.Name, vm.Namespace)
+	if err != nil {
+		return "", err
+	}
+	log.Infof("VM Name - %s", vm.Name)
+	ipAddress := vmInstance.Status.Interfaces[0].IP
+	log.Infof("IP Address - %s", ipAddress)
+
+	// Getting username of the VM
+	// Username has to be added as a label to the VM Spec
+	username := vmInstance.Labels["username"]
+	log.Infof("Username - %s", username)
+
+	// Get password of the VM
+	// Password has to be added as a value in the ConfigMap named kubevirt-creds whose key the name of the VM
+	cm, err := core.Instance().GetConfigMap("kubevirt-creds", "default")
+	if err != nil {
+		return "", err
+	}
+	password := cm.Data[vm.Name]
+
+	// SSH command to be executed
+	sshCmd := fmt.Sprintf("sshpass -p '%s' ssh -o StrictHostKeyChecking=no %s@%s %s", password, username, ipAddress, cmd)
+	log.Infof("SSH Command - %s", sshCmd)
+
+	// If the cluster provider is openshift then we are creating ssh pod and running the command in it
+	if os.Getenv("CLUSTER_PROVIDER") == "openshift" {
+		log.Infof("Cluster is openshift hence creating the SSH Pod")
+		err = initSSHPod(sshPodNamespace)
+		if err != nil {
+			return "", err
+		}
+
+		testCmdArgs := getSSHCommandArgs(username, password, ipAddress, "hostname")
+		cmdArgs := getSSHCommandArgs(username, password, ipAddress, cmd)
+
+		// To check if the ssh server is up and running
+		t := func() (interface{}, bool, error) {
+			output, err := k8sCore.RunCommandInPod(testCmdArgs, sshPodName, "ssh-container", "default")
+			if err != nil {
+				log.Infof("Error encountered")
+				if isConnectionError(err.Error()) {
+					log.Infof("Test connection output - \n%s", output)
+					return "", true, err
+				} else {
+					return "", false, err
+				}
+			}
+			log.Infof("Test connection success output - \n%s", output)
+			return "", false, nil
+		}
+		_, err = task.DoRetryWithTimeout(t, 10*time.Minute, 30*time.Second)
+		if err != nil {
+			return "", err
+		}
+
+		// Executing the actual command
+		output, err := k8sCore.RunCommandInPod(cmdArgs, sshPodName, "ssh-container", "default")
+		if err != nil {
+			return output, err
+		}
+		log.Infof("Output of cmd %s - \n%s", cmd, output)
+		return output, nil
+	} else {
+		workerNode := node.GetWorkerNodes()[0]
+		t := func() (interface{}, bool, error) {
+			output, err := runCmdGetOutput(sshCmd, workerNode)
+			if err != nil {
+				log.Infof("Error encountered")
+				if isConnectionError(err.Error()) {
+					log.Infof("Output of cmd %s - \n%s", cmd, output)
+					return "", true, err
+				} else {
+					return "", false, err
+				}
+			}
+			log.Infof("Output of cmd %s - \n%s", cmd, output)
+			return output, false, nil
+		}
+		commandOutput, err := task.DoRetryWithTimeout(t, 10*time.Minute, 30*time.Second)
+		return commandOutput.(string), err
+	}
+}
+
+// initSSHPod creates a pod with ssh server installed and running along with sshpass utility
+func initSSHPod(namespace string) error {
+	var p *corev1.Pod
+	var err error
+	// Check if namespace exists
+	_, err = k8sCore.GetNamespace(namespace)
+	if err != nil {
+		// Namespace doesn't exist, create it
+		log.Infof("Namespace %s does not exist. Creating...", namespace)
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		}
+		if _, err = k8sCore.CreateNamespace(ns); err != nil {
+			log.Errorf("Failed to create namespace %s: %v", namespace, err)
+			return err
+		}
+		log.Infof("Namespace %s created successfully", namespace)
+	}
+	if p, err = k8sCore.GetPodByName(sshPodName, namespace); p == nil {
+		sshPodSpec := &corev1.Pod{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Pod",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      sshPodName,
+				Namespace: namespace,
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "ssh-container",
+						Image: "ubuntu:latest",
+						Command: []string{
+							"/bin/bash",
+							"-c",
+						},
+						Args: []string{
+							"apt-get update && apt-get install -y openssh-server sshpass && service ssh start && echo 'root:toor' | chpasswd && sleep infinity",
+						},
+					},
+				},
+			},
+		}
+		log.Infof("Creating ssh pod")
+		_, err = k8sCore.CreatePod(sshPodSpec)
+		if err != nil {
+			log.Errorf("An Error Occured while creating %v", err)
+			return err
+		}
+		t := func() (interface{}, bool, error) {
+			pod, err := k8sCore.GetPodByName(sshPodName, namespace)
+			if err != nil {
+				return "", false, err
+			}
+			if !k8sCore.IsPodRunning(*pod) {
+				return "", true, fmt.Errorf("waiting for pod %s to be in running state", sshPodName)
+			}
+			// Adding static sleep to let the ssh server start
+			time.Sleep(30 * time.Second)
+			log.Infof("ssh pod creation complete")
+			return "", false, nil
+		}
+		_, err = task.DoRetryWithTimeout(t, 5*time.Minute, 30*time.Second)
+		return err
+	}
+	return err
+}
+
+// isConnectionError checks if the error message is a connection error
+func isConnectionError(errorMessage string) bool {
+	return strings.Contains(errorMessage, "Connection refused") || strings.Contains(errorMessage, "Host is unreachable") ||
+		strings.Contains(errorMessage, "No route to host")
+}
+
+func getSSHCommandArgs(username, password, ipAddress, cmd string) []string {
+	return []string{"sshpass", "-p", password, "ssh", "-o", "StrictHostKeyChecking=no", fmt.Sprintf("%s@%s", username, ipAddress), cmd}
 }
 
 // UpgradeKubevirt upgrades the kubevirt control plane to the given version

--- a/tests/backup_helper.go
+++ b/tests/backup_helper.go
@@ -6077,7 +6077,7 @@ func RunCmdInVM(vm kubevirtv1.VirtualMachine, cmd string, ctx context1.Context) 
 					log.Infof("Output of cmd %s - \n%s", cmd, output)
 					return "", true, err
 				} else {
-					return "", false, err
+					return output, false, err
 				}
 			}
 			log.Infof("Output of cmd %s - \n%s", cmd, output)

--- a/tests/basic/customer_issues_test.go
+++ b/tests/basic/customer_issues_test.go
@@ -879,7 +879,7 @@ var _ = Describe("{ContainerCreateDeviceRemoval}", func() {
 				time.Sleep(2 * time.Minute)
 				_, restartNodeAfter, err := isPodStuckNotRunning(nameSpace)
 				if podRestarting && len(restartNode) > 1 {
-					for key, _ := range restartNodeAfter {
+					for key := range restartNodeAfter {
 						if restartNodeAfter[key] == restartNode[key] {
 							isPodRestarting = true
 						}

--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -650,7 +650,7 @@ func nodePoolsExpansion(testName string) {
 	})
 	JustAfterEach(func() {
 		defer EndTorpedoTest()
-		for poolUUID, _ := range poolsExpectedSizeMap {
+		for poolUUID := range poolsExpectedSizeMap {
 			exitPoolMaintenance(poolUUID)
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- [x] Added helper function `RunCmdInVM` to SSH into a VM and run a command
- [x] Added label `username` to VM spec from where the username for login will be fetched
- [x] Added openssh and sshpass utility to torpedo image
- [x] Added a new kubevirt application spec - `kubevirt-cirros-container-disk`
- [x] Added `VirtualMachineInstanceOps` interface to sched-ops and vendored it in

**Which issue(s) this PR fixes** (optional)
Closes #PB-4793

**Special notes for your reviewer**:

- The `KubevirtTest` is a dummy test to verify if SSH works correctly
- [Jenkins run on Vanilla](https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/4402)
- [Jenkins run on OCP](https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/4376/)
- [Jenkins run with SSH on VM in destination cluster](https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/4373/)

