### PR TITLE
Added code to get backup status before proceeding for restore for test case SwapShareBackup

### DIFF
--- a/tests/backup/backup_share_test.go
+++ b/tests/backup/backup_share_test.go
@@ -4085,6 +4085,8 @@ var _ = Describe("{SwapShareBackup}", func() {
 			log.FailOnError(err, "Failed to share backup %s", backupName)
 		})
 		Step(fmt.Sprintf("validate the backup shared %s is present in user context %s", backupName, users[1]), func() {
+			ctxNonAdmin, err := backup.GetNonAdminCtx(users[1], CommonPassword)
+			log.FailOnError(err, "Fetching non admin ctx")
 			userBackups, _ := GetAllBackupsForUser(users[1], CommonPassword)
 			backupCount := 0
 			for _, backup := range userBackups {
@@ -4093,6 +4095,8 @@ var _ = Describe("{SwapShareBackup}", func() {
 				}
 			}
 			dash.VerifyFatal(backupCount, numberOfUsers, fmt.Sprintf("Validating the shared backup [%s] is present in user context [%s]", backupName, users[1]))
+			bkpStatus, bkpReason, err := Inst().Backup.GetBackupStatusWithReason(backupName, ctxNonAdmin, BackupOrgID)
+			dash.VerifyFatal(err, nil, fmt.Sprintf("Backup [%s] has status: %s with reason: %s", backupName, bkpStatus, bkpReason))
 		})
 		Step(fmt.Sprintf("Restore the shared backup  %s with user context %s", backupName, users[1]), func() {
 			log.InfoD(fmt.Sprintf("Restore the shared backup  %s with user context %s", users[1], users[0]))
@@ -4111,6 +4115,8 @@ var _ = Describe("{SwapShareBackup}", func() {
 			log.FailOnError(err, "Failed to share backup %s", backupName)
 		})
 		Step(fmt.Sprintf("validate the backup shared %s is present in user context %s", backupName, users[0]), func() {
+			ctxNonAdmin, err := backup.GetNonAdminCtx(users[0], CommonPassword)
+			log.FailOnError(err, "Fetching non admin ctx")
 			userBackups, _ := GetAllBackupsForUser(users[0], CommonPassword)
 			backupCount := 0
 			for _, backup := range userBackups {
@@ -4119,6 +4125,8 @@ var _ = Describe("{SwapShareBackup}", func() {
 				}
 			}
 			dash.VerifyFatal(backupCount, numberOfUsers, fmt.Sprintf("Validating the shared backup [%s] is present in user context [%s]", backupName, users[0]))
+			bkpStatus, bkpReason, err := Inst().Backup.GetBackupStatusWithReason(backupName, ctxNonAdmin, BackupOrgID)
+			dash.VerifyFatal(err, nil, fmt.Sprintf("Backup [%s] has status: %s with reason: %s", backupName, bkpStatus, bkpReason))
 		})
 		Step(fmt.Sprintf("Restore the shared backup  %s with user context %s", backupName, users[0]), func() {
 			log.InfoD(fmt.Sprintf("Restore the shared backup  %s with user context %s", users[0], users[0]))


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Testcase SwapShareBackup is failing intermittently . When trying to restore the shared backup, it fails with error that backup is not in success state
We do not have sufficient logs to see what state the backup is in and the reason for that state
hence added GetBackupStatusWithReason before restoring the backup
**Which issue(s) this PR fixes** (optional)
Closes #https://portworx.atlassian.net/browse/PB-5663

**Special notes for your reviewer**:

log : https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/4641/consoleFull
https://aetos.pwx.purestorage.com/resultSet/testSetID/558632/testCaseID/3353536
