### PR TITLE
PB-5650: TaaS - Issue with torpedoutils API calls

### DIFF
--- a/Dockerfile-taas
+++ b/Dockerfile-taas
@@ -43,6 +43,7 @@ RUN apk add --update --no-cache docker
 
 # Copy binaries over from previous container
 COPY --from=build /go/src/github.com/portworx/torpedo/bin bin
+COPY drivers drivers
 
 ENTRYPOINT []
 CMD []

--- a/deployments/deploy-ssh-taas.sh
+++ b/deployments/deploy-ssh-taas.sh
@@ -489,7 +489,8 @@ spec:
     imagePullPolicy: Always
     securityContext:
       privileged: ${SECURITY_CONTEXT}
-    command: ["sh", "-c", "cd /bin && ./taas"]
+    command: ["sh", "-c"]
+    args: ["cd /bin && ./taas -spec-dir=$SPEC_DIR"]
     tty: true
     volumeMounts: [${VOLUME_MOUNTS}]
     env:


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Passing the spec dir to taas args command, all torpedo util API calls were failing 

**Which issue(s) this PR fixes** (optional)
Closes #PB-5650
https://jenkins.pwx.dev.purestorage.com/blue/organizations/jenkins/PX-Central%2Fpx-central-ui-automation/detail/px-central-ui-automation/43/pipeline
**Special notes for your reviewer**:
```[GIN] 2024/02/20 - 13:54:32 | 200 | 18.181493988s |    10.13.184.98 | POST     "/taas/inittorpedo"
[GIN] 2024/02/20 - 13:55:24 | 200 |   11.118322ms |    10.13.184.98 | POST     "/taas/createns"
[GIN] 2024/02/20 - 13:56:12 | 200 |       617.9µs |    10.13.184.98 | GET      "/taas/getnodes"
2024-02-20 13:56:29 +0000:[INFO] [portworx.(*portworx).testAndSetEndpoint:#3288] - Using 10.233.12.43:9020 as endpoint for portworx volume driver
2024-02-20 13:56:29 +0000:[DEBUG] [portworx.(*portworx).GetDriverNode:#983] - Inspecting node [ip-10-13-176-137.pwx.purestorage.com] with volume driver node id [e6d6cccd-58b7-4d66-80cf-088b10ad8608]
2024-02-20 13:56:29 +0000:[INFO] [portworx.(*portworx).testAndSetEndpoint:#3288] - Using 10.233.12.43:9020 as endpoint for portworx volume driver
2024-02-20 13:56:29 +0000:[DEBUG] [portworx.(*portworx).GetDriverNode:#983] - Inspecting node [ip-10-13-182-251.pwx.purestorage.com] with volume driver node id [2ce54b8a-1f56-4c6b-ba12-af9a632b1570]
2024-02-20 13:56:29 +0000:[INFO] [portworx.(*portworx).testAndSetEndpoint:#3288] - Using 10.233.12.43:9020 as endpoint for portworx volume driver
2024-02-20 13:56:29 +0000:[DEBUG] [portworx.(*portworx).GetDriverNode:#983] - Inspecting node [ip-10-13-186-250.pwx.purestorage.com] with volume driver node id [3243a834-6987-4c96-b0a0-282077c795e9]
[GIN] 2024/02/20 - 13:56:29 | 200 |  413.785504ms |    10.13.184.98 | GET      "/taas/storagenodes"
2024-02-20 13:56:55 +0000:[DEBUG] [portworx.(*portworx).getPxVersionOnNode.func1:#1029] - Getting PX version on node [ip-10-13-176-137.pwx.purestorage.com]
2024-02-20 13:56:55 +0000:[INFO] [portworx.(*portworx).testAndSetEndpoint:#3288] - Using 10.233.12.43:9020 as endpoint for portworx volume driver
2024-02-20 13:56:55 +0000:[DEBUG] [portworx.(*portworx).GetDriverNode:#983] - Inspecting node [ip-10-13-176-137.pwx.purestorage.com] with volume driver node id [e6d6cccd-58b7-4d66-80cf-088b10ad8608]
[GIN] 2024/02/20 - 13:56:55 | 200 |   42.296774ms |    10.13.184.98 | GET      "/taas/pxversion"
2024-02-20 13:57:04 +0000:[INFO] [portworx.(*portworx).IsDriverInstalled:#688] - Checking if PX is installed on node [ip-10-13-176-137.pwx.purestorage.com]
2024-02-20 13:57:04 +0000:[INFO] [schedops.(*k8sSchedOps).IsPXEnabled:#857] - PX is enabled on node ip-10-13-176-137.pwx.purestorage.com.
2024-02-20 13:57:04 +0000:[INFO] [portworx.(*portworx).IsDriverInstalled:#688] - Checking if PX is installed on node [ip-10-13-182-251.pwx.purestorage.com]
2024-02-20 13:57:04 +0000:[INFO] [schedops.(*k8sSchedOps).IsPXEnabled:#857] - PX is enabled on node ip-10-13-182-251.pwx.purestorage.com.
2024-02-20 13:57:04 +0000:[INFO] [portworx.(*portworx).IsDriverInstalled:#688] - Checking if PX is installed on node [ip-10-13-186-250.pwx.purestorage.com]
2024-02-20 13:57:04 +0000:[INFO] [schedops.(*k8sSchedOps).IsPXEnabled:#857] - PX is enabled on node ip-10-13-186-250.pwx.purestorage.com.
[GIN] 2024/02/20 - 13:57:04 | 200 |  100.985157ms |    10.13.184.98 | GET      "/taas/ispxinstalled"
[GIN] 2024/02/20 - 13:57:18 | 200 |  2.495735181s |    10.13.184.98 | GET      "/taas/getpxctloutput"

