### PR TITLE
Fixed the test sse-s3 cleanup issue as per the new changes made in 2.7.0

### DIFF
--- a/tests/backup/backup_sse_test.go
+++ b/tests/backup/backup_sse_test.go
@@ -520,8 +520,8 @@ var _ = Describe("{CreateBackupAndRestoreForAllCombinationsOfSSES3AndDenyPolicy}
 			err = DeleteRestore(restoreName, BackupOrgID, ctx)
 			dash.VerifySafely(err, nil, fmt.Sprintf("Deleting restore [%s]", restoreName))
 		}
-		// Delete backup schedule policy
-		log.Infof("Deleting backup schedule policy")
+		// Delete backup schedule
+		log.Infof("Deleting backup schedule")
 		err = DeleteSchedule(scheduleName, SourceClusterName, BackupOrgID, ctx)
 		dash.VerifySafely(err, nil, fmt.Sprintf("Verification of deleting backup schedule - %s", scheduleName))
 		CleanupCloudSettingsAndClusters(backupLocationMap, credName, cloudCredUID, ctx)

--- a/tests/backup/backup_sse_test.go
+++ b/tests/backup/backup_sse_test.go
@@ -515,16 +515,16 @@ var _ = Describe("{CreateBackupAndRestoreForAllCombinationsOfSSES3AndDenyPolicy}
 		DestroyApps(scheduledAppContexts, opts)
 		ctx, err := backup.GetAdminCtxFromSecret()
 		log.FailOnError(err, "Fetching px-central-admin ctx")
-		// Delete backup schedule policy
-		log.Infof("Deleting backup schedule policy")
-		err = DeleteSchedule(scheduleName, SourceClusterName, BackupOrgID, ctx)
-		dash.VerifySafely(err, nil, fmt.Sprintf("Verification of deleting backup schedule - %s", scheduleName))
-		CleanupCloudSettingsAndClusters(backupLocationMap, credName, cloudCredUID, ctx)
 		// Delete restores
 		for _, restoreName := range restoreList {
 			err = DeleteRestore(restoreName, BackupOrgID, ctx)
 			dash.VerifySafely(err, nil, fmt.Sprintf("Deleting restore [%s]", restoreName))
 		}
+		// Delete backup schedule policy
+		log.Infof("Deleting backup schedule policy")
+		err = DeleteSchedule(scheduleName, SourceClusterName, BackupOrgID, ctx)
+		dash.VerifySafely(err, nil, fmt.Sprintf("Verification of deleting backup schedule - %s", scheduleName))
+		CleanupCloudSettingsAndClusters(backupLocationMap, credName, cloudCredUID, ctx)
 		// Delete custom buckets
 		providers := GetBackupProviders()
 		for _, provider := range providers {


### PR DESCRIPTION
**What this PR does / why we need it**:
Minor fix to move deleting restore object before cluster delete is performed

**Which issue(s) this PR fixes** (optional)
Closes #https://portworx.atlassian.net/browse/PB-5873

**Special notes for your reviewer**:
https://aetos.pwx.purestorage.com/resultSet/testSetID/561802
https://jenkins.pwx.dev.purestorage.com/job/Users/job/santoshn/job/sse-byoc/16/consoleFull
