### PR TITLE
PB-6000 API expose for adding labels to namespace

### DIFF
--- a/apiServer/taas/apiserver.go
+++ b/apiServer/taas/apiserver.go
@@ -29,5 +29,6 @@ func main() {
 	router.GET("taas/getpxctloutput", utils.GetPxctlStatusOutput)
 	router.GET("taas/getkubevirtvmsbyns", utils.GetVMsInNamespaces)
 	router.GET("taas/getkubevirtvmsbynslabels", utils.GetVMsWithNamespaceLabels)
+	router.POST("taas/namespaces/addLabel", utils.AddNSLabel)
 	log.Fatal(router.Run(":8080"))
 }


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Exposes adding labels to namespace

**Which issue(s) this PR fixes** (optional)
Closes # PB-6000

**Special notes for your reviewer**:
```
API: taas/namespaces/addLabel
method: post
body: {
    "namespaces": ["central","ns1"],
    "ns_label": {"env":"dev"}
}

}


