### PR TITLE
Removed deletion of app after deleting the VM

### DIFF
--- a/tests/backup/backup_kubevirt_test.go
+++ b/tests/backup/backup_kubevirt_test.go
@@ -2684,10 +2684,6 @@ var _ = Describe("{KubevirtScheduledVMDelete}", Label(TestCaseLabelsMap[Kubevirt
 				err := DeleteAllVMsInNamespace(namespace)
 				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying deletion of kubevirt VMs from the namespace [%s]", namespace))
 			}
-			log.InfoD("Deleting remaining kubevirt VM related specs from the namespace")
-			opts := make(map[string]bool)
-			opts[SkipClusterScopedObjects] = true
-			DestroyApps(scheduledAppContexts, opts)
 		})
 
 		Step("Verify next namespace labelled and non labelled scheduled backup is success state after VM deletion", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Removed deletion of app after deleting the VM from test KubevirtScheduledVMDelete
We observed that it started failing in the OCP runs - https://aetos.pwx.purestorage.com/resultSet/testSetID/616477

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

