### PR TITLE
Fixed VM spec deletion issue in KubevirtScheduledVMDelete

### DIFF
--- a/tests/backup/backup_kubevirt_test.go
+++ b/tests/backup/backup_kubevirt_test.go
@@ -2536,7 +2536,6 @@ var _ = Describe("{DefaultBackupRestoreWithKubevirtAndNonKubevirtNS}", Label(Tes
 // This testcase verifies scheduled backup status when Kubevirt VMs are deleted and recreated from namespace in between schedules.
 var _ = Describe("{KubevirtScheduledVMDelete}", Label(TestCaseLabelsMap[KubevirtScheduledVMDelete]...), func() {
 	var (
-		backupPreUpgrade               string
 		scheduledAppContexts           []*scheduler.Context
 		bkpNamespaces                  = make([]string, 0)
 		sourceClusterUid               string
@@ -2657,7 +2656,7 @@ var _ = Describe("{KubevirtScheduledVMDelete}", Label(TestCaseLabelsMap[Kubevirt
 				scheduleNames = append(scheduleNames, nonLabelScheduleName)
 				_, err = CreateVMScheduledBackupWithValidation(nonLabelScheduleName, vms, SourceClusterName, backupLocationName, backupLocationUID, scheduledAppContexts,
 					labelSelectors, BackupOrgID, sourceClusterUid, "", "", "", "", false, periodicSchedulePolicyName, periodicSchedulePolicyUid, ctx)
-				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation and validation of schedule backup [%s] of namespace", backupPreUpgrade))
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation and validation of schedule backup [%s] of namespace", nonLabelScheduleName))
 				nonLabelSchNamespaceMap[namespace] = nonLabelScheduleName
 			}
 		})
@@ -2741,7 +2740,6 @@ var _ = Describe("{KubevirtScheduledVMDelete}", Label(TestCaseLabelsMap[Kubevirt
 					appName := Inst().AppList[index]
 					appCtx.ReadinessTimeout = AppReadinessTimeout
 					log.InfoD("Scheduled VM [%s] in source cluster in namespace [%s]", appName, namespace)
-					scheduledAppContexts = append(scheduledAppContexts, appCtx)
 				}
 			}
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
Removed step which we append the app context as we are recreating the VM in same namespace.


**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

OCP:
https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/5069/consoleFull
Vanilla:
https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/5070/