### PR TITLE
Fixing update torpedo yaml for image pull secrets

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -404,24 +404,6 @@ fi
 
 echo '' > torpedo.yaml
 
-# If these are passed, we will create a docker config secret to use to pull images
-if [ ! -z $IMAGE_PULL_SERVER ] && [ ! -z $IMAGE_PULL_USERNAME ] && [ ! -z $IMAGE_PULL_PASSWORD ]; then
-  echo "Adding Docker registry secret ..."
-  auth=$(echo "$IMAGE_PULL_USERNAME:$IMAGE_PULL_PASSWORD" | base64)
-  secret=$(echo "{\"auths\":{\"$IMAGE_PULL_SERVER\":{\"auth\":\"$auth\"}}}" | base64 -w 0)
-  cat >> torpedo.yaml <<EOF
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: torpedo
-type: kubernetes.io/dockerconfigjson
-data:
-  .dockerconfigjson: $secret
-
-EOF
-  sed -i '/spec:/a\  imagePullSecrets:\n    - name: torpedo' torpedo.yaml
-fi
 
 cat >> torpedo.yaml <<EOF
 ---
@@ -794,6 +776,25 @@ spec:
 
 
 EOF
+
+# If these are passed, we will create a docker config secret to use to pull images
+if [ ! -z $IMAGE_PULL_SERVER ] && [ ! -z $IMAGE_PULL_USERNAME ] && [ ! -z $IMAGE_PULL_PASSWORD ]; then
+  echo "Adding Docker registry secret ..."
+  auth=$(echo -n "$IMAGE_PULL_USERNAME:$IMAGE_PULL_PASSWORD" | base64)
+  secret=$(echo -n "{\"auths\":{\"$IMAGE_PULL_SERVER\":{\"auth\":\"$auth\"}}}" | base64 -w 0)
+  cat >> torpedo.yaml <<EOF
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: torpedo
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: $secret
+
+EOF
+  sed -i '/spec:/a\  imagePullSecrets:\n    - name: torpedo' torpedo.yaml
+fi
 
 cat torpedo.yaml
 

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -8144,9 +8144,7 @@ func (k *K8s) createDockerRegistrySecret(secretName, secretNamespace string) (*v
 	if dockerServer != "" && dockerUsername != "" && dockerPassword != "" {
 		auths.AuthConfigs = map[string]docker_types.AuthConfig{
 			dockerServer: {
-				Username: dockerUsername,
-				Password: dockerPassword,
-				Auth:     base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", dockerUsername, dockerPassword))),
+				Auth: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", dockerUsername, dockerPassword))),
 			},
 		}
 		authConfigsEnc, _ := json.Marshal(auths)
@@ -8156,18 +8154,18 @@ func (k *K8s) createDockerRegistrySecret(secretName, secretNamespace string) (*v
 				Name:      secretName,
 				Namespace: secretNamespace,
 			},
-			Type: "docker-registry",
+			Type: v1.SecretTypeDockerConfigJson,
 			Data: map[string][]byte{".dockerconfigjson": authConfigsEnc},
 		}
 		secret, err := k8sCore.CreateSecret(secretObj)
 		if k8serrors.IsAlreadyExists(err) {
 			if secret, err = k8sCore.GetSecret(secretName, secretNamespace); err == nil {
-				log.Infof("Using existing Docker regisrty secret: %v", secret.Name)
+				log.Infof("Using existing Docker registry secret: %v", secret.Name)
 				return secret, nil
 			}
 		}
 		if err != nil {
-			return nil, fmt.Errorf("failed to create Docker registry secret: %s. Err: %v", secretName, err)
+			return nil, fmt.Errorf("failed to create Docker registry secret: %s in namespace: %s . Err: %v", secretName, secretNamespace, err)
 		}
 		log.Infof("Created Docker registry secret: %s", secret.Name)
 		return secret, nil


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Fixing docker pull issue in torpedo
**Which issue(s) this PR fixes** (optional)
Closes #PTX-23068
**Special notes for your reviewer**:

Test job : https://jenkins.pwx.dev.purestorage.com/view/Leela-monitoring-jobs/job/Torpedo/job/tp-nextpx-btrfs-eks/73/console

```
kubectl -n vdbench-sharedv4-pooladddisk-0-03-27-18h51m43s get po
NAME                                READY   STATUS    RESTARTS   AGE
vdbench-sharedv4-7b566bb875-5v4vd   1/1     Running   0          4m44s
vdbench-sharedv4-7b566bb875-9rn64   1/1     Running   0          4m44s
vdbench-sharedv4-7b566bb875-rlbq8   1/1     Running   0          4m44s

kubectl -n nginx-sv4-svc-pooladddisk-0-03-27-18h51m43s get po
NAME                     READY   STATUS    RESTARTS   AGE
nginx-6bd8749764-d5vdb   1/1     Running   0          4m49s
nginx-6bd8749764-gqfql   1/1     Running   0          4m49s
nginx-6bd8749764-wt65k   1/1     Running   0          4m49s

kubectl -n fio-writes-pooladddisk-0-03-27-18h51m43s get po
NAME    READY   STATUS    RESTARTS        AGE
fio-0   2/2     Running   0               4m53s
fio-1   2/2     Running   0               3m56s
fio-2   2/2     Running   1 (2m44s ago)   3m27s
fio-3   2/2     Running   0               2m42s
fio-4   2/2     Running   0               2m5s
fio-5   2/2     Running   0               73s

kubectl -n elasticsearch-pooladddisk-0-03-27-18h51m43s get po
NAME                       READY   STATUS    RESTARTS   AGE
es-load-555449867f-r9xrt   1/1     Running   0          5m2s
esnode-0                   1/1     Running   0          5m2s
esnode-1                   1/1     Running   0          3m13s
esnode-2                   1/1     Running   0          103s

kubectl -n kube-system get po -l name=debug
NAME          READY   STATUS    RESTARTS   AGE
debug-2glc4   1/1     Running   0          6m
debug-6wbtx   1/1     Running   0          6m
debug-77vlg   1/1     Running   0          6m
debug-7b2dw   1/1     Running   0          6m1s
debug-8hbwt   1/1     Running   0          6m
debug-bt2d7   1/1     Running   0          6m
debug-cp2qw   1/1     Running   0          6m
debug-nx4tg   1/1     Running   0          6m1s
debug-pck2m   1/1     Running   0          6m1s
debug-s6m7k   1/1     Running   0          6m

kubectl get po
NAME      READY   STATUS    RESTARTS   AGE
torpedo   1/1     Running   0          6m25s
```
