### PR TITLE
Added Kubevirt related steps in upgrade test

### DIFF
--- a/tests/backup/backup_kubevirt_test.go
+++ b/tests/backup/backup_kubevirt_test.go
@@ -273,7 +273,7 @@ var _ = Describe("{KubevirtVMBackupRestoreWithDifferentStates}", Label(TestCaseL
 			var namespaces []string
 			for _, appCtx := range scheduledAppContexts {
 				namespaces = append(namespaces, appCtx.ScheduleOptions.Namespace)
-				namespaceMappingMixed[appCtx.ScheduleOptions.Namespace] = appCtx.ScheduleOptions.Namespace + "-mixed"
+				namespaceMappingMixed[appCtx.ScheduleOptions.Namespace] = appCtx.ScheduleOptions.Namespace + "-mxd"
 			}
 			backupWithVMMixed = fmt.Sprintf("%s-%s", "auto-backup-mixed", RandomString(6))
 			backupNames = append(backupNames, backupWithVMMixed)
@@ -313,7 +313,7 @@ var _ = Describe("{KubevirtVMBackupRestoreWithDifferentStates}", Label(TestCaseL
 			var namespaces []string
 			for _, appCtx := range scheduledAppContexts {
 				namespaces = append(namespaces, appCtx.ScheduleOptions.Namespace)
-				namespaceMappingRestart[appCtx.ScheduleOptions.Namespace] = appCtx.ScheduleOptions.Namespace + "-restart"
+				namespaceMappingRestart[appCtx.ScheduleOptions.Namespace] = appCtx.ScheduleOptions.Namespace + "-rst"
 			}
 			backupWithVMRestart = fmt.Sprintf("%s-%s", "auto-backup-restart", RandomString(6))
 			backupNames = append(backupNames, backupWithVMRestart)
@@ -365,7 +365,7 @@ var _ = Describe("{KubevirtVMBackupRestoreWithDifferentStates}", Label(TestCaseL
 			var namespaces []string
 			for _, appCtx := range scheduledAppContexts {
 				namespaces = append(namespaces, appCtx.ScheduleOptions.Namespace)
-				namespaceMappingStopped[appCtx.ScheduleOptions.Namespace] = appCtx.ScheduleOptions.Namespace + "-stopped"
+				namespaceMappingStopped[appCtx.ScheduleOptions.Namespace] = appCtx.ScheduleOptions.Namespace + "-stp"
 			}
 			backupWithVMStopped = fmt.Sprintf("%s-%s", "auto-backup-stopped", RandomString(6))
 			backupNames = append(backupNames, backupWithVMStopped)


### PR DESCRIPTION
**What this PR does / why we need it**:

- [x] Added a step in upgrade to verify the newly introduced backup type field in 2.7.0
- [x] Added a step to check if the backup type is `All` for namespace backups and `VM` for VM backups
- [x] Fixed a minor issue in the test `KubevirtVMBackupRestoreWithDifferentStates` where the destination namespace was going above 63 chars

**Which issue(s) this PR fixes** (optional)
Closes #PB-6231

**Special notes for your reviewer**:
[Jenkins Run](https://jenkins.pwx.dev.purestorage.com/job/Users/job/Mithun/job/Quick%20BYOC/64/console)

