### PR TITLE
repro clousnap restore

### DIFF
--- a/tests/basic/longevity_test.go
+++ b/tests/basic/longevity_test.go
@@ -344,6 +344,7 @@ var _ = Describe("{UpgradeLongevity}", func() {
 			log.InfoD("Deploying new apps")
 			TriggerDeployNewApps(&contexts, &triggerEventsChan)
 			dash.VerifySafely(len(contexts) > 0, true, "Verifying if the new apps are deployed")
+
 		})
 
 		Step("Register test triggers", func() {
@@ -1547,6 +1548,17 @@ func populateIntervals() {
 	triggerInterval[CloudSnapShot][2] = 24 * baseInterval
 	triggerInterval[CloudSnapShot][1] = 27 * baseInterval
 
+	triggerInterval[CloudSnapShotRestore][10] = 1 * baseInterval
+	triggerInterval[CloudSnapShotRestore][9] = 3 * baseInterval
+	triggerInterval[CloudSnapShotRestore][8] = 6 * baseInterval
+	triggerInterval[CloudSnapShotRestore][7] = 9 * baseInterval
+	triggerInterval[CloudSnapShotRestore][6] = 12 * baseInterval
+	triggerInterval[CloudSnapShotRestore][5] = 15 * baseInterval // Default global chaos level, 3 hrs
+	triggerInterval[CloudSnapShotRestore][4] = 18 * baseInterval
+	triggerInterval[CloudSnapShotRestore][3] = 21 * baseInterval
+	triggerInterval[CloudSnapShotRestore][2] = 24 * baseInterval
+	triggerInterval[CloudSnapShotRestore][1] = 27 * baseInterval
+
 	triggerInterval[LocalSnapShot][10] = 1 * baseInterval
 	triggerInterval[LocalSnapShot][9] = 3 * baseInterval
 	triggerInterval[LocalSnapShot][8] = 6 * baseInterval
@@ -1862,17 +1874,6 @@ func populateIntervals() {
 	triggerInterval[AddDrive][7] = 4 * baseInterval
 	triggerInterval[AddDrive][6] = 5 * baseInterval
 	triggerInterval[AddDrive][5] = 6 * baseInterval
-
-	triggerInterval[CloudSnapShotRestore][10] = 1 * baseInterval
-	triggerInterval[CloudSnapShotRestore][9] = 3 * baseInterval
-	triggerInterval[CloudSnapShotRestore][8] = 6 * baseInterval
-	triggerInterval[CloudSnapShotRestore][7] = 9 * baseInterval
-	triggerInterval[CloudSnapShotRestore][6] = 12 * baseInterval
-	triggerInterval[CloudSnapShotRestore][5] = 15 * baseInterval // Default global chaos level, 3 hrs
-	triggerInterval[CloudSnapShotRestore][4] = 18 * baseInterval
-	triggerInterval[CloudSnapShotRestore][3] = 21 * baseInterval
-	triggerInterval[CloudSnapShotRestore][2] = 24 * baseInterval
-	triggerInterval[CloudSnapShotRestore][1] = 27 * baseInterval
 
 	triggerInterval[AggrVolDepReplResizeOps][10] = 1 * baseInterval
 	triggerInterval[AggrVolDepReplResizeOps][9] = 2 * baseInterval

--- a/tests/testTriggers.go
+++ b/tests/testTriggers.go
@@ -3388,6 +3388,10 @@ func TriggerCloudSnapshotRestore(contexts *[]*scheduler.Context, recordChan *cha
 				}
 				err = storkops.Instance().ValidateVolumeSnapshotRestore(restore.Name, restore.Namespace, snapshotScheduleRetryTimeout, snapshotScheduleRetryInterval)
 				dash.VerifySafely(err, nil, fmt.Sprintf("validate snapshot restore source: %s , destnation: %s in namespace %s", restore.Name, vol.Name, vol.Namespace))
+				if err == nil {
+					err = storkops.Instance().DeleteVolumeSnapshotRestore(restore.Name, restore.Namespace)
+					UpdateOutcome(event, err)
+				}
 			}
 		}
 		for k := range cloudsnapMap {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Cloudsnap restore test is failing when restore happens multiple times as previously created `volumesnapshotrestores.stork.libopenstorage.org `crd still exists.
This fix will delete `volumesnapshotrestores.stork.libopenstorage.org` CRD once successfully validated.

**Which issue(s) this PR fixes** (optional)
Closes # PTX-22599

**Special notes for your reviewer**:

