### PR TITLE
[PTX-22784,PTX-22774] -Changes for Anthos and OCP Dmthin longevity stablization

### DIFF
--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -4260,6 +4260,7 @@ func (k *K8s) GetVolumes(ctx *scheduler.Context) ([]*volume.Volume, error) {
 	var vols []*volume.Volume
 	for _, specObj := range ctx.App.SpecList {
 		if obj, ok := specObj.(*corev1.PersistentVolumeClaim); ok {
+			log.Debugf("Getting PVC [%s], namespace: [%s] for depolyment [%s]", obj.Name, obj.Namespace, ctx.App.Key)
 			pvcObj, err := k8sCore.GetPersistentVolumeClaim(obj.Name, obj.Namespace)
 			if err != nil {
 				return nil, fmt.Errorf("error getting pvc: %s, namespace: %s. Err: %v", obj.Name, obj.Namespace, err)
@@ -4298,6 +4299,8 @@ func (k *K8s) GetVolumes(ctx *scheduler.Context) ([]*volume.Volume, error) {
 					Cause: fmt.Sprintf("Failed to get StatefulSet: %v , Namespace: %v. Err: %v", obj.Name, obj.Namespace, err),
 				}
 			}
+
+			log.Debugf("Getting PVCs from namespace: [%s] for statefulset [%s]", obj.Namespace, obj.Name)
 
 			pvcList, err := k8sOps.GetPVCsForStatefulSet(ss)
 			if err != nil || pvcList == nil {

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -4205,20 +4205,24 @@ func (k *K8s) appendVolForPVC(vols []*volume.Volume, pvc *v1.PersistentVolumeCla
 	labels := pvc.Labels
 
 	if pvc.Spec.VolumeName != "" {
+		log.Debugf("pvc spec volume name [%s]", pvc.Spec.VolumeName)
 		// If this is a Pure volume, run some extra checks to get more information.
 		// Store them as labels as they are not applicable to all volume types.
 		driver, err := volume.Get(k.VolDriverName)
 		if err != nil {
+			log.Errorf("error getting volume driver name")
 			return nil, err
 		}
 
 		inspectedVol, err := driver.InspectVolume(pvc.Spec.VolumeName)
 		if err != nil {
+			log.Warnf("error inspecting volume [%s],err: %v", pvc.Spec.VolumeName, err)
 			if _, ok := err.(*errors.ErrNotSupported); !ok {
 				return nil, fmt.Errorf("failed to inspect volume %s: %v", pvc.Name, err)
 			}
 			// If the driver doesn't support InspectVolume, then it's definitely not a Pure volume. Do nothing special
 		} else {
+			log.Debugf("inspected volume [%s] to add labels", inspectedVol.Id)
 			// If this is a Pure volume, run some extra checks to get more information.
 			// Store them as labels as they are not applicable to all volume types.
 			if labels == nil {
@@ -4251,6 +4255,7 @@ func (k *K8s) appendVolForPVC(vols []*volume.Volume, pvc *v1.PersistentVolumeCla
 		Size:        uint64(pvcSize),
 		Raw:         isRaw,
 	}
+	log.Debugf("Adding vol [%s/%s] to volume list", vol.ID, vol.Name)
 	return append(vols, vol), nil
 }
 
@@ -4262,6 +4267,7 @@ func (k *K8s) GetVolumes(ctx *scheduler.Context) ([]*volume.Volume, error) {
 		if obj, ok := specObj.(*corev1.PersistentVolumeClaim); ok {
 			log.Debugf("Getting PVC [%s], namespace: [%s] for depolyment [%s]", obj.Name, obj.Namespace, ctx.App.Key)
 			pvcObj, err := k8sCore.GetPersistentVolumeClaim(obj.Name, obj.Namespace)
+			log.Debugf("got pvc object [%s]", pvcObj.Name)
 			if err != nil {
 				return nil, fmt.Errorf("error getting pvc: %s, namespace: %s. Err: %v", obj.Name, obj.Namespace, err)
 			}

--- a/tests/basic/pool_function_test.go
+++ b/tests/basic/pool_function_test.go
@@ -308,7 +308,7 @@ var _ = Describe("{PoolExpandWithReboot}", func() {
 		Step("Wait for expansion to start and reboot node", func() {
 			err := WaitForExpansionToStart(poolIDToResize)
 			log.FailOnError(err, "Timed out waiting for expansion to start")
-			err = RebootNodeAndWait(*storageNode)
+			err = RebootNodeAndWaitForPxUp(*storageNode)
 			log.FailOnError(err, "Failed to reboot node and wait till it is up")
 		})
 

--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -9973,6 +9973,12 @@ var _ = Describe("{AddDriveWithKernelPanic}", func() {
 })
 
 func isMaintenanceModeRequiredForAddDisk() bool {
+	isDmthin, err := IsDMthin()
+	log.FailOnError(err, "error validating for dmthin check")
+	if isDmthin {
+		return true
+	}
+
 	if Inst().N.String() == ssh.DriverName || Inst().N.String() == vsphere.DriverName {
 		cmd := "uname -r"
 
@@ -10001,6 +10007,7 @@ func isMaintenanceModeRequiredForAddDisk() bool {
 		}
 
 	}
+
 	return false
 }
 

--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -333,7 +333,7 @@ var _ = Describe("{PoolResizeDiskReboot}", func() {
 
 			storageNode, err := GetNodeWithGivenPoolID(poolIDToResize)
 			log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", poolIDToResize))
-			err = RebootNodeAndWait(*storageNode)
+			err = RebootNodeAndWaitForPxUp(*storageNode)
 			log.FailOnError(err, "Failed to reboot node and wait till it is up")
 			resizeErr := waitForPoolToBeResized(expectedSize, poolIDToResize, isjournal)
 			dash.VerifyFatal(resizeErr, nil, fmt.Sprintf("Expected new size to be '%d' or '%d'", expectedSize, expectedSizeWithJournal))
@@ -442,7 +442,7 @@ var _ = Describe("{PoolAddDiskReboot}", func() {
 
 			storageNode, err := GetNodeWithGivenPoolID(poolIDToResize)
 			log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", poolIDToResize))
-			err = RebootNodeAndWait(*storageNode)
+			err = RebootNodeAndWaitForPxUp(*storageNode)
 			if err != nil {
 				if !strings.Contains(err.Error(), "Actual: STATUS_POOLMAINTENANCE") {
 					log.FailOnError(err, "Failed to reboot node and wait till it is up")
@@ -2583,7 +2583,7 @@ var _ = Describe("{AddDriveWithNodeReboot}", func() {
 			err = Inst().V.AddCloudDrive(&stNode, deviceSpec, -1)
 			log.FailOnError(err, fmt.Sprintf("Add cloud drive failed on node %s", stNode.Name))
 			time.Sleep(3 * time.Second)
-			err = RebootNodeAndWait(stNode)
+			err = RebootNodeAndWaitForPxUp(stNode)
 			log.FailOnError(err, fmt.Sprintf("error rebooting node %s", stNode.Name))
 			log.InfoD("Validate pool rebalance after drive add")
 			err = ValidateDriveRebalance(stNode)
@@ -7100,7 +7100,7 @@ var _ = Describe("{ExpandUsingAddDriveAndNodeRestart}", func() {
 
 		storageNode, err := GetNodeWithGivenPoolID(poolToBeResized.Uuid)
 		log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID [%s]", poolToBeResized.Uuid))
-		err = RebootNodeAndWait(*storageNode)
+		err = RebootNodeAndWaitForPxUp(*storageNode)
 		log.FailOnError(err, "Failed to reboot node [%v] and wait till it is up", storageNode.Name)
 
 		log.FailOnError(Inst().V.WaitDriverUpOnNode(*storageNode, addDriveUpTimeOut), fmt.Sprintf("Driver is down on node [%s]", storageNode.Name))
@@ -9064,7 +9064,7 @@ var _ = Describe("{KvdbRestartNewNodeAcquired}", func() {
 			if eachType == "kill" {
 				log.FailOnError(KillKvdbMemberUsingPid(*masterNode), "failed to kill kvdb master node")
 			} else {
-				err = RebootNodeAndWait(*masterNode)
+				err = RebootNodeAndWaitForPxUp(*masterNode)
 				log.FailOnError(err, "Failed to reboot node and wait till it is up")
 			}
 			masterNodeAfterKill, err := GetKvdbMasterNode()
@@ -10594,7 +10594,7 @@ var _ = Describe("{PoolDeleteServiceDisruption}", func() {
 		stepLog = "3. Verify reboot"
 		Step(stepLog, func() {
 			log.InfoD(stepLog)
-			err = RebootNodeAndWait(*testNode)
+			err = RebootNodeAndWaitForPxUp(*testNode)
 			log.FailOnError(err, "Failed to reboot node and wait till it is up")
 			log.Info("Verify reboot succeed")
 		})

--- a/tests/basic/unhappypath_test.go
+++ b/tests/basic/unhappypath_test.go
@@ -29,7 +29,7 @@ const (
 	totalTimeInHours              = 24
 	errorPersistTimeInMinutes     = 60 * time.Minute
 	snapshotScheduleRetryInterval = 10 * time.Second
-	snapshotScheduleRetryTimeout  = 5 * time.Minute
+	snapshotScheduleRetryTimeout  = 15 * time.Minute
 	waitTimeForPXAfterError       = 20 * time.Minute
 )
 

--- a/tests/common.go
+++ b/tests/common.go
@@ -2110,7 +2110,7 @@ func CrashVolDriverAndWait(appNodes []node.Node, errChan ...*chan error) {
 
 		stepLog = fmt.Sprintf("wait for volume driver to start on nodes: %v", appNodes)
 		Step(stepLog, func() {
-			log.Info(stepLog)
+			log.InfoD(stepLog)
 			for _, n := range appNodes {
 				err := Inst().V.WaitDriverUpOnNode(n, Inst().DriverStartTimeout)
 				processError(err, errChan...)

--- a/tests/common.go
+++ b/tests/common.go
@@ -7121,8 +7121,21 @@ func WaitForExpansionToStart(poolID string) error {
 	return err
 }
 
-// RebootNodeAndWait reboots node and waits for to be up
-func RebootNodeAndWait(n node.Node) error {
+// RebootNodeAndWaitForPxUp reboots node and waits for  volume driver to be up
+func RebootNodeAndWaitForPxUp(n node.Node) error {
+
+	err := RebootNodeAndWaitForPxDown(n)
+	err = Inst().V.WaitDriverUpOnNode(n, Inst().DriverStartTimeout)
+	if err != nil {
+		return err
+	}
+
+	return nil
+
+}
+
+// RebootNodeAndWaitForPxDown reboots node and waits for volume driver to be down
+func RebootNodeAndWaitForPxDown(n node.Node) error {
 
 	if &n == nil {
 		return fmt.Errorf("no Node is provided to reboot")
@@ -7151,10 +7164,6 @@ func RebootNodeAndWait(n node.Node) error {
 		return err
 	}
 	err = Inst().S.IsNodeReady(n)
-	if err != nil {
-		return err
-	}
-	err = Inst().V.WaitDriverUpOnNode(n, Inst().DriverStartTimeout)
 	if err != nil {
 		return err
 	}

--- a/tests/testTriggers.go
+++ b/tests/testTriggers.go
@@ -3244,7 +3244,7 @@ func TriggerCloudSnapShot(contexts *[]*scheduler.Context, recordChan *chan *Even
 					policyName := "intervalpolicy"
 					schedPolicy, err := storkops.Instance().GetSchedulePolicy(policyName)
 					if err != nil {
-						retain := 2
+						retain := 10
 						interval := getCloudSnapInterval(CloudSnapShot)
 						log.InfoD("Creating a interval schedule policy %v with interval %v minutes", policyName, interval)
 						schedPolicy = &storkv1.SchedulePolicy{
@@ -3395,35 +3395,76 @@ func TriggerCloudSnapshotRestore(contexts *[]*scheduler.Context, recordChan *cha
 	setMetrics(*event)
 
 	stepLog := "Verify cloud snap restore"
+
 	Step(stepLog, func() {
-		for ns, volSnap := range cloudsnapMap {
-			for vol, snap := range volSnap {
-				dashStats := make(map[string]string)
-				dashStats["source-name"] = snap.Name
-				dashStats["source-namespace"] = ns
-				dashStats["destination-name"] = vol.Name
-				dashStats["destination-namespace"] = vol.Namespace
-				updateLongevityStats(CloudSnapShotRestore, stats.CloudsnapRestorEventName, dashStats)
-				restoreSpec := &storkv1.VolumeSnapshotRestore{ObjectMeta: meta_v1.ObjectMeta{
-					Name:      vol.Name,
-					Namespace: vol.Namespace,
-				}, Spec: storkv1.VolumeSnapshotRestoreSpec{SourceName: snap.Name, SourceNamespace: ns, GroupSnapshot: false}}
-				restore, err := storkops.Instance().CreateVolumeSnapshotRestore(restoreSpec)
+		for _, ctx := range *contexts {
+			if strings.Contains(ctx.App.Key, "cloudsnap") {
+				appNamespace := ctx.App.Key + "-" + ctx.UID
+				snapSchedList, err := storkops.Instance().ListSnapshotSchedules(appNamespace)
 				if err != nil {
 					UpdateOutcome(event, err)
 					return
 				}
-				err = storkops.Instance().ValidateVolumeSnapshotRestore(restore.Name, restore.Namespace, snapshotScheduleRetryTimeout, snapshotScheduleRetryInterval)
-				dash.VerifySafely(err, nil, fmt.Sprintf("validate snapshot restore source: %s , destnation: %s in namespace %s", restore.Name, vol.Name, vol.Namespace))
-				if err == nil {
-					err = storkops.Instance().DeleteVolumeSnapshotRestore(restore.Name, restore.Namespace)
-					UpdateOutcome(event, err)
+				vols, err := Inst().S.GetVolumes(ctx)
+				UpdateOutcome(event, err)
+
+				for _, vol := range vols {
+					var snapshotScheduleName string
+					for _, snap := range snapSchedList.Items {
+						snapshotScheduleName = snap.Name
+						if strings.Contains(snapshotScheduleName, vol.Name) {
+							break
+						}
+					}
+					resp, err := storkops.Instance().GetSnapshotSchedule(snapshotScheduleName, appNamespace)
+					if err != nil {
+						UpdateOutcome(event, err)
+						return
+					}
+					var volumeSnapshotStatus *storkv1.ScheduledVolumeSnapshotStatus
+				outer:
+					for _, snapshotStatuses := range resp.Status.Items {
+						for _, vsStatus := range snapshotStatuses {
+							if vsStatus.Status == snapv1.VolumeSnapshotConditionReady {
+								volumeSnapshotStatus = vsStatus
+								break outer
+							}
+						}
+					}
+					if volumeSnapshotStatus != nil {
+						dashStats := make(map[string]string)
+						dashStats["source-name"] = volumeSnapshotStatus.Name
+						dashStats["source-namespace"] = appNamespace
+						dashStats["destination-name"] = vol.Name
+						dashStats["destination-namespace"] = vol.Namespace
+						updateLongevityStats(CloudSnapShotRestore, stats.CloudsnapRestorEventName, dashStats)
+						restoreSpec := &storkv1.VolumeSnapshotRestore{ObjectMeta: meta_v1.ObjectMeta{
+							Name:      vol.Name,
+							Namespace: vol.Namespace,
+						}, Spec: storkv1.VolumeSnapshotRestoreSpec{SourceName: volumeSnapshotStatus.Name, SourceNamespace: appNamespace, GroupSnapshot: false}}
+						restore, err := storkops.Instance().CreateVolumeSnapshotRestore(restoreSpec)
+						if err != nil {
+							UpdateOutcome(event, err)
+							return
+						}
+						err = storkops.Instance().ValidateVolumeSnapshotRestore(restore.Name, restore.Namespace, snapshotScheduleRetryTimeout, snapshotScheduleRetryInterval)
+						dash.VerifySafely(err, nil, fmt.Sprintf("validate snapshot restore source: %s , destnation: %s in namespace %s", restore.Name, vol.Name, vol.Namespace))
+						if err == nil {
+							err = storkops.Instance().DeleteVolumeSnapshotRestore(restore.Name, restore.Namespace)
+							if err != nil {
+								UpdateOutcome(event, err)
+								return
+							}
+						}
+					} else {
+						UpdateOutcome(event, fmt.Errorf("no snapshot with Ready status found for vol[%s] in namespace[%s]", vol.Name, vol.Namespace))
+					}
+
 				}
+
 			}
 		}
-		for k := range cloudsnapMap {
-			delete(cloudsnapMap, k)
-		}
+
 	})
 	err := ValidateDataIntegrity(contexts)
 	UpdateOutcome(event, err)
@@ -5239,7 +5280,7 @@ func waitForPoolToBeResized(initialSize uint64, poolIDToResize string) error {
 			return nil, false, fmt.Errorf("expanded pool value is nil")
 		}
 		if expandedPool.LastOperation != nil {
-			log.Infof("Pool Resize Status : %v, Message : %s", expandedPool.LastOperation.Status, expandedPool.LastOperation.Msg)
+			log.Infof("Pool [%s] Resize Status : %v, Message : %s", expandedPool.Uuid, expandedPool.LastOperation.Status, expandedPool.LastOperation.Msg)
 			if expandedPool.LastOperation.Status == opsapi.SdkStoragePool_OPERATION_FAILED {
 				return nil, false, fmt.Errorf("pool %s expansion has failed. Error: %s", poolIDToResize, expandedPool.LastOperation)
 			}
@@ -5278,7 +5319,7 @@ func waitForPoolToBeResized(initialSize uint64, poolIDToResize string) error {
 		return nil, true, fmt.Errorf("pool has not been resized. Waiting...Current size is %d", newPoolSize)
 	}
 
-	_, err := task.DoRetryWithTimeout(f, 120*time.Minute, 2*time.Minute)
+	_, err := task.DoRetryWithTimeout(f, 300*time.Minute, 2*time.Minute)
 	return err
 }
 
@@ -5292,9 +5333,12 @@ func getStoragePoolsToExpand() ([]*opsapi.StoragePool, error) {
 			return nil, err
 		}
 		if len(poolsToExpand) <= expectedCapacity {
+			log.Debugf("validating node [%s] for pool expansion", stNode.Id)
 			if eligibility[stNode.Id] {
 				for _, p := range stNode.Pools {
+					log.Debugf("validating pool [%s] in node [%s] for pool expansion", p.Uuid, stNode.Id)
 					if eligibility[p.Uuid] {
+						log.Debugf("Marking pool [%s] for expansion", p.Uuid)
 						poolsToExpand = append(poolsToExpand, p)
 					}
 				}


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
- Added more debug logs for anthos volumes failure
- Added retry logic to get VM name while VMs are rebooting
- Added logic to verify machine count for OCP scaling
- Changes for cloudsnap restore to get snapshots with ready status
- Fix for AdddiskReboot event to skip pool maintenance mode failure after reboot in case of dmthin
**Which issue(s) this PR fixes** (optional)
Closes #PTX-22784,PTX-22774

**Special notes for your reviewer**:
Test result for cloudsnap restore: https://aetos.pwx.purestorage.com/resultSet/testSetID/575186
OCP test : https://jenkins.pwx.dev.purestorage.com/job/Torpedo/view/OCP%20Jobs/job/OCP-PWX-152-249/98/console

