### PR TITLE
[PTX-23237]Moving delete node to schedulers

### DIFF
--- a/drivers/node/node.go
+++ b/drivers/node/node.go
@@ -132,7 +132,7 @@ type Driver interface {
 	Init(nodeOpts InitOptions) error
 
 	// DeleteNode deletes the given node
-	DeleteNode(node Node, timeout time.Duration) error
+	//DeleteNode(node Node, timeout time.Duration) error
 
 	// String returns the string name of this driver.
 	String() string

--- a/drivers/scheduler/aks/aks.go
+++ b/drivers/scheduler/aks/aks.go
@@ -413,8 +413,7 @@ func (a *aks) GetAKSCluster() (AKSCluster, error) {
 func (a *aks) DeleteNode(node node.Node) error {
 	log.Infof("Delete node [%s] from node pool [%s]", node.Hostname, a.instanceGroup)
 
-	cmd := fmt.Sprintf("%s aks nodepool delete-machines --resource-group %s --cluster-name %s --nodepool-name %s  --machine-names %s --no-wait --yes", azCli, a.clusterName, a.clusterName, a.instanceGroup, node.Hostname)
-	log.Infof("Running command [%s]", cmd)
+	cmd := fmt.Sprintf("%s aks nodepool delete-machines --resource-group %s --cluster-name %s --nodepool-name %s  --machine-names %s --no-wait", azCli, a.clusterName, a.clusterName, a.instanceGroup, node.Hostname)
 	stdout, stderr, err := osutils.ExecShell(cmd)
 	if err != nil {
 		return fmt.Errorf("failed to delete node [%s] , Err: %v %v %v", node.Hostname, stderr, err, stdout)

--- a/drivers/scheduler/aks/aks.go
+++ b/drivers/scheduler/aks/aks.go
@@ -275,20 +275,6 @@ func (a *aks) AzureLogin() error {
 }
 
 func (a *aks) UpgradeScheduler(version string) error {
-	instanceGroup := os.Getenv("INSTANCE_GROUP")
-	if len(instanceGroup) != 0 {
-		a.instanceGroup = instanceGroup
-	} else {
-		a.instanceGroup = defaultAksInstanceGroupName
-	}
-
-	log.Info("Authenticating with Azure")
-
-	envAzureClusterName := os.Getenv("AZURE_CLUSTER_NAME")
-	if envAzureClusterName == "" {
-		return fmt.Errorf("environment variable AZURE_CLUSTER_NAME is not defined")
-	}
-	a.clusterName = envAzureClusterName
 
 	aksCluster, err := a.GetAKSCluster()
 	if err != nil {
@@ -386,6 +372,22 @@ func (a *aks) UpgradeNodePool(nodePoolName, version string) error {
 // GetAKSCluster Gets and return AKS cluster object
 func (a *aks) GetAKSCluster() (AKSCluster, error) {
 	log.Info("Get AKS cluster object")
+
+	instanceGroup := os.Getenv("INSTANCE_GROUP")
+	if len(instanceGroup) != 0 {
+		a.instanceGroup = instanceGroup
+	} else {
+		a.instanceGroup = defaultAksInstanceGroupName
+	}
+
+	log.Info("Authenticating with Azure")
+
+	envAzureClusterName := os.Getenv("AZURE_CLUSTER_NAME")
+	if envAzureClusterName == "" {
+		return AKSCluster{}, fmt.Errorf("environment variable AZURE_CLUSTER_NAME is not defined")
+	}
+	a.clusterName = envAzureClusterName
+
 	var aksCluster AKSCluster
 
 	t := func() (interface{}, bool, error) {
@@ -411,9 +413,13 @@ func (a *aks) GetAKSCluster() (AKSCluster, error) {
 
 // DeleteNode deletes the given node
 func (a *aks) DeleteNode(node node.Node) error {
+	aksCluster, err := a.GetAKSCluster()
+	if err != nil {
+		return fmt.Errorf("failed to get AKS cluster, Err: %v", err)
+	}
 	log.Infof("Delete node [%s] from node pool [%s]", node.Hostname, a.instanceGroup)
 
-	cmd := fmt.Sprintf("%s aks nodepool delete-machines --resource-group %s --cluster-name %s --nodepool-name %s  --machine-names %s --no-wait", azCli, a.clusterName, a.clusterName, a.instanceGroup, node.Hostname)
+	cmd := fmt.Sprintf("%s aks nodepool delete-machines --resource-group %s --cluster-name %s --nodepool-name %s  --machine-names %s --no-wait", azCli, aksCluster.Name, aksCluster.Name, a.instanceGroup, node.Hostname)
 	stdout, stderr, err := osutils.ExecShell(cmd)
 	if err != nil {
 		return fmt.Errorf("failed to delete node [%s] , Err: %v %v %v", node.Hostname, stderr, err, stdout)

--- a/drivers/scheduler/aks/aks.go
+++ b/drivers/scheduler/aks/aks.go
@@ -3,6 +3,7 @@ package aks
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/portworx/torpedo/drivers/node"
 	"os"
 	"time"
 
@@ -406,6 +407,20 @@ func (a *aks) GetAKSCluster() (AKSCluster, error) {
 
 	log.Infof("Successfully got AKS cluster [%s] object", aksCluster.Name)
 	return aksCluster, nil
+}
+
+// DeleteNode deletes the given node
+func (a *aks) DeleteNode(node node.Node) error {
+	log.Infof("Delete node [%s] from node pool [%s]", node.Hostname, a.instanceGroup)
+
+	cmd := fmt.Sprintf("%s aks nodepool delete-machines --resource-group %s --cluster-name %s --nodepool-name %s  --machine-names %s --no-wait --yes", azCli, a.clusterName, a.clusterName, a.instanceGroup, node.Hostname)
+	log.Infof("Running command [%s]", cmd)
+	stdout, stderr, err := osutils.ExecShell(cmd)
+	if err != nil {
+		return fmt.Errorf("failed to delete node [%s] , Err: %v %v %v", node.Hostname, stderr, err, stdout)
+	}
+	log.Infof("Deleted node [%s] from node pool [%s] successfully", node.Hostname, a.instanceGroup)
+	return nil
 }
 
 // WaitForAKSNodePoolToUpgrade Waits for AKS Node Pool to be upgraded to a specific version

--- a/drivers/scheduler/aks/aks.go
+++ b/drivers/scheduler/aks/aks.go
@@ -411,23 +411,6 @@ func (a *aks) GetAKSCluster() (AKSCluster, error) {
 	return aksCluster, nil
 }
 
-// DeleteNode deletes the given node
-func (a *aks) DeleteNode(node node.Node) error {
-	aksCluster, err := a.GetAKSCluster()
-	if err != nil {
-		return fmt.Errorf("failed to get AKS cluster, Err: %v", err)
-	}
-	log.Infof("Delete node [%s] from node pool [%s]", node.Hostname, a.instanceGroup)
-
-	cmd := fmt.Sprintf("%s aks nodepool delete-machines --resource-group %s --cluster-name %s --nodepool-name %s  --machine-names %s --no-wait", azCli, aksCluster.Name, aksCluster.Name, a.instanceGroup, node.Hostname)
-	stdout, stderr, err := osutils.ExecShell(cmd)
-	if err != nil {
-		return fmt.Errorf("failed to delete node [%s] , Err: %v %v %v", node.Hostname, stderr, err, stdout)
-	}
-	log.Infof("Deleted node [%s] from node pool [%s] successfully", node.Hostname, a.instanceGroup)
-	return nil
-}
-
 // WaitForAKSNodePoolToUpgrade Waits for AKS Node Pool to be upgraded to a specific version
 func (a *aks) WaitForAKSNodePoolToUpgrade(nodePoolName, version string) error {
 	log.Infof("Waiting for AKS Node Pool [%s] to be upgraded to [%s]", nodePoolName, version)
@@ -486,5 +469,22 @@ func (a *aks) WaitForControlPlaneToUpgrade(version string) error {
 		return fmt.Errorf("failed to upgrade AKS Control Plane version to [%s], Err: %v", version, err)
 	}
 	log.Infof("Successfully upgraded AKS Control Plane to [%s]", version)
+	return nil
+}
+
+// DeleteNode deletes the given node
+func (a *aks) DeleteNode(node node.Node) error {
+	aksCluster, err := a.GetAKSCluster()
+	if err != nil {
+		return fmt.Errorf("failed to get AKS cluster, Err: %v", err)
+	}
+	log.Infof("Delete node [%s] from node pool [%s]", node.Hostname, a.instanceGroup)
+
+	cmd := fmt.Sprintf("%s aks nodepool delete-machines --resource-group %s --cluster-name %s --nodepool-name %s  --machine-names %s --no-wait", azCli, aksCluster.Name, aksCluster.Name, a.instanceGroup, node.Hostname)
+	stdout, stderr, err := osutils.ExecShell(cmd)
+	if err != nil {
+		return fmt.Errorf("failed to delete node [%s] , Err: %v %v %v", node.Hostname, stderr, err, stdout)
+	}
+	log.Infof("Deleted node [%s] from node pool [%s] successfully", node.Hostname, a.instanceGroup)
 	return nil
 }

--- a/drivers/scheduler/anthos/anthos.go
+++ b/drivers/scheduler/anthos/anthos.go
@@ -3,6 +3,7 @@ package anthos
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/portworx/torpedo/pkg/errors"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -842,6 +843,14 @@ func getExecPath() (string, error) {
 	envPath := strings.TrimSpace(string(execPath))
 	return fmt.Sprintf("PATH=%s:%s:%s", curWkDir, envPath, gcloudExecPath), nil
 
+}
+
+func (anth *anthos) DeleteNode(node node.Node) error {
+	// TODO: Add implementation
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "DeleteNode()",
+	}
 }
 
 // init registering anthos sheduler

--- a/drivers/scheduler/anthos/anthos.go
+++ b/drivers/scheduler/anthos/anthos.go
@@ -853,6 +853,22 @@ func (anth *anthos) DeleteNode(node node.Node) error {
 	}
 }
 
+func (anth *anthos) GetZones() ([]string, error) {
+	// TODO: Add implementation
+	return nil, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "GetZones()",
+	}
+}
+
+func (anth *anthos) GetASGClusterSize() (int64, error) {
+	// TODO: Add implementation
+	return 0, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "GetASGClusterSize()",
+	}
+}
+
 // init registering anthos sheduler
 func init() {
 	anthos := &anthos{}

--- a/drivers/scheduler/dcos/dcos.go
+++ b/drivers/scheduler/dcos/dcos.go
@@ -910,7 +910,7 @@ func (d *dcos) UpgradeScheduler(version string) error {
 	}
 }
 
-func (d *dcos) DeleteNode(node node.Node, timeout time.Duration) error {
+func (d *dcos) DeleteNode(node node.Node) error {
 	// TODO: Add implementation
 	return &errors.ErrNotSupported{
 		Type:      "Function",
@@ -947,14 +947,6 @@ func (d *dcos) ParseCharts(chartDir string) (*scheduler.HelmRepo, error) {
 	return nil, &errors.ErrNotSupported{
 		Type:      "Function",
 		Operation: "ParseCharts()",
-	}
-}
-
-func (d *dcos) RecycleNode(n node.Node) error {
-	//Recycle is not supported
-	return &errors.ErrNotSupported{
-		Type:      "Function",
-		Operation: "RecycleNode()",
 	}
 }
 

--- a/drivers/scheduler/dcos/dcos.go
+++ b/drivers/scheduler/dcos/dcos.go
@@ -910,11 +910,19 @@ func (d *dcos) UpgradeScheduler(version string) error {
 	}
 }
 
-func (d *dcos) DeleteNode(node node.Node) error {
+func (d *dcos) GetZones() ([]string, error) {
 	// TODO: Add implementation
-	return &errors.ErrNotSupported{
+	return nil, &errors.ErrNotSupported{
 		Type:      "Function",
-		Operation: "DeleteNode()",
+		Operation: "GetZones()",
+	}
+}
+
+func (d *dcos) GetASGClusterSize() (int64, error) {
+	// TODO: Add implementation
+	return 0, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "GetASGClusterSize()",
 	}
 }
 
@@ -1096,6 +1104,14 @@ func (d *dcos) GetNamespaceLabel(namespace string) (map[string]string, error) {
 	return nil, &errors.ErrNotSupported{
 		Type:      "Function",
 		Operation: "GetNamespaceLabel()",
+	}
+}
+
+func (d *dcos) DeleteNode(node node.Node) error {
+	// TODO: Add implementation
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "DeleteNode()",
 	}
 }
 

--- a/drivers/scheduler/dcos/dcos.go
+++ b/drivers/scheduler/dcos/dcos.go
@@ -910,6 +910,14 @@ func (d *dcos) UpgradeScheduler(version string) error {
 	}
 }
 
+func (d *dcos) DeleteNode(node node.Node, timeout time.Duration) error {
+	// TODO: Add implementation
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "DeleteNode()",
+	}
+}
+
 func (d *dcos) CreateSecret(namespace, name, dataField, secretDataString string) error {
 	// TODO: Add implementation
 	return &errors.ErrNotSupported{

--- a/drivers/scheduler/eks/eks.go
+++ b/drivers/scheduler/eks/eks.go
@@ -309,6 +309,14 @@ func (e *EKS) UpgradeScheduler(version string) error {
 	return nil
 }
 
+func (e *EKS) GetZones() ([]string, error) {
+	// TODO: Add implementation
+	return nil, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "GetZones()",
+	}
+}
+
 func (e *EKS) DeleteNode(node node.Node) error {
 	// TODO: Add implementation
 	return &errors.ErrNotSupported{
@@ -317,6 +325,13 @@ func (e *EKS) DeleteNode(node node.Node) error {
 	}
 }
 
+func (e *EKS) GetASGClusterSize() (int64, error) {
+	// TODO: Add implementation
+	return 0, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "GetASGClusterSize()",
+	}
+}
 func init() {
 	e := &EKS{}
 	scheduler.Register(SchedName, e)

--- a/drivers/scheduler/eks/eks.go
+++ b/drivers/scheduler/eks/eks.go
@@ -10,8 +10,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/eks/types"
 	"github.com/portworx/sched-ops/k8s/core"
 	"github.com/portworx/sched-ops/task"
+	"github.com/portworx/torpedo/drivers/node"
 	"github.com/portworx/torpedo/drivers/scheduler"
 	kube "github.com/portworx/torpedo/drivers/scheduler/k8s"
+	"github.com/portworx/torpedo/pkg/errors"
 	"github.com/portworx/torpedo/pkg/log"
 	"os"
 	"strings"
@@ -305,6 +307,14 @@ func (e *EKS) UpgradeScheduler(version string) error {
 	}
 	log.Infof("Successfully finished EKS cluster [%s] upgrade from [%s] to [%s]", e.clusterName, currentVersion, version)
 	return nil
+}
+
+func (e *EKS) DeleteNode(node node.Node) error {
+	// TODO: Add implementation
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "DeleteNode()",
+	}
 }
 
 func init() {

--- a/drivers/scheduler/gke/gke.go
+++ b/drivers/scheduler/gke/gke.go
@@ -115,8 +115,8 @@ func (g *Gke) upgradeGkeNodeGroupVersion(nodeGroup, version string, timeout time
 	return nil
 }
 
-func (g *Gke) DeleteNode(node node.Node, timeout time.Duration) error {
-	if err := g.ops.DeleteInstance(node.Name, node.Zone, timeout); err != nil {
+func (g *Gke) DeleteNode(node node.Node) error {
+	if err := g.ops.DeleteInstance(node.Name, node.Zone, 10*time.Minute); err != nil {
 		return err
 	}
 	return nil

--- a/drivers/scheduler/gke/gke.go
+++ b/drivers/scheduler/gke/gke.go
@@ -78,6 +78,13 @@ func (g *Gke) UpgradeScheduler(version string) error {
 }
 
 func (g *Gke) SetASGClusterSize(perZoneCount int64, timeout time.Duration) error {
+
+	instanceGroup := os.Getenv("INSTANCE_GROUP")
+	if len(instanceGroup) != 0 {
+		g.instanceGroup = instanceGroup
+	} else {
+		g.instanceGroup = "default-pool"
+	}
 	// GCP SDK requires per zone cluster size
 	if err := g.ops.SetInstanceGroupSize(g.instanceGroup, perZoneCount, timeout); err != nil {
 		return fmt.Errorf("failed to set size of node pool %s. Error: %v", g.instanceGroup, err)
@@ -87,6 +94,13 @@ func (g *Gke) SetASGClusterSize(perZoneCount int64, timeout time.Duration) error
 }
 
 func (g *Gke) GetASGClusterSize() (int64, error) {
+
+	instanceGroup := os.Getenv("INSTANCE_GROUP")
+	if len(instanceGroup) != 0 {
+		g.instanceGroup = instanceGroup
+	} else {
+		g.instanceGroup = "default-pool"
+	}
 	nodeCount, err := g.ops.GetInstanceGroupSize(g.instanceGroup)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get size of GKE Node Pool [%s] Err: %v", g.instanceGroup, err)

--- a/drivers/scheduler/iks/iks.go
+++ b/drivers/scheduler/iks/iks.go
@@ -10,8 +10,10 @@ import (
 	"github.com/IBM/go-sdk-core/v5/core"
 	k8sCore "github.com/portworx/sched-ops/k8s/core"
 	"github.com/portworx/sched-ops/task"
+	"github.com/portworx/torpedo/drivers/node"
 	"github.com/portworx/torpedo/drivers/scheduler"
 	kube "github.com/portworx/torpedo/drivers/scheduler/k8s"
+	"github.com/portworx/torpedo/pkg/errors"
 	"github.com/portworx/torpedo/pkg/log"
 	"os"
 	"strings"
@@ -385,6 +387,14 @@ func (i *IKS) UpgradeScheduler(version string) error {
 
 	log.Infof("Successfully upgraded IKS cluster [%s] scheduler and worker pool to version [%s]", i.clusterName, version)
 	return nil
+}
+
+func (i *IKS) DeleteNode(node node.Node) error {
+	// TODO: Add implementation
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "DeleteNode()",
+	}
 }
 
 func init() {

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -7067,6 +7067,22 @@ func (k *K8s) ScaleCluster(replicas int) error {
 	}
 }
 
+func (k *K8s) GetZones() ([]string, error) {
+	// TODO: Add implementation
+	return nil, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "GetZones()",
+	}
+}
+
+func (k *K8s) GetASGClusterSize() (int64, error) {
+	// TODO: Add implementation
+	return 0, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "GetASGClusterSize()",
+	}
+}
+
 // CreateCsiSnapsForVolumes create csi snapshots for Apps
 func (k *K8s) CreateCsiSnapsForVolumes(ctx *scheduler.Context, snapClass string) (map[string]*volsnapv1.VolumeSnapshot, error) {
 	// Only FA (pure_block) volume is supported

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -7018,7 +7018,7 @@ func (k *K8s) UpgradeScheduler(version string) error {
 }
 
 // DeleteNode deletes the given in the cluster
-func (k *K8s) DeleteNode(node node.Node, timeout time.Duration) error {
+func (k *K8s) DeleteNode(node node.Node) error {
 	// TODO: Add implementation
 	return &errors.ErrNotSupported{
 		Type:      "Function",
@@ -7056,15 +7056,6 @@ func (k *K8s) CreateSecret(namespace, name, dataField, secretDataString string) 
 
 	_, err := k8sCore.CreateSecret(secret)
 	return err
-}
-
-// RecycleNode method not supported for K8s scheduler
-func (k *K8s) RecycleNode(n node.Node) error {
-	// Recycle is not supported
-	return &errors.ErrNotSupported{
-		Type:      "Function",
-		Operation: "RecycleNode()",
-	}
 }
 
 // ScaleCluster scale the cluster to the given replicas

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -7017,6 +7017,15 @@ func (k *K8s) UpgradeScheduler(version string) error {
 	}
 }
 
+// DeleteNode deletes the given in the cluster
+func (k *K8s) DeleteNode(node node.Node, timeout time.Duration) error {
+	// TODO: Add implementation
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "DeleteNode()",
+	}
+}
+
 // DeleteSecret deletes secret with given name in given namespace
 func (k *K8s) DeleteSecret(namespace, name string) error {
 	return k8sCore.DeleteSecret(name, namespace)

--- a/drivers/scheduler/oke/oke.go
+++ b/drivers/scheduler/oke/oke.go
@@ -546,7 +546,7 @@ func (o *oke) deleteNodePool(nodePool NodePool) error {
 }
 
 // DeleteNode deletes the given node
-func (o *oke) DeleteNode(node node.Node, timeout time.Duration) error {
+func (o *oke) DeleteNode(node node.Node) error {
 	err := o.configureUser()
 	if err != nil {
 		return err
@@ -563,7 +563,7 @@ func (o *oke) DeleteNode(node node.Node, timeout time.Duration) error {
 	if !ok {
 		return fmt.Errorf("could not retrive oke instance details for %s", node.Hostname)
 	}
-	err = o.ops.DeleteInstance(*oracleInstance.Id, "", timeout)
+	err = o.ops.DeleteInstance(*oracleInstance.Id, "", 10*time.Minute)
 	if err != nil {
 		return err
 	}

--- a/drivers/scheduler/oke/oke.go
+++ b/drivers/scheduler/oke/oke.go
@@ -264,7 +264,7 @@ func (o *oke) configureUser() error {
 			return fmt.Errorf("error in configuring User info in OCI CLI, error %v %v", err, stderr)
 		}
 
-		cmd = fmt.Sprintf("sudo chmod 400 %s", okeConfigFile)
+		cmd = fmt.Sprintf("chmod 400 %s", okeConfigFile)
 		_, stderr, err = osutils.ExecShell(cmd)
 		if err != nil {
 			return fmt.Errorf("error in setting permissions for oci config, error %v %v", err, stderr)
@@ -345,11 +345,7 @@ func (o *oke) GetASGClusterSize() (int64, error) {
 		return 0, err
 
 	}
-	err = o.setCluster()
-	if err != nil {
-		return 0, err
 
-	}
 	nodePool, err := o.getNodePool()
 	if err != nil {
 		return 0, fmt.Errorf("failed to get size of node pool [%s]. Error: %v", o.instanceGroupName, err)
@@ -371,11 +367,6 @@ func (o *oke) GetZones() ([]string, error) {
 func (o *oke) UpgradeScheduler(version string) error {
 
 	err := o.configureUser()
-	if err != nil {
-		return err
-
-	}
-	err = o.setCluster()
 	if err != nil {
 		return err
 
@@ -561,11 +552,7 @@ func (o *oke) DeleteNode(node node.Node, timeout time.Duration) error {
 		return err
 
 	}
-	err = o.setCluster()
-	if err != nil {
-		return err
 
-	}
 	log.Infof("Deleting node [%s]", node.Hostname)
 	instanceDetails, err := o.ops.GetInstance(node.Hostname)
 	if err != nil {

--- a/drivers/scheduler/openshift/openshift.go
+++ b/drivers/scheduler/openshift/openshift.go
@@ -909,7 +909,7 @@ func (k *openshift) getMachinesCount() (int, error) {
 }
 
 // Method to recycling OCP node
-func (k *openshift) RecycleNode(n node.Node) error {
+func (k *openshift) DeleteNode(n node.Node) error {
 	// Check if node is valid before proceeding for delete a node
 	var worker []node.Node = node.GetWorkerNodes()
 	var delNode *api.StorageNode

--- a/drivers/scheduler/rke/rke.go
+++ b/drivers/scheduler/rke/rke.go
@@ -8,6 +8,7 @@ import (
 	"github.com/portworx/torpedo/drivers/node"
 	"github.com/portworx/torpedo/drivers/scheduler"
 	kube "github.com/portworx/torpedo/drivers/scheduler/k8s"
+	"github.com/portworx/torpedo/pkg/errors"
 	"github.com/portworx/torpedo/pkg/log"
 	_ "github.com/rancher/norman/clientbase"
 	rancherClientBase "github.com/rancher/norman/clientbase"
@@ -438,6 +439,15 @@ func (r *Rancher) ChangeProjectForNamespace(projectName string, nsList []string)
 		}
 	}
 	return nil
+}
+
+// DeleteNode deletes the given node
+func (o *Rancher) DeleteNode(node node.Node) error {
+	// TODO implement this method
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "DeleteActionApproval()",
+	}
 }
 
 func init() {

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -438,6 +438,10 @@ type Driver interface {
 
 	// ScaleCluster scale the cluster to the given replicas
 	ScaleCluster(replicas int) error
+	// GetZones get the zones of cluster
+	GetZones() ([]string, error)
+	// GetASGClusterSize gets node count for an asg cluster
+	GetASGClusterSize() (int64, error)
 }
 
 var (

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -367,6 +367,9 @@ type Driver interface {
 	// UpgradeScheduler upgrades the scheduler on the cluster to the specified version
 	UpgradeScheduler(version string) error
 
+	// DeleteNode deletes the given node
+	DeleteNode(node node.Node, timeout time.Duration) error
+
 	// CreateSecret creates new secret with given name in given namespace
 	CreateSecret(namespace, name, dataField, secretDataString string) error
 

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -367,9 +367,6 @@ type Driver interface {
 	// UpgradeScheduler upgrades the scheduler on the cluster to the specified version
 	UpgradeScheduler(version string) error
 
-	// DeleteNode deletes the given node
-	DeleteNode(node node.Node, timeout time.Duration) error
-
 	// CreateSecret creates new secret with given name in given namespace
 	CreateSecret(namespace, name, dataField, secretDataString string) error
 
@@ -380,7 +377,7 @@ type Driver interface {
 	DeleteSecret(namespace, name string) error
 
 	// RecyleNode deletes nodes with given node
-	RecycleNode(n node.Node) error
+	DeleteNode(n node.Node) error
 
 	// CreateCsiSnapshotClass create csi snapshot class
 	CreateCsiSnapshotClass(snapClassName string, deleionPolicy string) (*volsnapv1.VolumeSnapshotClass, error)

--- a/tests/basic/asg_test.go
+++ b/tests/basic/asg_test.go
@@ -249,7 +249,7 @@ func asgKillANodeAndValidate(storageDriverNodes []node.Node) {
 	stepLog := fmt.Sprintf("Deleting node [%v]", nodeToKill.Name)
 	Step(stepLog, func() {
 		log.InfoD(stepLog)
-		err := Inst().N.DeleteNode(nodeToKill, nodeDeleteTimeoutMins)
+		err := Inst().S.DeleteNode(nodeToKill, nodeDeleteTimeoutMins)
 		dash.VerifyFatal(err, nil, fmt.Sprintf("Valdiate node %s deletion", nodeToKill.Name))
 	})
 

--- a/tests/basic/asg_test.go
+++ b/tests/basic/asg_test.go
@@ -253,21 +253,7 @@ func asgKillANodeAndValidate(storageDriverNodes []node.Node) {
 		err := Inst().S.DeleteNode(nodeToKill)
 		dash.VerifyFatal(err, nil, fmt.Sprintf("Valdiate node %s deletion", nodeToKill.Name))
 	})
-
-	if Inst().S.String() == ibm.DriverName {
-
-		err := waitForIBMNodeToDelete(nodeToKill)
-		log.FailOnError(err, "failed to kill node [%s]", nodeToKill.Hostname)
-
-		log.InfoD("Initiating IBM worker pool rebalance")
-		err = Inst().N.RebalanceWorkerPool()
-		log.FailOnError(err, "Failed to rebalance worker pool")
-		log.Infof("Sleeping for 2 mins for new node to start deploying")
-		time.Sleep(2 * time.Minute)
-		err = waitForIBMNodeTODeploy()
-		log.FailOnError(err, "Failed to deploy new worker")
-	}
-
+	
 	waitTime := 10
 	if Inst().S.String() == oke.SchedName {
 		waitTime = 15 // OKE takes more time to replace the node

--- a/tests/basic/asg_test.go
+++ b/tests/basic/asg_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/libopenstorage/openstorage/api"
 	"github.com/portworx/torpedo/drivers/node/ibm"
+	"github.com/portworx/torpedo/drivers/scheduler/oke"
 	"github.com/portworx/torpedo/pkg/log"
 	"math/rand"
 	"time"
@@ -249,11 +250,11 @@ func asgKillANodeAndValidate(storageDriverNodes []node.Node) {
 	stepLog := fmt.Sprintf("Deleting node [%v]", nodeToKill.Name)
 	Step(stepLog, func() {
 		log.InfoD(stepLog)
-		err := Inst().S.DeleteNode(nodeToKill, nodeDeleteTimeoutMins)
+		err := Inst().S.DeleteNode(nodeToKill)
 		dash.VerifyFatal(err, nil, fmt.Sprintf("Valdiate node %s deletion", nodeToKill.Name))
 	})
 
-	if Inst().N.String() == ibm.DriverName {
+	if Inst().S.String() == ibm.DriverName {
 
 		err := waitForIBMNodeToDelete(nodeToKill)
 		log.FailOnError(err, "failed to kill node [%s]", nodeToKill.Hostname)
@@ -267,10 +268,15 @@ func asgKillANodeAndValidate(storageDriverNodes []node.Node) {
 		log.FailOnError(err, "Failed to deploy new worker")
 	}
 
-	stepLog = "Wait for 10 min. to node get replaced by autoscalling group"
+	waitTime := 10
+	if Inst().S.String() == oke.SchedName {
+		waitTime = 15 // OKE takes more time to replace the node
+	}
+
+	stepLog = fmt.Sprintf("Wait for %d min. to node get replaced by autoscalling group", waitTime)
 	Step(stepLog, func() {
 		log.InfoD(stepLog)
-		time.Sleep(10 * time.Minute)
+		time.Sleep(time.Duration(waitTime) * time.Minute)
 	})
 
 	err := Inst().S.RefreshNodeRegistry()

--- a/tests/basic/ocp_node_recycle_test.go
+++ b/tests/basic/ocp_node_recycle_test.go
@@ -2,14 +2,13 @@ package tests
 
 import (
 	"fmt"
-	"github.com/portworx/sched-ops/k8s/operator"
-	"github.com/portworx/torpedo/drivers/scheduler/openshift"
-	"github.com/portworx/torpedo/pkg/log"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/portworx/sched-ops/k8s/operator"
 	"github.com/portworx/torpedo/drivers/node"
 	"github.com/portworx/torpedo/drivers/scheduler"
+	"github.com/portworx/torpedo/drivers/scheduler/openshift"
+	"github.com/portworx/torpedo/pkg/log"
 	. "github.com/portworx/torpedo/tests"
 )
 
@@ -55,7 +54,7 @@ var _ = Describe("{RecycleOCPNode}", func() {
 				Step(
 					fmt.Sprintf("Recycle a storageless node and validating the drives: %s", delNode.Name),
 					func() {
-						err := Inst().S.RecycleNode(delNode)
+						err := Inst().S.DeleteNode(delNode)
 						Expect(err).NotTo(HaveOccurred(),
 							fmt.Sprintf("Failed to recycle a node [%s]. Error: [%v]", delNode.Name, err))
 
@@ -76,7 +75,7 @@ var _ = Describe("{RecycleOCPNode}", func() {
 			Step(
 				fmt.Sprintf("Recycle a storage node: [%s] and validating the drives", delNode.Name),
 				func() {
-					err := Inst().S.RecycleNode(delNode)
+					err := Inst().S.DeleteNode(delNode)
 					Expect(err).NotTo(HaveOccurred(),
 						fmt.Sprintf("Failed to recycle a node [%s]. Error: [%v]", delNode.Name, err))
 				})

--- a/tests/basic/sharedv4_multivol_test.go
+++ b/tests/basic/sharedv4_multivol_test.go
@@ -229,8 +229,8 @@ func sv4KillANodeAndValidate(nodeToKill node.Node) {
 	steplog := fmt.Sprintf("Deleting node [%v]", nodeToKill.Name)
 	Step(steplog, func() {
 		log.InfoD(steplog)
-		log.Infof("Instance is of %v ", Inst().N.String())
-		err := Inst().S.DeleteNode(nodeToKill, nodeDeleteTimeoutMins)
+		log.Infof("Instance is of %v ", Inst().S.String())
+		err := Inst().S.DeleteNode(nodeToKill)
 		dash.VerifyFatal(err, nil, "Validate node delete init")
 	})
 	steplog = fmt.Sprintf("Wait for node: %v to be deleted", nodeToKill.Name)

--- a/tests/basic/sharedv4_multivol_test.go
+++ b/tests/basic/sharedv4_multivol_test.go
@@ -230,7 +230,7 @@ func sv4KillANodeAndValidate(nodeToKill node.Node) {
 	Step(steplog, func() {
 		log.InfoD(steplog)
 		log.Infof("Instance is of %v ", Inst().N.String())
-		err := Inst().N.DeleteNode(nodeToKill, nodeDeleteTimeoutMins)
+		err := Inst().S.DeleteNode(nodeToKill, nodeDeleteTimeoutMins)
 		dash.VerifyFatal(err, nil, "Validate node delete init")
 	})
 	steplog = fmt.Sprintf("Wait for node: %v to be deleted", nodeToKill.Name)

--- a/tests/basic/upgrade_cluster_test.go
+++ b/tests/basic/upgrade_cluster_test.go
@@ -111,22 +111,6 @@ var _ = Describe("{UpgradeCluster}", func() {
 				PrintK8sCluterInfo()
 			})
 
-			Step("validate storage components", func() {
-				urlToParse := fmt.Sprintf("%s/%s", Inst().StorageDriverUpgradeEndpointURL, Inst().StorageDriverUpgradeEndpointVersion)
-				u, err := url.Parse(urlToParse)
-				log.FailOnError(err, fmt.Sprintf("error parsing PX version the url [%s]", urlToParse))
-				err = Inst().V.ValidateDriver(u.String(), true)
-				dash.VerifyFatal(err, nil, fmt.Sprintf("verify volume driver after upgrade to %s", version))
-
-				// Printing cluster node info after the upgrade
-				PrintK8sCluterInfo()
-			})
-
-			// TODO: This currently doesn't work for most distros and commenting out this change, see PTX-22409
-			/*if Inst().S.String() != aks.SchedName {
-				dash.VerifyFatal(mError, nil, "validate no parallel upgrade of nodes")
-			}*/
-
 			Step("update node drive endpoints", func() {
 				// Update NodeRegistry, this is needed as node names and IDs might change after upgrade
 				err = Inst().S.RefreshNodeRegistry()
@@ -139,6 +123,25 @@ var _ = Describe("{UpgradeCluster}", func() {
 				// Printing pxctl status after the upgrade
 				PrintPxctlStatus()
 			})
+
+			Step("validate storage components", func() {
+				urlToParse := fmt.Sprintf("%s/%s", Inst().StorageDriverUpgradeEndpointURL, Inst().StorageDriverUpgradeEndpointVersion)
+				u, err := url.Parse(urlToParse)
+				log.FailOnError(err, fmt.Sprintf("error parsing PX version the url [%s]", urlToParse))
+				err = Inst().V.ValidateDriver(u.String(), true)
+				if err != nil {
+					PrintPxctlStatus()
+				}
+				// Printing cluster node info after the upgrade
+				PrintK8sCluterInfo()
+				dash.VerifyFatal(err, nil, fmt.Sprintf("verify volume driver after upgrade to %s", version))
+
+			})
+
+			// TODO: This currently doesn't work for most distros and commenting out this change, see PTX-22409
+			/*if Inst().S.String() != aks.SchedName {
+				dash.VerifyFatal(mError, nil, "validate no parallel upgrade of nodes")
+			}*/
 
 			Step("validate all apps after upgrade", func() {
 				ValidateApplications(contexts)

--- a/tests/common.go
+++ b/tests/common.go
@@ -8698,7 +8698,7 @@ func AsgKillNode(nodeToKill node.Node) error {
 			})
 
 		} else {
-			err = Inst().N.DeleteNode(nodeToKill, 5*time.Minute)
+			err = Inst().S.DeleteNode(nodeToKill, 5*time.Minute)
 		}
 
 	})

--- a/tests/common.go
+++ b/tests/common.go
@@ -8698,7 +8698,7 @@ func AsgKillNode(nodeToKill node.Node) error {
 			})
 
 		} else {
-			err = Inst().S.DeleteNode(nodeToKill, 5*time.Minute)
+			err = Inst().S.DeleteNode(nodeToKill)
 		}
 
 	})

--- a/tests/common.go
+++ b/tests/common.go
@@ -2633,41 +2633,44 @@ func DescribeNamespace(contexts []*scheduler.Context) {
 // ValidateClusterSize validates number of storage nodes in given cluster
 // using total cluster size `count` and max_storage_nodes_per_zone
 func ValidateClusterSize(count int64) {
-	zones, err := Inst().N.GetZones()
+	zones, err := Inst().S.GetZones()
 	log.FailOnError(err, "Zones empty")
 	log.InfoD("ASG is running in [%+v] zones\n", zones)
-	perZoneCount := count / int64(len(zones))
+
+	volDriverSpec, err := Inst().V.GetDriver()
+	log.FailOnError(err, "error getting storage cluster volDriverSpec")
+	perZoneCount := *volDriverSpec.Spec.CloudStorage.MaxStorageNodesPerZone
 
 	// Validate total node count
-	currentNodeCount, err := Inst().N.GetASGClusterSize()
+	currentNodeCount, err := Inst().S.GetASGClusterSize()
 	log.FailOnError(err, "Failed to Get ASG Cluster Size")
 
-	dash.VerifyFatal(currentNodeCount, perZoneCount*int64(len(zones)), "ASG cluster size is as expected?")
+	dash.VerifyFatal(currentNodeCount, count, "ASG cluster size is as expected?")
 
 	// Validate storage node count
-	var expectedStorageNodesPerZone int
-	if Inst().MaxStorageNodesPerAZ <= int(perZoneCount) {
-		expectedStorageNodesPerZone = Inst().MaxStorageNodesPerAZ
-	} else {
-		expectedStorageNodesPerZone = int(perZoneCount)
+	totalStorageNodesAllowed := int(perZoneCount) * len(zones)
+	expectedStoragesNodes := totalStorageNodesAllowed
+
+	if totalStorageNodesAllowed > int(count) {
+		expectedStoragesNodes = int(count)
 	}
 	storageNodes := node.GetStorageNodes()
-	dash.VerifyFatal(len(storageNodes), expectedStorageNodesPerZone*len(zones), "Storage nodes matches the expected number?")
+	dash.VerifyFatal(len(storageNodes), expectedStoragesNodes, "Storage nodes matches the expected number?")
 }
 
 // GetStorageNodes get storage nodes in the cluster
 func GetStorageNodes() ([]node.Node, error) {
 
-	storageNodes := []node.Node{}
+	var storageNodes []node.Node
 	nodes := node.GetStorageDriverNodes()
 
-	for _, node := range nodes {
-		devices, err := Inst().V.GetStorageDevices(node)
+	for _, n := range nodes {
+		devices, err := Inst().V.GetStorageDevices(n)
 		if err != nil {
 			return nil, err
 		}
 		if len(devices) > 0 {
-			storageNodes = append(storageNodes, node)
+			storageNodes = append(storageNodes, n)
 		}
 	}
 	return storageNodes, nil

--- a/tests/testTriggers.go
+++ b/tests/testTriggers.go
@@ -39,8 +39,6 @@ import (
 	storageapi "k8s.io/api/storage/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/portworx/torpedo/drivers/vcluster"
-	"github.com/portworx/torpedo/pkg/pureutils"
 	"github.com/portworx/torpedo/drivers/backup"
 	"github.com/portworx/torpedo/drivers/monitor/prometheus"
 	"github.com/portworx/torpedo/drivers/node"
@@ -49,6 +47,7 @@ import (
 	"github.com/portworx/torpedo/drivers/scheduler/k8s"
 	"github.com/portworx/torpedo/drivers/scheduler/openshift"
 	"github.com/portworx/torpedo/drivers/scheduler/spec"
+	"github.com/portworx/torpedo/drivers/vcluster"
 	"github.com/portworx/torpedo/drivers/volume"
 	"github.com/portworx/torpedo/pkg/aetosutil"
 	"github.com/portworx/torpedo/pkg/applicationbackup"
@@ -57,6 +56,7 @@ import (
 	"github.com/portworx/torpedo/pkg/email"
 	"github.com/portworx/torpedo/pkg/errors"
 	"github.com/portworx/torpedo/pkg/log"
+	"github.com/portworx/torpedo/pkg/pureutils"
 	"github.com/portworx/torpedo/pkg/stats"
 	"github.com/portworx/torpedo/pkg/units"
 )
@@ -9948,7 +9948,7 @@ func TriggerOCPStorageNodeRecycle(contexts *[]*scheduler.Context, recordChan *ch
 				dashStats := make(map[string]string)
 				dashStats["node"] = delNode.Name
 				updateLongevityStats(OCPStorageNodeRecycle, stats.NodeRecycleEventName, dashStats)
-				err := Inst().S.RecycleNode(delNode)
+				err := Inst().S.DeleteNode(delNode)
 				UpdateOutcome(event, err)
 			})
 		Step(fmt.Sprintf("Listing all nodes after recycling a storage node %s", delNode.Name), func() {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
- Moved DeleteNode, GetZones, GetASGClusterSize functions to schedular driver interface

**Which issue(s) this PR fixes** (optional)
Closes #PTX-23237

**Special notes for your reviewer**:

AKS : https://jenkins.pwx.dev.purestorage.com/view/Leela-monitoring-jobs/job/Torpedo/job/tp-nextpx-aks/676/console
GKE: https://jenkins.pwx.dev.purestorage.com/view/Leela-monitoring-jobs/job/Torpedo/job/tp-nextpx-asggke/821/console
IKS: https://jenkins.pwx.dev.purestorage.com/view/Leela-monitoring-jobs/job/Torpedo/job/tp-nextpx-iks-catalog-pl/272/
OKE: https://jenkins.pwx.dev.purestorage.com/view/Leela-monitoring-jobs/job/Torpedo/job/tp-nextpx-btrfs-oke/128/consoleFull

