### PR TITLE
[PB-6037]Add receiver and recipient object Support

### DIFF
--- a/drivers/backup/backup.go
+++ b/drivers/backup/backup.go
@@ -80,6 +80,10 @@ type Driver interface {
 	ActivityTimeLine
 	//Metrics interface
 	Metrics
+	//Receiver interface
+	Receiver
+	//Recipient interface
+	Recipient
 
 	// Init initializes the backup driver under a given scheduler
 	Init(schedulerDriverName string, nodeDriverName string, volumeDriverName string, token string) error
@@ -478,6 +482,45 @@ type ActivityTimeLine interface {
 type Metrics interface {
 	// InspectMetrics inspects metricsData
 	InspectMetrics(ctx context.Context, req *api.MetricsInspectRequest) (*api.MetricsInspectResponse, error)
+}
+
+// Receiver object interface
+type Receiver interface {
+	// CreateReceiver creates receiver object
+	CreateReceiver(ctx context.Context, req *api.ReceiverCreateRequest) (*api.ReceiverCreateResponse, error)
+
+	// InspectReceiver inspects a receiver object
+	InspectReceiver(ctx context.Context, req *api.ReceiverInspectRequest) (*api.ReceiverInspectResponse, error)
+
+	// EnumerateReceiver enumerates all receiver object
+	EnumerateReceiver(ctx context.Context, req *api.ReceiverEnumerateRequest) (*api.ReceiverEnumerateResponse, error)
+
+	// DeleteReceiver deletes a receiver object
+	DeleteReceiver(ctx context.Context, req *api.ReceiverDeleteRequest) (*api.ReceiverDeleteResponse, error)
+
+	// UpdateReceiver updates a receiver object
+	UpdateReceiver(ctx context.Context, req *api.ReceiverUpdateRequest) (*api.ReceiverUpdateResponse, error)
+
+	// ValidateReceiver validates a receiver object
+	ValidateReceiver(ctx context.Context, req *api.ReceiverValidateSMTPRequest) (*api.ReceiverValidateSMTPResponse, error)
+}
+
+// Recipient object interface
+type Recipient interface {
+	// CreateRecipient creates Recipient object
+	CreateRecipient(ctx context.Context, req *api.RecipientCreateRequest) (*api.RecipientCreateResponse, error)
+
+	// InspectRecipient inspects a Recipient object
+	InspectRecipient(ctx context.Context, req *api.RecipientInspectRequest) (*api.RecipientInspectResponse, error)
+
+	// EnumerateRecipient enumerates all Recipient object
+	EnumerateRecipient(ctx context.Context, req *api.RecipientEnumerateRequest) (*api.RecipientEnumerateResponse, error)
+
+	// DeleteRecipient deletes a Recipient object
+	DeleteRecipient(ctx context.Context, req *api.RecipientDeleteRequest) (*api.RecipientDeleteResponse, error)
+
+	// UpdateRecipient updates a Recipient object
+	UpdateRecipient(ctx context.Context, req *api.RecipientUpdateRequest) (*api.RecipientUpdateResponse, error)
 }
 
 var backupDrivers = make(map[string]Driver)

--- a/drivers/backup/portworx/portworx.go
+++ b/drivers/backup/portworx/portworx.go
@@ -66,6 +66,8 @@ type portworx struct {
 	versionManager          api.VersionClient
 	activityTimeLineManager api.ActivityTimeLineClient
 	metricsManager          api.MetricsClient
+	receiverManager         api.ReceiverClient
+	recipientManager        api.RecipientClient
 
 	schedulerDriver scheduler.Driver
 	nodeDriver      node.Driver
@@ -191,6 +193,8 @@ func (p *portworx) testAndSetEndpoint(endpoint string) error {
 	p.activityTimeLineManager = api.NewActivityTimeLineClient(conn)
 	p.metricsManager = api.NewMetricsClient(conn)
 	p.roleManager = api.NewRoleClient(conn)
+	p.receiverManager = api.NewReceiverClient(conn)
+	p.recipientManager = api.NewRecipientClient(conn)
 
 	log.Infof("Using %v as endpoint for portworx backup driver", pxEndpoint)
 
@@ -2662,6 +2666,61 @@ func (p *portworx) UpdateRole(ctx context.Context, req *api.RoleUpdateRequest) (
 
 func (p *portworx) InspectRole(ctx context.Context, req *api.RoleInspectRequest) (*api.RoleInspectResponse, error) {
 	return p.roleManager.Inspect(ctx, req)
+}
+
+// CreateReceiver creates receiver object
+func (p *portworx) CreateReceiver(ctx context.Context, req *api.ReceiverCreateRequest) (*api.ReceiverCreateResponse, error) {
+	return p.receiverManager.Create(ctx, req)
+}
+
+// DeleteReceiver deletes receiver object
+func (p *portworx) DeleteReceiver(ctx context.Context, req *api.ReceiverDeleteRequest) (*api.ReceiverDeleteResponse, error) {
+	return p.receiverManager.Delete(ctx, req)
+}
+
+// EnumerateReceiver enumerates receiver object
+func (p *portworx) EnumerateReceiver(ctx context.Context, req *api.ReceiverEnumerateRequest) (*api.ReceiverEnumerateResponse, error) {
+	return p.receiverManager.Enumerate(ctx, req)
+}
+
+// UpdateReceiver updates receiver object
+func (p *portworx) UpdateReceiver(ctx context.Context, req *api.ReceiverUpdateRequest) (*api.ReceiverUpdateResponse, error) {
+	return p.receiverManager.Update(ctx, req)
+}
+
+// InspectReceiver inspects receiver object
+func (p *portworx) InspectReceiver(ctx context.Context, req *api.ReceiverInspectRequest) (*api.ReceiverInspectResponse, error) {
+	return p.receiverManager.Inspect(ctx, req)
+}
+
+// ValidateReceiver validates receiver object
+func (p *portworx) ValidateReceiver(ctx context.Context, req *api.ReceiverValidateSMTPRequest) (*api.ReceiverValidateSMTPResponse, error) {
+	return p.receiverManager.ValidateSMTP(ctx, req)
+}
+
+// CreateRecipient creates recipient object
+func (p *portworx) CreateRecipient(ctx context.Context, req *api.RecipientCreateRequest) (*api.RecipientCreateResponse, error) {
+	return p.recipientManager.Create(ctx, req)
+}
+
+// DeleteRecipient deletes recipient object
+func (p *portworx) DeleteRecipient(ctx context.Context, req *api.RecipientDeleteRequest) (*api.RecipientDeleteResponse, error) {
+	return p.recipientManager.Delete(ctx, req)
+}
+
+// EnumerateRecipient enumerates recipient object
+func (p *portworx) EnumerateRecipient(ctx context.Context, req *api.RecipientEnumerateRequest) (*api.RecipientEnumerateResponse, error) {
+	return p.recipientManager.Enumerate(ctx, req)
+}
+
+// UpdateRecipient updates recipient object
+func (p *portworx) UpdateRecipient(ctx context.Context, req *api.RecipientUpdateRequest) (*api.RecipientUpdateResponse, error) {
+	return p.recipientManager.Update(ctx, req)
+}
+
+// InspectRecipient inspects recipient object
+func (p *portworx) InspectRecipient(ctx context.Context, req *api.RecipientInspectRequest) (*api.RecipientInspectResponse, error) {
+	return p.recipientManager.Inspect(ctx, req)
 }
 
 func init() {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Added support for receiver and recipient objects which is to be used for px-backup automation

**Which issue(s) this PR fixes** (optional)
Closes #PB-6037

**Special notes for your reviewer**:
To avoid exposing credentials,ran it locally.Here's the aetos link :
https://aetos.pwx.purestorage.com/resultSet/testSetID/574786
