### PR TITLE
[PTX-23388] Add GinkgoRecover In UpgradeLongevity

### DIFF
--- a/tests/longevity/longevity_test.go
+++ b/tests/longevity/longevity_test.go
@@ -371,6 +371,7 @@ var _ = Describe("{UpgradeLongevity}", func() {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
+				defer GinkgoRecover()
 				start := time.Now().Local()
 				timeout := Inst().MinRunTimeMins * 60
 				currentUpgradeIndex := 0

--- a/tests/longevity/longevity_test.go
+++ b/tests/longevity/longevity_test.go
@@ -449,7 +449,6 @@ var _ = Describe("{UpgradeLongevity}", func() {
 						Inst().SchedUpgradeHops = strings.Join(upgradeSchedHops, ",")
 						Inst().UpgradeStorageDriverEndpointList = strings.Join(upgradeEndpoints, ",")
 						upgradeCounter.Increment(triggerType)
-						ValidateApplications(contexts)
 					}
 					time.Sleep(controlLoopSleepTime)
 				}

--- a/tests/testTriggers.go
+++ b/tests/testTriggers.go
@@ -6091,7 +6091,7 @@ func TriggerUpdateCluster(contexts *[]*scheduler.Context, recordChan *chan *Even
 			})
 
 			Step("validate all apps after upgrade", func() {
-				ValidateApplications(*contexts)
+				validateContexts(event, contexts)
 			})
 		}
 	})
@@ -6129,7 +6129,7 @@ func TriggerUpgradeVolumeDriverFromCatalog(contexts *[]*scheduler.Context, recor
 			timeBeforeUpgrade time.Time
 			timeAfterUpgrade  time.Time
 		)
-		ValidateApplications(*contexts)
+		validateContexts(event, contexts)
 		stepLog = "start the upgrade of volume driver from catalog"
 		Step(stepLog, func() {
 			log.InfoD(stepLog)
@@ -6272,7 +6272,7 @@ func TriggerUpgradeVolumeDriverFromCatalog(contexts *[]*scheduler.Context, recor
 				statsData["status"] = upgradeStatus
 				dash.UpdateStats("px-upgrade-stats", "px-enterprise", "upgrade", majorVersion, statsData)
 				// Validate Apps after volume driver upgrade
-				ValidateApplications(*contexts)
+				validateContexts(event, contexts)
 			}
 		})
 		err := ValidateDataIntegrity(contexts)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR adds GinkgoRecover to the upgrade go routine in UpgradeLongevity to recover from any panics. It ensures we use validateContexts in place of ValidateApplications.

**Which issue(s) this PR fixes** (optional)
Closes #PTX-23388

**Special notes for your reviewer**:
There is no easy way to test this, so I will monitor the pipeline once the changes are merged.