### PR TITLE
[PTX-23000] Pool expand check for DMTHIN

### DIFF
--- a/tests/basic/pool_function_test.go
+++ b/tests/basic/pool_function_test.go
@@ -923,13 +923,6 @@ var _ = Describe("{PoolExpandAddDiskInMaintenanceMode}", func() {
 
 	stepLog := "Start pool expand with add-disk on node which is already in maintenance mode "
 	It(stepLog, func() {
-		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
-		if !isPoolAddDiskSupported {
-			if disk_err != nil {
-				log.Warnf("Add disk operation is not supported for DMTHIN but continuing the operation")
-			}
-
-		}
 		log.InfoD(stepLog)
 		var nodeDetail *node.Node
 		var err error

--- a/tests/basic/pool_function_test.go
+++ b/tests/basic/pool_function_test.go
@@ -966,7 +966,6 @@ var _ = Describe("{PoolExpandAddDiskInMaintenanceMode}", func() {
 			verifyPoolSizeEqualOrLargerThanExpected(poolIDToResize, targetSizeGiB)
 		})
 	})
-
 })
 
 var _ = Describe("{StorageFullPoolExpansion}", func() {

--- a/tests/basic/pool_function_test.go
+++ b/tests/basic/pool_function_test.go
@@ -899,74 +899,77 @@ var _ = Describe("{PoolExpandAddDiskInMaintenanceMode}", func() {
 			3. Exit out of maintenance mode (PX only performs pool expand in normal mode, not in maintenance mode)
 			4. Verify pool expand operation goes to completion.
 	*/
-
-	BeforeEach(func() {
-		StartTorpedoTest("PoolExpandAddDiskInMaintenanceMode",
-			"Initiate pool expand with add-disk when node is already in maintenance mode", nil, testrailID)
-		contexts = scheduleApps()
-	})
-
-	JustBeforeEach(func() {
-		poolIDToResize = pickPoolToResize()
-		log.Infof("Picked pool %s to resize", poolIDToResize)
-		poolToResize = getStoragePool(poolIDToResize)
-	})
-
-	JustAfterEach(func() {
-		AfterEachTest(contexts)
-	})
-
-	AfterEach(func() {
-		appsValidateAndDestroy(contexts)
-		EndTorpedoTest()
-	})
-
-	stepLog := "Start pool expand with add-disk on node which is already in maintenance mode "
-	It(stepLog, func() {
-		log.InfoD(stepLog)
-		var nodeDetail *node.Node
-		var err error
-		stepLog = "Move node to maintenance mode"
-		Step(stepLog, func() {
-			log.InfoD(stepLog)
-			nodeDetail, err = GetNodeWithGivenPoolID(poolToResize.Uuid)
-			dash.VerifyFatal(err, nil, fmt.Sprintf("Failed to get Node Details using PoolUUID [%v]", poolToResize.Uuid))
-
-			log.InfoD("Bring Node to Maintenance Mode")
-			err = Inst().V.EnterMaintenance(*nodeDetail)
-			dash.VerifyFatal(err, nil, fmt.Sprintf("Failed to shift Node [%s] to Mainteinance Mode", nodeDetail.Name))
+	Support, err := IsPoolAddDiskSupported()
+	if Support {
+		BeforeEach(func() {
+			StartTorpedoTest("PoolExpandAddDiskInMaintenanceMode",
+				"Initiate pool expand with add-disk when node is already in maintenance mode", nil, testrailID)
+			contexts = scheduleApps()
 		})
 
-		stepLog = "Initiate pool expand with add-disk operation"
-		Step(stepLog, func() {
-			log.InfoD(stepLog)
-			originalSizeInBytes = poolToResize.TotalSize
-			targetSizeInBytes = originalSizeInBytes + 100*units.GiB
-			targetSizeGiB = targetSizeInBytes / units.GiB
-
-			log.InfoD("Current Size of the pool %s is %d GiB. Trying to expand to %v GiB with type add-disk",
-				poolIDToResize, poolToResize.TotalSize/units.GiB, targetSizeGiB)
-			err := Inst().V.ExpandPool(poolIDToResize, api.SdkStoragePool_RESIZE_TYPE_ADD_DISK, targetSizeGiB, true)
-			dash.VerifyFatal(err, nil, "pool expansion requested successfully")
+		JustBeforeEach(func() {
+			poolIDToResize = pickPoolToResize()
+			log.Infof("Picked pool %s to resize", poolIDToResize)
+			poolToResize = getStoragePool(poolIDToResize)
 		})
 
-		stepLog = "Exit node out of maintenance mode"
-		Step(stepLog, func() {
-			log.InfoD(stepLog)
-			log.InfoD("Bring Node out of Maintenance Mode")
-			err = Inst().V.ExitMaintenance(*nodeDetail)
-			dash.VerifyFatal(err, nil, fmt.Sprintf("Failed to shift Node [%s] out of Mainteinance Mode", nodeDetail.Name))
+		JustAfterEach(func() {
+			AfterEachTest(contexts)
 		})
 
-		stepLog = "Verify pool expand completes successfully"
-		Step(stepLog, func() {
-			log.InfoD(stepLog)
-			resizeErr := waitForOngoingPoolExpansionToComplete(poolIDToResize)
-			dash.VerifyFatal(resizeErr, nil, "Pool expansion does not result in error")
-			verifyPoolSizeEqualOrLargerThanExpected(poolIDToResize, targetSizeGiB)
+		AfterEach(func() {
+			appsValidateAndDestroy(contexts)
+			EndTorpedoTest()
 		})
-	})
-})
+
+		stepLog := "Start pool expand with add-disk on node which is already in maintenance mode "
+		It(stepLog, func() {
+			log.InfoD(stepLog)
+			var nodeDetail *node.Node
+			var err error
+			stepLog = "Move node to maintenance mode"
+			Step(stepLog, func() {
+				log.InfoD(stepLog)
+				nodeDetail, err = GetNodeWithGivenPoolID(poolToResize.Uuid)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Failed to get Node Details using PoolUUID [%v]", poolToResize.Uuid))
+
+				log.InfoD("Bring Node to Maintenance Mode")
+				err = Inst().V.EnterMaintenance(*nodeDetail)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Failed to shift Node [%s] to Mainteinance Mode", nodeDetail.Name))
+			})
+
+			stepLog = "Initiate pool expand with add-disk operation"
+			Step(stepLog, func() {
+				log.InfoD(stepLog)
+				originalSizeInBytes = poolToResize.TotalSize
+				targetSizeInBytes = originalSizeInBytes + 100*units.GiB
+				targetSizeGiB = targetSizeInBytes / units.GiB
+
+				log.InfoD("Current Size of the pool %s is %d GiB. Trying to expand to %v GiB with type add-disk",
+					poolIDToResize, poolToResize.TotalSize/units.GiB, targetSizeGiB)
+				err := Inst().V.ExpandPool(poolIDToResize, api.SdkStoragePool_RESIZE_TYPE_ADD_DISK, targetSizeGiB, true)
+				dash.VerifyFatal(err, nil, "pool expansion requested successfully")
+			})
+
+			stepLog = "Exit node out of maintenance mode"
+			Step(stepLog, func() {
+				log.InfoD(stepLog)
+				log.InfoD("Bring Node out of Maintenance Mode")
+				err = Inst().V.ExitMaintenance(*nodeDetail)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Failed to shift Node [%s] out of Mainteinance Mode", nodeDetail.Name))
+			})
+
+			stepLog = "Verify pool expand completes successfully"
+			Step(stepLog, func() {
+				log.InfoD(stepLog)
+				resizeErr := waitForOngoingPoolExpansionToComplete(poolIDToResize)
+				dash.VerifyFatal(resizeErr, nil, "Pool expansion does not result in error")
+				verifyPoolSizeEqualOrLargerThanExpected(poolIDToResize, targetSizeGiB)
+			})
+		})
+} else {
+	fmt.Sprintf("Function Skipped due to:%s", err)
+}
 
 var _ = Describe("{StorageFullPoolExpansion}", func() {
 	var (

--- a/tests/basic/pool_function_test.go
+++ b/tests/basic/pool_function_test.go
@@ -947,12 +947,6 @@ var _ = Describe("{PoolExpandAddDiskInMaintenanceMode}", func() {
 			log.InfoD("Current Size of the pool %s is %d GiB. Trying to expand to %v GiB with type add-disk",
 				poolIDToResize, poolToResize.TotalSize/units.GiB, targetSizeGiB)
 			err := Inst().V.ExpandPool(poolIDToResize, api.SdkStoragePool_RESIZE_TYPE_ADD_DISK, targetSizeGiB, true)
-			if err != nil {
-				if strings.Contains(err.Error(), "add-drive type expansion is not supported with px-storev2. Use resize-drive expansion type") {
-					log.InfoD("add-drive type expansion is not supported with px-storev2. Use resize-drive expansion type")
-					return
-				}
-			}
 			dash.VerifyFatal(err, nil, "pool expansion requested successfully")
 		})
 

--- a/tests/basic/pool_function_test.go
+++ b/tests/basic/pool_function_test.go
@@ -967,9 +967,10 @@ var _ = Describe("{PoolExpandAddDiskInMaintenanceMode}", func() {
 				verifyPoolSizeEqualOrLargerThanExpected(poolIDToResize, targetSizeGiB)
 			})
 		})
-} else {
-	fmt.Sprintf("Function Skipped due to:%s", err)
-}
+	} else {
+		fmt.Sprintf("Function Skipped due to:%s", err)
+	}
+})
 
 var _ = Describe("{StorageFullPoolExpansion}", func() {
 	var (

--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -5585,10 +5585,10 @@ var _ = Describe("{PoolIncreaseSize20TB}", func() {
 func addDiskToSpecificPool(node node.Node, sizeOfDisk uint64, poolID int32) bool {
 	// Get the Spec to add the disk to the Node
 	//  if the diskSize ( sizeOfDisK ) is 0 , then Disk of default spec size will be picked
-	isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
-	if !isPoolAddDiskSupported {
-		log.FailOnError(disk_err, "Add disk operation is not supported")
-	}
+	//isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+	//if !isPoolAddDiskSupported {
+	//	log.FailOnError(disk_err, "Add disk operation is not supported")
+	//}
 	driveSpecs, err := GetCloudDriveDeviceSpecs()
 	log.FailOnError(err, "Error getting cloud drive specs")
 	log.InfoD("Cloud Drive Spec %s", driveSpecs)

--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -142,7 +142,7 @@ var _ = Describe("{StoragePoolExpandDiskAdd}", func() {
 			if err != nil {
 				isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
 				if disk_err != nil {
-
+					log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
 				}
 				if isPoolAddDiskSupported {
 					dash.VerifyFatal(err, nil, "Pool expansion init successful?")
@@ -152,6 +152,7 @@ var _ = Describe("{StoragePoolExpandDiskAdd}", func() {
 				} else {
 					if strings.Contains(err.Error(), "add-drive type expansion is not supported with px-storev2. Use resize-drive expansion type") {
 						dash.VerifyFatal(disk_err, nil, "drive add to existing pool not supported for px-storev2 or px-cache pools")
+						log.InfoD("Drive add not supported :%s, hence skipping the test", disk_err)
 						Skip("drive add to existing pool not supported for px-storev2 or px-cache pools")
 
 					}

--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -538,10 +538,6 @@ func nodePoolsExpansion(testName string) {
 
 	stepLog := fmt.Sprintf("has to schedule apps, and expand it by %s", option)
 	It(stepLog, func() {
-		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
-		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported")
-		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
 
@@ -1395,10 +1391,6 @@ var _ = Describe("{AddDriveStoragelessAndResize}", func() {
 	stepLog := "should get the storageless node and add a drive"
 
 	It(stepLog, func() {
-		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
-		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported")
-		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -3741,6 +3733,12 @@ var _ = Describe("{PoolMaintenanceModeAddDisk}", func() {
 
 			log.InfoD("Current Size of the pool %s is %d", poolToBeResized.Uuid, poolToBeResized.TotalSize/units.GiB)
 			err = Inst().V.ExpandPool(poolToBeResized.Uuid, api.SdkStoragePool_RESIZE_TYPE_ADD_DISK, expectedSize, true)
+			if err != nil {
+				if strings.Contains(err.Error(), "add-drive type expansion is not supported with px-storev2. Use resize-drive expansion type") {
+					log.InfoD("add-drive type expansion is not supported with px-storev2. Use resize-drive expansion type")
+					return
+				}
+			}
 			dash.VerifyFatal(err, nil, "Pool expansion init successful?")
 			resizeErr := waitForPoolToBeResized(expectedSize, poolToBeResized.Uuid, isjournal)
 			dash.VerifyFatal(resizeErr, nil, fmt.Sprintf("Verify pool %s on node %s expansion using add-disk", poolToBeResized.Uuid, stNode.Name))
@@ -7351,10 +7349,6 @@ var _ = Describe("{DriveAddRebalanceInMaintenance}", func() {
 	stepLog := "Rebalance taking long time during drive add in pool maintenance mode"
 
 	It(stepLog, func() {
-		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
-		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported")
-		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {

--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -141,12 +141,7 @@ var _ = Describe("{StoragePoolExpandDiskAdd}", func() {
 			err = Inst().V.ExpandPool(poolIDToResize, api.SdkStoragePool_RESIZE_TYPE_ADD_DISK, expectedSize, false)
 			if err != nil {
 				isPoolAddDiskSupported := IsPoolAddDiskSupported()
-				if isPoolAddDiskSupported {
-					dash.VerifyFatal(err, nil, "Pool expansion init successful?")
-					resizeErr := waitForPoolToBeResized(expectedSize, poolIDToResize, isjournal)
-					dash.VerifyFatal(resizeErr, nil, fmt.Sprintf("Expected new size to be '%d' or '%d' if pool has journal", expectedSize, expectedSizeWithJournal))
-
-				} else {
+				if !isPoolAddDiskSupported {
 					IsExpectederr := strings.Contains(err.Error(), "add-drive type expansion is not supported with px-storev2. Use resize-drive expansion type")
 					dash.VerifyFatal(IsExpectederr, true, err.Error())
 					log.InfoD("Drive add not supported :%s, hence skipping the test", err.Error())
@@ -3760,12 +3755,7 @@ var _ = Describe("{PoolMaintenanceModeAddDisk}", func() {
 			err = Inst().V.ExpandPool(poolToBeResized.Uuid, api.SdkStoragePool_RESIZE_TYPE_ADD_DISK, expectedSize, true)
 			if err != nil {
 				isPoolAddDiskSupported := IsPoolAddDiskSupported()
-				if isPoolAddDiskSupported {
-					dash.VerifyFatal(err, nil, "Pool expansion init successful?")
-					resizeErr := waitForPoolToBeResized(expectedSize, poolToBeResized.Uuid, isjournal)
-					dash.VerifyFatal(resizeErr, nil, fmt.Sprintf("Verify pool %s on node %s expansion using add-disk", poolToBeResized.Uuid, stNode.Name))
-
-				} else {
+				if !isPoolAddDiskSupported {
 					IsExpectederr := strings.Contains(err.Error(), "add-drive type expansion is not supported with px-storev2. Use resize-drive expansion type")
 					dash.VerifyFatal(IsExpectederr, true, err.Error())
 					log.InfoD("Drive add not supported :%s, hence skipping the test", err.Error())

--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -142,7 +142,8 @@ var _ = Describe("{StoragePoolExpandDiskAdd}", func() {
 			if err != nil {
 				if strings.Contains(err.Error(), "add-drive type expansion is not supported with px-storev2. Use resize-drive expansion type") {
 					log.InfoD("add-drive type expansion is not supported with px-storev2. Use resize-drive expansion type")
-					return
+					Skip("drive add to existing pool not supported for px-storev2 or px-cache pools")
+
 				}
 			}
 			dash.VerifyFatal(err, nil, "Pool expansion init successful?")
@@ -151,7 +152,6 @@ var _ = Describe("{StoragePoolExpandDiskAdd}", func() {
 			dash.VerifyFatal(resizeErr, nil, fmt.Sprintf("Expected new size to be '%d' or '%d' if pool has journal", expectedSize, expectedSizeWithJournal))
 
 		})
-
 		Step("Ensure that new pool has been expanded to the expected size", func() {
 			ValidateApplications(contexts)
 			resizedPool, err := GetStoragePoolByUUID(poolIDToResize)

--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -3774,7 +3774,7 @@ var _ = Describe("{PoolMaintenanceModeAddDisk}", func() {
 				} else {
 					if strings.Contains(err.Error(), "add-drive type expansion is not supported with px-storev2. Use resize-drive expansion type") {
 						dash.VerifyFatal(err, nil, "drive add to existing pool not supported for px-storev2 or px-cache pools")
-						log.InfoD("")
+						log.InfoD("Drive add not supported :%s, hence skipping the test", disk_err)
 						Skip("drive add to existing pool not supported for px-storev2 or px-cache pools")
 
 					}

--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -135,13 +135,15 @@ var _ = Describe("{StoragePoolExpandDiskAdd}", func() {
 			}
 
 			log.InfoD("Current Size of the pool %s is %d", poolIDToResize, poolToBeResized.TotalSize/units.GiB)
-			log.Infof("Commented out the code to add disk to the pool %s", poolIDToResize)
 			enterPoolMaintenanceAddDisk(poolIDToResize)
 			defer exitPoolMaintenance(poolIDToResize)
 
 			err = Inst().V.ExpandPool(poolIDToResize, api.SdkStoragePool_RESIZE_TYPE_ADD_DISK, expectedSize, false)
 			if err != nil {
 				isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+				if disk_err != nil {
+
+				}
 				if isPoolAddDiskSupported {
 					dash.VerifyFatal(err, nil, "Pool expansion init successful?")
 					resizeErr := waitForPoolToBeResized(expectedSize, poolIDToResize, isjournal)
@@ -507,10 +509,6 @@ var _ = Describe("{NodePoolsAddDisk}", func() {
 		1. Initiate pool expansion on multiple pools in the same node using add-disk
 		2. Validate pool expansion in all the pools
 	*/
-	//isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
-	//if !isPoolAddDiskSupported {
-	//	log.FailOnError(disk_err, "Add disk operation is not supported")
-	//}
 	nodePoolsExpansion("NodePoolsAddDisk")
 
 })
@@ -5601,10 +5599,6 @@ var _ = Describe("{PoolIncreaseSize20TB}", func() {
 func addDiskToSpecificPool(node node.Node, sizeOfDisk uint64, poolID int32) bool {
 	// Get the Spec to add the disk to the Node
 	//  if the diskSize ( sizeOfDisK ) is 0 , then Disk of default spec size will be picked
-	//isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
-	//if !isPoolAddDiskSupported {
-	//	log.FailOnError(disk_err, "Add disk operation is not supported")
-	//}
 	driveSpecs, err := GetCloudDriveDeviceSpecs()
 	log.FailOnError(err, "Error getting cloud drive specs")
 	log.InfoD("Cloud Drive Spec %s", driveSpecs)

--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -154,7 +154,9 @@ var _ = Describe("{StoragePoolExpandDiskAdd}", func() {
 
 				}
 			}
-
+			dash.VerifyFatal(err, nil, "Pool expansion init successful?")
+			resizeErr := waitForPoolToBeResized(expectedSize, poolIDToResize, isjournal)
+			dash.VerifyFatal(resizeErr, nil, fmt.Sprintf("Expected new size to be '%d' or '%d' if pool has journal", expectedSize, expectedSizeWithJournal))
 		})
 		Step("Ensure that new pool has been expanded to the expected size", func() {
 			ValidateApplications(contexts)
@@ -3772,6 +3774,9 @@ var _ = Describe("{PoolMaintenanceModeAddDisk}", func() {
 				}
 
 			}
+			dash.VerifyFatal(err, nil, "Pool expansion init successful?")
+			resizeErr := waitForPoolToBeResized(expectedSize, poolToBeResized.Uuid, isjournal)
+			dash.VerifyFatal(resizeErr, nil, fmt.Sprintf("Verify pool %s on node %s expansion using add-disk", poolToBeResized.Uuid, stNode.Name))
 
 		})
 

--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -148,7 +148,7 @@ var _ = Describe("{StoragePoolExpandDiskAdd}", func() {
 
 				} else {
 					IsExpectederr := strings.Contains(err.Error(), "add-drive type expansion is not supported with px-storev2. Use resize-drive expansion type")
-					dash.VerifyFatal(IsExpectederr, true, "drive add to existing pool not supported for px-storev2 or px-cache pools")
+					dash.VerifyFatal(IsExpectederr, true, err.Error())
 					log.InfoD("Drive add not supported :%s, hence skipping the test", err.Error())
 					Skip("drive add to existing pool not supported for px-storev2 or px-cache pools")
 
@@ -3765,7 +3765,7 @@ var _ = Describe("{PoolMaintenanceModeAddDisk}", func() {
 
 				} else {
 					IsExpectederr := strings.Contains(err.Error(), "add-drive type expansion is not supported with px-storev2. Use resize-drive expansion type")
-					dash.VerifyFatal(IsExpectederr, true, "drive add to existing pool not supported for px-storev2 or px-cache pools")
+					dash.VerifyFatal(IsExpectederr, true, err.Error())
 					log.InfoD("Drive add not supported :%s, hence skipping the test", err.Error())
 					Skip("drive add to existing pool not supported for px-storev2 or px-cache pools")
 

--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -501,10 +501,10 @@ var _ = Describe("{NodePoolsAddDisk}", func() {
 		1. Initiate pool expansion on multiple pools in the same node using add-disk
 		2. Validate pool expansion in all the pools
 	*/
-	isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
-	if !isPoolAddDiskSupported {
-		log.FailOnError(disk_err, "Add disk operation is not supported")
-	}
+	//isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+	//if !isPoolAddDiskSupported {
+	//	log.FailOnError(disk_err, "Add disk operation is not supported")
+	//}
 	nodePoolsExpansion("NodePoolsAddDisk")
 
 })

--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -140,24 +140,19 @@ var _ = Describe("{StoragePoolExpandDiskAdd}", func() {
 
 			err = Inst().V.ExpandPool(poolIDToResize, api.SdkStoragePool_RESIZE_TYPE_ADD_DISK, expectedSize, false)
 			if err != nil {
-				isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
-				if disk_err != nil {
-					log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
-				}
+				isPoolAddDiskSupported := IsPoolAddDiskSupported()
 				if isPoolAddDiskSupported {
 					dash.VerifyFatal(err, nil, "Pool expansion init successful?")
 					resizeErr := waitForPoolToBeResized(expectedSize, poolIDToResize, isjournal)
 					dash.VerifyFatal(resizeErr, nil, fmt.Sprintf("Expected new size to be '%d' or '%d' if pool has journal", expectedSize, expectedSizeWithJournal))
 
 				} else {
-					if strings.Contains(err.Error(), "add-drive type expansion is not supported with px-storev2. Use resize-drive expansion type") {
-						dash.VerifyFatal(disk_err, nil, "drive add to existing pool not supported for px-storev2 or px-cache pools")
-						log.InfoD("Drive add not supported :%s, hence skipping the test", disk_err)
-						Skip("drive add to existing pool not supported for px-storev2 or px-cache pools")
+					IsExpectederr := strings.Contains(err.Error(), "add-drive type expansion is not supported with px-storev2. Use resize-drive expansion type")
+					dash.VerifyFatal(IsExpectederr, true, "drive add to existing pool not supported for px-storev2 or px-cache pools")
+					log.InfoD("Drive add not supported :%s, hence skipping the test", err.Error())
+					Skip("drive add to existing pool not supported for px-storev2 or px-cache pools")
 
-					}
 				}
-
 			}
 
 		})
@@ -396,9 +391,9 @@ var _ = Describe("{PoolAddDiskReboot}", func() {
 	stepLog := "should get the existing pool and expand it by adding a disk"
 
 	It(stepLog, func() {
-		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		isPoolAddDiskSupported := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
+			dash.VerifyFatal(false, true, "Add disk operation is not supported for DMThin Setup")
 		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
@@ -1834,9 +1829,9 @@ var _ = Describe("{PoolAddDiskDiff}", func() {
 	stepLog := "should get the existing storage node and expand the pool multiple times"
 
 	It(stepLog, func() {
-		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		isPoolAddDiskSupported := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
+			dash.VerifyFatal(false, true, "Add disk operation is not supported for DMThin Setup")
 		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
@@ -2079,9 +2074,9 @@ var _ = Describe("{AddWithPXRestart}", func() {
 	stepLog := "should get the existing storage node and expand the pool by resize-disk"
 
 	It(stepLog, func() {
-		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		isPoolAddDiskSupported := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
+			dash.VerifyFatal(false, true, "Add disk operation is not supported for DMThin Setup")
 		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
@@ -2386,9 +2381,9 @@ var _ = Describe("{VolUpdateAddDisk}", func() {
 	stepLog := "should get the existing storage node and expand the pool by resize-disk"
 
 	It(stepLog, func() {
-		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		isPoolAddDiskSupported := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup ")
+			dash.VerifyFatal(false, true, "Add disk operation is not supported for DMThin Setup")
 		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
@@ -2759,9 +2754,9 @@ var _ = Describe("{MulPoolsAddDisk}", func() {
 	stepLog := "should get the existing storage node with multiple pools and expand pools at same time using add-disk"
 
 	It(stepLog, func() {
-		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		isPoolAddDiskSupported := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
+			dash.VerifyFatal(false, true, "Add disk operation is not supported for DMThin Setup")
 		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
@@ -3081,9 +3076,9 @@ var _ = Describe("{AddDiskNodeMaintenanceCycle}", func() {
 	stepLog := "should get the volume with IOs, expand the pool by add-disk and perform node maintenance cycle"
 
 	It(stepLog, func() {
-		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		isPoolAddDiskSupported := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
+			dash.VerifyFatal(false, true, "Add disk operation is not supported for DMThin Setup")
 		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
@@ -3243,9 +3238,9 @@ var _ = Describe("{AddDiskPoolMaintenanceCycle}", func() {
 	stepLog := "should get the volume with IOs, expand the pool by add-disk and perform pool maintenance cycle"
 
 	It(stepLog, func() {
-		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		isPoolAddDiskSupported := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
+			dash.VerifyFatal(false, true, "Add disk operation is not supported for DMThin Setup")
 		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
@@ -3448,9 +3443,9 @@ var _ = Describe("{NodeMaintenanceModeAddDisk}", func() {
 	stepLog := "should get the existing storage node and put it in maintenance mode"
 
 	It(stepLog, func() {
-		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		isPoolAddDiskSupported := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
+			dash.VerifyFatal(false, true, "Add disk operation is not supported for DMThin Setup")
 		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
@@ -3679,9 +3674,9 @@ var _ = Describe("{PoolMaintenanceModeAddDisk}", func() {
 	stepLog := "should get the existing storage node and put it in maintenance mode"
 
 	It(stepLog, func() {
-		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		isPoolAddDiskSupported := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
+			dash.VerifyFatal(false, true, "Add disk operation is not supported for DMThin Setup")
 		}
 		log.InfoD(stepLog)
 
@@ -3762,22 +3757,18 @@ var _ = Describe("{PoolMaintenanceModeAddDisk}", func() {
 			log.InfoD("Current Size of the pool %s is %d", poolToBeResized.Uuid, poolToBeResized.TotalSize/units.GiB)
 			err = Inst().V.ExpandPool(poolToBeResized.Uuid, api.SdkStoragePool_RESIZE_TYPE_ADD_DISK, expectedSize, true)
 			if err != nil {
-				isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
-				if disk_err != nil {
-					log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
-				}
+				isPoolAddDiskSupported := IsPoolAddDiskSupported()
 				if isPoolAddDiskSupported {
 					dash.VerifyFatal(err, nil, "Pool expansion init successful?")
 					resizeErr := waitForPoolToBeResized(expectedSize, poolToBeResized.Uuid, isjournal)
 					dash.VerifyFatal(resizeErr, nil, fmt.Sprintf("Verify pool %s on node %s expansion using add-disk", poolToBeResized.Uuid, stNode.Name))
 
 				} else {
-					if strings.Contains(err.Error(), "add-drive type expansion is not supported with px-storev2. Use resize-drive expansion type") {
-						dash.VerifyFatal(err, nil, "drive add to existing pool not supported for px-storev2 or px-cache pools")
-						log.InfoD("Drive add not supported :%s, hence skipping the test", disk_err)
-						Skip("drive add to existing pool not supported for px-storev2 or px-cache pools")
+					IsExpectederr := strings.Contains(err.Error(), "add-drive type expansion is not supported with px-storev2. Use resize-drive expansion type")
+					dash.VerifyFatal(IsExpectederr, true, "drive add to existing pool not supported for px-storev2 or px-cache pools")
+					log.InfoD("Drive add not supported :%s, hence skipping the test", err.Error())
+					Skip("drive add to existing pool not supported for px-storev2 or px-cache pools")
 
-					}
 				}
 
 			}
@@ -3814,9 +3805,9 @@ var _ = Describe("{AddDiskNodeMaintenanceMode}", func() {
 	stepLog := "should get the existing storage node,trigger add-disk and put it in maintenance mode"
 
 	It(stepLog, func() {
-		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		isPoolAddDiskSupported := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
+			dash.VerifyFatal(false, true, "Add disk operation is not supported for DMThin Setup")
 		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
@@ -4169,9 +4160,9 @@ var _ = Describe("{AddDiskPoolMaintenanceMode}", func() {
 	stepLog := "should get the existing storage node and put it in maintenance mode"
 
 	It(stepLog, func() {
-		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		isPoolAddDiskSupported := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
+			dash.VerifyFatal(false, true, "Add disk operation is not supported for DMThin Setup")
 		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
@@ -4342,9 +4333,9 @@ var _ = Describe("{PXRestartAddDisk}", func() {
 	stepLog := "should get the existing storage node and expand the pool by add-disk"
 
 	It(stepLog, func() {
-		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		isPoolAddDiskSupported := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
+			dash.VerifyFatal(false, true, "Add disk operation is not supported for DMThin Setup")
 		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
@@ -4886,9 +4877,9 @@ var _ = Describe("{StorageFullPoolAddDisk}", func() {
 
 	stepLog := "Create vols and make pool full"
 	It(stepLog, func() {
-		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		isPoolAddDiskSupported := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
+			dash.VerifyFatal(false, true, "Add disk operation is not supported for DMThin Setup")
 		}
 		log.InfoD(stepLog)
 		selectedNode := GetNodeWithLeastSize()
@@ -5666,9 +5657,9 @@ var _ = Describe("{ResizePoolDrivesInDifferentSize}", func() {
 
 	stepLog := "should get the existing storage node and expand the pool by resize-disk"
 	It(stepLog, func() {
-		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		isPoolAddDiskSupported := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup ")
+			dash.VerifyFatal(false, true, "Add disk operation is not supported for DMThin Setup")
 		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
@@ -7265,11 +7256,10 @@ var _ = Describe("{ResizeDiskAddDiskSamePool}", func() {
 	stepLog := "Resize Disk Followed by adddisk should not create a new pool"
 
 	It(stepLog, func() {
-		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		isPoolAddDiskSupported := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
+			dash.VerifyFatal(false, true, "Add disk operation is not supported for DMThin Setup")
 		}
-
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -7684,9 +7674,9 @@ var _ = Describe("{NodeAddDiskWhileAddDiskInProgress}", func() {
 	stepLog := "should get the existing storage node and expand the pool by adding a drive while one already in progress"
 
 	It(stepLog, func() {
-		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		isPoolAddDiskSupported := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
+			dash.VerifyFatal(false, true, "Add disk operation is not supported for DMThin Setup")
 		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
@@ -7799,9 +7789,9 @@ var _ = Describe("{NodeAddDiskWhileResizeDiskInProgress}", func() {
 	stepLog := "should get the existing storage node and expand the pool by adding a drive while one already in progress"
 
 	It(stepLog, func() {
-		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		isPoolAddDiskSupported := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
+			dash.VerifyFatal(false, true, "Add disk operation is not supported for DMThin Setup")
 		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
@@ -8379,9 +8369,9 @@ var _ = Describe("{AddDiskAddDriveAndDeleteInstance}", func() {
 	stepLog := "should get the existing pool, expand the pool by adding disk and create a new pool and then delete the instance"
 
 	It(stepLog, func() {
-		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		isPoolAddDiskSupported := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
+			dash.VerifyFatal(false, true, "Add disk operation is not supported for DMThin Setup")
 		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
@@ -10133,11 +10123,12 @@ func isMaintenanceModeRequiredForAddDisk() bool {
 		log.FailOnError(err, "error checking if dmthin is enabled")
 	}
 	if isDmthin {
-		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
-		if isPoolAddDiskSupported {
-			return true
+		isPoolAddDiskSupported := IsPoolAddDiskSupported()
+		if !isPoolAddDiskSupported {
+			dash.VerifyFatal(false, true, "Add disk operation is not supported for DMThin Setup")
 		}
-		log.FailOnError(disk_err, "error checking if pool add disk is supported")
+		return true
+
 	}
 	if Inst().N.String() == ssh.DriverName || Inst().N.String() == vsphere.DriverName {
 		cmd := "uname -r"
@@ -10806,9 +10797,9 @@ var _ = Describe("{HAIncreasePoolresizeAndAdddisk}", func() {
 
 	itLog := "HAIncreasePoolresizeAndAdddisk"
 	It(itLog, func() {
-		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		isPoolAddDiskSupported := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
+			dash.VerifyFatal(false, true, "Add disk operation is not supported for DMThin Setup")
 		}
 		stepLog := "schedule Application"
 		Step(stepLog, func() {

--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -10147,7 +10147,7 @@ func isMaintenanceModeRequiredForAddDisk() bool {
 		}
 		currentPxVersionOnCluster, err := semver.NewVersion(new_trimmedVersion)
 		if err != nil {
-			log.InfoD("[semver.NewVersion] error is", err)
+			log.InfoD(fmt.Sprintf("[semver.NewVersion] error is: %s", err))
 			return false
 		}
 		if currentPxVersionOnCluster.GreaterThan(pxVersion) {

--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -151,7 +151,7 @@ var _ = Describe("{StoragePoolExpandDiskAdd}", func() {
 
 				} else {
 					if strings.Contains(err.Error(), "add-drive type expansion is not supported with px-storev2. Use resize-drive expansion type") {
-						log.InfoD(fmt.Sprintf("----drive add to existing pool not supported for px-storev2 or px-cache pools-------- Test Error:%s", disk_err))
+						dash.VerifyFatal(disk_err, nil, "drive add to existing pool not supported for px-storev2 or px-cache pools")
 						Skip("drive add to existing pool not supported for px-storev2 or px-cache pools")
 
 					}
@@ -397,7 +397,7 @@ var _ = Describe("{PoolAddDiskReboot}", func() {
 	It(stepLog, func() {
 		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported")
+			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
 		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
@@ -1835,7 +1835,7 @@ var _ = Describe("{PoolAddDiskDiff}", func() {
 	It(stepLog, func() {
 		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported")
+			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
 		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
@@ -2080,7 +2080,7 @@ var _ = Describe("{AddWithPXRestart}", func() {
 	It(stepLog, func() {
 		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported")
+			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
 		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
@@ -2387,7 +2387,7 @@ var _ = Describe("{VolUpdateAddDisk}", func() {
 	It(stepLog, func() {
 		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported")
+			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup ")
 		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
@@ -2760,7 +2760,7 @@ var _ = Describe("{MulPoolsAddDisk}", func() {
 	It(stepLog, func() {
 		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported")
+			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
 		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
@@ -3082,7 +3082,7 @@ var _ = Describe("{AddDiskNodeMaintenanceCycle}", func() {
 	It(stepLog, func() {
 		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported")
+			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
 		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
@@ -3244,7 +3244,7 @@ var _ = Describe("{AddDiskPoolMaintenanceCycle}", func() {
 	It(stepLog, func() {
 		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported")
+			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
 		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
@@ -3449,7 +3449,7 @@ var _ = Describe("{NodeMaintenanceModeAddDisk}", func() {
 	It(stepLog, func() {
 		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported")
+			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
 		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
@@ -3680,7 +3680,7 @@ var _ = Describe("{PoolMaintenanceModeAddDisk}", func() {
 	It(stepLog, func() {
 		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported")
+			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
 		}
 		log.InfoD(stepLog)
 
@@ -3762,6 +3762,9 @@ var _ = Describe("{PoolMaintenanceModeAddDisk}", func() {
 			err = Inst().V.ExpandPool(poolToBeResized.Uuid, api.SdkStoragePool_RESIZE_TYPE_ADD_DISK, expectedSize, true)
 			if err != nil {
 				isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+				if disk_err != nil {
+					log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
+				}
 				if isPoolAddDiskSupported {
 					dash.VerifyFatal(err, nil, "Pool expansion init successful?")
 					resizeErr := waitForPoolToBeResized(expectedSize, poolToBeResized.Uuid, isjournal)
@@ -3769,7 +3772,8 @@ var _ = Describe("{PoolMaintenanceModeAddDisk}", func() {
 
 				} else {
 					if strings.Contains(err.Error(), "add-drive type expansion is not supported with px-storev2. Use resize-drive expansion type") {
-						log.InfoD(fmt.Sprintf("----drive add to existing pool not supported for px-storev2 or px-cache pools-------- Test Error:%s", disk_err))
+						dash.VerifyFatal(err, nil, "drive add to existing pool not supported for px-storev2 or px-cache pools")
+						log.InfoD("")
 						Skip("drive add to existing pool not supported for px-storev2 or px-cache pools")
 
 					}
@@ -3811,7 +3815,7 @@ var _ = Describe("{AddDiskNodeMaintenanceMode}", func() {
 	It(stepLog, func() {
 		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported")
+			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
 		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
@@ -4166,7 +4170,7 @@ var _ = Describe("{AddDiskPoolMaintenanceMode}", func() {
 	It(stepLog, func() {
 		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported")
+			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
 		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
@@ -4339,7 +4343,7 @@ var _ = Describe("{PXRestartAddDisk}", func() {
 	It(stepLog, func() {
 		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported")
+			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
 		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
@@ -4883,7 +4887,7 @@ var _ = Describe("{StorageFullPoolAddDisk}", func() {
 	It(stepLog, func() {
 		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported")
+			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
 		}
 		log.InfoD(stepLog)
 		selectedNode := GetNodeWithLeastSize()
@@ -5663,7 +5667,7 @@ var _ = Describe("{ResizePoolDrivesInDifferentSize}", func() {
 	It(stepLog, func() {
 		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported")
+			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup ")
 		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
@@ -7262,7 +7266,7 @@ var _ = Describe("{ResizeDiskAddDiskSamePool}", func() {
 	It(stepLog, func() {
 		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported")
+			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
 		}
 
 		log.InfoD(stepLog)
@@ -7681,7 +7685,7 @@ var _ = Describe("{NodeAddDiskWhileAddDiskInProgress}", func() {
 	It(stepLog, func() {
 		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported")
+			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
 		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
@@ -7796,7 +7800,7 @@ var _ = Describe("{NodeAddDiskWhileResizeDiskInProgress}", func() {
 	It(stepLog, func() {
 		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported")
+			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
 		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
@@ -8376,7 +8380,7 @@ var _ = Describe("{AddDiskAddDriveAndDeleteInstance}", func() {
 	It(stepLog, func() {
 		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported")
+			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
 		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
@@ -10125,37 +10129,14 @@ var _ = Describe("{AddDriveWithKernelPanic}", func() {
 func isMaintenanceModeRequiredForAddDisk() bool {
 	isDmthin, err := IsDMthin()
 	if err != nil {
-		return true
+		log.FailOnError(err, "error checking if dmthin is enabled")
 	}
 	if isDmthin {
-		pxVersion, err := semver.NewVersion("3.1.0")
-		if err != nil {
-			return false
+		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		if isPoolAddDiskSupported {
+			return true
 		}
-		log.Infof("DMTHIN is enabled")
-		driverVersion, err := Inst().V.GetDriverVersion()
-		if err != nil {
-			return false
-		}
-		var new_trimmedVersion string
-		parts := strings.Split(driverVersion, "-")
-		trimmedVersion := strings.Split(parts[0], ".")
-		if len(trimmedVersion) > 3 {
-			new_trimmedVersion = strings.Join(trimmedVersion[:3], ".")
-		} else {
-			new_trimmedVersion = parts[0]
-		}
-		currentPxVersionOnCluster, err := semver.NewVersion(new_trimmedVersion)
-		if err != nil {
-			log.InfoD(fmt.Sprintf("[semver.NewVersion] error is: %s", err))
-			return false
-		}
-		if currentPxVersionOnCluster.GreaterThan(pxVersion) {
-			err = fmt.Errorf("Maintenance Mode is not allowed for version greater than 3.1.0 ")
-			return false
-		}
-		log.Infof("drive add to existing pool supported for px-storev2 or px-cache pools")
-		return true
+		log.FailOnError(disk_err, "error checking if pool add disk is supported")
 	}
 	if Inst().N.String() == ssh.DriverName || Inst().N.String() == vsphere.DriverName {
 		cmd := "uname -r"
@@ -10826,7 +10807,7 @@ var _ = Describe("{HAIncreasePoolresizeAndAdddisk}", func() {
 	It(itLog, func() {
 		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
 		if !isPoolAddDiskSupported {
-			log.FailOnError(disk_err, "Add disk operation is not supported")
+			log.FailOnError(disk_err, "Add disk operation is not supported for DMThin Setup")
 		}
 		stepLog := "schedule Application"
 		Step(stepLog, func() {

--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -75,100 +75,100 @@ var _ = Describe("{StoragePoolExpandDiskResize}", func() {
 })
 
 var _ = Describe("{StoragePoolExpandDiskAdd}", func() {
-	Support, err := IsPoolAddDiskSupported()
-	if Support {
-		JustBeforeEach(func() {
-			StartTorpedoTest("StoragePoolExpandDiskAdd", "Validate storage pool expansion using add-disk option", nil, 0)
+
+	JustBeforeEach(func() {
+		StartTorpedoTest("StoragePoolExpandDiskAdd", "Validate storage pool expansion using add-disk option", nil, 0)
+	})
+
+	stepLog := "should get the existing pool and expand it by adding a disk"
+	It(stepLog, func() {
+		Support, err := IsPoolAddDiskSupported()
+		if !Support {
+			log.FailOnError(err, "Add disk operation is not supported")
+		}
+
+		log.InfoD(stepLog)
+		contexts = make([]*scheduler.Context, 0)
+
+		for i := 0; i < Inst().GlobalScaleFactor; i++ {
+			contexts = append(contexts, ScheduleApplications(fmt.Sprintf("pooladddisk-%d", i))...)
+		}
+
+		ValidateApplications(contexts)
+
+		pools, err := Inst().V.ListStoragePools(metav1.LabelSelector{})
+		log.FailOnError(err, "Failed to list storage pools")
+		dash.VerifyFatal(len(pools) > 0, true, "Storage pools exist ?")
+
+		// pick a pool from a pools list and resize it
+		poolIDToResize = pickPoolToResize()
+		dash.VerifyFatal(len(poolIDToResize) > 0, true, fmt.Sprintf("Expected poolIDToResize to not be empty, pool id to resize %s", poolIDToResize))
+
+		poolToBeResized := pools[poolIDToResize]
+		dash.VerifyFatal(poolToBeResized != nil, true, "Pool to be resized exist?")
+
+		// px will put a new request in a queue, but in this case we can't calculate the expected size,
+		// so need to wain until the ongoing operation is completed
+		stepLog = "Verify that pool resize is not in progress"
+		Step(stepLog, func() {
+
+			log.InfoD(stepLog)
+			if val, err := poolResizeIsInProgress(poolToBeResized); val {
+				// wait until resize is completed and get the updated pool again
+				poolToBeResized, err = GetStoragePoolByUUID(poolIDToResize)
+				log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", poolIDToResize))
+			} else {
+				log.FailOnError(err, fmt.Sprintf("pool [%s] cannot be expanded due to error: %v", poolIDToResize, err))
+			}
 		})
 
-		stepLog := "should get the existing pool and expand it by adding a disk"
-		It(stepLog, func() {
-			log.InfoD(stepLog)
-			contexts = make([]*scheduler.Context, 0)
+		var expectedSize uint64
+		var expectedSizeWithJournal uint64
 
-			for i := 0; i < Inst().GlobalScaleFactor; i++ {
-				contexts = append(contexts, ScheduleApplications(fmt.Sprintf("pooladddisk-%d", i))...)
+		stepLog = "Calculate expected pool size and trigger pool resize"
+		Step(stepLog, func() {
+			log.InfoD(stepLog)
+			expectedSize = poolToBeResized.TotalSize * 2 / units.GiB
+			expectedSize = roundUpValue(expectedSize)
+			isjournal, err := IsJournalEnabled()
+			log.FailOnError(err, "Failed to check is Journal enabled")
+
+			//To-Do Need to handle the case for multiple pools
+			expectedSizeWithJournal = expectedSize
+			if isjournal {
+				expectedSizeWithJournal = expectedSizeWithJournal - 3
 			}
 
+			log.InfoD("Current Size of the pool %s is %d", poolIDToResize, poolToBeResized.TotalSize/units.GiB)
+			enterPoolMaintenanceAddDisk(poolIDToResize)
+			defer exitPoolMaintenance(poolIDToResize)
+
+			err = Inst().V.ExpandPool(poolIDToResize, api.SdkStoragePool_RESIZE_TYPE_ADD_DISK, expectedSize, false)
+			dash.VerifyFatal(err, nil, "Pool expansion init successful?")
+
+			resizeErr := waitForPoolToBeResized(expectedSize, poolIDToResize, isjournal)
+			dash.VerifyFatal(resizeErr, nil, fmt.Sprintf("Expected new size to be '%d' or '%d' if pool has journal", expectedSize, expectedSizeWithJournal))
+
+		})
+
+		Step("Ensure that new pool has been expanded to the expected size", func() {
 			ValidateApplications(contexts)
-
-			pools, err := Inst().V.ListStoragePools(metav1.LabelSelector{})
-			log.FailOnError(err, "Failed to list storage pools")
-			dash.VerifyFatal(len(pools) > 0, true, "Storage pools exist ?")
-
-			// pick a pool from a pools list and resize it
-			poolIDToResize = pickPoolToResize()
-			dash.VerifyFatal(len(poolIDToResize) > 0, true, fmt.Sprintf("Expected poolIDToResize to not be empty, pool id to resize %s", poolIDToResize))
-
-			poolToBeResized := pools[poolIDToResize]
-			dash.VerifyFatal(poolToBeResized != nil, true, "Pool to be resized exist?")
-
-			// px will put a new request in a queue, but in this case we can't calculate the expected size,
-			// so need to wain until the ongoing operation is completed
-			stepLog = "Verify that pool resize is not in progress"
-			Step(stepLog, func() {
-
-				log.InfoD(stepLog)
-				if val, err := poolResizeIsInProgress(poolToBeResized); val {
-					// wait until resize is completed and get the updated pool again
-					poolToBeResized, err = GetStoragePoolByUUID(poolIDToResize)
-					log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", poolIDToResize))
-				} else {
-					log.FailOnError(err, fmt.Sprintf("pool [%s] cannot be expanded due to error: %v", poolIDToResize, err))
-				}
-			})
-
-			var expectedSize uint64
-			var expectedSizeWithJournal uint64
-
-			stepLog = "Calculate expected pool size and trigger pool resize"
-			Step(stepLog, func() {
-				log.InfoD(stepLog)
-				expectedSize = poolToBeResized.TotalSize * 2 / units.GiB
-				expectedSize = roundUpValue(expectedSize)
-				isjournal, err := IsJournalEnabled()
-				log.FailOnError(err, "Failed to check is Journal enabled")
-
-				//To-Do Need to handle the case for multiple pools
-				expectedSizeWithJournal = expectedSize
-				if isjournal {
-					expectedSizeWithJournal = expectedSizeWithJournal - 3
-				}
-
-				log.InfoD("Current Size of the pool %s is %d", poolIDToResize, poolToBeResized.TotalSize/units.GiB)
-				enterPoolMaintenanceAddDisk(poolIDToResize)
-				defer exitPoolMaintenance(poolIDToResize)
-
-				err = Inst().V.ExpandPool(poolIDToResize, api.SdkStoragePool_RESIZE_TYPE_ADD_DISK, expectedSize, false)
-				dash.VerifyFatal(err, nil, "Pool expansion init successful?")
-
-				resizeErr := waitForPoolToBeResized(expectedSize, poolIDToResize, isjournal)
-				dash.VerifyFatal(resizeErr, nil, fmt.Sprintf("Expected new size to be '%d' or '%d' if pool has journal", expectedSize, expectedSizeWithJournal))
-
-			})
-
-			Step("Ensure that new pool has been expanded to the expected size", func() {
-				ValidateApplications(contexts)
-				resizedPool, err := GetStoragePoolByUUID(poolIDToResize)
-				log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", poolIDToResize))
-				newPoolSize := resizedPool.TotalSize / units.GiB
-				isExpansionSuccess := false
-				if newPoolSize >= expectedSizeWithJournal {
-					isExpansionSuccess = true
-				}
-				dash.VerifyFatal(isExpansionSuccess, true,
-					fmt.Sprintf("expected new pool size to be %v or %v if pool has journal, got %v", expectedSize, expectedSizeWithJournal, newPoolSize))
-				appsValidateAndDestroy(contexts)
-			})
+			resizedPool, err := GetStoragePoolByUUID(poolIDToResize)
+			log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", poolIDToResize))
+			newPoolSize := resizedPool.TotalSize / units.GiB
+			isExpansionSuccess := false
+			if newPoolSize >= expectedSizeWithJournal {
+				isExpansionSuccess = true
+			}
+			dash.VerifyFatal(isExpansionSuccess, true,
+				fmt.Sprintf("expected new pool size to be %v or %v if pool has journal, got %v", expectedSize, expectedSizeWithJournal, newPoolSize))
+			appsValidateAndDestroy(contexts)
 		})
-		JustAfterEach(func() {
-			defer EndTorpedoTest()
-			AfterEachTest(contexts)
-		})
-	} else {
-		fmt.Sprintf("Function Skipped due to:%s", err)
-	}
-
+	})
+	JustAfterEach(func() {
+		defer EndTorpedoTest()
+		AfterEachTest(contexts)
+	})
 })
 
 var _ = Describe("{StoragePoolExpandDiskAuto}", func() {

--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -82,13 +82,6 @@ var _ = Describe("{StoragePoolExpandDiskAdd}", func() {
 
 	stepLog := "should get the existing pool and expand it by adding a disk"
 	It(stepLog, func() {
-		isPoolAddDiskSupported, err := IsPoolAddDiskSupported()
-		if !isPoolAddDiskSupported {
-			if err != nil {
-				log.Warnf("Add disk operation is not supported for DMTHIN but continuing the operation")
-			}
-
-		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
 
@@ -218,6 +211,7 @@ var _ = Describe("{StoragePoolExpandDiskAuto}", func() {
 				poolToBeResized, err = GetStoragePoolByUUID(poolIDToResize)
 				log.FailOnError(err, fmt.Sprintf("Failed to get pool using UUID %s", poolIDToResize))
 			} else {
+
 				log.FailOnError(err, fmt.Sprintf("pool [%s] cannot be expanded due to error: %v", poolIDToResize, err))
 			}
 		})
@@ -393,6 +387,10 @@ var _ = Describe("{PoolAddDiskReboot}", func() {
 	stepLog := "should get the existing pool and expand it by adding a disk"
 
 	It(stepLog, func() {
+		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		if !isPoolAddDiskSupported {
+			log.FailOnError(disk_err, "Add disk operation is not supported")
+		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
 
@@ -503,7 +501,10 @@ var _ = Describe("{NodePoolsAddDisk}", func() {
 		1. Initiate pool expansion on multiple pools in the same node using add-disk
 		2. Validate pool expansion in all the pools
 	*/
-
+	isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+	if !isPoolAddDiskSupported {
+		log.FailOnError(disk_err, "Add disk operation is not supported")
+	}
 	nodePoolsExpansion("NodePoolsAddDisk")
 
 })
@@ -537,6 +538,10 @@ func nodePoolsExpansion(testName string) {
 
 	stepLog := fmt.Sprintf("has to schedule apps, and expand it by %s", option)
 	It(stepLog, func() {
+		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		if !isPoolAddDiskSupported {
+			log.FailOnError(disk_err, "Add disk operation is not supported")
+		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
 
@@ -1390,6 +1395,10 @@ var _ = Describe("{AddDriveStoragelessAndResize}", func() {
 	stepLog := "should get the storageless node and add a drive"
 
 	It(stepLog, func() {
+		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		if !isPoolAddDiskSupported {
+			log.FailOnError(disk_err, "Add disk operation is not supported")
+		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -1828,6 +1837,10 @@ var _ = Describe("{PoolAddDiskDiff}", func() {
 	stepLog := "should get the existing storage node and expand the pool multiple times"
 
 	It(stepLog, func() {
+		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		if !isPoolAddDiskSupported {
+			log.FailOnError(disk_err, "Add disk operation is not supported")
+		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
 
@@ -2069,6 +2082,10 @@ var _ = Describe("{AddWithPXRestart}", func() {
 	stepLog := "should get the existing storage node and expand the pool by resize-disk"
 
 	It(stepLog, func() {
+		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		if !isPoolAddDiskSupported {
+			log.FailOnError(disk_err, "Add disk operation is not supported")
+		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
 
@@ -2372,6 +2389,10 @@ var _ = Describe("{VolUpdateAddDisk}", func() {
 	stepLog := "should get the existing storage node and expand the pool by resize-disk"
 
 	It(stepLog, func() {
+		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		if !isPoolAddDiskSupported {
+			log.FailOnError(disk_err, "Add disk operation is not supported")
+		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -2741,6 +2762,10 @@ var _ = Describe("{MulPoolsAddDisk}", func() {
 	stepLog := "should get the existing storage node with multiple pools and expand pools at same time using add-disk"
 
 	It(stepLog, func() {
+		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		if !isPoolAddDiskSupported {
+			log.FailOnError(disk_err, "Add disk operation is not supported")
+		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
 
@@ -3059,6 +3084,10 @@ var _ = Describe("{AddDiskNodeMaintenanceCycle}", func() {
 	stepLog := "should get the volume with IOs, expand the pool by add-disk and perform node maintenance cycle"
 
 	It(stepLog, func() {
+		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		if !isPoolAddDiskSupported {
+			log.FailOnError(disk_err, "Add disk operation is not supported")
+		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -3217,6 +3246,10 @@ var _ = Describe("{AddDiskPoolMaintenanceCycle}", func() {
 	stepLog := "should get the volume with IOs, expand the pool by add-disk and perform pool maintenance cycle"
 
 	It(stepLog, func() {
+		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		if !isPoolAddDiskSupported {
+			log.FailOnError(disk_err, "Add disk operation is not supported")
+		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -3418,6 +3451,10 @@ var _ = Describe("{NodeMaintenanceModeAddDisk}", func() {
 	stepLog := "should get the existing storage node and put it in maintenance mode"
 
 	It(stepLog, func() {
+		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		if !isPoolAddDiskSupported {
+			log.FailOnError(disk_err, "Add disk operation is not supported")
+		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -3645,6 +3682,10 @@ var _ = Describe("{PoolMaintenanceModeAddDisk}", func() {
 	stepLog := "should get the existing storage node and put it in maintenance mode"
 
 	It(stepLog, func() {
+		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		if !isPoolAddDiskSupported {
+			log.FailOnError(disk_err, "Add disk operation is not supported")
+		}
 		log.InfoD(stepLog)
 
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -3756,6 +3797,10 @@ var _ = Describe("{AddDiskNodeMaintenanceMode}", func() {
 	stepLog := "should get the existing storage node,trigger add-disk and put it in maintenance mode"
 
 	It(stepLog, func() {
+		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		if !isPoolAddDiskSupported {
+			log.FailOnError(disk_err, "Add disk operation is not supported")
+		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -4107,6 +4152,10 @@ var _ = Describe("{AddDiskPoolMaintenanceMode}", func() {
 	stepLog := "should get the existing storage node and put it in maintenance mode"
 
 	It(stepLog, func() {
+		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		if !isPoolAddDiskSupported {
+			log.FailOnError(disk_err, "Add disk operation is not supported")
+		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -4276,6 +4325,10 @@ var _ = Describe("{PXRestartAddDisk}", func() {
 	stepLog := "should get the existing storage node and expand the pool by add-disk"
 
 	It(stepLog, func() {
+		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		if !isPoolAddDiskSupported {
+			log.FailOnError(disk_err, "Add disk operation is not supported")
+		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -4816,6 +4869,10 @@ var _ = Describe("{StorageFullPoolAddDisk}", func() {
 
 	stepLog := "Create vols and make pool full"
 	It(stepLog, func() {
+		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		if !isPoolAddDiskSupported {
+			log.FailOnError(disk_err, "Add disk operation is not supported")
+		}
 		log.InfoD(stepLog)
 		selectedNode := GetNodeWithLeastSize()
 		stNodes := node.GetStorageNodes()
@@ -5530,6 +5587,10 @@ var _ = Describe("{PoolIncreaseSize20TB}", func() {
 func addDiskToSpecificPool(node node.Node, sizeOfDisk uint64, poolID int32) bool {
 	// Get the Spec to add the disk to the Node
 	//  if the diskSize ( sizeOfDisK ) is 0 , then Disk of default spec size will be picked
+	isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+	if !isPoolAddDiskSupported {
+		log.FailOnError(disk_err, "Add disk operation is not supported")
+	}
 	driveSpecs, err := GetCloudDriveDeviceSpecs()
 	log.FailOnError(err, "Error getting cloud drive specs")
 	log.InfoD("Cloud Drive Spec %s", driveSpecs)
@@ -5592,6 +5653,10 @@ var _ = Describe("{ResizePoolDrivesInDifferentSize}", func() {
 
 	stepLog := "should get the existing storage node and expand the pool by resize-disk"
 	It(stepLog, func() {
+		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		if !isPoolAddDiskSupported {
+			log.FailOnError(disk_err, "Add disk operation is not supported")
+		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -7187,6 +7252,11 @@ var _ = Describe("{ResizeDiskAddDiskSamePool}", func() {
 	stepLog := "Resize Disk Followed by adddisk should not create a new pool"
 
 	It(stepLog, func() {
+		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		if !isPoolAddDiskSupported {
+			log.FailOnError(disk_err, "Add disk operation is not supported")
+		}
+
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -7281,6 +7351,10 @@ var _ = Describe("{DriveAddRebalanceInMaintenance}", func() {
 	stepLog := "Rebalance taking long time during drive add in pool maintenance mode"
 
 	It(stepLog, func() {
+		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		if !isPoolAddDiskSupported {
+			log.FailOnError(disk_err, "Add disk operation is not supported")
+		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -7601,6 +7675,10 @@ var _ = Describe("{NodeAddDiskWhileAddDiskInProgress}", func() {
 	stepLog := "should get the existing storage node and expand the pool by adding a drive while one already in progress"
 
 	It(stepLog, func() {
+		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		if !isPoolAddDiskSupported {
+			log.FailOnError(disk_err, "Add disk operation is not supported")
+		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -7712,6 +7790,10 @@ var _ = Describe("{NodeAddDiskWhileResizeDiskInProgress}", func() {
 	stepLog := "should get the existing storage node and expand the pool by adding a drive while one already in progress"
 
 	It(stepLog, func() {
+		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		if !isPoolAddDiskSupported {
+			log.FailOnError(disk_err, "Add disk operation is not supported")
+		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -8288,6 +8370,10 @@ var _ = Describe("{AddDiskAddDriveAndDeleteInstance}", func() {
 	stepLog := "should get the existing pool, expand the pool by adding disk and create a new pool and then delete the instance"
 
 	It(stepLog, func() {
+		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		if !isPoolAddDiskSupported {
+			log.FailOnError(disk_err, "Add disk operation is not supported")
+		}
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
@@ -10706,6 +10792,10 @@ var _ = Describe("{HAIncreasePoolresizeAndAdddisk}", func() {
 
 	itLog := "HAIncreasePoolresizeAndAdddisk"
 	It(itLog, func() {
+		isPoolAddDiskSupported, disk_err := IsPoolAddDiskSupported()
+		if !isPoolAddDiskSupported {
+			log.FailOnError(disk_err, "Add disk operation is not supported")
+		}
 		stepLog := "schedule Application"
 		Step(stepLog, func() {
 			log.InfoD(stepLog)

--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -135,8 +135,9 @@ var _ = Describe("{StoragePoolExpandDiskAdd}", func() {
 			}
 
 			log.InfoD("Current Size of the pool %s is %d", poolIDToResize, poolToBeResized.TotalSize/units.GiB)
-			enterPoolMaintenanceAddDisk(poolIDToResize)
-			defer exitPoolMaintenance(poolIDToResize)
+			log.Infof("Commented out the code to add disk to the pool %s", poolIDToResize)
+			//enterPoolMaintenanceAddDisk(poolIDToResize)
+			//defer exitPoolMaintenance(poolIDToResize)
 
 			err = Inst().V.ExpandPool(poolIDToResize, api.SdkStoragePool_RESIZE_TYPE_ADD_DISK, expectedSize, false)
 			if err != nil {

--- a/tests/common.go
+++ b/tests/common.go
@@ -703,14 +703,20 @@ func IsPoolAddDiskSupported() (bool, error) {
 		if err != nil {
 			return false, err
 		}
-		parts := strings.Split(driverVersion, ".")
-		trimmedVersion := strings.Join(parts[:3], ".")
-		currentPxVersionOnCluster, err := semver.NewVersion(trimmedVersion)
+		var new_trimmedVersion string
+		parts := strings.Split(driverVersion, "-")
+		trimmedVersion := strings.Split(parts[0], ".")
+		if len(trimmedVersion) > 3 {
+			new_trimmedVersion = strings.Join(trimmedVersion[:3], ".")
+		} else {
+			new_trimmedVersion = parts[0]
+		}
+		currentPxVersionOnCluster, err := semver.NewVersion(new_trimmedVersion)
 		if err != nil {
 			log.InfoD("[semver.NewVersion] error is", err)
 			return false, err
 		}
-		if pxVersion.LessThan(currentPxVersionOnCluster) {
+		if currentPxVersionOnCluster.GreaterThan(pxVersion) {
 			log.Infof("drive add to existing pool not supported for px-storev2 or px-cache pools")
 			err = fmt.Errorf("drive add to existing pool not supported for px-storev2 or px-cache pools ")
 			return false, err

--- a/tests/common.go
+++ b/tests/common.go
@@ -703,8 +703,16 @@ func IsPoolAddDiskSupported() (bool, error) {
 		if err != nil {
 			return false, err
 		}
-		log.InfoD("current driver version", driverVersion)
-		currentPxVersionOnCluster, err := semver.NewVersion(driverVersion)
+		log.InfoD("current driver version %s", driverVersion)
+		parts := strings.Split(driverVersion, ".")
+		if len(parts) >= 3 {
+			trimmedVersion := strings.Join(parts[:3], ".")
+			fmt.Println(trimmedVersion)
+		} else {
+			fmt.Println("Invalid version string")
+		}
+		log.InfoD("trimmed version %s", trimmedVersion)
+		currentPxVersionOnCluster, err := semver.NewVersion(trimmedVersion)
 		if err != nil {
 			log.InfoD("[semver.NewVersion] error is", err)
 			return false, err

--- a/tests/common.go
+++ b/tests/common.go
@@ -698,11 +698,11 @@ func IsPoolAddDiskSupported() (bool, error) {
 		return true, nil
 	}
 	if DMthin {
-		pxVersion, err := semver.NewVersion("3.1.0")
+		log.Infof("DMTHIN is enabled")
+		dmthinSupportedPxVersion, err := semver.NewVersion("3.1.0")
 		if err != nil {
 			return false, err
 		}
-		log.Infof("DMTHIN is enabled")
 		driverVersion, err := Inst().V.GetDriverVersion()
 		if err != nil {
 			return false, err
@@ -717,10 +717,11 @@ func IsPoolAddDiskSupported() (bool, error) {
 		}
 		currentPxVersionOnCluster, err := semver.NewVersion(new_trimmedVersion)
 		if err != nil {
-			log.InfoD("[semver.NewVersion] error is", err)
+			log.InfoD(fmt.Sprintf("[semver.NewVersion] error is", err))
 			return false, err
 		}
-		if currentPxVersionOnCluster.GreaterThan(pxVersion) {
+		log.InfoD(fmt.Sprintf("The current version on the cluster is :%s", currentPxVersionOnCluster))
+		if currentPxVersionOnCluster.GreaterThan(dmthinSupportedPxVersion) {
 			err = fmt.Errorf("drive add to existing pool not supported for px-storev2 or px-cache pools ")
 			return false, err
 		}

--- a/tests/common.go
+++ b/tests/common.go
@@ -714,7 +714,7 @@ func IsPoolAddDiskSupported() (bool, error) {
 			return false, err
 		}
 
-		if pxVersion.GreaterThan(currentPxVersionOnCluster) {
+		if pxVersion.LessThan(currentPxVersionOnCluster) {
 			log.Infof("drive add to existing pool not supported for px-storev2 or px-cache pools")
 			return false, err
 		}

--- a/tests/common.go
+++ b/tests/common.go
@@ -694,7 +694,7 @@ func ValidatePDSDataServices(ctx *scheduler.Context, errChan ...*chan error) {
 func IsPoolAddDiskSupported() (bool, error) {
 	DMthin, err := IsDMthin()
 	if err != nil {
-		log.InfoD("Failed to determine if DMTHIN is enabled")
+		log.Infof("Failed to determine if DMTHIN is enabled")
 		return false, err
 	}
 	if !DMthin {

--- a/tests/common.go
+++ b/tests/common.go
@@ -694,11 +694,9 @@ func ValidatePDSDataServices(ctx *scheduler.Context, errChan ...*chan error) {
 func IsPoolAddDiskSupported() (bool, error) {
 	DMthin, err := IsDMthin()
 	if err != nil {
-		log.Info("Failed to determine if DMTHIN is enabled")
 		return false, err
 	}
 	if !DMthin {
-		log.Info("DMTHIN is not enabled on this setup, Add Disk to Pool is  supported")
 		return true, nil
 	} else {
 		log.Info("DMTHIN is enabled")
@@ -724,10 +722,9 @@ func IsPoolAddDiskSupported() (bool, error) {
 		}
 		log.InfoD(fmt.Sprintf("The current version on the cluster is :%s", currentPxVersionOnCluster))
 		if currentPxVersionOnCluster.GreaterThan(dmthinSupportedPxVersion) {
-			err = fmt.Errorf("drive add to existing pool not supported for px-storev2 or px-cache pools ")
+			err = fmt.Errorf("drive add to existing pool not supported for px-storev2 or px-cache pools as the current version is:%s", currentPxVersionOnCluster)
 			return false, err
 		}
-		log.Info("drive add to existing pool supported for px-storev2 or px-cache pools")
 		return true, nil
 	}
 	return true, nil

--- a/tests/common.go
+++ b/tests/common.go
@@ -691,19 +691,21 @@ func ValidatePDSDataServices(ctx *scheduler.Context, errChan ...*chan error) {
 	})
 }
 
-func IsPoolAddDiskSupported() (bool, error) {
+func IsPoolAddDiskSupported() bool {
 	DMthin, err := IsDMthin()
 	if err != nil {
-		return false, err
+		log.FailOnError(err, "Error occured while checking if DMthin is enabled")
 	}
 	if DMthin {
-		dmthinSupportedPxVersion, err := semver.NewVersion("3.1.0")
-		if err != nil {
-			return false, err
+		dmthinSupportedPxVersion, px_err := semver.NewVersion("3.1.0")
+		if px_err != nil {
+			log.Errorf(fmt.Sprintf("Error occured :%s", px_err))
+			return false
 		}
 		driverVersion, version_err := Inst().V.GetDriverVersion()
 		if version_err != nil {
-			return false, version_err
+			log.Errorf(fmt.Sprintf("Error occured while fetching current version :%s", version_err))
+			return false
 		}
 		var new_trimmedVersion string
 		parts := strings.Split(driverVersion, "-")
@@ -715,16 +717,16 @@ func IsPoolAddDiskSupported() (bool, error) {
 		}
 		currentPxVersionOnCluster, semver_err := semver.NewVersion(new_trimmedVersion)
 		if semver_err != nil {
-			return false, semver_err
+			log.Errorf(fmt.Sprintf("Error occured while comparing the current and expected version:%s", semver_err))
+			return false
 		}
 		log.InfoD(fmt.Sprintf("The current version on the cluster is :%s", currentPxVersionOnCluster))
 		if currentPxVersionOnCluster.GreaterThan(dmthinSupportedPxVersion) {
-			err = fmt.Errorf("drive add to existing pool not supported for px-storev2 or px-cache pools as the current version is:%s", currentPxVersionOnCluster)
-			return false, err
+			log.Errorf(fmt.Sprintf("drive add to existing pool not supported for px-storev2 or px-cache pools as the current version is:%s", currentPxVersionOnCluster))
+			return false
 		}
-		return true, nil
 	}
-	return true, nil
+	return true
 }
 
 // ValidateContext is the ginkgo spec for validating a scheduled context

--- a/tests/common.go
+++ b/tests/common.go
@@ -693,18 +693,16 @@ func ValidatePDSDataServices(ctx *scheduler.Context, errChan ...*chan error) {
 
 func IsPoolAddDiskSupported() bool {
 	DMthin, err := IsDMthin()
-	if err != nil {
-		log.FailOnError(err, "Error occured while checking if DMthin is enabled")
-	}
+	log.FailOnError(err, "Error occured while checking if DMthin is enabled")
 	if DMthin {
 		dmthinSupportedPxVersion, px_err := semver.NewVersion("3.1.0")
 		if px_err != nil {
-			log.Errorf("Error occured :%s", px_err)
+			log.FailOnError(px_err, "Error occured :%s")
 			return false
 		}
 		driverVersion, version_err := Inst().V.GetDriverVersion()
 		if version_err != nil {
-			log.Errorf("Error occured while fetching current version :%s", version_err)
+			log.FailOnError(version_err, "Error occured while fetching current version")
 			return false
 		}
 		var new_trimmedVersion string
@@ -717,7 +715,7 @@ func IsPoolAddDiskSupported() bool {
 		}
 		currentPxVersionOnCluster, semver_err := semver.NewVersion(new_trimmedVersion)
 		if semver_err != nil {
-			log.Errorf("Error occured while comparing the current and expected version:%s", semver_err)
+			log.FailOnError(semver_err, "Error occured while comparing the current and expected version")
 			return false
 		}
 		log.InfoD(fmt.Sprintf("The current version on the cluster is :%s", currentPxVersionOnCluster))

--- a/tests/common.go
+++ b/tests/common.go
@@ -696,9 +696,7 @@ func IsPoolAddDiskSupported() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if !DMthin {
-		return true, nil
-	} else {
+	if DMthin {
 		dmthinSupportedPxVersion, err := semver.NewVersion("3.1.0")
 		if err != nil {
 			return false, err

--- a/tests/common.go
+++ b/tests/common.go
@@ -703,12 +703,13 @@ func IsPoolAddDiskSupported() (bool, error) {
 		if err != nil {
 			return false, err
 		}
+		log.InfoD("current driver version", driverVersion)
 		currentPxVersionOnCluster, err := semver.NewVersion(driverVersion)
 		if err != nil {
 			log.InfoD("[semver.NewVersion] error is", err)
 			return false, err
 		}
-		log.InfoD("current driver version", driverVersion)
+
 		if pxVersion.GreaterThan(currentPxVersionOnCluster) {
 			log.Infof("drive add to existing pool not supported for px-storev2 or px-cache pools")
 			return false, err

--- a/tests/common.go
+++ b/tests/common.go
@@ -699,12 +699,12 @@ func IsPoolAddDiskSupported() bool {
 	if DMthin {
 		dmthinSupportedPxVersion, px_err := semver.NewVersion("3.1.0")
 		if px_err != nil {
-			log.Errorf(fmt.Sprintf("Error occured :%s", px_err))
+			log.Errorf("Error occured :%s", px_err)
 			return false
 		}
 		driverVersion, version_err := Inst().V.GetDriverVersion()
 		if version_err != nil {
-			log.Errorf(fmt.Sprintf("Error occured while fetching current version :%s", version_err))
+			log.Errorf("Error occured while fetching current version :%s", version_err)
 			return false
 		}
 		var new_trimmedVersion string
@@ -717,12 +717,12 @@ func IsPoolAddDiskSupported() bool {
 		}
 		currentPxVersionOnCluster, semver_err := semver.NewVersion(new_trimmedVersion)
 		if semver_err != nil {
-			log.Errorf(fmt.Sprintf("Error occured while comparing the current and expected version:%s", semver_err))
+			log.Errorf("Error occured while comparing the current and expected version:%s", semver_err)
 			return false
 		}
 		log.InfoD(fmt.Sprintf("The current version on the cluster is :%s", currentPxVersionOnCluster))
 		if currentPxVersionOnCluster.GreaterThan(dmthinSupportedPxVersion) {
-			log.Errorf(fmt.Sprintf("drive add to existing pool not supported for px-storev2 or px-cache pools as the current version is:%s", currentPxVersionOnCluster))
+			log.Errorf("drive add to existing pool not supported for px-storev2 or px-cache pools as the current version is:%s", currentPxVersionOnCluster)
 			return false
 		}
 	}

--- a/tests/common.go
+++ b/tests/common.go
@@ -720,7 +720,6 @@ func IsPoolAddDiskSupported() (bool, error) {
 		}
 		currentPxVersionOnCluster, semver_err := semver.NewVersion(new_trimmedVersion)
 		if semver_err != nil {
-			log.InfoD(fmt.Sprintf("[semver.NewVersion] error is", semver_err))
 			return false, semver_err
 		}
 		log.InfoD(fmt.Sprintf("The current version on the cluster is :%s", currentPxVersionOnCluster))

--- a/tests/common.go
+++ b/tests/common.go
@@ -699,7 +699,6 @@ func IsPoolAddDiskSupported() (bool, error) {
 	if !DMthin {
 		return true, nil
 	} else {
-		log.Info("DMTHIN is enabled")
 		dmthinSupportedPxVersion, err := semver.NewVersion("3.1.0")
 		if err != nil {
 			return false, err

--- a/tests/common.go
+++ b/tests/common.go
@@ -698,12 +698,10 @@ func IsPoolAddDiskSupported() bool {
 		dmthinSupportedPxVersion, px_err := semver.NewVersion("3.1.0")
 		if px_err != nil {
 			log.FailOnError(px_err, "Error occured :%s")
-			return false
 		}
 		driverVersion, version_err := Inst().V.GetDriverVersion()
 		if version_err != nil {
 			log.FailOnError(version_err, "Error occured while fetching current version")
-			return false
 		}
 		var new_trimmedVersion string
 		parts := strings.Split(driverVersion, "-")
@@ -716,7 +714,6 @@ func IsPoolAddDiskSupported() bool {
 		currentPxVersionOnCluster, semver_err := semver.NewVersion(new_trimmedVersion)
 		if semver_err != nil {
 			log.FailOnError(semver_err, "Error occured while comparing the current and expected version")
-			return false
 		}
 		log.InfoD(fmt.Sprintf("The current version on the cluster is :%s", currentPxVersionOnCluster))
 		if currentPxVersionOnCluster.GreaterThan(dmthinSupportedPxVersion) {

--- a/tests/common.go
+++ b/tests/common.go
@@ -703,11 +703,8 @@ func IsPoolAddDiskSupported() (bool, error) {
 		if err != nil {
 			return false, err
 		}
-		log.InfoD("current driver version %s", driverVersion)
 		parts := strings.Split(driverVersion, ".")
 		trimmedVersion := strings.Join(parts[:3], ".")
-		fmt.Println(trimmedVersion)
-		log.InfoD("trimmed version %s", trimmedVersion)
 		currentPxVersionOnCluster, err := semver.NewVersion(trimmedVersion)
 		if err != nil {
 			log.InfoD("[semver.NewVersion] error is", err)

--- a/tests/common.go
+++ b/tests/common.go
@@ -710,9 +710,9 @@ func IsPoolAddDiskSupported() (bool, error) {
 			log.InfoD("[semver.NewVersion] error is", err)
 			return false, err
 		}
-
 		if pxVersion.LessThan(currentPxVersionOnCluster) {
 			log.Infof("drive add to existing pool not supported for px-storev2 or px-cache pools")
+			err = fmt.Errorf("drive add to existing pool not supported for px-storev2 or px-cache pools ")
 			return false, err
 		}
 		log.Infof("drive add to existing pool supported for px-storev2 or px-cache pools")

--- a/tests/common.go
+++ b/tests/common.go
@@ -705,12 +705,8 @@ func IsPoolAddDiskSupported() (bool, error) {
 		}
 		log.InfoD("current driver version %s", driverVersion)
 		parts := strings.Split(driverVersion, ".")
-		if len(parts) >= 3 {
-			trimmedVersion := strings.Join(parts[:3], ".")
-			fmt.Println(trimmedVersion)
-		} else {
-			fmt.Println("Invalid version string")
-		}
+		trimmedVersion := strings.Join(parts[:3], ".")
+		fmt.Println(trimmedVersion)
 		log.InfoD("trimmed version %s", trimmedVersion)
 		currentPxVersionOnCluster, err := semver.NewVersion(trimmedVersion)
 		if err != nil {

--- a/tests/common.go
+++ b/tests/common.go
@@ -704,6 +704,11 @@ func IsPoolAddDiskSupported() (bool, error) {
 			return false, err
 		}
 		currentPxVersionOnCluster, err := semver.NewVersion(driverVersion)
+		if err != nil {
+			log.InfoD("[semver.NewVersion] error is", err)
+			return false, err
+		}
+		log.InfoD("current driver version", driverVersion)
 		if pxVersion.GreaterThan(currentPxVersionOnCluster) {
 			log.Infof("drive add to existing pool not supported for px-storev2 or px-cache pools")
 			return false, err

--- a/tests/common.go
+++ b/tests/common.go
@@ -692,12 +692,16 @@ func ValidatePDSDataServices(ctx *scheduler.Context, errChan ...*chan error) {
 }
 
 func IsPoolAddDiskSupported() (bool, error) {
-	pxVersion, err := semver.NewVersion("3.1.0")
-	if err != nil {
-		return false, err
-	}
+
 	DMthin, err := IsDMthin()
+	if err != nil {
+		return true, nil
+	}
 	if DMthin {
+		pxVersion, err := semver.NewVersion("3.1.0")
+		if err != nil {
+			return false, err
+		}
 		log.Infof("DMTHIN is enabled")
 		driverVersion, err := Inst().V.GetDriverVersion()
 		if err != nil {
@@ -717,7 +721,6 @@ func IsPoolAddDiskSupported() (bool, error) {
 			return false, err
 		}
 		if currentPxVersionOnCluster.GreaterThan(pxVersion) {
-			log.Infof("drive add to existing pool not supported for px-storev2 or px-cache pools")
 			err = fmt.Errorf("drive add to existing pool not supported for px-storev2 or px-cache pools ")
 			return false, err
 		}

--- a/tests/common.go
+++ b/tests/common.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"github.com/Masterminds/semver/v3"
 	"github.com/hashicorp/go-version"
 	"github.com/portworx/sched-ops/k8s/apiextensions"
 	"github.com/portworx/sched-ops/k8s/kubevirt"
@@ -688,6 +689,29 @@ func ValidatePDSDataServices(ctx *scheduler.Context, errChan ...*chan error) {
 			}
 		})
 	})
+}
+
+func IsPoolAddDiskSupported() (bool, error) {
+	pxVersion, err := semver.NewVersion("3.1.0")
+	if err != nil {
+		return false, err
+	}
+	DMthin, err := IsDMthin()
+	if DMthin {
+		log.Infof("DMTHIN is enabled")
+		driverVersion, err := Inst().V.GetDriverVersion()
+		if err != nil {
+			return false, err
+		}
+		currentPxVersionOnCluster, err := semver.NewVersion(driverVersion)
+		if pxVersion.GreaterThan(currentPxVersionOnCluster) {
+			log.Infof("drive add to existing pool not supported for px-storev2 or px-cache pools")
+			return false, err
+		}
+		log.Infof("drive add to existing pool supported for px-storev2 or px-cache pools")
+		return true, nil
+	}
+	return true, nil
 }
 
 // ValidateContext is the ginkgo spec for validating a scheduled context

--- a/tests/common.go
+++ b/tests/common.go
@@ -694,14 +694,14 @@ func ValidatePDSDataServices(ctx *scheduler.Context, errChan ...*chan error) {
 func IsPoolAddDiskSupported() (bool, error) {
 	DMthin, err := IsDMthin()
 	if err != nil {
-		log.Infof("Failed to determine if DMTHIN is enabled")
+		log.Info("Failed to determine if DMTHIN is enabled")
 		return false, err
 	}
 	if !DMthin {
-		log.InfoD("DMTHIN is not enabled on this setup, Add Disk to Pool is  supported")
+		log.Info("DMTHIN is not enabled on this setup, Add Disk to Pool is  supported")
 		return true, nil
 	} else {
-		log.Infof("DMTHIN is enabled")
+		log.Info("DMTHIN is enabled")
 		dmthinSupportedPxVersion, err := semver.NewVersion("3.1.0")
 		if err != nil {
 			return false, err
@@ -727,7 +727,7 @@ func IsPoolAddDiskSupported() (bool, error) {
 			err = fmt.Errorf("drive add to existing pool not supported for px-storev2 or px-cache pools ")
 			return false, err
 		}
-		log.Infof("drive add to existing pool supported for px-storev2 or px-cache pools")
+		log.Info("drive add to existing pool supported for px-storev2 or px-cache pools")
 		return true, nil
 	}
 	return true, nil


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Checks for DMthin enabled or not for poolexpand operations, if yes will check for px version and returns true if poolexpand possible

**Which issue(s) this PR fixes** (optional)
Closes #  PTX-23000

**Special notes for your reviewer**:
ResizeDiskAddDiskSamePool
AddDiskAddDriveAndDeleteInstance
HAIncreasePoolresizeAndAdddisk
NodeAddDiskWhileResizeDiskInProgress
NodeAddDiskWhileAddDiskInProgress
addDiskToSpecificPool
StorageFullPoolAddDisk
PXRestartAddDisk
AddDiskPoolMaintenanceMode
PoolMaintenanceModeAddDisk
NodeMaintenanceModeAddDisk
AddDiskPoolMaintenanceCycle
AddDiskNodeMaintenanceCycle
MulPoolsAddDisk
VolUpdateAddDisk
 AddWithPXRestart
PoolAddDiskDiff
NodePoolsAddDisk
 PoolAddDiskReboot
StoragePoolExpandDiskAuto
PoolResizeInTrashCanNode
nodePoolsExpansion
AddDriveStoragelessAndResize
ResizePoolDrivesInDifferentSize
 ResizeDiskAddDiskSamePool



PASS LOGS:

BTRFS : https://jenkins.pwx.dev.purestorage.com/job/Users/job/krishna/job/tp-pxe-byoc/2274/console

DMTHIN 3.1.1 PX :https://jenkins.pwx.dev.purestorage.com/job/Users/job/krishna/job/tp-pxe-byoc/2279/console
https://jenkins.pwx.dev.purestorage.com/job/Users/job/krishna/job/tp-pxe-byoc/2282/console


DMTHIN 3.1.0 PX : https://jenkins.pwx.dev.purestorage.com/job/Users/job/krishna/job/tp-pxe-byoc/2304/console
https://jenkins.pwx.dev.purestorage.com/job/Users/job/krishna/job/tp-pxe-byoc/2303/console





