### PR TITLE
PB-5851: Change logic to use `GetNodes()` instead of `GetWorkerNodes()`

### DIFF
--- a/tests/backup/backup_license_test.go
+++ b/tests/backup/backup_license_test.go
@@ -2,6 +2,8 @@ package tests
 
 import (
 	"fmt"
+	"github.com/portworx/torpedo/drivers"
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -47,12 +49,21 @@ var _ = Describe("{NodeCountForLicensing}", func() {
 		Step("Getting the total number of worker nodes in source and destination cluster", func() {
 			log.InfoD("Getting the total number of worker nodes in source and destination cluster")
 			sourceClusterWorkerNodes = node.GetWorkerNodes()
+			if len(sourceClusterWorkerNodes) == 0 && os.Getenv("CLUSTER_PROVIDER") == drivers.ProviderIbm {
+				sourceClusterWorkerNodes = node.GetNodes()
+			}
 			log.InfoD("Total number of worker nodes in source cluster are %v", len(sourceClusterWorkerNodes))
 			totalNumberOfWorkerNodes = append(totalNumberOfWorkerNodes, sourceClusterWorkerNodes...)
 			log.InfoD("Switching cluster context to destination cluster")
 			err := SetDestinationKubeConfig()
 			log.FailOnError(err, "Switching context to destination cluster failed")
 			destinationClusterWorkerNodes = node.GetWorkerNodes()
+			if len(destinationClusterWorkerNodes) == 0 && os.Getenv("CLUSTER_PROVIDER") == drivers.ProviderIbm {
+				destinationClusterWorkerNodes = node.GetNodes()
+			}
+			if len(destinationClusterWorkerNodes) == 0 && os.Getenv("CLUSTER_PROVIDER") == drivers.ProviderIbm {
+				destinationClusterWorkerNodes = node.GetNodes()
+			}
 			log.InfoD("Total number of worker nodes in destination cluster are %v", len(destinationClusterWorkerNodes))
 			totalNumberOfWorkerNodes = append(totalNumberOfWorkerNodes, destinationClusterWorkerNodes...)
 			log.InfoD("Total number of worker nodes in source and destination cluster are %v", len(totalNumberOfWorkerNodes))
@@ -204,6 +215,9 @@ var _ = Describe("{LicensingCountWithNodeLabelledBeforeClusterAddition}", func()
 		Step("Getting the number of worker nodes in source cluster and applying label portworx.io/nobackup=true to all its worker nodes", func() {
 			log.InfoD("Getting the total number of worker nodes in source cluster")
 			sourceClusterWorkerNodes = node.GetWorkerNodes()
+			if len(sourceClusterWorkerNodes) == 0 && os.Getenv("CLUSTER_PROVIDER") == drivers.ProviderIbm {
+				sourceClusterWorkerNodes = node.GetNodes()
+			}
 			log.InfoD("Total number of worker nodes in source cluster are %v", len(sourceClusterWorkerNodes))
 			totalNumberOfWorkerNodes = append(totalNumberOfWorkerNodes, sourceClusterWorkerNodes...)
 
@@ -219,6 +233,9 @@ var _ = Describe("{LicensingCountWithNodeLabelledBeforeClusterAddition}", func()
 			log.FailOnError(err, "Switching context to destination cluster failed")
 			log.InfoD("Getting the total number of worker nodes in destination cluster")
 			destinationClusterWorkerNodes = node.GetWorkerNodes()
+			if len(destinationClusterWorkerNodes) == 0 && os.Getenv("CLUSTER_PROVIDER") == drivers.ProviderIbm {
+				destinationClusterWorkerNodes = node.GetNodes()
+			}
 			log.InfoD("Total number of worker nodes in destination cluster are %v", len(destinationClusterWorkerNodes))
 			totalNumberOfWorkerNodes = append(totalNumberOfWorkerNodes, destinationClusterWorkerNodes...)
 			log.InfoD("Total number of worker nodes in source and destination cluster are %v", len(totalNumberOfWorkerNodes))
@@ -345,12 +362,18 @@ var _ = Describe("{LicensingCountBeforeAndAfterBackupPodRestart}", func() {
 		Step("Getting the total number of worker nodes in source and destination cluster", func() {
 			log.InfoD("Getting the total number of worker nodes in source and destination cluster")
 			sourceClusterWorkerNodes = node.GetWorkerNodes()
+			if len(sourceClusterWorkerNodes) == 0 && os.Getenv("CLUSTER_PROVIDER") == drivers.ProviderIbm {
+				sourceClusterWorkerNodes = node.GetNodes()
+			}
 			log.InfoD("Total number of worker nodes in source cluster are %v", len(sourceClusterWorkerNodes))
 			totalNumberOfWorkerNodes = append(totalNumberOfWorkerNodes, sourceClusterWorkerNodes...)
 			log.InfoD("Switching cluster context to destination cluster")
 			err := SetDestinationKubeConfig()
 			log.FailOnError(err, "Switching context to destination cluster failed")
 			destinationClusterWorkerNodes = node.GetWorkerNodes()
+			if len(destinationClusterWorkerNodes) == 0 && os.Getenv("CLUSTER_PROVIDER") == drivers.ProviderIbm {
+				destinationClusterWorkerNodes = node.GetNodes()
+			}
 			log.InfoD("Total number of worker nodes in destination cluster are %v", len(destinationClusterWorkerNodes))
 			totalNumberOfWorkerNodes = append(totalNumberOfWorkerNodes, destinationClusterWorkerNodes...)
 			log.InfoD("Total number of worker nodes in source and destination cluster are %v", len(totalNumberOfWorkerNodes))

--- a/tests/backup/backup_license_test.go
+++ b/tests/backup/backup_license_test.go
@@ -61,9 +61,6 @@ var _ = Describe("{NodeCountForLicensing}", func() {
 			if len(destinationClusterWorkerNodes) == 0 && os.Getenv("CLUSTER_PROVIDER") == drivers.ProviderIbm {
 				destinationClusterWorkerNodes = node.GetNodes()
 			}
-			if len(destinationClusterWorkerNodes) == 0 && os.Getenv("CLUSTER_PROVIDER") == drivers.ProviderIbm {
-				destinationClusterWorkerNodes = node.GetNodes()
-			}
 			log.InfoD("Total number of worker nodes in destination cluster are %v", len(destinationClusterWorkerNodes))
 			totalNumberOfWorkerNodes = append(totalNumberOfWorkerNodes, destinationClusterWorkerNodes...)
 			log.InfoD("Total number of worker nodes in source and destination cluster are %v", len(totalNumberOfWorkerNodes))


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
On ROKS cluster on IBM cloud I am seeing that the roles on the nodes is set to both `master,worker` due to which the `node.GetWorkerNodes()` is returning `0` which is cause the cases to fail in the pipeline runs. 
```
NAME             STATUS   ROLES           AGE     VERSION            INTERNAL-IP      EXTERNAL-IP      OS-IMAGE                               KERNEL-VERSION                 CONTAINER-RUNTIME
<IP Address>     Ready    master,worker   3h28m   v1.27.10+28ed2d7   <IP Address>     <IP Address>     Red Hat Enterprise Linux 8.9 (Ootpa)   4.18.0-513.11.1.el8_9.x86_64   cri-o://1.27.3-2.rhaos4.14.git03502b6.el8
```

- [x] Change logic to use `GetNodes()` instead of `GetWorkerNodes()` if `CLUSTER_PROVIDER` is `ibm`

**Which issue(s) this PR fixes** (optional)
Closes #PB-5851

**Special notes for your reviewer**:
I am seeing the failure which I am fixing in https://github.com/portworx/torpedo/pull/2119 
https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/Cloud_BYOC/142/console
https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/Cloud_BYOC/140/console

