### PR TITLE
DS-8916: Refactoring Templates as per new PDS client

### DIFF
--- a/drivers/pds/parameters/parameters_utils.go
+++ b/drivers/pds/parameters/parameters_utils.go
@@ -180,21 +180,19 @@ type NewPDSParams struct {
 		Iterations     int
 	} `json:"StorageConfigurationsSSIE"`
 	StorageConfiguration struct {
-		FSType         string `json:"FSType"`
-		ReplFactor     int32  `json:"ReplFactor"`
-		StorageRequest string `json:"StorageRequest"`
-		NewStorageSize string `json:"NewStorageSize"`
+		FSType     string `json:"FSType"`
+		ReplFactor int32  `json:"ReplFactor"`
 	} `json:"StorageConfiguration"`
 	ResourceConfiguration struct {
-		CpuLimit      string `json:"CpuLimit"`
-		CpuRequest    string `json:"CpuRequest"`
-		MemoryLimit   string `json:"MemoryLimit"`
-		MemoryRequest string `json:"MemoryRequest"`
+		CpuLimit       string `json:"CpuLimit"`
+		CpuRequest     string `json:"CpuRequest"`
+		MemoryLimit    string `json:"MemoryLimit"`
+		MemoryRequest  string `json:"MemoryRequest"`
+		StorageRequest string `json:"StorageRequest"`
+		NewStorageSize string `json:"NewStorageSize"`
 	} `json:"ResourceConfiguration"`
 	ServiceConfiguration struct {
-		HeapSize int    `json:"HeapSize"`
-		Username string `json:"Username"`
-		Password string `json:"Password"`
+		MaxConnection string `json:"MaxConnection"`
 	} `json:"ServiceConfiguration"`
 	RbacParams struct {
 		RunWithRbac bool   //true

--- a/drivers/unifiedPlatform/automationModels/templateDefinitions.go
+++ b/drivers/unifiedPlatform/automationModels/templateDefinitions.go
@@ -26,8 +26,7 @@ type V1TemplateType struct {
 }
 
 type ListRevisionResponse struct {
-	Meta *Meta         `copier:"must,nopanic"`
-	Info *RevisionInfo `copier:"must,nopanic"`
+	Revisions []Revision
 }
 
 type RevisionInfo struct {

--- a/drivers/unifiedPlatform/automationModels/templates.go
+++ b/drivers/unifiedPlatform/automationModels/templates.go
@@ -10,12 +10,12 @@ type PlatformTemplatesRequest struct {
 }
 
 type PlatformTemplatesResponse struct {
-	Create        V1Template             `copier:"must,nopanic"`
-	List          V1ListTemplateResopnse `copier:"must,nopanic"`
-	ListForTenant V1ListTemplateResopnse `copier:"must,nopanic"`
-	Update        V1Template             `copier:"must,nopanic"`
-	Get           V1Template             `copier:"must,nopanic"`
-	Delete        V1Template             `copier:"must,nopanic"`
+	Create        V1Template              `copier:"must,nopanic"`
+	List          V1ListTemplateResopnse  `copier:"must,nopanic"`
+	ListForTenant V1ListTemplateResopnse  `copier:"must,nopanic"`
+	Update        V1Template              `copier:"must,nopanic"`
+	Get           V1Template              `copier:"must,nopanic"`
+	Delete        DeletePlatformTemplates `copier:"must,nopanic"`
 }
 
 type CreatePlatformTemplates struct {

--- a/drivers/unifiedPlatform/pds/backend/v1/api/templateDefinition.go
+++ b/drivers/unifiedPlatform/pds/backend/v1/api/templateDefinition.go
@@ -106,26 +106,7 @@ func (tempDef *PDS_API_V1) GetTemplateRevisions() (*TemplateDefinitionResponse, 
 	}
 	log.InfoD("Successfully fetched the template Roles")
 	log.Infof("Value of template - [%v]", templateModel)
-	err = utilities.CopyStruct(templateModel, templateResponse)
-	log.Infof("Value of template after copy - [%v]", templateResponse)
-	return &templateResponse, nil
-}
-
-func (tempDef *PDS_API_V1) GetTemplateTypes(tempDefinitionReq *TemplateDefinitionRequest) (*TemplateDefinitionResponse, error) {
-	ctx, client, err := tempDef.getTemplateDefinitionClient()
-	if err != nil {
-		return nil, fmt.Errorf("Error in getting context for api call: %v\n", err)
-	}
-	templateResponse := TemplateDefinitionResponse{}
-	templateGetRequest := tempDefv1.ApiTemplateDefinitionServiceGetTemplateTypeRequest{}
-	templateGetRequest = templateGetRequest.ApiService.TemplateDefinitionServiceGetTemplateType(ctx, tempDefinitionReq.GetType.Id)
-	templateModel, res, err := client.TemplateDefinitionServiceGetTemplateTypeExecute(templateGetRequest)
-	if err != nil && res.StatusCode != status.StatusOK {
-		return nil, fmt.Errorf("Error when calling `TemplateDefinitionServiceGetTemplateType`: %v\n.Full HTTP response: %v", err, res)
-	}
-	log.InfoD("Successfully fetched the template Roles")
-	log.Infof("Value of template - [%v]", templateModel)
-	err = utilities.CopyStruct(templateModel, templateResponse)
+	err = utilities.CopyStruct(templateModel, templateResponse.GetRevision)
 	log.Infof("Value of template after copy - [%v]", templateResponse)
 	return &templateResponse, nil
 }

--- a/drivers/unifiedPlatform/pds/backend/v1/api/templateDefinition.go
+++ b/drivers/unifiedPlatform/pds/backend/v1/api/templateDefinition.go
@@ -84,7 +84,6 @@ func (tempDef *PDS_API_V1) ListTemplateRevisions() (*TemplateDefinitionResponse,
 	var tempRevisionReq tempDefv1.ApiTemplateDefinitionServiceListRevisionsRequest
 	tempRevisionReq = tempRevisionReq.ApiService.TemplateDefinitionServiceListRevisions(ctx)
 	tempRevisions, res, err := client.TemplateDefinitionServiceListRevisionsExecute(tempRevisionReq)
-	log.InfoD("rEVISON IS- [%v]", tempRevisions)
 	if err != nil && res.StatusCode != status.StatusOK {
 		return nil, fmt.Errorf("Error when calling `TemplateDefinitionServiceGetRevision`: %v\n.Full HTTP response: %v", err, res)
 	}

--- a/drivers/unifiedPlatform/pds/backend/v1/api/templateDefinition.go
+++ b/drivers/unifiedPlatform/pds/backend/v1/api/templateDefinition.go
@@ -24,7 +24,7 @@ func (tempDef *PDS_API_V1) ListTemplateKinds() (*TemplateDefinitionResponse, err
 	if err != nil && res.StatusCode != status.StatusOK {
 		return nil, fmt.Errorf("Error when calling `TemplateDefinitionServiceListTemplateKinds`: %v\n.Full HTTP response: %v", err, res)
 	}
-	err = utilities.CopyStruct(&tempDefResponse, templatesList.Kinds)
+	err = utilities.CopyStruct(templatesList, tempDefResponse.ListKinds)
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func (tempDef *PDS_API_V1) ListTemplateTypes() (*TemplateDefinitionResponse, err
 	if err != nil && res.StatusCode != status.StatusOK {
 		return nil, fmt.Errorf("Error when calling `TemplateDefinitionServiceListTemplateTypes`: %v\n.Full HTTP response: %v", err, res)
 	}
-	err = utilities.CopyStruct(&tempDefResponse, templatesList.TemplateTypes)
+	err = utilities.CopyStruct(templatesList, tempDefResponse.ListTypes)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func (tempDef *PDS_API_V1) ListTemplateSamples() (*TemplateDefinitionResponse, e
 	if err != nil && res.StatusCode != status.StatusOK {
 		return nil, fmt.Errorf("Error when calling `TemplateDefinitionServiceListTemplateSamples`: %v\n.Full HTTP response: %v", err, res)
 	}
-	err = utilities.CopyStruct(&tempDefResponse, templatesList.TemplateSamples)
+	err = utilities.CopyStruct(templatesList, tempDefResponse.ListSamples)
 	if err != nil {
 		return nil, err
 	}
@@ -81,13 +81,14 @@ func (tempDef *PDS_API_V1) ListTemplateRevisions() (*TemplateDefinitionResponse,
 	tempDefResponse := TemplateDefinitionResponse{
 		ListRevision: ListRevisionResponse{},
 	}
-	var listRequest tempDefv1.ApiTemplateDefinitionServiceListRevisionsRequest
-	listRequest = listRequest.ApiService.TemplateDefinitionServiceListRevisions(ctx)
-	templatesList, res, err := client.TemplateDefinitionServiceListRevisionsExecute(listRequest)
+	var tempRevisionReq tempDefv1.ApiTemplateDefinitionServiceListRevisionsRequest
+	tempRevisionReq = tempRevisionReq.ApiService.TemplateDefinitionServiceListRevisions(ctx)
+	tempRevisions, res, err := client.TemplateDefinitionServiceListRevisionsExecute(tempRevisionReq)
+	log.InfoD("rEVISON IS- [%v]", tempRevisions)
 	if err != nil && res.StatusCode != status.StatusOK {
-		return nil, fmt.Errorf("Error when calling `TemplateDefinitionServiceListRevisions`: %v\n.Full HTTP response: %v", err, res)
+		return nil, fmt.Errorf("Error when calling `TemplateDefinitionServiceGetRevision`: %v\n.Full HTTP response: %v", err, res)
 	}
-	err = utilities.CopyStruct(&tempDefResponse, templatesList.Revisions)
+	err = utilities.CopyStruct(tempRevisions, &tempDefResponse.ListRevision)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +107,7 @@ func (tempDef *PDS_API_V1) GetTemplateRevisions() (*TemplateDefinitionResponse, 
 	}
 	log.InfoD("Successfully fetched the template Roles")
 	log.Infof("Value of template - [%v]", templateModel)
-	err = utilities.CopyStruct(&templateResponse, templateModel)
+	err = utilities.CopyStruct(templateModel, templateResponse)
 	log.Infof("Value of template after copy - [%v]", templateResponse)
 	return &templateResponse, nil
 }
@@ -125,7 +126,7 @@ func (tempDef *PDS_API_V1) GetTemplateTypes(tempDefinitionReq *TemplateDefinitio
 	}
 	log.InfoD("Successfully fetched the template Roles")
 	log.Infof("Value of template - [%v]", templateModel)
-	err = utilities.CopyStruct(&templateResponse, templateModel)
+	err = utilities.CopyStruct(templateModel, templateResponse)
 	log.Infof("Value of template after copy - [%v]", templateResponse)
 	return &templateResponse, nil
 }

--- a/drivers/unifiedPlatform/pdsLibs/templateDefinitionLib.go
+++ b/drivers/unifiedPlatform/pdsLibs/templateDefinitionLib.go
@@ -80,7 +80,6 @@ func CreateStorageConfigTemplate(tenantId string, dsName string, templateConfigs
 }
 
 func CreateResourceConfigTemplate(tenantId string, dsName string, templateConfigs ResourceConfiguration) (*automationModels.PlatformTemplatesResponse, error) {
-	log.InfoD("DSNAME fetched is- [%v]", dsName)
 	revisionUid, err := GetRevisionUidForApplication(dsName)
 	templateName := "pdsAutoResTemp" + utilities.RandomString(5)
 	templateValue := structToMap(templateConfigs)

--- a/drivers/unifiedPlatform/pdsLibs/templateDefinitionLib.go
+++ b/drivers/unifiedPlatform/pdsLibs/templateDefinitionLib.go
@@ -7,6 +7,7 @@ import (
 	"github.com/portworx/torpedo/pkg/log"
 	"reflect"
 	"strings"
+)
 
 type StorageConfiguration struct {
 	FSType     string
@@ -148,27 +149,4 @@ func structToMap(structType interface{}) map[string]interface{} {
 	}
 	log.InfoD("templateValue formed is- [%v]", result)
 	return result
-}
-
-func UpdateAppStorageAndFetchIds(templates *parameters.NewPDSParams, tenantId string) (string, error) {
-
-	//Todo: Mechanism to populate dynamic/Unknown key-value pairs for App config
-	//ToDo: Take configurationValue incrementation count from user/testcase
-
-	resConfigParams := ResourceConfiguration{
-		CpuLimit:       templates.ResourceConfiguration.CpuLimit,
-		CpuRequest:     templates.ResourceConfiguration.CpuRequest,
-		MemoryLimit:    templates.ResourceConfiguration.MemoryLimit,
-		MemoryRequest:  templates.ResourceConfiguration.MemoryRequest,
-		StorageRequest: templates.StorageConfiguration.StorageRequest,
-		NewStorageSize: templates.StorageConfiguration.NewStorageSize,
-	}
-	//create new templates with new storage Req-
-	newStorageReq, _ := strconv.Atoi(templates.StorageConfiguration.NewStorageSize)
-	templates.StorageConfiguration.StorageRequest = fmt.Sprint(string(rune(newStorageReq+1))) + "G"
-
-	resConfig, _ := CreateResourceConfigTemplate(tenantId, resConfigParams)
-	log.InfoD("resConfig ID-  %v", *resConfig.Create.Meta.Uid)
-	resourceConfigId := resConfig.Create.Meta.Uid
-	return *resourceConfigId, nil
 }

--- a/drivers/unifiedPlatform/pdsLibs/templateDefinitionLib.go
+++ b/drivers/unifiedPlatform/pdsLibs/templateDefinitionLib.go
@@ -5,18 +5,12 @@ import (
 	"github.com/portworx/torpedo/drivers/utilities"
 	"github.com/portworx/torpedo/pkg/log"
 	"reflect"
-)
-
-const (
-	defaultPXProvisioner = "pxd.portworx.com"
-	defaultVolGroup      = false
-	defaultVolSecure     = false
+	"strings"
 )
 
 type StorageConfiguration struct {
-	FSType      string
-	ReplFactor  int32
-	Provisioner string
+	FSType     string
+	ReplFactor int32
 }
 type ResourceConfiguration struct {
 	CpuLimit       string
@@ -27,35 +21,24 @@ type ResourceConfiguration struct {
 	NewStorageSize string
 }
 type ServiceConfiguration struct {
-	HeapSize int
-	Username string
-	Password string
+	MaxConnection string
 }
 
-func CreateServiceConfigTemplate(tenantId string, serviceConfig ServiceConfiguration) (*automationModels.PlatformTemplatesResponse, error) {
-	//revisionUid, err := GetRevisionUidForApplication() PDS APIs not Available
-	//templateKind, err := GetTemplateKind()
-
-	//Dummy values for testing
-	revisionUid := utilities.RandomString(12)
-	templateKind := utilities.RandomString(12)
+func CreateServiceConfigTemplate(tenantId string, dsName string, serviceConfig ServiceConfiguration) (*automationModels.PlatformTemplatesResponse, error) {
+	log.InfoD("DSNAME fetched is- [%v]", dsName)
+	revisionUid, err := GetRevisionUidForApplication(dsName)
 	templateName := "pdsAutoSVCTemp" + utilities.RandomString(5)
 
 	keyValue := ServiceConfiguration{
-		HeapSize: serviceConfig.HeapSize,
-		Username: serviceConfig.Username,
-		Password: serviceConfig.Password,
+		MaxConnection: serviceConfig.MaxConnection,
 	}
 	templateValue := structToMap(keyValue)
-	if err != nil {
-		return nil, err
-	}
+	log.InfoD("Tenant is- [%v]", tenantId)
 	createReq := automationModels.PlatformTemplatesRequest{Create: automationModels.CreatePlatformTemplates{
 		TenantId: tenantId,
 		Template: &automationModels.V1Template{
 			Meta: &automationModels.V1Meta{Name: &templateName},
 			Config: &automationModels.V1Config{
-				Kind:           &templateKind,
 				RevisionUid:    &revisionUid,
 				TemplateValues: templateValue,
 			},
@@ -69,24 +52,12 @@ func CreateServiceConfigTemplate(tenantId string, serviceConfig ServiceConfigura
 	return templateResponse, nil
 }
 
-func CreateStorageConfigTemplate(tenantId string, templateConfigs StorageConfiguration) (*automationModels.PlatformTemplatesResponse, error) {
-	//PDS APIs not Available
-	//templateKind, err := GetTemplateKind()
-	//semanticVersion, err := GetSemanticVersion()
+func CreateStorageConfigTemplate(tenantId string, dsName string, templateConfigs StorageConfiguration) (*automationModels.PlatformTemplatesResponse, error) {
+	revisionUid, err := GetRevisionUidForApplication(dsName)
+	templateName := "pdsAutoSVCTemp" + utilities.RandomString(5)
 
-	//Dummy values for testing
-	semanticVersion := utilities.RandomString(12)
-	templateKind := utilities.RandomString(12)
-
-	var templateValue map[string]interface{}
-	templateValue["fs"] = templateConfigs.FSType
-	templateValue["repl"] = templateConfigs.ReplFactor
-	templateValue["provisioner"] = defaultPXProvisioner
-	templateValue["fg"] = defaultVolGroup
-	templateValue["secure"] = defaultVolSecure
-
-	templateName := "pdsAutoStTemp" + utilities.RandomString(5)
-	log.InfoD("Temp value formed in lib folder is- [%v]", templateValue)
+	templateValue := structToMap(templateConfigs)
+	log.InfoD("Temp value fromed in lib folder is- [%v]", templateValue)
 	if err != nil {
 		return nil, err
 	}
@@ -95,9 +66,8 @@ func CreateStorageConfigTemplate(tenantId string, templateConfigs StorageConfigu
 		Template: &automationModels.V1Template{
 			Meta: &automationModels.V1Meta{Name: &templateName},
 			Config: &automationModels.V1Config{
-				Kind:            &templateKind,
-				SemanticVersion: &semanticVersion,
-				TemplateValues:  templateValue,
+				TemplateValues: templateValue,
+				RevisionUid:    &revisionUid,
 			},
 		},
 	}}
@@ -109,23 +79,11 @@ func CreateStorageConfigTemplate(tenantId string, templateConfigs StorageConfigu
 	return templateResponse, nil
 }
 
-func CreateResourceConfigTemplate(tenantId string, templateConfigs ResourceConfiguration) (*automationModels.PlatformTemplatesResponse, error) {
-	//PDS APIs not Available
-	//templateKind, err := GetTemplateKind()
-	//semanticVersion, err := GetSemanticVersion()
-
-	//Dummy values for testing
-	semanticVersion := utilities.RandomString(12)
-	templateKind := utilities.RandomString(12)
+func CreateResourceConfigTemplate(tenantId string, dsName string, templateConfigs ResourceConfiguration) (*automationModels.PlatformTemplatesResponse, error) {
+	log.InfoD("DSNAME fetched is- [%v]", dsName)
+	revisionUid, err := GetRevisionUidForApplication(dsName)
 	templateName := "pdsAutoResTemp" + utilities.RandomString(5)
-
-	var templateValue map[string]interface{}
-	templateValue["cpu_limit"] = templateConfigs.CpuLimit
-	templateValue["cpu_request"] = templateConfigs.CpuRequest
-	templateValue["memory_limit"] = templateConfigs.MemoryLimit
-	templateValue["memory_request"] = templateConfigs.MemoryRequest
-	templateValue["storage_request"] = templateConfigs.StorageRequest
-
+	templateValue := structToMap(templateConfigs)
 	if err != nil {
 		return nil, err
 	}
@@ -134,9 +92,8 @@ func CreateResourceConfigTemplate(tenantId string, templateConfigs ResourceConfi
 		Template: &automationModels.V1Template{
 			Meta: &automationModels.V1Meta{Name: &templateName},
 			Config: &automationModels.V1Config{
-				Kind:            &templateKind,
-				SemanticVersion: &semanticVersion,
-				TemplateValues:  templateValue,
+				RevisionUid:    &revisionUid,
+				TemplateValues: templateValue,
 			},
 			Status: nil,
 		},
@@ -151,38 +108,30 @@ func CreateResourceConfigTemplate(tenantId string, templateConfigs ResourceConfi
 
 func DeleteTemplate(id string) error {
 	delReq := automationModels.PlatformTemplatesRequest{Delete: automationModels.DeletePlatformTemplates{Id: id}}
+	log.InfoD("Template to be deleted is- [%v]", id)
 	templateResponse := v2Components.Platform.DeleteTemplate(&delReq)
 	if err != nil {
 		return templateResponse
 	}
 	return nil
 }
-func GetRevisionUidForApplication() (string, error) {
-	revision, err := v2Components.PDS.GetTemplateRevisions()
+
+func GetRevisionUidForApplication(dsName string) (string, error) {
+	revisionList, err := v2Components.PDS.ListTemplateRevisions()
+	var revisionUid string
 	if err != nil {
 		return "", err
 	}
-	revisionUuid := revision.GetRevision.Meta.Uid
-	return *revisionUuid, nil
-
-}
-
-func GetSemanticVersion() (string, error) {
-	semantic, err := v2Components.PDS.GetTemplateRevisions()
-	if err != nil {
-		return "", err
+	for _, revision := range revisionList.ListRevision.Revisions {
+		mainStringLower := strings.ToLower(*revision.Meta.Name)
+		subStringLower := strings.ToLower(dsName)
+		if strings.Contains(mainStringLower, subStringLower) {
+			revisionUid = *revision.Meta.Uid
+		}
 	}
-	semanticVersion := semantic.GetRevision.Info.SemanticVersion
-	return semanticVersion, nil
-}
+	log.InfoD("RevisionUid for the ds under test [%v] is- [%v]", dsName, revisionUid)
+	return revisionUid, nil
 
-func GetTemplateKind() (string, error) {
-	semantic, err := v2Components.PDS.GetTemplateRevisions()
-	if err != nil {
-		return "", err
-	}
-	kind := semantic.GetRevision.Meta.Name
-	return *kind, nil
 }
 
 func structToMap(structType interface{}) map[string]interface{} {
@@ -193,10 +142,7 @@ func structToMap(structType interface{}) map[string]interface{} {
 		field := val.Field(i)
 		key := typ.Field(i).Name
 		value := field.Interface()
-		log.InfoD("templateValue key is- [KEY- %v]", key)
-		log.InfoD("templateValue value is- [KEY- %v]", value)
 		result[key] = value
-		log.InfoD("templateValue key-value pair formed is- [%v]", result)
 	}
 	log.InfoD("templateValue formed is- [%v]", result)
 	return result

--- a/drivers/unifiedPlatform/platform/backend/v1/api/templates.go
+++ b/drivers/unifiedPlatform/platform/backend/v1/api/templates.go
@@ -134,14 +134,13 @@ func (template *PLATFORM_API_V1) DeleteTemplate(templateReq *PlatformTemplatesRe
 	if err != nil {
 		return fmt.Errorf("Error in getting context for api call: %v\n", err)
 	}
-	templateResponse := PlatformTemplatesResponse{}
-	templateModel, res, err := templateClient.TemplateServiceDeleteTemplate(ctx, templateReq.Delete.Id).Execute()
-	if err != nil && res.StatusCode != status.StatusOK {
-		return fmt.Errorf("Error when calling `templateServiceDeletetemplateExecute`: %v\n.Full HTTP response: %v", err, res)
+	templateResponse := PlatformTemplatesResponse{Delete: DeletePlatformTemplates{}}
+	templateDelRequest := templateClient.TemplateServiceDeleteTemplate(ctx, templateReq.Delete.Id)
+	log.InfoD("Template create req formed is- %v", templateDelRequest)
+	templateModel, res, err := templateDelRequest.Execute()
+	if err != nil || res.StatusCode != status.StatusOK {
+		return fmt.Errorf("Error when calling `TemplateServiceCreateTemplateExecute`: %v\n.Full HTTP response: %v", err, res)
 	}
-	log.InfoD("Successfully DELETED the template Roles")
-	log.Infof("Value of template - [%v]", templateModel)
-	err = utilities.CopyStruct(templateModel, &templateResponse)
-	log.Infof("Value of template after copy - [%v]", templateResponse)
+	err = utilities.CopyStruct(templateModel, &templateResponse.Create)
 	return nil
 }

--- a/drivers/unifiedPlatform/platform/backend/v1/api/templates.go
+++ b/drivers/unifiedPlatform/platform/backend/v1/api/templates.go
@@ -70,16 +70,12 @@ func (template *PLATFORM_API_V1) CreateTemplates(templateReq *PlatformTemplatesR
 			TemplateValues:  templateReq.Create.Template.Config.TemplateValues,
 		},
 	}
-	log.InfoD("tenantID fetched is- %v", templateReq.Create.TenantId)
 	templateCreateRequest := client.TemplateServiceCreateTemplate(ctx, templateReq.Create.TenantId)
 	templateCreateRequest = templateCreateRequest.V1Template(tempValueBody)
-	log.InfoD("Template create req formed is- %v", templateCreateRequest)
 	templateModel, res, err := templateCreateRequest.Execute()
 	if err != nil || res.StatusCode != status.StatusOK {
 		return nil, fmt.Errorf("Error when calling `TemplateServiceCreateTemplateExecute`: %v\n.Full HTTP response: %v", err, res)
 	}
-	log.InfoD("response got is- %v", *templateModel)
-	log.InfoD("App config ID- %v", *templateModel.Meta.Uid)
 	err = utilities.CopyStruct(templateModel, &templateResponse.Create)
 	return &templateResponse, err
 }

--- a/drivers/unifiedPlatform/stworkflows/pds/workflowTemplates.go
+++ b/drivers/unifiedPlatform/stworkflows/pds/workflowTemplates.go
@@ -53,32 +53,6 @@ func (cusTemp *CustomTemplates) CreatePdsCustomTemplatesAndFetchIds(templates *p
 	return *appConfigId, *stConfigId, *resourceConfigId, nil
 }
 
-func (cusTemp *CustomTemplates) IncreaseStorageAndFetchIds(templates *parameters.NewPDSParams) (string, error) {
-
-	//Todo: Mechanism to populate dynamic/Unknown key-value pairs for App config
-	//ToDo: Take configurationValue incrementation count from user/testcase
-
-	//Initializing the parameters required for template generation
-	resConfigParams := pdslibs.ResourceConfiguration{
-		CpuLimit:       templates.ResourceConfiguration.CpuLimit,
-		CpuRequest:     templates.ResourceConfiguration.CpuRequest,
-		MemoryLimit:    templates.ResourceConfiguration.MemoryLimit,
-		MemoryRequest:  templates.ResourceConfiguration.MemoryRequest,
-		StorageRequest: templates.StorageConfiguration.StorageRequest,
-		NewStorageSize: templates.StorageConfiguration.NewStorageSize,
-	}
-
-	//create new templates with new storage Req-
-	newStorageReq, _ := strconv.Atoi(templates.StorageConfiguration.NewStorageSize)
-	templates.StorageConfiguration.StorageRequest = fmt.Sprint(string(rune(newStorageReq+1))) + "G"
-
-	resConfig, _ := pdslibs.CreateResourceConfigTemplate(cusTemp.Platform.TenantId, resConfigParams)
-	log.InfoD("resConfig ID-  %v", *resConfig.Create.Meta.Uid)
-	resourceConfigId := resConfig.Create.Meta.Uid
-	cusTemp.ResourceTemplateId = *resourceConfigId
-	return *resourceConfigId, nil
-}
-
 func (cusTemp *CustomTemplates) DeleteCreatedCustomPdsTemplates(tempList []string) error {
 	for _, id := range tempList {
 		err := pdslibs.DeleteTemplate(id)

--- a/drivers/unifiedPlatform/stworkflows/pds/workflowTemplates.go
+++ b/drivers/unifiedPlatform/stworkflows/pds/workflowTemplates.go
@@ -16,16 +16,14 @@ type CustomTemplates struct {
 	ServiceConfigTemplateId string
 }
 
-func (cusTemp *CustomTemplates) CreatePdsCustomTemplatesAndFetchIds(templates *parameters.NewPDSParams, updateTemplate bool) (string, string, string, error) {
+func (cusTemp *CustomTemplates) CreatePdsCustomTemplatesAndFetchIds(templates *parameters.NewPDSParams, dsName string) (string, string, string, error) {
 
 	//Todo: Mechanism to populate dynamic/Unknown key-value pairs for App config
 	//ToDo: Take configurationValue incrementation count from user/testcase
 
 	//Initializing the parameters required for template generation
 	appConfigParams := pdslibs.ServiceConfiguration{
-		HeapSize: templates.ServiceConfiguration.HeapSize,
-		Username: templates.ServiceConfiguration.Username,
-		Password: templates.ServiceConfiguration.Password,
+		MaxConnection: templates.ServiceConfiguration.MaxConnection,
 	}
 	stConfigParams := pdslibs.StorageConfiguration{
 		FSType:     templates.StorageConfiguration.FSType,
@@ -36,40 +34,23 @@ func (cusTemp *CustomTemplates) CreatePdsCustomTemplatesAndFetchIds(templates *p
 		CpuRequest:     templates.ResourceConfiguration.CpuRequest,
 		MemoryLimit:    templates.ResourceConfiguration.MemoryLimit,
 		MemoryRequest:  templates.ResourceConfiguration.MemoryRequest,
-		StorageRequest: templates.StorageConfiguration.StorageRequest,
-		NewStorageSize: templates.StorageConfiguration.NewStorageSize,
+		StorageRequest: templates.ResourceConfiguration.StorageRequest,
+		NewStorageSize: templates.ResourceConfiguration.NewStorageSize,
 	}
-	if updateTemplate {
-		//create new templates with changed values of CPU Values -
-		newCpuLimits, _ := strconv.Atoi(templates.ResourceConfiguration.CpuLimit)
-		templates.ResourceConfiguration.CpuLimit = fmt.Sprint(string(rune(newCpuLimits + 1)))
-		newCpuReq, _ := strconv.Atoi(templates.ResourceConfiguration.CpuLimit)
-		templates.ResourceConfiguration.CpuRequest = fmt.Sprint(string(rune(newCpuReq + 1)))
-
-		//create new templates with changed values of MEM Values -
-		newMemLimits, _ := strconv.Atoi(templates.ResourceConfiguration.MemoryLimit)
-		templates.ResourceConfiguration.MemoryLimit = fmt.Sprint(string(rune(newMemLimits + 1)))
-		newMemReq, _ := strconv.Atoi(templates.ResourceConfiguration.MemoryLimit)
-		templates.ResourceConfiguration.MemoryRequest = fmt.Sprint(string(rune(newMemReq + 1)))
-
-		//create new templates with new storage Req-
-		newStorageReq, _ := strconv.Atoi(templates.StorageConfiguration.NewStorageSize)
-		templates.StorageConfiguration.StorageRequest = fmt.Sprint(string(rune(newStorageReq+1))) + "G"
-	}
-	appConfig, _ := pdslibs.CreateServiceConfigTemplate(cusTemp.Platform.TenantId, appConfigParams)
+	appConfig, _ := pdslibs.CreateServiceConfigTemplate(cusTemp.Platform.TenantId, dsName, appConfigParams)
 	log.InfoD("appConfig ID-  %v", *appConfig.Create.Meta.Uid)
 	appConfigId := appConfig.Create.Meta.Uid
 	cusTemp.ServiceConfigTemplateId = *appConfigId
 
-	stConfig, _ := pdslibs.CreateStorageConfigTemplate(cusTemp.Platform.TenantId, stConfigParams)
+	stConfig, _ := pdslibs.CreateStorageConfigTemplate(cusTemp.Platform.TenantId, dsName, stConfigParams)
 	log.InfoD("stConfig ID-  %v", *stConfig.Create.Meta.Uid)
 	stConfigId := stConfig.Create.Meta.Uid
 	cusTemp.StorageTemplateId = *stConfigId
 
-	resConfig, _ := pdslibs.CreateResourceConfigTemplate(cusTemp.Platform.TenantId, resConfigParams)
+	resConfig, _ := pdslibs.CreateResourceConfigTemplate(cusTemp.Platform.TenantId, dsName, resConfigParams)
 	log.InfoD("resConfig ID-  %v", *resConfig.Create.Meta.Uid)
 	resourceConfigId := resConfig.Create.Meta.Uid
-	cusTemp.ResourceTemplateId = *stConfigId
+	cusTemp.ResourceTemplateId = *resourceConfigId
 	return *appConfigId, *stConfigId, *resourceConfigId, nil
 }
 
@@ -81,4 +62,34 @@ func (cusTemp *CustomTemplates) DeleteCreatedCustomPdsTemplates(tempList []strin
 		}
 	}
 	return nil
+}
+
+func (cusTemp *CustomTemplates) CreateResourceTemplateWithCustomValue(templates *parameters.NewPDSParams, dsName string, updateValue int) (string, error) {
+	resConfigParams := pdslibs.ResourceConfiguration{
+		CpuLimit:       templates.ResourceConfiguration.CpuLimit,
+		CpuRequest:     templates.ResourceConfiguration.CpuRequest,
+		MemoryLimit:    templates.ResourceConfiguration.MemoryLimit,
+		MemoryRequest:  templates.ResourceConfiguration.MemoryRequest,
+		StorageRequest: templates.ResourceConfiguration.StorageRequest,
+		NewStorageSize: templates.ResourceConfiguration.NewStorageSize,
+	}
+	newCpuLimits, _ := strconv.Atoi(templates.ResourceConfiguration.CpuLimit)
+	templates.ResourceConfiguration.CpuLimit = fmt.Sprint(string(rune(newCpuLimits + updateValue)))
+	newCpuReq, _ := strconv.Atoi(templates.ResourceConfiguration.CpuLimit)
+	templates.ResourceConfiguration.CpuRequest = fmt.Sprint(string(rune(newCpuReq + updateValue)))
+
+	//create new templates with changed values of MEM Values -
+	newMemLimits, _ := strconv.Atoi(templates.ResourceConfiguration.MemoryLimit)
+	templates.ResourceConfiguration.MemoryLimit = fmt.Sprint(string(rune(newMemLimits + updateValue)))
+	newMemReq, _ := strconv.Atoi(templates.ResourceConfiguration.MemoryLimit)
+	templates.ResourceConfiguration.MemoryRequest = fmt.Sprint(string(rune(newMemReq + updateValue)))
+
+	//create new templates with new storage Req-
+	newStorageReq, _ := strconv.Atoi(templates.ResourceConfiguration.NewStorageSize)
+	templates.ResourceConfiguration.StorageRequest = fmt.Sprint(string(rune(newStorageReq+1))) + "G"
+	resConfig, _ := pdslibs.CreateResourceConfigTemplate(cusTemp.Platform.TenantId, dsName, resConfigParams)
+	log.InfoD("resConfig ID-  %v", *resConfig.Create.Meta.Uid)
+	resourceConfigId := resConfig.Create.Meta.Uid
+	cusTemp.ResourceTemplateId = *resourceConfigId
+	return *resourceConfigId, nil
 }

--- a/drivers/unifiedPlatform/stworkflows/pds/workflowTemplates.go
+++ b/drivers/unifiedPlatform/stworkflows/pds/workflowTemplates.go
@@ -19,7 +19,6 @@ type CustomTemplates struct {
 func (cusTemp *CustomTemplates) CreatePdsCustomTemplatesAndFetchIds(templates *parameters.NewPDSParams, dsName string) (string, string, string, error) {
 
 	//Todo: Mechanism to populate dynamic/Unknown key-value pairs for App config
-	//ToDo: Take configurationValue incrementation count from user/testcase
 
 	//Initializing the parameters required for template generation
 	appConfigParams := pdslibs.ServiceConfiguration{

--- a/tests/unifiedPlatform/pds2/pds_dataservice_test.go
+++ b/tests/unifiedPlatform/pds2/pds_dataservice_test.go
@@ -34,16 +34,18 @@ var _ = Describe("{DeployDataServicesOnDemandAndScaleUp}", func() {
 			log.Infof("Namespaces created - [%s]", workflowNamespace.Namespaces)
 			log.Infof("Namespace id - [%s]", workflowNamespace.Namespaces[Namespace])
 
-			serviceConfigId, stConfigId, resConfigId, err := workFlowTemplates.CreatePdsCustomTemplatesAndFetchIds(NewPdsParams, false)
-			log.FailOnError(err, "Unable to create Custom Templates for PDS")
-			workflowDataservice.PDSTemplates.ServiceConfigTemplateId = serviceConfigId
-			workflowDataservice.PDSTemplates.StorageTemplateId = stConfigId
-			workflowDataservice.PDSTemplates.ResourceTemplateId = resConfigId
 		})
 
 		for _, ds := range NewPdsParams.DataServiceToTest {
 			workflowDataservice.Namespace = WorkflowNamespace
 			workflowDataservice.NamespaceName = Namespace
+
+			serviceConfigId, stConfigId, resConfigId, err := workFlowTemplates.CreatePdsCustomTemplatesAndFetchIds(NewPdsParams, ds.Name)
+			log.FailOnError(err, "Unable to create Custom Templates for PDS")
+			workflowDataservice.PDSTemplates.ServiceConfigTemplateId = serviceConfigId
+			workflowDataservice.PDSTemplates.StorageTemplateId = stConfigId
+			workflowDataservice.PDSTemplates.ResourceTemplateId = resConfigId
+
 			deployment, err = workflowDataservice.DeployDataService(ds, ds.Image, ds.Version)
 			log.FailOnError(err, "Error while deploying ds")
 			log.Debugf("Source Deployment Id: [%s]", *deployment.Create.Meta.Uid)
@@ -93,7 +95,6 @@ var _ = Describe("{UpgradeDataServiceImageAndVersion}", func() {
 		workflowDataservice pds.WorkflowDataService
 		workFlowTemplates   pds.CustomTemplates
 		deployment          *automationModels.PDSDeploymentResponse
-		err                 error
 	)
 
 	It("Deploy and Validate DataService", func() {
@@ -107,16 +108,18 @@ var _ = Describe("{UpgradeDataServiceImageAndVersion}", func() {
 			log.Infof("Namespaces created - [%s]", workflowNamespace.Namespaces)
 			log.Infof("Namespace id - [%s]", workflowNamespace.Namespaces[Namespace])
 
-			serviceConfigId, stConfigId, resConfigId, err := workFlowTemplates.CreatePdsCustomTemplatesAndFetchIds(NewPdsParams, false)
-			log.FailOnError(err, "Unable to create Custom Templates for PDS")
-			workflowDataservice.PDSTemplates.ServiceConfigTemplateId = serviceConfigId
-			workflowDataservice.PDSTemplates.StorageTemplateId = stConfigId
-			workflowDataservice.PDSTemplates.ResourceTemplateId = resConfigId
 		})
 
 		for _, ds := range NewPdsParams.DataServiceToTest {
 			workflowDataservice.Namespace = WorkflowNamespace
 			workflowDataservice.NamespaceName = Namespace
+
+			serviceConfigId, stConfigId, resConfigId, err := workFlowTemplates.CreatePdsCustomTemplatesAndFetchIds(NewPdsParams, ds.Name)
+			log.FailOnError(err, "Unable to create Custom Templates for PDS")
+			workflowDataservice.PDSTemplates.ServiceConfigTemplateId = serviceConfigId
+			workflowDataservice.PDSTemplates.StorageTemplateId = stConfigId
+			workflowDataservice.PDSTemplates.ResourceTemplateId = resConfigId
+
 			deployment, err = workflowDataservice.DeployDataService(ds, ds.OldImage, ds.OldVersion)
 			log.FailOnError(err, "Error while deploying ds")
 		}
@@ -178,23 +181,23 @@ var _ = Describe("{ScaleUpCpuMemLimitsOfDS}", func() {
 			log.Infof("Namespace id - [%s]", workflowNamespace.Namespaces[Namespace])
 		})
 
-		serviceConfigId, stConfigId, resConfigId, err := workFlowTemplates.CreatePdsCustomTemplatesAndFetchIds(NewPdsParams, false)
-		log.FailOnError(err, "Unable to create Custom Templates for PDS")
-		workflowDataservice.PDSTemplates.ServiceConfigTemplateId = serviceConfigId
-		workflowDataservice.PDSTemplates.StorageTemplateId = stConfigId
-		workflowDataservice.PDSTemplates.ResourceTemplateId = resConfigId
-
-		log.InfoD("Original Resource Template ID- [resTempId- %v]", resConfigId)
-
 		for _, ds := range NewPdsParams.DataServiceToTest {
 			workflowDataservice.Namespace = WorkflowNamespace
 			workflowDataservice.NamespaceName = Namespace
+
+			serviceConfigId, stConfigId, resConfigId, err := workFlowTemplates.CreatePdsCustomTemplatesAndFetchIds(NewPdsParams, ds.Name)
+			log.FailOnError(err, "Unable to create Custom Templates for PDS")
+			workflowDataservice.PDSTemplates.ServiceConfigTemplateId = serviceConfigId
+			workflowDataservice.PDSTemplates.StorageTemplateId = stConfigId
+			workflowDataservice.PDSTemplates.ResourceTemplateId = resConfigId
+			log.InfoD("Original Resource Template ID- [resTempId- %v]", resConfigId)
+
 			deployment, err = workflowDataservice.DeployDataService(ds, ds.OldImage, ds.OldVersion)
 			log.FailOnError(err, "Error while deploying ds")
 		}
 
 		//Update Ds With New Values of Resource Templates
-		_, _, resConfigIdUpdated, err := workFlowTemplates.CreatePdsCustomTemplatesAndFetchIds(NewPdsParams, true)
+		resConfigIdUpdated, err := workFlowTemplates.CreateResourceTemplateWithCustomValue(NewPdsParams, *deployment.Create.Meta.Name, 1)
 		log.FailOnError(err, "Unable to create Custom Templates for PDS")
 
 		log.InfoD("Updated Resource Template ID- [updated- %v]", resConfigIdUpdated)
@@ -230,27 +233,28 @@ var _ = Describe("{IncreasePVCby1gb}", func() {
 			log.Infof("Namespace id - [%s]", workflowNamespace.Namespaces[Namespace])
 		})
 
-		serviceConfigId, stConfigId, resConfigId, err := workFlowTemplates.CreatePdsCustomTemplatesAndFetchIds(NewPdsParams, false)
-		log.FailOnError(err, "Unable to create Custom Templates for PDS")
-		workflowDataservice.PDSTemplates.ServiceConfigTemplateId = serviceConfigId
-		workflowDataservice.PDSTemplates.StorageTemplateId = stConfigId
-		workflowDataservice.PDSTemplates.ResourceTemplateId = resConfigId
-
-		log.InfoD("Original Storage Template ID- [resTempId- %v]", stConfigId)
-
 		for _, ds := range NewPdsParams.DataServiceToTest {
 			workflowDataservice.Namespace = WorkflowNamespace
 			workflowDataservice.NamespaceName = Namespace
-			_, err := workflowDataservice.DeployDataService(ds, ds.OldImage, ds.OldVersion)
+
+			serviceConfigId, stConfigId, resConfigId, err := workFlowTemplates.CreatePdsCustomTemplatesAndFetchIds(NewPdsParams, ds.Name)
+			log.FailOnError(err, "Unable to create Custom Templates for PDS")
+			workflowDataservice.PDSTemplates.ServiceConfigTemplateId = serviceConfigId
+			workflowDataservice.PDSTemplates.StorageTemplateId = stConfigId
+			workflowDataservice.PDSTemplates.ResourceTemplateId = resConfigId
+
+			log.InfoD("Original Storage Template ID- [resTempId- %v]", stConfigId)
+			deployment, err = workflowDataservice.DeployDataService(ds, ds.OldImage, ds.OldVersion)
 			log.FailOnError(err, "Error while deploying ds")
 		}
 
 		//Update Ds With New Values of Resource Templates
-		_, stConfigIdUpdated, _, err := workFlowTemplates.CreatePdsCustomTemplatesAndFetchIds(NewPdsParams, true)
+		//Update Ds With New Values of Resource Templates
+		resConfigIdUpdated, err := workFlowTemplates.CreateResourceTemplateWithCustomValue(NewPdsParams, *deployment.Create.Meta.Name, 1)
 		log.FailOnError(err, "Unable to create Custom Templates for PDS")
 
-		log.InfoD("Updated Storage Template ID- [updated- %v]", stConfigIdUpdated)
-		workflowDataservice.PDSTemplates.StorageTemplateId = stConfigIdUpdated
+		log.InfoD("Updated Resource Template ID- [updated- %v]", resConfigIdUpdated)
+		workflowDataservice.PDSTemplates.ResourceTemplateId = resConfigIdUpdated
 		for _, ds := range NewPdsParams.DataServiceToTest {
 			_, err := workflowDataservice.UpdateDataService(ds, *deployment.Create.Meta.Uid, ds.OldImage, ds.OldVersion)
 			log.FailOnError(err, "Error while updating ds")

--- a/tests/unifiedPlatform/pds2/pds_restore_negative_test.go
+++ b/tests/unifiedPlatform/pds2/pds_restore_negative_test.go
@@ -43,7 +43,7 @@ var _ = Describe("{PerformRestoreValidatingHA}", func() {
 		for _, ds := range NewPdsParams.DataServiceToTest {
 			workflowDataService.Namespace = WorkflowNamespace
 			workflowDataService.NamespaceName = Namespace
-			serviceConfigId, stConfigId, resConfigId, err := workFlowTemplates.CreatePdsCustomTemplatesAndFetchIds(NewPdsParams, false)
+			serviceConfigId, stConfigId, resConfigId, err := workFlowTemplates.CreatePdsCustomTemplatesAndFetchIds(NewPdsParams, ds.Name)
 			log.FailOnError(err, "Unable to create Custom Templates for PDS")
 			workflowDataService.PDSTemplates.ServiceConfigTemplateId = serviceConfigId
 			workflowDataService.PDSTemplates.StorageTemplateId = stConfigId

--- a/tests/unifiedPlatform/pds2/pds_restore_test.go
+++ b/tests/unifiedPlatform/pds2/pds_restore_test.go
@@ -248,16 +248,18 @@ var _ = Describe("{UpgradeDataServiceImageAndVersionWithBackUpRestore}", func() 
 			log.Infof("Namespaces created - [%s]", workflowNamespace.Namespaces)
 			log.Infof("Namespace id - [%s]", workflowNamespace.Namespaces[Namespace])
 
-			serviceConfigId, stConfigId, resConfigId, err := workFlowTemplates.CreatePdsCustomTemplatesAndFetchIds(NewPdsParams, false)
-			log.FailOnError(err, "Unable to create Custom Templates for PDS")
-			workflowDataservice.PDSTemplates.ServiceConfigTemplateId = serviceConfigId
-			workflowDataservice.PDSTemplates.StorageTemplateId = stConfigId
-			workflowDataservice.PDSTemplates.ResourceTemplateId = resConfigId
 		})
 
 		for _, ds := range NewPdsParams.DataServiceToTest {
 			workflowDataservice.Namespace = WorkflowNamespace
 			workflowDataservice.NamespaceName = Namespace
+
+			serviceConfigId, stConfigId, resConfigId, err := workFlowTemplates.CreatePdsCustomTemplatesAndFetchIds(NewPdsParams, ds.Name)
+			log.FailOnError(err, "Unable to create Custom Templates for PDS")
+			workflowDataservice.PDSTemplates.ServiceConfigTemplateId = serviceConfigId
+			workflowDataservice.PDSTemplates.StorageTemplateId = stConfigId
+			workflowDataservice.PDSTemplates.ResourceTemplateId = resConfigId
+
 			deployment, err = workflowDataservice.DeployDataService(ds, ds.OldImage, ds.OldVersion)
 			log.FailOnError(err, "Error while deploying ds")
 		}
@@ -506,7 +508,7 @@ var _ = Describe("{PerformRestoreAfterPVCResize}", func() {
 		for _, ds := range NewPdsParams.DataServiceToTest {
 			workflowDataService.Namespace = WorkflowNamespace
 			workflowDataService.NamespaceName = Namespace
-			serviceConfigId, stConfigId, resConfigId, err := workFlowTemplates.CreatePdsCustomTemplatesAndFetchIds(NewPdsParams, false)
+			serviceConfigId, stConfigId, resConfigId, err := workFlowTemplates.CreatePdsCustomTemplatesAndFetchIds(NewPdsParams, ds.Name)
 			log.FailOnError(err, "Unable to create Custom Templates for PDS")
 			workflowDataService.PDSTemplates.ServiceConfigTemplateId = serviceConfigId
 			workflowDataService.PDSTemplates.StorageTemplateId = stConfigId

--- a/tests/unifiedPlatform/platform/platform_test_dummy.go
+++ b/tests/unifiedPlatform/platform/platform_test_dummy.go
@@ -312,12 +312,14 @@ var _ = Describe("{TestPlatformTemplates}", func() {
 	It("TestPlatformTemplates", func() {
 		Step("create custom templates for PDS", func() {
 			workFlowTemplates.Platform = WorkflowPlatform
-			serviceConfigId, stConfigId, resConfigId, err := workFlowTemplates.CreatePdsCustomTemplatesAndFetchIds(NewPdsParams, false)
-			log.FailOnError(err, "Unable to create Custom Templates for PDS")
-			log.InfoD("Created serviceConfig Template ID- [serviceConfigId- %v]", serviceConfigId)
-			log.InfoD("Created stConfig Template ID- [stConfigId- %v]", stConfigId)
-			log.InfoD("Created resConfig Template ID- [resConfigId- %v]", resConfigId)
-			tempList = append(tempList, serviceConfigId, stConfigId, resConfigId)
+			for _, ds := range NewPdsParams.DataServiceToTest {
+				serviceConfigId, stConfigId, resConfigId, err := workFlowTemplates.CreatePdsCustomTemplatesAndFetchIds(NewPdsParams, ds.Name)
+				log.FailOnError(err, "Unable to create Custom Templates for PDS")
+				log.InfoD("Created serviceConfig Template ID- [serviceConfigId- %v]", serviceConfigId)
+				log.InfoD("Created stConfig Template ID- [stConfigId- %v]", stConfigId)
+				log.InfoD("Created resConfig Template ID- [resConfigId- %v]", resConfigId)
+				tempList = append(tempList, serviceConfigId, stConfigId, resConfigId)
+			}
 		})
 		Step("Cleanup Created Templates after dissociating linked resources", func() {
 			err := workFlowTemplates.DeleteCreatedCustomPdsTemplates(tempList)


### PR DESCRIPTION
solves - https://purestorage.atlassian.net/browse/DS-8916

Torpedo Build - https://jenkins.pwx.dev.purestorage.com/job/Users/job/Madan/job/platfrom-build-torpedo/423/


Able to create templates based on DS Under test. 
```
RevisionUid for the ds under test [PostgreSQL] is- [pds:rev:89ebd55d-7827-418e-bb0c-f47a4eddcc47]
2024-04-08 18:05:44 +0530:[INFO] [{TestPlatformTemplates}] templateValue formed is- [map[CpuLimit:2 CpuRequest:1 MemoryLimit:4G MemoryRequest:2G NewStorageSize:5G StorageRequest:1G]]
2024-04-08 18:05:46 +0530:[INFO] [{TestPlatformTemplates}] Create ResourceConfiguration Request formed is- {{{ten:acc:e9272122-9d7e-4c20-b257-bee7ebb9561a 0x1400000fc50} {{ {0 0} {[]} {[]} {[]}  {0 0}}} {} { <nil>} {} {}}}
2024-04-08 18:05:46 +0530:[INFO] [{TestPlatformTemplates}] [api.(*PLATFORM_API_V1).getTemplateClient:#223] - Creating client from PLATFORM_API_V1 package
2024-04-08 18:05:48 +0530:[INFO] [{TestPlatformTemplates}] tenantID fetched is- ten:acc:e9272122-9d7e-4c20-b257-bee7ebb9561a
2024-04-08 18:05:49 +0530:[INFO] [{TestPlatformTemplates}] Template create req formed is- {{{}} 0x14000bf3b68 ten:acc:e9272122-9d7e-4c20-b257-bee7ebb9561a 0x14001342168}
2024-04-08 18:05:51 +0530:[INFO] [{TestPlatformTemplates}] response got is- {0x14000cc3450 0x14000aa4920 0x1400011b068}
2024-04-08 18:05:53 +0530:[INFO] [{TestPlatformTemplates}] App config ID- tmpl:079d7d4b-4cd1-498f-bb5c-6536d069520d
```
