### PR TITLE
Create and attach 250 + FADA volumes in Longevity or scale testing au…

### DIFF
--- a/tests/longevity/longevity_helper.go
+++ b/tests/longevity/longevity_helper.go
@@ -618,9 +618,9 @@ func populateIntervals() {
 	triggerInterval[VolumeDriverDownVCluster] = make(map[int]time.Duration)
 	triggerInterval[SetDiscardMounts] = make(map[int]time.Duration)
 	triggerInterval[ResetDiscardMounts] = make(map[int]time.Duration)
+	triggerInterval[ScaleFADAVolumeAttach] = map[int]time.Duration{}
 
 	baseInterval := 10 * time.Minute
-
 	triggerInterval[BackupScaleMongo][10] = 1 * baseInterval
 	triggerInterval[BackupScaleMongo][9] = 2 * baseInterval
 	triggerInterval[BackupScaleMongo][8] = 3 * baseInterval
@@ -1617,6 +1617,17 @@ func populateIntervals() {
 	triggerInterval[OCPStorageNodeRecycle][2] = 24 * baseInterval
 	triggerInterval[OCPStorageNodeRecycle][1] = 30 * baseInterval
 
+	triggerInterval[ScaleFADAVolumeAttach][10] = 1 * baseInterval
+	triggerInterval[ScaleFADAVolumeAttach][9] = 3 * baseInterval
+	triggerInterval[ScaleFADAVolumeAttach][8] = 6 * baseInterval
+	triggerInterval[ScaleFADAVolumeAttach][7] = 9 * baseInterval
+	triggerInterval[ScaleFADAVolumeAttach][6] = 12 * baseInterval
+	triggerInterval[ScaleFADAVolumeAttach][5] = 15 * baseInterval
+	triggerInterval[ScaleFADAVolumeAttach][4] = 18 * baseInterval
+	triggerInterval[ScaleFADAVolumeAttach][3] = 21 * baseInterval
+	triggerInterval[ScaleFADAVolumeAttach][2] = 24 * baseInterval
+	triggerInterval[ScaleFADAVolumeAttach][1] = 30 * baseInterval
+
 	// Chaos Level of 0 means disable test trigger
 	triggerInterval[DeployApps][0] = 0
 	triggerInterval[RebootNode][0] = 0
@@ -1705,6 +1716,7 @@ func populateIntervals() {
 	triggerInterval[ReallocateSharedMount][0] = 0
 	triggerInterval[SetDiscardMounts][0] = 0
 	triggerInterval[ResetDiscardMounts][0] = 0
+	triggerInterval[ScaleFADAVolumeAttach][0] = 0
 }
 
 func isTriggerEnabled(triggerType string) (time.Duration, bool) {

--- a/tests/longevity/longevity_test.go
+++ b/tests/longevity/longevity_test.go
@@ -2,13 +2,14 @@ package tests
 
 import (
 	"fmt"
-	"github.com/portworx/torpedo/drivers/scheduler/iks"
 	"math"
 	"os"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/portworx/torpedo/drivers/scheduler/iks"
 
 	"github.com/portworx/torpedo/pkg/log"
 
@@ -106,6 +107,7 @@ var _ = Describe("{Longevity}", func() {
 		VolumeDriverDownVCluster:          TriggerVolumeDriverDownVCluster,
 		SetDiscardMounts:                  TriggerSetDiscardMounts,
 		ResetDiscardMounts:                TriggerResetDiscardMounts,
+		ScaleFADAVolumeAttach:             TriggerScaleFADAVolumeAttach,
 	}
 	//Creating a distinct trigger to make sure email triggers at regular intervals
 	emailTriggerFunction = map[string]func(){


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Create and attach 250 + FADA volumes in Longevity or scale testing automation

**Which issue(s) this PR fixes** (optional)
Closes # PTX-18941

**Special notes for your reviewer**:
```
2024-04-24 23:14:33 +0000:[INFO] [{Longevity}] Adding FADA volumes at scale to validate FADA volumes attachment in scale 
2024-04-24 23:14:33 +0000:[INFO] [{Longevity}] [tests.TriggerScaleFADAVolumeAttach.func2:#11011] - Creating pure_block storage class class: px-pure-block04-24-23h14m33s
2024-04-24 23:14:33 +0000:[INFO] [{Longevity}] Deployng FADA based applications
2024-04-24 23:14:53 +0000:[INFO] [{Longevity}] Validating applications context
2024-04-24 23:14:53 +0000:[INFO] [{Longevity}] Validate applications
2024-04-24 23:14:53 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:14:53 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:14:53 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:14:54 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-0
2024-04-24 23:14:54 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:14:54 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:14:54 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:14:54 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:14:54 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-1
2024-04-24 23:14:54 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:14:54 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:14:54 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:14:54 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:14:54 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-2
2024-04-24 23:14:55 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:14:55 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:14:55 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:14:55 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:14:55 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-3
2024-04-24 23:14:56 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:14:56 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:14:56 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:14:56 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:14:56 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-4
2024-04-24 23:14:57 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:14:57 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:14:57 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:14:57 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:14:57 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-5
2024-04-24 23:14:58 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:14:58 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:14:58 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:14:58 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:14:58 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-6
2024-04-24 23:14:59 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:14:59 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:14:59 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:14:59 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:14:59 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-7
2024-04-24 23:15:00 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:00 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:00 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:00 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:00 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-8
2024-04-24 23:15:01 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:01 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:01 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:01 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:01 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-9
2024-04-24 23:15:02 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:02 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:02 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:02 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:02 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-10
2024-04-24 23:15:03 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:03 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:03 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:03 +0000:[INFO] [{Longevity}] wait for  app to start running
2024/04/24 23:15:03 DoRetryWithTimeout - Error: {app px-pure-block04-24-23h14m33s-11 is not ready yet. Cause: Expected replicas: 1 Available replicas: 0 Current pods overview:
  pod name:px-pure-block04-24-23h14m33s-11-5cbb68647f-cjmfj namespace:fada-namespace-11 running:false ready:false node:10.13.235.133
}, Next try in [10s], timeout [5m0s]
2024-04-24 23:15:13 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-11
2024-04-24 23:15:13 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:13 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:13 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:13 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:13 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-12
2024-04-24 23:15:13 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:13 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:13 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:13 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:14 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-13
2024-04-24 23:15:14 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:14 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:14 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:14 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:15 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-14
2024-04-24 23:15:15 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:15 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:15 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:15 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:16 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-15
2024-04-24 23:15:17 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:17 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:17 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:17 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:17 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-16
2024-04-24 23:15:17 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:17 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:17 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:17 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:18 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-17
2024-04-24 23:15:18 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:18 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:18 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:18 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:19 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-18
2024-04-24 23:15:19 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:19 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:19 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:19 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:20 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-19
2024-04-24 23:15:20 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:20 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:20 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:20 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:21 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-20
2024-04-24 23:15:21 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:21 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:21 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:21 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:22 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-21
2024-04-24 23:15:22 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:22 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:22 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:22 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:23 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-22
2024-04-24 23:15:23 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:23 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:23 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:23 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:24 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-23
2024-04-24 23:15:24 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:24 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:24 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:24 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:25 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-24
2024-04-24 23:15:25 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:25 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:25 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:25 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:26 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-25
2024-04-24 23:15:26 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:26 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:26 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:26 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:27 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-26
2024-04-24 23:15:27 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:27 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:27 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:27 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:28 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-27
2024-04-24 23:15:28 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:28 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:28 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:28 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:29 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-28
2024-04-24 23:15:29 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:29 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:29 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:29 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:30 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-29
2024-04-24 23:15:30 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:30 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:30 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:30 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:31 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-30
2024-04-24 23:15:31 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:31 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:31 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:31 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:32 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-31
2024-04-24 23:15:32 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:32 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:32 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:32 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:33 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-32
2024-04-24 23:15:33 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:33 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:33 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:33 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:34 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-33
2024-04-24 23:15:34 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:34 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:34 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:34 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:35 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-34
2024-04-24 23:15:35 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:35 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:35 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:35 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:36 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-35
2024-04-24 23:15:36 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:36 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:36 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:36 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:37 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-36
2024-04-24 23:15:37 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:37 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:37 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:37 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:38 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-37
2024-04-24 23:15:38 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:38 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:38 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:38 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:39 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-38
2024-04-24 23:15:39 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:39 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:39 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:39 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:40 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-39
2024-04-24 23:15:40 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:40 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:40 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:40 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:41 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-40
2024-04-24 23:15:41 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:41 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:41 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:41 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:42 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-41
2024-04-24 23:15:42 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:42 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:42 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:42 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:43 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-42
2024-04-24 23:15:43 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:43 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:43 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:43 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:44 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-43
2024-04-24 23:15:44 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:44 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:44 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:44 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:45 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-44
2024-04-24 23:15:45 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:45 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:45 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:45 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:46 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-45
2024-04-24 23:15:46 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:46 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:46 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:46 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:47 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-46
2024-04-24 23:15:47 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:47 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:47 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:47 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:48 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-47
2024-04-24 23:15:48 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:48 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:48 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:48 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:49 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-48
2024-04-24 23:15:49 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:49 +0000:[INFO] [{Longevity}] Validating  app
2024-04-24 23:15:49 +0000:[INFO] [{Longevity}] Validating  app's volumes
2024-04-24 23:15:49 +0000:[INFO] [{Longevity}] wait for  app to start running
2024-04-24 23:15:50 +0000:[INFO] [{Longevity}] [k8s.(*K8s).WaitForRunning:#3001] - [] Validated deployment: px-pure-block04-24-23h14m33s-49
2024-04-24 23:15:50 +0000:[INFO] [{Longevity}] validate if  app's volumes are setup
2024-04-24 23:15:50 +0000:[INFO] [{Longevity}] Cleaning up the FADA deployments
2024-04-24 23:16:09 +0000:[INFO] [{Longevity}] Successfully cleaned up the FADA deployments
2024-04-24 23:16:09 +0000:[DEBUG] [{Longevity}] [ssh.(*SSH).doCmdUsingPod.func1:#730] - Finding the debug pod to run command on node pwx-ocp-224-227-dcw8p-worker-0-fzz2r
2024-04-24 23:16:09 +0000:[INFO] [{Longevity}] [tests.CollectEventRecords:#3840] - TestExecutionCountMap: map[ScaleFADAVolumeAttach:1 deployApps:1]
2024-04-24 23:16:09 +0000:[DEBUG] [{Longevity}] [ssh.(*SSH).doCmdUsingPod.func1:#750] - Running command on pod debug-s25ph [[nsenter --mount=/hostproc/1/ns/mnt /bin/bash -c pxctl status]]
2024-04-24 23:16:09 +0000:[INFO] [{Longevity}] [tests.PrintCommandOutput:#743] - Status: PX is operational
Telemetry: Disabled or Unhealthy
Metering: Healthy
License: Portworx CSI for FA/FB (lease renewal in 23h, 37m)
Node ID: 2ba62d59-5f38-4b55-b0d8-c2962f9d600d
	IP: 10.13.235.133 
 	Local Storage Pool: 1 pool
	POOL	IO_PRIORITY	RAID_LEVEL	USABLE	USED	STATUS	ZONE	REGION
	0	HIGH		raid0		150 GiB	7.5 GiB	Online	default	default
	Local Storage Devices: 1 device
	Device	Path						Media Type		Size		Last-Scan
	0:1	/dev/mapper/3624a9370b54fa92064ac42f2000be1e9	STORAGE_MEDIUM_SSD	150 GiB		24 Apr 24 04:53 UTC
	total							-			150 GiB
	Cache Devices:
	 * No cache devices
Cluster Summary
	Cluster ID: px-cluster-4b66ca9e-45bd-4a13-bbed-89654975c52a
	Cluster UUID: 23bd649f-d56c-421a-9315-28f792a19bef
	Scheduler: kubernetes
	Total Nodes: 7 node(s) with storage (7 online), 3 node(s) without storage (2 online)
	IP		ID					SchedulerNodeName			Auth		StorageNode	Used		Capacity	Status	StorageStatus	Version		Kernel				OS
	10.13.231.14	f5752132-05ee-4882-bb3b-9eb84223091a	pwx-ocp-224-227-dcw8p-worker-0-5s2hs	Disabled	Yes		7.5 GiB		150 GiB		Online	Up		3.1.1.0-519c78f	5.14.0-284.48.1.el9_2.x86_64	Red Hat Enterprise Linux CoreOS 414.92.202401121330-0 (Plow)
	10.13.234.30	b6833f40-7b51-493d-8819-34e179ec670c	pwx-ocp-224-227-dcw8p-worker-0-2m4c4	Disabled	Yes		7.5 GiB		150 GiB		Online	Up		3.1.1.0-519c78f	5.14.0-284.48.1.el9_2.x86_64	Red Hat Enterprise Linux CoreOS 414.92.202401121330-0 (Plow)
	10.13.231.16	7d08dfe9-7b32-492c-af5d-be657cf47b21	pwx-ocp-224-227-dcw8p-worker-0-w7z58	Disabled	Yes		7.5 GiB		150 GiB		Online	Up		3.1.1.0-519c78f	5.14.0-284.48.1.el9_2.x86_64	Red Hat Enterprise Linux CoreOS 414.92.202401121330-0 (Plow)
	10.13.234.31	77ca140f-20ac-436b-8e85-3c057e0440d8	pwx-ocp-224-227-dcw8p-worker-0-fqtw9	Disabled	Yes		7.5 GiB		150 GiB		Online	Up		3.1.1.0-519c78f	5.14.0-284.48.1.el9_2.x86_64	Red Hat Enterprise Linux CoreOS 414.92.202401121330-0 (Plow)
	10.13.235.83	6fb9fbe1-18f7-410f-be97-625f4fa2e21c	pwx-ocp-224-227-dcw8p-worker-0-k2zq9	Disabled	Yes		7.5 GiB		150 GiB		Online	Up		3.1.1.0-519c78f	5.14.0-284.48.1.el9_2.x86_64	Red Hat Enterprise Linux CoreOS 414.92.202401121330-0 (Plow)
	10.13.235.134	4b08a5ad-88ff-4818-89f7-8c019ac4bc50	pwx-ocp-224-227-dcw8p-worker-0-vjg6m	Disabled	Yes		7.5 GiB		150 GiB		Online	Up		3.1.1.0-519c78f	5.14.0-284.48.1.el9_2.x86_64	Red Hat Enterprise Linux CoreOS 414.92.202401121330-0 (Plow)
	10.13.235.133	2ba62d59-5f38-4b55-b0d8-c2962f9d600d	pwx-ocp-224-227-dcw8p-worker-0-fzz2r	Disabled	Yes		7.5 GiB		150 GiB		Online	Up (This node)	3.1.1.0-519c78f	5.14.0-284.48.1.el9_2.x86_64	Red Hat Enterprise Linux CoreOS 414.92.202401121330-0 (Plow)
	10.13.235.90	6a37efdb-2a22-4aeb-8981-36b852a2469e	pwx-ocp-224-227-dcw8p-worker-0-c48b2	Disabled	No		0 B		0 B		Online	No Storage	3.1.1.0-519c78f	5.14.0-284.48.1.el9_2.x86_64	Red Hat Enterprise Linux CoreOS 414.92.202401121330-0 (Plow)
	10.13.230.75	4d6cdd86-ce86-420d-a62c-e5a0a98d6615	pwx-ocp-224-227-dcw8p-worker-0-4h9l9	Disabled	No		0 B		0 B		Online	No Storage	3.1.1.0-519c78f	5.14.0-284.48.1.el9_2.x86_64	Red Hat Enterprise Linux CoreOS 414.92.202401121330-0 (Plow)
	10.13.230.76	4b944ea3-1d71-4f93-b4a6-82f368a92d1c	pwx-ocp-224-227-dcw8p-worker-0-gf75s	Disabled	No		Unavailable	Unavailable	Offline	No Storage	3.1.1.0-519c78f	5.14.0-284.48.1.el9_2.x86_64	Red Hat Enterprise Linux CoreOS 414.92.202401121330-0 (Plow)
Global Storage Pool
	Total Used    	:  53 GiB
	Total Capacity	:  1.0 TiB

INFO[2024-04-24 23:16:09] Verifying : Description : Test completed successfully ? 
INFO[2024-04-24 23:16:09] Actual:PASS, Expected: PASS         
INFO[2024-04-24 23:16:09] --------Test End------                       
INFO[2024-04-24 23:16:09] #Test: ScaleFADAVolumeAttach                 
INFO[2024-04-24 23:16:09] #Description: validating ScaleFADAVolumeAttach in longevity cluster 
```

