### PR TITLE
kubevirt vendor updates for schedops

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/portworx/pds-api-go-client v0.0.0-20231102112445-993d38984eae
 	github.com/portworx/px-backup-api v1.2.2-0.20240229114136-e58baeb9fbe1
-	github.com/portworx/sched-ops v1.20.4-rc1.0.20240411193047-d17313c6c11b
+	github.com/portworx/sched-ops v1.20.4-rc1.0.20240424153814-f3083bdb4578
 	github.com/portworx/talisman v1.1.3
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.63.0
 	github.com/prometheus/client_golang v1.15.1

--- a/go.sum
+++ b/go.sum
@@ -3096,8 +3096,8 @@ github.com/portworx/sched-ops v1.20.4-rc1.0.20221208153443-c95ed6d757fa/go.mod h
 github.com/portworx/sched-ops v1.20.4-rc1.0.20230103234348-243afb3bb8aa/go.mod h1:wQK24M7cbrhAk378J2WwR0nMx86W/iJwRc1JilEmP40=
 github.com/portworx/sched-ops v1.20.4-rc1.0.20230207070155-2e0ef25efadd/go.mod h1:JbHASXqA/GXwFD4blS1DZkrxtS5llb98ViZgUerOtQA=
 github.com/portworx/sched-ops v1.20.4-rc1.0.20230207140221-24ec094deec4/go.mod h1:drIYh+6f/vh11dVmbpwFv3GIusQCSMThPX774U8ix7w=
-github.com/portworx/sched-ops v1.20.4-rc1.0.20240411193047-d17313c6c11b h1:i9MQ68H2YvpNzlU625qQFuGqQBBqFUVqVoV1ggOqK8M=
-github.com/portworx/sched-ops v1.20.4-rc1.0.20240411193047-d17313c6c11b/go.mod h1:LZkYF7Ke6gh3urQXFie1yBntpq1bINLVz05F8x314go=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20240424153814-f3083bdb4578 h1:vajTIDp7gaCTOltq2kwbQEk9LKNI+Dx1k9UfJ7uEYb4=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20240424153814-f3083bdb4578/go.mod h1:KOe618gr1FAzVmLNe9LFHss19df3MBZ0qom6Ct7RpyM=
 github.com/portworx/talisman v0.0.0-20191007232806-837747f38224/go.mod h1:OjpMH9Uh5o9ntVGktm4FbjLNwubJ3ITih2OfYrAeWtA=
 github.com/portworx/talisman v0.0.0-20210302012732-8af4564777f7/go.mod h1:e8a6uFpSbOlRpZQlW9aXYogC+GWAo065G0RL9hDkD4Q=
 github.com/portworx/talisman v1.1.3 h1:XrDE0fs4UACgDGi5bvt04uePC+QbhbA5YXozGYg5tr8=

--- a/vendor/github.com/portworx/sched-ops/k8s/kubevirt/virtualmachine.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/kubevirt/virtualmachine.go
@@ -150,7 +150,7 @@ func (c *Client) ValidateVirtualMachineRunning(name, namespace string, timeout, 
 			return "", false, fmt.Errorf("failed to get Virtual Machine")
 		}
 
-		if vm.Status.PrintableStatus == kubevirtv1.VirtualMachineStatusRunning {
+		if vm.Status.PrintableStatus == kubevirtv1.VirtualMachineStatusRunning && vm.Status.Ready == true {
 			return "", false, nil
 		}
 		return "", true, fmt.Errorf("Virtual Machine not in running state: %v", vm.Status.PrintableStatus)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1334,7 +1334,7 @@ github.com/portworx/pds-api-go-client/pds/v1alpha1
 github.com/portworx/px-backup-api/pkg/apis/v1
 github.com/portworx/px-backup-api/pkg/kubeauth
 github.com/portworx/px-backup-api/pkg/kubeauth/gcp
-# github.com/portworx/sched-ops v1.20.4-rc1.0.20240411193047-d17313c6c11b
+# github.com/portworx/sched-ops v1.20.4-rc1.0.20240424153814-f3083bdb4578
 ## explicit; go 1.19
 github.com/portworx/sched-ops/k8s/admissionregistration
 github.com/portworx/sched-ops/k8s/apiextensions


### PR DESCRIPTION
**What this PR does / why we need it**:
* Extra validation added to sched-ops for kubevirt VMs to be qualified as running, is needed in torpedo


**Which issue(s) this PR fixes** (optional)
Closes # https://purestorage.atlassian.net/browse/PTX-23643

**Special notes for your reviewer**:

