### PR TITLE
Changed file creation count to 10k for each iteration

### DIFF
--- a/tests/backup/backup_kdmp_test.go
+++ b/tests/backup/backup_kdmp_test.go
@@ -141,8 +141,8 @@ var _ = Describe("{ExcludeDirectoryFileBackup}", func() {
 							sc := podScMountPathMap[pod.Name][mountPath]
 							DirectoryConfig := PodDirectoryConfig{
 								BasePath:          mountPath,
-								Depth:             10,
-								Levels:            3,
+								Depth:             100,
+								Levels:            1,
 								FilesPerDirectory: 100,
 							}
 							log.Infof(fmt.Sprintf("creating nested directories and files within mountPath [%s] with depth [%d] , level [%d] and FilesPerDirectory [%d]", DirectoryConfig.BasePath, DirectoryConfig.Depth, DirectoryConfig.Levels, DirectoryConfig.FilesPerDirectory))
@@ -226,11 +226,11 @@ var _ = Describe("{ExcludeDirectoryFileBackup}", func() {
 						for _, mountPath := range mountPaths {
 							excludeFileDirList := make([]string, 0)
 							log.Infof(fmt.Sprintf("Fetch some random directories from created list %v", dirListMountMap[mountPath]))
-							randomDirs, err := GetRandomSubset(dirListMountMap[mountPath], 500)
+							randomDirs, err := GetRandomSubset(dirListMountMap[mountPath], 50)
 							dash.VerifyFatal(err, nil, fmt.Sprintf("Getting random directories from the list"))
 							log.Infof(fmt.Sprintf("the list of directories randomly selected from mountPath- %v : %v", mountPath, randomDirs))
 							log.Infof(fmt.Sprintf("Fetch some random files from created list %v", fileListMountMap[mountPath]))
-							randomFiles, err := GetRandomSubset(fileListMountMap[mountPath], 500)
+							randomFiles, err := GetRandomSubset(fileListMountMap[mountPath], 100)
 							dash.VerifyFatal(err, nil, fmt.Sprintf("Getting random files from the list"))
 							log.Infof(fmt.Sprintf("the list of files randomly selected from mountPath- %v : %v", mountPath, randomFiles))
 							excludeFileDirList = append(excludeFileDirList, randomDirs...)
@@ -867,8 +867,8 @@ var _ = Describe("{ExcludeInvalidDirectoryFileBackup}", func() {
 						for _, mountPath := range mountPaths {
 							DirectoryConfig := PodDirectoryConfig{
 								BasePath:          mountPath,
-								Depth:             10,
-								Levels:            3,
+								Depth:             100,
+								Levels:            1,
 								FilesPerDirectory: 100,
 							}
 							log.Infof(fmt.Sprintf("creating nested directories and files within mountPath [%s] with depth [%d] , level [%d] and FilesPerDirectory [%d]", DirectoryConfig.BasePath, DirectoryConfig.Depth, DirectoryConfig.Levels, DirectoryConfig.FilesPerDirectory))
@@ -898,11 +898,11 @@ var _ = Describe("{ExcludeInvalidDirectoryFileBackup}", func() {
 						for _, mountPath := range mountPaths {
 							excludeFileDirList := make([]string, 0)
 							log.Infof(fmt.Sprintf("Fetch some random directories from created list %v", dirListMountMap[mountPath]))
-							randomDirs, err := GetRandomSubset(dirListMountMap[mountPath], 500)
+							randomDirs, err := GetRandomSubset(dirListMountMap[mountPath], 50)
 							dash.VerifyFatal(err, nil, fmt.Sprintf("Getting random directories from the list"))
 							log.Infof(fmt.Sprintf("the list of directories randomly selected from mountPath- %v : %v", mountPath, randomDirs))
 							log.Infof(fmt.Sprintf("Fetch some random files from created list %v", fileListMountMap[mountPath]))
-							randomFiles, err := GetRandomSubset(fileListMountMap[mountPath], 500)
+							randomFiles, err := GetRandomSubset(fileListMountMap[mountPath], 100)
 							dash.VerifyFatal(err, nil, fmt.Sprintf("Getting random files from the list"))
 							log.Infof(fmt.Sprintf("the list of files randomly selected from mountPath- %v : %v", mountPath, randomFiles))
 							excludeFileDirList = append(excludeFileDirList, randomDirs...)


### PR DESCRIPTION
**What this PR does / why we need it**:
Changed file creation count to 10k for each iteration.
Reduced the count so that the total test execution time will reduce and can be included in regular runlist.

**Which issue(s) this PR fixes** (optional)
Closes #PB-6068

**Special notes for your reviewer**:
https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/basic-system-test/job/px/job/s3/job/Vanilla-FBDA/75/

https://aetos.pwx.purestorage.com/resultSet/testSetID/570401
