### PR TITLE
PB-6550: Minor fix in `LockedBucketResizeVolumeOnScheduleBackup` test

### DIFF
--- a/tests/backup/backup_locked_bucket_test.go
+++ b/tests/backup/backup_locked_bucket_test.go
@@ -676,10 +676,16 @@ var _ = Describe("{LockedBucketResizeVolumeOnScheduleBackup}", Label(TestCaseLab
 					log.InfoD("Create schedule backup after initializing volume resize")
 					ctx, err := backup.GetAdminCtxFromSecret()
 					log.FailOnError(err, "Unable to px-central-admin ctx")
-					preRuleUid, err := Inst().Backup.GetRuleUid(BackupOrgID, ctx, preRuleNameList[i])
-					log.FailOnError(err, "Unable to fetch pre rule Uid")
-					postRuleUid, err := Inst().Backup.GetRuleUid(BackupOrgID, ctx, postRuleNameList[i])
-					log.FailOnError(err, "Unable to fetch post rule Uid")
+					preRuleUid := ""
+					if preRuleNameList[i] != "" {
+						preRuleUid, err = Inst().Backup.GetRuleUid(BackupOrgID, ctx, preRuleNameList[i])
+						log.FailOnError(err, "Unable to fetch pre rule Uid")
+					}
+					postRuleUid := ""
+					if postRuleNameList[i] != "" {
+						postRuleUid, err = Inst().Backup.GetRuleUid(BackupOrgID, ctx, postRuleNameList[i])
+						log.FailOnError(err, "Unable to fetch post rule Uid")
+					}
 					scheduleName = fmt.Sprintf("%s-schedule-%v", BackupNamePrefix, time.Now().Unix())
 					appContextsToBackup := FilterAppContextsByNamespace(scheduledAppContexts, []string{namespace})
 					_, err = CreateScheduleBackupWithValidation(ctx, scheduleName, SourceClusterName, backupLocationName, backupLocationUID, appContextsToBackup, make(map[string]string), BackupOrgID, preRuleNameList[i], preRuleUid, postRuleNameList[i], postRuleUid, periodicSchedulePolicyName, periodicSchedulePolicyUid)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
While running the locked bucket Pipeline I saw that testcase `LockedBucketResizeVolumeOnScheduleBackup` failed with the below error:
```
[backup.glob..func25.2.11:#682] - Unable to fetch post rule Uid. Err: unable to find uid for rule []	
```

This was mostly because the post rule was empty and we were trying to fetch the UID for the same which is now failing with the newest backup APIs. 

Dashboard URL: 
 https://aetos.pwx.purestorage.com/resultSet/testSetID/600571 

**Which issue(s) this PR fixes** (optional)
Closes #PB-6550

**Special notes for your reviewer**:

