### PR TITLE
Added test case to run VM Backup with freeze only without unfreeze and vice versa

### DIFF
--- a/tests/backup_helper.go
+++ b/tests/backup_helper.go
@@ -161,6 +161,7 @@ const (
 	backupScheduleDeleteRetryTime             = 30 * time.Second
 	sshPodName                                = "ssh-pod"
 	sshPodNamespace                           = "ssh-pod-namespace"
+	VirtLauncherContainerName                 = "compute"
 )
 
 var (
@@ -531,10 +532,24 @@ func CreateBackupWithValidation(ctx context1.Context, backupName string, cluster
 // CreateVMBackupWithValidation creates VM backup, checks for success, and validates the VM backup
 func CreateVMBackupWithValidation(ctx context1.Context, backupName string, vms []kubevirtv1.VirtualMachine, clusterName string, bLocation string, bLocationUID string, scheduledAppContextsToBackup []*scheduler.Context, labelSelectors map[string]string, orgID string, uid string, preRuleName string, preRuleUid string, postRuleName string, postRuleUid string, skipVMAutoExecRules bool) error {
 	namespaces := make([]string, 0)
+	var removeSpecs []interface{}
 	for _, scheduledAppContext := range scheduledAppContextsToBackup {
 		namespace := scheduledAppContext.ScheduleOptions.Namespace
 		if !Contains(namespaces, namespace) {
 			namespaces = append(namespaces, namespace)
+		}
+
+		// Removing specs which are outside the scope of VM Backup
+		for _, spec := range scheduledAppContext.App.SpecList {
+			// VM Backup will not consider service object for now
+			if appSpec, ok := spec.(*corev1.Service); ok {
+				removeSpecs = append(removeSpecs, appSpec)
+			}
+			// TODO: Add more types of specs to remove depending on the app context
+		}
+		err := Inst().S.RemoveAppSpecsByName(scheduledAppContext, removeSpecs)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -882,6 +897,16 @@ func GetNamespacesFromVMs(vms []kubevirtv1.VirtualMachine) []string {
 		}
 	}
 	return namespaces
+}
+
+// GetNamespacesToVMsMap gets a map of namespaces to VM names
+func GetNamespacesToVMsMap(vms []kubevirtv1.VirtualMachine) map[string][]string {
+	namespacesToVMsMap := make(map[string][]string, len(vms))
+	for _, v := range vms {
+		namespacesToVMsMap[v.Namespace] = append(namespacesToVMsMap[v.Namespace], v.Name)
+	}
+	return namespacesToVMsMap
+
 }
 
 // GenerateResourceInfo generates []*api.ResourceInfo
@@ -4920,6 +4945,42 @@ func CreateRuleForBackupWithMultipleApplications(orgID string, appList []string,
 	return preRuleName, postRuleName, nil
 }
 
+type VMRuleType string
+
+const (
+	Freeze   VMRuleType = "freeze"
+	Unfreeze VMRuleType = "unfreeze"
+)
+
+// CreateRuleForVMBackup creates freeze/unfreeze rule for VM backup
+func CreateRuleForVMBackup(ruleName string, vms []kubevirtv1.VirtualMachine, ruleType VMRuleType, ctx context1.Context) error {
+	var rulesInfo api.RulesInfo
+	namespaceToVMs := GetNamespacesToVMsMap(vms)
+	for namespace, vmList := range namespaceToVMs {
+		for _, vm := range vmList {
+			freezeAction := fmt.Sprintf("/usr/bin/virt-freezer --%s --name %s --namespace %s", ruleType, vm, namespace)
+			ruleAction := api.RulesInfo_Action{Background: false, RunInSinglePod: false,
+				Value: freezeAction}
+			var actions = []*api.RulesInfo_Action{&ruleAction}
+
+			rulesInfo.Rules = append(rulesInfo.Rules, &api.RulesInfo_RuleItem{
+				PodSelector: map[string]string{"vm.kubevirt.io/name": vm},
+				Actions:     actions,
+				Container:   VirtLauncherContainerName,
+			})
+		}
+	}
+	RuleCreateReq := &api.RuleCreateRequest{
+		CreateMetadata: &api.CreateMetadata{
+			Name:  ruleName,
+			OrgId: BackupOrgID,
+		},
+		RulesInfo: &rulesInfo,
+	}
+	_, err := Inst().Backup.CreateRule(ctx, RuleCreateReq)
+	return err
+}
+
 // GetAllBackupNamesByOwnerID gets all backup names associated with the given ownerID
 func GetAllBackupNamesByOwnerID(ownerID string, orgID string, ctx context1.Context) ([]string, error) {
 	isAdminCtx, err := portworx.IsAdminCtx(ctx)
@@ -6269,6 +6330,8 @@ func GetAllVMsInNamespace(namespace string) ([]kubevirtv1.VirtualMachine, error)
 
 // RunCmdInVM runs a command in the VM by SSHing into it
 func RunCmdInVM(vm kubevirtv1.VirtualMachine, cmd string, ctx context1.Context) (string, error) {
+	var username string
+	var password string
 	// Kubevirt client
 	k8sKubevirt := kubevirt.Instance()
 
@@ -6282,9 +6345,13 @@ func RunCmdInVM(vm kubevirtv1.VirtualMachine, cmd string, ctx context1.Context) 
 	log.Infof("IP Address - %s", ipAddress)
 
 	// Getting username of the VM
-	// Username has to be added as a label to the VM Spec
-	username := vmInstance.Labels["username"]
-	log.Infof("Username - %s", username)
+	// Username has to be added as a label to the VMI Spec
+	if u, ok := vmInstance.Labels["username"]; !ok {
+		return "", fmt.Errorf("username not found in the labels of the vmi spec")
+	} else {
+		log.Infof("Username - %s", u)
+		username = u
+	}
 
 	// Get password of the VM
 	// Password has to be added as a value in the ConfigMap named kubevirt-creds whose key the name of the VM
@@ -6292,7 +6359,13 @@ func RunCmdInVM(vm kubevirtv1.VirtualMachine, cmd string, ctx context1.Context) 
 	if err != nil {
 		return "", err
 	}
-	password := cm.Data[vm.Name]
+	if p, ok := cm.Data[vm.Name]; !ok {
+		return "", fmt.Errorf("password not found in the configmap [%s/%s] for vm - [%s]", "default", "kubevirt-creds", vm.Name)
+	} else {
+		log.Infof("Password - %s", p)
+		password = p
+
+	}
 
 	// SSH command to be executed
 	sshCmd := fmt.Sprintf("sshpass -p '%s' ssh -o StrictHostKeyChecking=no %s@%s %s", password, username, ipAddress, cmd)
@@ -6311,7 +6384,7 @@ func RunCmdInVM(vm kubevirtv1.VirtualMachine, cmd string, ctx context1.Context) 
 
 		// To check if the ssh server is up and running
 		t := func() (interface{}, bool, error) {
-			output, err := k8sCore.RunCommandInPod(testCmdArgs, sshPodName, "ssh-container", "default")
+			output, err := k8sCore.RunCommandInPod(testCmdArgs, sshPodName, "ssh-container", sshPodNamespace)
 			if err != nil {
 				log.Infof("Error encountered")
 				if isConnectionError(err.Error()) {
@@ -6330,7 +6403,7 @@ func RunCmdInVM(vm kubevirtv1.VirtualMachine, cmd string, ctx context1.Context) 
 		}
 
 		// Executing the actual command
-		output, err := k8sCore.RunCommandInPod(cmdArgs, sshPodName, "ssh-container", "default")
+		output, err := k8sCore.RunCommandInPod(cmdArgs, sshPodName, "ssh-container", sshPodNamespace)
 		if err != nil {
 			return output, err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

- [x] Added new test case `KubevirtVMWithFreezeUnfreeze`
- [x] Changed the testrail ID for `KubevirtVMBackupRestoreWithDifferentStates` and `KubevirtUpgradeTest`
- [x] Added new function to create freeze and unfreeze rules - `CreateVMRule`
- [x] Handled the panic in `RunCmdInVM` when the username or password is not found


**Which issue(s) this PR fixes** (optional)
Closes #PB-5790

**Special notes for your reviewer**:
[Jenkins Run on Vanilla](https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/4744/)

