### PR TITLE
PTX-23652: be resilient to failures of GetVolumes() call

### DIFF
--- a/tests/basic/legacy_shared_sharedv4_service_migration_test.go
+++ b/tests/basic/legacy_shared_sharedv4_service_migration_test.go
@@ -91,13 +91,20 @@ func getLegacySharedVolumeCount(contexts []*scheduler.Context) int {
 	count := 0
 	for _, ctx := range contexts {
 		vols, err := Inst().S.GetVolumes(ctx)
-		log.FailOnError(err, "error geting volumes used by app")
-		for _, v := range vols {
-			vol, err := Inst().V.InspectVolume(v.ID)
-			log.FailOnError(err, "Failed to inspect volume %v", v.ID)
-			if vol.Spec.Shared {
-				count++
+		if err == nil {
+			for _, v := range vols {
+				vol, err := Inst().V.InspectVolume(v.ID)
+				log.FailOnError(err, "Failed to inspect volume %v", v.ID)
+				if vol.Spec.Shared {
+					count++
+				}
 			}
+		} else {
+			// Failed to get the volume for the context.
+			// It can happen if the pods are restarting or in flux.
+			// For now add a count of one. Will revist this in next iteration.
+			log.Infof("Failed to Get Volumes err=[%v]", err)
+			count++
 		}
 	}
 	return count

--- a/tests/basic/legacy_shared_sharedv4_service_migration_test.go
+++ b/tests/basic/legacy_shared_sharedv4_service_migration_test.go
@@ -396,10 +396,11 @@ var _ = Describe("{LegacySharedToSharedv4ServiceMigrationRestart}", func() {
 		for _, ctx := range contexts {
 			returnMapOfPodsUsingApiSharedVolumes(podMap, volMap, ctx)
 		}
-		setMigrateLegacySharedToSharedv4Service(true)
-		time.Sleep(210 * time.Second) // sleep 3.5 minutes.
 		totalSharedVolumes := getLegacySharedVolumeCount(contexts)
 		timeForMigration := ((totalSharedVolumes + 30) / 30) * 10
+
+		setMigrateLegacySharedToSharedv4Service(true)
+		time.Sleep(210 * time.Second) // sleep 3.5 minutes.
 
 		stepLog := "Pause Migration and let all Apps come up and restart Migration"
 		Step(stepLog, func() {
@@ -453,6 +454,9 @@ var _ = Describe("{LegacySharedToSharedv4ServicePxRestart}", func() {
 		for _, ctx := range contexts {
 			returnMapOfPodsUsingApiSharedVolumes(podMap, volMap, ctx)
 		}
+		totalSharedVolumes := getLegacySharedVolumeCount(contexts)
+		timeForMigration := ((totalSharedVolumes + 30) / 30) * 10
+
 		setMigrateLegacySharedToSharedv4Service(true)
 		time.Sleep(210 * time.Second) // sleep 3.5 minutes.
 
@@ -467,8 +471,6 @@ var _ = Describe("{LegacySharedToSharedv4ServicePxRestart}", func() {
 			log.FailOnError(err, fmt.Sprintf("Driver is down on node %s", pxNode.Name))
 		})
 
-		totalSharedVolumes := getLegacySharedVolumeCount(contexts)
-		timeForMigration := ((totalSharedVolumes + 30) / 30) * 10
 		waitAllSharedVolumesToGetMigrated(contexts, timeForMigration)
 		countPostTimeout := getLegacySharedVolumeCount(contexts)
 		dash.VerifyFatal(countPostTimeout == 0, true, fmt.Sprintf("Post migration count is [%d] instead of 0", countPostTimeout))
@@ -523,6 +525,8 @@ var _ = Describe("{LegacySharedToSharedv4ServiceNodeDecommission}", func() {
 		log.FailOnError(err, fmt.Sprintf("error in executing prereq for node %s decommission", pxNode.Name))
 
 		// Transition after preparing for decommission.
+		totalSharedVolumes := getLegacySharedVolumeCount(contexts)
+		timeForMigration := ((totalSharedVolumes + 30) / 30) * 10
 		setMigrateLegacySharedToSharedv4Service(true)
 		time.Sleep(90 * time.Second) // sleep 1.5 minute.
 
@@ -537,8 +541,6 @@ var _ = Describe("{LegacySharedToSharedv4ServiceNodeDecommission}", func() {
 
 		stepLog = "Validate migration process after node Decommission"
 		Step(stepLog, func() {
-			totalSharedVolumes := getLegacySharedVolumeCount(contexts)
-			timeForMigration := ((totalSharedVolumes + 30) / 30) * 10
 			waitAllSharedVolumesToGetMigrated(contexts, timeForMigration)
 			countPostTimeout := getLegacySharedVolumeCount(contexts)
 			dash.VerifyFatal(countPostTimeout == 0, true, fmt.Sprintf("Post migration count is [%d] instead of 0", countPostTimeout))
@@ -634,6 +636,9 @@ var _ = Describe("{LegacySharedToSharedv4ServiceRestartCoordinator}", func() {
 				break
 			}
 		}
+		totalSharedVolumes := getLegacySharedVolumeCount(contexts)
+		timeForMigration := ((totalSharedVolumes + 30) / 30) * 10
+
 		setMigrateLegacySharedToSharedv4Service(true)
 		time.Sleep(120 * time.Second) // sleep 2 minutes.
 
@@ -645,8 +650,6 @@ var _ = Describe("{LegacySharedToSharedv4ServiceRestartCoordinator}", func() {
 			log.FailOnError(err, fmt.Sprintf("Driver is down on node %s", nodeForPxRestart.Name))
 		})
 
-		totalSharedVolumes := getLegacySharedVolumeCount(contexts)
-		timeForMigration := ((totalSharedVolumes + 30) / 30) * 10
 		waitAllSharedVolumesToGetMigrated(contexts, timeForMigration)
 		countPostTimeout := getLegacySharedVolumeCount(contexts)
 		dash.VerifyFatal(countPostTimeout == 0, true, fmt.Sprintf("Post migration count is [%d] instead of 0", countPostTimeout))
@@ -692,13 +695,13 @@ var _ = Describe("{LegacySharedToSharedv4ServiceCreateSnapshotsClones}", func() 
 			returnMapOfPodsUsingApiSharedVolumes(podMap, volMap, ctx)
 		}
 		createSnapshotsAndClones(volMap, "snapshot-1", "clone-1")
+		totalSharedVolumes := getLegacySharedVolumeCount(contexts)
+		timeForMigration := ((totalSharedVolumes + 30) / 30) * 10
 		setMigrateLegacySharedToSharedv4Service(true)
 		time.Sleep(120 * time.Second) // sleep 2 minutes.
 
 		createSnapshotsAndClones(volMap, "snapshot-2", "clone-2")
 
-		totalSharedVolumes := getLegacySharedVolumeCount(contexts)
-		timeForMigration := ((totalSharedVolumes + 30) / 30) * 10
 		waitAllSharedVolumesToGetMigrated(contexts, timeForMigration)
 		countPostTimeout := getLegacySharedVolumeCount(contexts)
 		dash.VerifyFatal(countPostTimeout == 0, true, fmt.Sprintf("Post migration count is [%d] instead of 0", countPostTimeout))
@@ -808,6 +811,8 @@ var _ = Describe("{LegacySharedToSharedv4ServicePxKill}", func() {
 		for _, ctx := range contexts {
 			returnMapOfPodsUsingApiSharedVolumes(podMap, volMap, ctx)
 		}
+		totalSharedVolumes := getLegacySharedVolumeCount(contexts)
+		timeForMigration := ((totalSharedVolumes + 30) / 30) * 10
 		setMigrateLegacySharedToSharedv4Service(true)
 		time.Sleep(180 * time.Second) // sleep 3 minutes.
 
@@ -822,8 +827,6 @@ var _ = Describe("{LegacySharedToSharedv4ServicePxKill}", func() {
 			log.FailOnError(err, fmt.Sprintf("Driver is down on node %s", pxNode.Name))
 		})
 
-		totalSharedVolumes := getLegacySharedVolumeCount(contexts)
-		timeForMigration := ((totalSharedVolumes + 30) / 30) * 10
 		waitAllSharedVolumesToGetMigrated(contexts, timeForMigration)
 		countPostTimeout := getLegacySharedVolumeCount(contexts)
 		dash.VerifyFatal(countPostTimeout == 0, true, fmt.Sprintf("Post migration count is [%d] instead of 0", countPostTimeout))


### PR DESCRIPTION
GetVolumes() call is supposed to be made when the pods in the context are stable. In case of migration, the pods can get restarted during the migration process and the call to gEtVolumes() can fail. Be resilient to these failures and don't fail the test case if this call fails, instead treat the failure as having a shared volume. This call will happen again and will get the correct count in further iterations.
