### PR TITLE
Added new service endpoints `/getvmsbyns` and `/getvmsbynslabels`

### DIFF
--- a/apiServer/taas/apiserver.go
+++ b/apiServer/taas/apiserver.go
@@ -27,5 +27,7 @@ func main() {
 	router.GET("taas/pxversion", utils.GetPxVersion)
 	router.GET("taas/ispxinstalled", utils.IsPxInstalled)
 	router.GET("taas/getpxctloutput", utils.GetPxctlStatusOutput)
+	router.GET("taas/getkubevirtvmsbyns", utils.GetVMsInNamespaces)
+	router.GET("taas/getkubevirtvmsbynslabels", utils.GetVMsWithNamespaceLabels)
 	log.Fatal(router.Run(":8080"))
 }

--- a/tests/backup_helper.go
+++ b/tests/backup_helper.go
@@ -6339,6 +6339,24 @@ func GetAllVMsInNamespace(namespace string) ([]kubevirtv1.VirtualMachine, error)
 
 }
 
+// GetAllVMsInNamespacesWithLabel returns all the Kubevirt VMs in the namespaces filtered by the namespace label provided
+func GetAllVMsInNamespacesWithLabel(namespaceLabel map[string]string) ([]kubevirtv1.VirtualMachine, error) {
+	var vms []kubevirtv1.VirtualMachine
+	nsList, err := k8sCore.ListNamespaces(namespaceLabel)
+	if err != nil {
+		return nil, err
+	}
+	for _, ns := range nsList.Items {
+		vmList, err := GetAllVMsInNamespace(ns.Name)
+		if err != nil {
+			return nil, err
+		}
+		vms = append(vms, vmList...)
+	}
+	return vms, nil
+
+}
+
 // RunCmdInVM runs a command in the VM by SSHing into it
 func RunCmdInVM(vm kubevirtv1.VirtualMachine, cmd string, ctx context1.Context) (string, error) {
 	var username string


### PR DESCRIPTION
**What this PR does / why we need it**:
Created 2 service endpoints for taas which will fetch the VMs based on the provided namespaces and provided namespace labels

**Which issue(s) this PR fixes** (optional)
Closes #PB-5857

**Special notes for your reviewer**:
Yet to be tested in the UI automation pipeline

