### PR TITLE
PTX-16934 Add sticky volume automation

### DIFF
--- a/pkg/aetosutil/dashboardutil.go
+++ b/pkg/aetosutil/dashboardutil.go
@@ -427,7 +427,7 @@ func (d *Dashboard) VerifyFatal(actual, expected interface{}, description string
 	expect(err).NotTo(haveOccurred())
 }
 
-// VerifyNotNilFatal verify error is nil and abort operation upon failure
+// VerifyNotNilFatal verify error is not nil and abort operation upon failure
 func (d *Dashboard) VerifyNotNilFatal(err error, description string) {
 	d.VerifyFatal(err != nil, true, description)
 }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -3,19 +3,18 @@ package log
 import (
 	"bytes"
 	"fmt"
+	"github.com/fatih/color"
 	"github.com/google/gnostic/compiler"
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/portworx/torpedo/pkg/aetosutil"
+	"github.com/sirupsen/logrus"
 	"gopkg.in/natefinch/lumberjack.v2"
 	"io"
 	"os"
 	"runtime"
 	"strings"
 	"sync"
-
-	"github.com/fatih/color"
-	"github.com/sirupsen/logrus"
 )
 
 type colorizer func(...interface{}) string
@@ -332,6 +331,21 @@ func FailOnError(err error, description string, args ...interface{}) {
 		dash.Fatal(extendedFormat)
 		tpLog.Errorf(extendedFormat)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+}
+
+func FailOnNoError(err error, description string, args ...interface{}) {
+	if err != nil {
+		errorString := fmt.Sprintf("%v. Err: %v", fmt.Sprintf(description, args...), err)
+		pc, _, line, _ := runtime.Caller(1)
+		callerFuncSlice := strings.Split(runtime.FuncForPC(pc).Name(), "/")
+		callerFunc := fmt.Sprintf("%s:#%d", callerFuncSlice[len(callerFuncSlice)-1], line)
+		extendedFormat := fmt.Sprintf("[%s] - %s", callerFunc, errorString)
+		dash.VerifyNotNilFatal(err, extendedFormat)
+		tpLog.Debugf(extendedFormat)
+	} else {
+		dash.Fatal(description, args...)
+		tpLog.Errorf(description, args...)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a testcase validation sticky volume use-case

**Which issue(s) this PR fixes** (optional)
Closes # PTX-16934

**Special notes for your reviewer**:
Steps: 
1. Deploy Apps
2. Validate Apps
3. Fetch Volume List and set `--sticky-on`
4. VolumeDriver Down & Up & validate no impact to workloads
5. Destroy apps & their pvc(s)
6. Try deleting the volume (should fail)
7. Set `--sticky-off`
8. Delete the volumes