### PR TITLE
Fixed the kubevirt tests for NFS backup location

### DIFF
--- a/tests/backup/backup_kubevirt_test.go
+++ b/tests/backup/backup_kubevirt_test.go
@@ -2667,11 +2667,11 @@ var _ = Describe("{KubevirtScheduledVMDelete}", Label(TestCaseLabelsMap[Kubevirt
 				vms, err := GetAllVMsInNamespace(namespace)
 				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying fetching VMs from namespace[%s]", namespace))
 				nonLabelScheduleName = fmt.Sprintf("%s-non-label-schedule-%s", BackupNamePrefix, RandomString(4))
+				scheduleNames = append(scheduleNames, nonLabelScheduleName)
 				_, err = CreateVMScheduledBackupWithValidation(nonLabelScheduleName, vms, SourceClusterName, backupLocationName, backupLocationUID, scheduledAppContexts,
 					labelSelectors, BackupOrgID, sourceClusterUid, "", "", "", "", false, periodicSchedulePolicyName, periodicSchedulePolicyUid, ctx)
 				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation and validation of schedule backup [%s] of namespace", backupPreUpgrade))
 				nonLabelSchNamespaceMap[namespace] = nonLabelScheduleName
-				scheduleNames = append(scheduleNames, nonLabelScheduleName)
 			}
 		})
 
@@ -2683,11 +2683,11 @@ var _ = Describe("{KubevirtScheduledVMDelete}", Label(TestCaseLabelsMap[Kubevirt
 				vms, err := GetAllVMsInNamespace(namespace)
 				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying fetching VMs from namespace[%s]", namespace))
 				labelScheduleName = fmt.Sprintf("%s-label-schedule-%s", BackupNamePrefix, RandomString(4))
+				scheduleNames = append(scheduleNames, labelScheduleName)
 				_, err = CreateVMScheduleBackupWithNamespaceLabelWithValidation(ctx, labelScheduleName, vms, SourceClusterName, backupLocationName, backupLocationUID, scheduledAppContexts,
 					labelSelectors, BackupOrgID, "", "", "", "", nsLabelString, periodicSchedulePolicyName, periodicSchedulePolicyUid, false)
 				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation and validation of schedule backup [%s] with namespace label", labelScheduleName))
 				labelSchNamespaceMap[namespace] = labelScheduleName
-				scheduleNames = append(scheduleNames, labelScheduleName)
 			}
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Few kubevirt tests were failing when running with NFS backup location because the `GetVolumes` function was trying to get all PVCs in the namespace when it finds a spec of type Virtual Machine. In case of NFS, backup creates a pvc for mounting the nfs backup location and even that was being inspected but because it was in terminating state it was failing.

Added logic to exclude the volumes created by px-backup in application namespace.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
https://aetos.pwx.purestorage.com/resultSet/testSetID/602647
Ignore the failed test cases because they have failed because of long running tests which will be fixed in the next PR

