### PR TITLE
Update Anthos version code check for upgrading Anthos from 1.16 to 1.28

### DIFF
--- a/drivers/scheduler/anthos/anthos.go
+++ b/drivers/scheduler/anthos/anthos.go
@@ -376,10 +376,13 @@ func (anth *anthos) VerifyUpgradeVersion(upgradeVersion string) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse version: %s. Error: %v", fromVersion, err)
 	}
-	if (len(toVersion) > 0 && len(fromVersion) > 0) &&
-		(toVersion[0][1] != fromVersion[0][1] || (val2-val1) > 1) {
-		return fmt.Errorf("incorrect upgrade version:%s is provided."+
-			"One major version upgrade support at a time", upgradeVersion)
+	// Skip below check when current version is 1.16 and upgrading to version 1.28
+	if !strings.Contains(anth.version, "1.16") && !strings.Contains(upgradeVersion, "1.28") {
+		if (len(toVersion) > 0 && len(fromVersion) > 0) &&
+			(toVersion[0][1] != fromVersion[0][1] || (val2-val1) > 1) {
+			return fmt.Errorf("incorrect upgrade version:%s is provided."+
+				"One major version upgrade support at a time", upgradeVersion)
+		}
 	}
 	log.Debugf("Successfully verified the version:[%]", upgradeVersion)
 	return nil


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Update Anthos version code check for upgrading Anthos from 1.16 to 1.28

**Which issue(s) this PR fixes** (optional)
Closes # PTX-22657

**Special notes for your reviewer**:
Minor change

Tested with older version 1.15 to 1.16
```
2024-03-02 01:09:28 +0000:[INFO] [{UpgradeCluster}] [anthos.(*anthos).VerifyUpgradeVersion:#350] - Checking the upgrade from version: [1.15.4-gke.37] to version: [1.16.0-gke.669]
2024-03-02 01:09:28 +0000:[DEBUG] [{UpgradeCluster}] [anthos.(*anthos).VerifyUpgradeVersion:#387] - Successfully verified the version:[%!](string=1.16.0-gke.669)
```

Tested with version 1.16 to 1.28

```
  STEP: start [k8s] scheduler upgrade @ 03/04/24 00:26:47.956
2024-03-04 00:26:47 +0000:[INFO] [{UpgradeCluster}] [anthos.(*anthos).UpgradeScheduler:#254] - Upgrading Anthos user cluster
2024-03-04 00:26:47 +0000:[INFO] [{UpgradeCluster}] [anthos.(*anthos).VerifyUpgradeVersion:#350] - Checking the upgrade from version: [1.16.5-gke.28] to version: [1.28.200-gke.111]
2024-03-04 00:26:47 +0000:[DEBUG] [{UpgradeCluster}] [anthos.(*anthos).VerifyUpgradeVersion:#387] - Successfully verified the version:[%!](string=1.28.200-gke.111)
```