### PR TITLE
Fix restore NS name

### DIFF
--- a/tests/backup/backup_share_test.go
+++ b/tests/backup/backup_share_test.go
@@ -3872,7 +3872,7 @@ var _ = Describe("{IssueMultipleDeletesForSharedBackup}", Label(TestCaseLabelsMa
 				backupMap[backupName] = backupUID
 
 				// Start Restore
-				namespaceMapping[bkpNamespaces[0]] = bkpNamespaces[0] + "restored"
+				namespaceMapping[bkpNamespaces[0]] = bkpNamespaces[0] + "-" + user
 				restoreName := fmt.Sprintf("%s-%s", RestoreNamePrefix, user)
 				restoreNames = append(restoreNames, restoreName)
 				log.Infof("Creating restore %s for user %s", restoreName, user)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

The test restores from multiple users  to the same namespace causing it to fail always on ROKS one such example is https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/basic-system-test/job/nonpx/job/ibm/job/s3/job/roks/job/ibm-roks-s3-csi-offload/18/

**What this PR does / why we need it**:
- [x] Fix restore NS name

Successful run: https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/basic-system-test/job/nonpx/job/ibm/job/s3/job/roks/job/ibm-roks-s3-csi-offload/21/

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

