### PR TITLE
Fixed the context switching issue for KubevirtVMBackupRestoreWithNodeSelector

### DIFF
--- a/tests/backup_helper.go
+++ b/tests/backup_helper.go
@@ -7989,7 +7989,7 @@ func ScaleApplicationToDesiredReplicas(namespace string) error {
 }
 
 // AddNodeToVirtualMachine applies node selector to the virtual machine
-func AddNodeToVirtualMachine(vm kubevirtv1.VirtualMachine, nodeSelector map[string]string, ctx context1.Context) error {
+func AddNodeToVirtualMachine(vm kubevirtv1.VirtualMachine, nodeSelector map[string]string) error {
 	k8sKubevirt := kubevirt.Instance()
 
 	vm.Spec.Template.Spec.NodeSelector = nodeSelector


### PR DESCRIPTION
**What this PR does / why we need it**:
In the test case `KubevirtVMBackupRestoreWithNodeSelector` in the step 
```
Validating restore for all Virtual Machine Instances expected to be running
```
We are switching to the destination cluster but never switching back to source cluster. In the next step
```
Verifying state and nodes for all restored Virtual Machine Instances
```
we have to be on the destination cluster itself but we are doing
```
ctx, err := backup.GetAdminCtxFromSecret()
```
which is resulting in failure. Hence, I made the `ctx` global for the test case. This will reduce unnecessary switch back to source cluster just to get the `ctx`

**Which issue(s) this PR fixes** (optional)
Closes #PB-6231

**Special notes for your reviewer**:
[Jenkins Run](https://jenkins.pwx.dev.purestorage.com/job/Users/job/Mithun/job/Quick%20BYOC/37/console)

