### PR TITLE
[PTX-23277] Revert ValidateCreateVolume Fix

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -1525,40 +1525,12 @@ func (d *portworx) ValidateCreateVolume(volumeName string, params map[string]str
 				}
 			}
 		case api.SpecIoProfile:
-			// Reference: https://docs.portworx.com/portworx-enterprise/concepts/io-profiles
-			if requestedSpec.IoProfile != vol.DerivedIoProfile {
-				switch requestedSpec.IoProfile {
-				case api.IoProfile_IO_PROFILE_AUTO:
-					// The profile auto-selects "db_remote" for volumes with a replication factor is
-					// greater than or equal to 2, and "none" otherwise, based on configuration details.
-					if vol.DerivedIoProfile != api.IoProfile_IO_PROFILE_DB_REMOTE && vol.DerivedIoProfile != api.IoProfile_IO_PROFILE_NONE {
-						log.Infof("requested Spec: %+v", requestedSpec)
-						log.Infof("actual Spec: %+v", vol)
-						return errFailedToInspectVolume(volumeName, k, requestedSpec.IoProfile.String(), vol.DerivedIoProfile.String())
-					}
-				case api.IoProfile_IO_PROFILE_AUTO_JOURNAL:
-					// The auto_journal IO profile adjusts a volume to use "journal" or "none"
-					// settings based on analyzing 24-second write pattern intervals to optimize
-					// performance.
-					if vol.DerivedIoProfile != api.IoProfile_IO_PROFILE_JOURNAL && vol.DerivedIoProfile != api.IoProfile_IO_PROFILE_NONE {
-						log.Infof("requested Spec: %+v", requestedSpec)
-						log.Infof("actual Spec: %+v", vol)
-						return errFailedToInspectVolume(volumeName, k, requestedSpec.IoProfile.String(), vol.DerivedIoProfile.String())
-					}
-				case api.IoProfile_IO_PROFILE_DB_REMOTE:
-					// The write-back flush coalescing algorithm consolidates syncs within 100ms into
-					// a single operation, necessitating at least two replications (HA factor) for
-					// reliability.
-					if vol.Spec.HaLevel >= 2 {
-						log.Infof("requested Spec: %+v", requestedSpec)
-						log.Infof("actual Spec: %+v", vol)
-						return errFailedToInspectVolume(volumeName, k, requestedSpec.IoProfile.String(), vol.DerivedIoProfile.String())
-					}
-				default:
-					log.Infof("requested Spec: %+v", requestedSpec)
-					log.Infof("actual Spec: %+v", vol)
-					return errFailedToInspectVolume(volumeName, k, requestedSpec.IoProfile.String(), vol.DerivedIoProfile.String())
-				}
+			if requestedSpec.IoProfile != vol.DerivedIoProfile &&
+				vol.DerivedIoProfile != api.IoProfile_IO_PROFILE_DB_REMOTE {
+				//there is intermittent issue occurring for io profile , keeping this to check when the issue occurs again
+				log.Infof("requested Spec: %+v", requestedSpec)
+				log.Infof("actual Spec: %+v", vol)
+				return errFailedToInspectVolume(volumeName, k, requestedSpec.IoProfile.String(), vol.DerivedIoProfile.String())
 			}
 		case api.SpecSize:
 			if requestedSpec.Size != vol.Spec.Size {

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -1528,29 +1528,27 @@ func (d *portworx) ValidateCreateVolume(volumeName string, params map[string]str
 			// Reference: https://docs.portworx.com/portworx-enterprise/concepts/io-profiles
 			if requestedSpec.IoProfile != vol.DerivedIoProfile {
 				switch requestedSpec.IoProfile {
-				// The "db" and "sequential" IO profiles are deprecated in newer versions of
-				// Portworx, with legacy volumes labeled as such now internally treated as "auto"
-				// profile volumes.
-				case api.IoProfile_IO_PROFILE_AUTO, api.IoProfile_IO_PROFILE_DB, api.IoProfile_IO_PROFILE_SEQUENTIAL:
-					// The "auto" IO profile selects "db_remote" for volumes with a replication factor
-					// of 2 or greater, and selects "none" otherwise.
+				case api.IoProfile_IO_PROFILE_AUTO:
+					// The profile auto-selects "db_remote" for volumes with a replication factor is
+					// greater than or equal to 2, and "none" otherwise, based on configuration details.
 					if vol.DerivedIoProfile != api.IoProfile_IO_PROFILE_DB_REMOTE && vol.DerivedIoProfile != api.IoProfile_IO_PROFILE_NONE {
 						log.Infof("requested Spec: %+v", requestedSpec)
 						log.Infof("actual Spec: %+v", vol)
 						return errFailedToInspectVolume(volumeName, k, requestedSpec.IoProfile.String(), vol.DerivedIoProfile.String())
 					}
 				case api.IoProfile_IO_PROFILE_AUTO_JOURNAL:
-					// The "auto_journal" IO profile dynamically switches between "none" and "journal" based on
-					// 24-second analyses of write patterns, optimizing application performance accordingly.
+					// The auto_journal IO profile adjusts a volume to use "journal" or "none"
+					// settings based on analyzing 24-second write pattern intervals to optimize
+					// performance.
 					if vol.DerivedIoProfile != api.IoProfile_IO_PROFILE_JOURNAL && vol.DerivedIoProfile != api.IoProfile_IO_PROFILE_NONE {
 						log.Infof("requested Spec: %+v", requestedSpec)
 						log.Infof("actual Spec: %+v", vol)
 						return errFailedToInspectVolume(volumeName, k, requestedSpec.IoProfile.String(), vol.DerivedIoProfile.String())
 					}
 				case api.IoProfile_IO_PROFILE_DB_REMOTE:
-					// The "db_remote" IO profile utilizes a write-back flush coalescing algorithm
-					// that consolidates syncs within 100ms into a single operation, necessitating at
-					// least two replications (HA factor) for reliability.
+					// The write-back flush coalescing algorithm consolidates syncs within 100ms into
+					// a single operation, necessitating at least two replications (HA factor) for
+					// reliability.
 					if vol.Spec.HaLevel >= 2 {
 						log.Infof("requested Spec: %+v", requestedSpec)
 						log.Infof("actual Spec: %+v", vol)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR is meant to revert the fix to ValidateCreateVolume introduced in https://github.com/portworx/torpedo/pull/2302 and https://github.com/portworx/torpedo/pull/2328 as the CBT jobs are failing.

**Which issue(s) this PR fixes** (optional)
Closes #PTX-23277

**Special notes for your reviewer**:
Please review the following Jenkins build: SetupTeardown with CBT Apps

https://jenkins.pwx.dev.purestorage.com/job/Users/job/krishna/job/tp-pxe-byoc/2422/
Aetos Dashboard: https://aetos.pwx.purestorage.com/resultSet/testSetID/607303