### PR TITLE
[PTX-22947] Print Volume inspect after volume operations in longevity

### DIFF
--- a/tests/common.go
+++ b/tests/common.go
@@ -7790,12 +7790,13 @@ func CreateMultiVolumesAndAttach(wg *sync.WaitGroup, count int, nodeName string)
 		}
 		if err != nil {
 			return createdVolIDs, fmt.Errorf("failed to creared volume %s, due to error : %v ", volName, err)
+
 		}
 		volPath = fmt.Sprintf("%v", out)
 		createdVolIDs[volId] = volPath
 		log.Infof("Volume %s attached to path %s", volId, volPath)
 		count--
-		log.InfoD("Printing the volume inspect for the volume")
+		log.Debugf("Printing the volume inspect for the volume:%s ,volID:%s  after creating the volume", volName, volId)
 		PrintInspectVolume(volId)
 	}
 	return createdVolIDs, nil

--- a/tests/common.go
+++ b/tests/common.go
@@ -5692,8 +5692,6 @@ func HaIncreaseErrorInjectionTargetNode(event *EventRecord, ctx *scheduler.Conte
 
 			if err != nil {
 				err = fmt.Errorf("error getting replication factor for volume %s, Error: %v", v.Name, err)
-				log.Debugf("Printing the volume inspect for the volume:%s ,volID:%s and namespace:%s  ", v.Name, v.ID, v.Namespace)
-				PrintInspectVolume(v.ID)
 				log.Error(err)
 				UpdateOutcome(event, err)
 				return
@@ -5786,10 +5784,6 @@ func HaIncreaseErrorInjectionTargetNode(event *EventRecord, ctx *scheduler.Conte
 							if err != nil {
 								err = fmt.Errorf("There is an error increasing repl [%v]", err.Error())
 								return
-								log.Debugf("Printing the volume inspect for the volume:%s ,volID:%s and namespace:%s after repl increase ", v.Name, v.ID, v.Namespace)
-								PrintInspectVolume(v.ID)
-								log.Errorf("There is an error increasing repl [%v]", err.Error())
-								UpdateOutcome(event, err)
 							}
 						})
 
@@ -5910,8 +5904,6 @@ func HaIncreaseErrorInjectSourceNode(event *EventRecord, ctx *scheduler.Context,
 			log.InfoD(stepLog)
 			currRep, err = Inst().V.GetReplicationFactor(v)
 			if err != nil {
-				log.Debugf("Printing the volume inspect for the volume:%s ,volID:%s and namespace:%s  ", v.Name, v.ID, v.Namespace)
-				PrintInspectVolume(v.ID)
 				err = fmt.Errorf("error getting replication factor for volume %s, Error: %v", v.Name, err)
 				return
 

--- a/tests/common.go
+++ b/tests/common.go
@@ -601,6 +601,10 @@ func PrintPxctlStatus() {
 	PrintCommandOutput("pxctl status")
 }
 
+func PrintInspectVolume(volID string) {
+	PrintCommandOutput(fmt.Sprintf("pxctl volume inspect %s", volID))
+}
+
 func PrintCommandOutput(cmnd string) {
 	output, err := Inst().N.RunCommand(node.GetStorageNodes()[0], cmnd, node.ConnectionOpts{
 		IgnoreError:     false,
@@ -5688,6 +5692,10 @@ func HaIncreaseErrorInjectionTargetNode(event *EventRecord, ctx *scheduler.Conte
 
 			if err != nil {
 				err = fmt.Errorf("error getting replication factor for volume %s, Error: %v", v.Name, err)
+				log.Debugf("Printing the volume inspect for the volume:%s ,volID:%s and namespace:%s  ", v.Name, v.ID, v.Namespace)
+				PrintInspectVolume(v.ID)
+				log.Error(err)
+				UpdateOutcome(event, err)
 				return
 			}
 			//if repl is 3 cannot increase repl for the volume
@@ -5778,6 +5786,10 @@ func HaIncreaseErrorInjectionTargetNode(event *EventRecord, ctx *scheduler.Conte
 							if err != nil {
 								err = fmt.Errorf("There is an error increasing repl [%v]", err.Error())
 								return
+								log.Debugf("Printing the volume inspect for the volume:%s ,volID:%s and namespace:%s after repl increase ", v.Name, v.ID, v.Namespace)
+								PrintInspectVolume(v.ID)
+								log.Errorf("There is an error increasing repl [%v]", err.Error())
+								UpdateOutcome(event, err)
 							}
 						})
 
@@ -5848,6 +5860,8 @@ func HaIncreaseErrorInjectionTargetNode(event *EventRecord, ctx *scheduler.Conte
 								}
 								err = ValidateReplFactorUpdate(v, currRep+1)
 								if err != nil {
+									log.Debugf("Printing the volume inspect for the volume:%s ,volID:%s and namespace:%s after repl increase ", v.Name, v.ID, v.Namespace)
+									PrintInspectVolume(v.ID)
 									err = fmt.Errorf("error in ha-increse after %s target node . Error: %v", action, err)
 									return
 								}
@@ -5896,6 +5910,8 @@ func HaIncreaseErrorInjectSourceNode(event *EventRecord, ctx *scheduler.Context,
 			log.InfoD(stepLog)
 			currRep, err = Inst().V.GetReplicationFactor(v)
 			if err != nil {
+				log.Debugf("Printing the volume inspect for the volume:%s ,volID:%s and namespace:%s  ", v.Name, v.ID, v.Namespace)
+				PrintInspectVolume(v.ID)
 				err = fmt.Errorf("error getting replication factor for volume %s, Error: %v", v.Name, err)
 				return
 
@@ -6002,6 +6018,8 @@ func HaIncreaseErrorInjectSourceNode(event *EventRecord, ctx *scheduler.Context,
 								}
 								err = ValidateReplFactorUpdate(v, currRep+1)
 								if err != nil {
+									log.Debugf("Printing the volume inspect for the volume:%s ,volID:%s and namespace:%s after repl increase ", v.Name, v.ID, v.Namespace)
+									PrintInspectVolume(v.ID)
 									err = fmt.Errorf("error in ha-increse after  source node reboot. Error: %v", err)
 									return
 								}
@@ -6045,6 +6063,10 @@ func HaIncreaseErrorInjectSourceNode(event *EventRecord, ctx *scheduler.Context,
 					})
 			} else {
 				err = fmt.Errorf("error getting current replication factor for volume %s, Error: %v", v.Name, err)
+				log.Debugf("Printing the volume inspect for the volume:%s ,volID:%s and namespace:%s after repl increase ", v.Name, v.ID, v.Namespace)
+				PrintInspectVolume(v.ID)
+				log.Error(err)
+				UpdateOutcome(event, err)
 			}
 
 		})
@@ -7791,6 +7813,8 @@ func CreateMultiVolumesAndAttach(wg *sync.WaitGroup, count int, nodeName string)
 		createdVolIDs[volId] = volPath
 		log.Infof("Volume %s attached to path %s", volId, volPath)
 		count--
+		log.InfoD("Printing the volume inspect for the volume")
+		PrintInspectVolume(volId)
 	}
 	return createdVolIDs, nil
 }

--- a/tests/common.go
+++ b/tests/common.go
@@ -5854,8 +5854,6 @@ func HaIncreaseErrorInjectionTargetNode(event *EventRecord, ctx *scheduler.Conte
 								}
 								err = ValidateReplFactorUpdate(v, currRep+1)
 								if err != nil {
-									log.Debugf("Printing the volume inspect for the volume:%s ,volID:%s and namespace:%s after repl increase ", v.Name, v.ID, v.Namespace)
-									PrintInspectVolume(v.ID)
 									err = fmt.Errorf("error in ha-increse after %s target node . Error: %v", action, err)
 									return
 								}
@@ -6010,8 +6008,6 @@ func HaIncreaseErrorInjectSourceNode(event *EventRecord, ctx *scheduler.Context,
 								}
 								err = ValidateReplFactorUpdate(v, currRep+1)
 								if err != nil {
-									log.Debugf("Printing the volume inspect for the volume:%s ,volID:%s and namespace:%s after repl increase ", v.Name, v.ID, v.Namespace)
-									PrintInspectVolume(v.ID)
 									err = fmt.Errorf("error in ha-increse after  source node reboot. Error: %v", err)
 									return
 								}
@@ -6055,8 +6051,6 @@ func HaIncreaseErrorInjectSourceNode(event *EventRecord, ctx *scheduler.Context,
 					})
 			} else {
 				err = fmt.Errorf("error getting current replication factor for volume %s, Error: %v", v.Name, err)
-				log.Debugf("Printing the volume inspect for the volume:%s ,volID:%s and namespace:%s after repl increase ", v.Name, v.ID, v.Namespace)
-				PrintInspectVolume(v.ID)
 				log.Error(err)
 				UpdateOutcome(event, err)
 			}

--- a/tests/common.go
+++ b/tests/common.go
@@ -5692,8 +5692,6 @@ func HaIncreaseErrorInjectionTargetNode(event *EventRecord, ctx *scheduler.Conte
 
 			if err != nil {
 				err = fmt.Errorf("error getting replication factor for volume %s, Error: %v", v.Name, err)
-				log.Error(err)
-				UpdateOutcome(event, err)
 				return
 			}
 			//if repl is 3 cannot increase repl for the volume
@@ -6051,8 +6049,6 @@ func HaIncreaseErrorInjectSourceNode(event *EventRecord, ctx *scheduler.Context,
 					})
 			} else {
 				err = fmt.Errorf("error getting current replication factor for volume %s, Error: %v", v.Name, err)
-				log.Error(err)
-				UpdateOutcome(event, err)
 			}
 
 		})

--- a/tests/testTriggers.go
+++ b/tests/testTriggers.go
@@ -1096,9 +1096,6 @@ func haIncreaseWithErrorInjection(event *EventRecord, contexts *[]*scheduler.Con
 						}
 					}
 				}
-				log.Debugf("Printing the volume inspect for the volume:%s ,volID:%s and namespace:%s", v.Name, v.ID, v.Namespace)
-				PrintInspectVolume(v.ID)
-
 				if err == nil {
 					err := HaIncreaseErrorInjectionTargetNode(event, selctx, v, storageNodeMap, errorInj)
 					log.Error(err)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR does inspect volumes after certain volume operations tests in longevity

**Which issue(s) this PR fixes** (optional)
Closes # PTX-22947

**Special notes for your reviewer**:
Will attach the logs once  test runs has been completed.
tests covered:
TriggerHAIncrease
TriggerHADecrease
TriggerVolumeClone
TriggerAggrVolDepReplResizeOps
TriggerHAIncreasWithPVCResize
haIncreaseWithErrorInjection
TriggerVolumeResize
TriggerVolumeUpdate
TriggerVolumeIOProfileUpdate
TriggerHAIncreaseAndReboot
TriggerVolumeCreatePXRestart
TriggerHAIncreaseAndCrashPX
TriggerHAIncreaseAndPXRestart

log:https://jenkins.pwx.dev.purestorage.com/job/Users/job/krishna/job/tp-pxe-byoc/2065/consoleFull
Dashboard url: https://aetos.pwx.purestorage.com/resultSet/testSetID/590718

