### PR TITLE
[PTX-22940,PTX-22907,PWX-36497]Stablizing node decomm and pool maintenance cycle validations in longevity

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -3930,6 +3930,7 @@ func (d *portworx) GetClusterPairingInfo(kubeConfigPath, token string, isPxLBSer
 }
 
 func (d *portworx) DecommissionNode(n *node.Node) error {
+
 	if err := k8sCore.AddLabelOnNode(n.Name, schedops.PXEnabledLabelKey, "remove"); err != nil {
 		return &ErrFailedToDecommissionNode{
 			Node:  n.Name,
@@ -4013,7 +4014,7 @@ func (d *portworx) DecommissionNode(n *node.Node) error {
 
 	// update node in registry
 	n.IsStorageDriverInstalled = false
-	if err = node.UpdateNode(*n); err != nil {
+	if err := node.UpdateNode(*n); err != nil {
 		return fmt.Errorf("failed to update node [%s], Err: %v", n.Name, err)
 	}
 
@@ -4047,7 +4048,7 @@ func (d *portworx) DecommissionNode(n *node.Node) error {
 		return nil, false, nil
 	}
 
-	_, err = task.DoRetryWithTimeout(t, 10*time.Minute, 1*time.Minute)
+	_, err = task.DoRetryWithTimeout(t, 25*time.Minute, 3*time.Minute)
 
 	if err != nil {
 		return &ErrFailedToDecommissionNode{
@@ -4056,7 +4057,7 @@ func (d *portworx) DecommissionNode(n *node.Node) error {
 		}
 	}
 
-	log.Infof("Successfully removed node [%s]", nodeResp.Node.Id)
+	log.Infof("Successfully removed node [%s/%s]", n.Name, n.VolDriverNodeID)
 	return nil
 }
 
@@ -5294,7 +5295,7 @@ func (d *portworx) GetPxctlCmdOutputConnectionOpts(n node.Node, command string, 
 		out, err = d.nodeDriver.RunCommandWithNoRetry(n, cmd, opts)
 	}
 	if err != nil {
-		return "", fmt.Errorf("failed to get pxctl status. cause: %v", err)
+		return "", fmt.Errorf("failed to get pxctl command output. cause: %v", err)
 	}
 
 	// Delete context

--- a/tests/basic/ha_update_test.go
+++ b/tests/basic/ha_update_test.go
@@ -121,13 +121,18 @@ func performHaIncreaseRebootTest(testName string) {
 					}
 
 					if testName == "ha-inc-reboot-src" {
-						HaIncreaseRebootSourceNode(nil, ctx, v, storageNodeMap, REBOOT)
+						err = HaIncreaseErrorInjectSourceNode(nil, ctx, v, storageNodeMap, REBOOT)
+						dash.VerifyFatal(err, nil, "Validate HA increase and reboot source node")
+
 					} else if testName == "ha-inc-restartpx-src" {
-						HaIncreaseRebootSourceNode(nil, ctx, v, storageNodeMap, PX_RESTART)
+						err = HaIncreaseErrorInjectSourceNode(nil, ctx, v, storageNodeMap, PX_RESTART)
+						dash.VerifyFatal(err, nil, "Validate HA increase and restart source node")
 					} else if testName == "ha-inc-restartpx-tgt" {
-						HaIncreaseRebootTargetNode(nil, ctx, v, storageNodeMap, PX_RESTART)
+						err = HaIncreaseErrorInjectionTargetNode(nil, ctx, v, storageNodeMap, PX_RESTART)
+						dash.VerifyFatal(err, nil, "Validate HA increase and restart target node")
 					} else {
-						HaIncreaseRebootTargetNode(nil, ctx, v, storageNodeMap, REBOOT)
+						err = HaIncreaseErrorInjectionTargetNode(nil, ctx, v, storageNodeMap, REBOOT)
+						dash.VerifyFatal(err, nil, "Validate HA increase and reboot target node")
 					}
 				}
 			}

--- a/tests/basic/upgrade_test.go
+++ b/tests/basic/upgrade_test.go
@@ -168,9 +168,8 @@ var _ = Describe("{UpgradeVolumeDriver}", func() {
 				fioJobName := "upg_vol"
 				log.Infof(upgradeHop)
 
-				n := storageNodes[rand.Intn(numOfNodes)]
-
 				if Inst().N.IsUsingSSH() {
+					n := storageNodes[rand.Intn(len(storageNodes))]
 
 					volName = fmt.Sprintf("vol-%s", time.Now().Format("01-02-15h04m05s"))
 					volId, err := Inst().V.CreateVolume(volName, 53687091200, 3)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
- Added logic to check node is healthy ,stop backups and move volume repls before node decommission
- Removed app validation when pool is in maintenance mode in maintenance cycle test
- Fixing csisnapshot reporting dummy error

**Which issue(s) this PR fixes** (optional)
Closes #PTX-22940,PTX-22907,PWX-36497

**Special notes for your reviewer**:
Test: https://aetos.pwx.purestorage.com/resultSet/testSetID/585491
