### PR TITLE
[PTX-23119] Calculating Latency between autopilot rule objects

### DIFF
--- a/drivers/scheduler/dcos/dcos.go
+++ b/drivers/scheduler/dcos/dcos.go
@@ -100,6 +100,12 @@ func (d *dcos) ValidateAutopilotRuleObjects() error {
 		Operation: "ValidateAutopilotRuleObjects()",
 	}
 }
+func (d *dcos) CalculateLatencyForAroStates(aroNamespace string) error {
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "CalculateLatencyForAroStates()",
+	}
+}
 
 // WaitForRebalanceToComplete validates autopilot rule objects for Rebalance
 func (d *dcos) WaitForRebalanceAROToComplete() error {

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -6556,6 +6556,62 @@ func (k *K8s) ValidateAutopilotRuleObjects() error {
 	}
 	return nil
 }
+func (k *K8s) CalculateLatencyForAroStates(ruleName apapi.AutopilotRule) error {
+	namespace, err := k.GetAutopilotNamespace()
+	if err != nil {
+		return err
+	}
+
+	expectedAroStates := []apapi.RuleState{
+		apapi.RuleStateInit,
+		apapi.RuleStateTriggered,
+		apapi.RuleStateActiveActionsPending,
+		apapi.RuleStateActiveActionsInProgress,
+		apapi.RuleStateActiveActionsTaken,
+		apapi.RuleStateNormal,
+	}
+
+	listAutopilotRuleObjects, err := k8sAutopilot.ListAutopilotRuleObjects(namespace)
+	if err != nil {
+		return err
+	}
+	if len(listAutopilotRuleObjects.Items) == 0 {
+		log.Warnf("the list of autopilot rule objects is empty, please make sure that you have an appropriate autopilot rule")
+		return nil
+	}
+
+	for _, aro := range listAutopilotRuleObjects.Items {
+		log.InfoD("Rule Name %v", aro.GetObjectMeta().GetName())
+		if strings.Contains(aro.GetObjectMeta().GetName(), ruleName.Name) {
+			stateTimestampMap := make(map[apapi.RuleState]metav1.Time)
+			for _, aroStatusItem := range aro.Status.Items {
+				if aroStatusItem.State == "" {
+					continue
+				}
+				stateTimestampMap[aroStatusItem.State] = aroStatusItem.LastProcessTimestamp
+			}
+
+			var prevState apapi.RuleState
+			var prevTimestamp metav1.Time
+			for _, state := range expectedAroStates {
+				timestamp, exists := stateTimestampMap[state]
+				if !exists {
+					continue
+				}
+				if prevState != "" {
+					duration := timestamp.Time.Sub(prevTimestamp.Time)
+					if duration.Minutes() > 10 {
+						log.Warnf("More than 10 minutes between state %s and %s for autopilot rule object: %s", prevState, state, aro.Name)
+					}
+				}
+				prevState = state
+				prevTimestamp = timestamp
+			}
+		}
+
+	}
+	return nil
+}
 
 // VerifyPoolResizeARO() created and resize completed
 func (k *K8s) VerifyPoolResizeARO(ruleName apapi.AutopilotRule) (bool, error) {

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -350,7 +350,7 @@ type Driver interface {
 	ValidateAutopilotRuleObjects() error
 
 	// CalculateLatencyForAroStates calculates the time difference between each state change
-	CalculateLatencyForAroStates(apRule apapi.AutopilotRule) error
+	CalculateLatencyForAroStates(aroNamespace string) error
 
 	//WaitForRebalanceAROToComplete waits for rebalance to start
 	WaitForRebalanceAROToComplete() error

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -349,6 +349,9 @@ type Driver interface {
 	// ValidateAutopilotRuleObject validates Autopilot rule object
 	ValidateAutopilotRuleObjects() error
 
+	// CalculateLatencyForAroStates calculates the time difference between each state change
+	CalculateLatencyForAroStates(apRule apapi.AutopilotRule) error
+
 	//WaitForRebalanceAROToComplete waits for rebalance to start
 	WaitForRebalanceAROToComplete() error
 

--- a/tests/basic/autopilot_test.go
+++ b/tests/basic/autopilot_test.go
@@ -1690,6 +1690,9 @@ var _ = Describe(fmt.Sprintf("{%sRebalanceProvMeanAndPoolResize}", testSuiteName
 			Expect(err).NotTo(HaveOccurred())
 			log.InfoD("aroAvailable value %v", aroAvailable)
 			log.InfoD("=====Pool resize ARO verified ========")
+			log.InfoD("=====Calculate Latency ==============")
+			err := Inst().S.CalculateLatencyForAroStates(apRules[1])
+			Expect(err).NotTo(HaveOccurred())
 
 		})
 		Step("destroy apps", func() {

--- a/tests/basic/autopilot_test.go
+++ b/tests/basic/autopilot_test.go
@@ -108,6 +108,15 @@ var _ = Describe(fmt.Sprintf("{%sPvcBasic}", testSuiteName), func() {
 				ValidateVolumes(ctx)
 			}
 		})
+		Step("Validte the Latency between each state in Aro Object ", func() {
+			log.InfoD("Validating the latency between each state in Aro Object")
+			for _, ctx := range contexts {
+
+				err := Inst().S.CalculateLatencyForAroStates(ctx.App.NameSpace)
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+		})
 
 		Step("destroy apps", func() {
 			opts := make(map[string]bool)
@@ -1690,9 +1699,6 @@ var _ = Describe(fmt.Sprintf("{%sRebalanceProvMeanAndPoolResize}", testSuiteName
 			Expect(err).NotTo(HaveOccurred())
 			log.InfoD("aroAvailable value %v", aroAvailable)
 			log.InfoD("=====Pool resize ARO verified ========")
-			log.InfoD("=====Calculate Latency ==============")
-			err := Inst().S.CalculateLatencyForAroStates(apRules[1])
-			Expect(err).NotTo(HaveOccurred())
 
 		})
 		Step("destroy apps", func() {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
We have created a function to calculate latency between autopilotrule objects , it will collects all ARO in all namespaces where apps or pvc are deployed on which we are imposing auto pilot rule

**Which issue(s) this PR fixes** (optional)
Closes # PTX-23119

**Special notes for your reviewer**:

PASS LOGS: https://jenkins.pwx.dev.purestorage.com/job/Users/job/krishna/job/tp-pxe-byoc/2749/console

As of now i have added it for a testcase called "PvcBasic" , checking to which testcases we need to add the validation

