### PR TITLE
PB-6777: Add Backup driver with WaitForBackupPartialCompletion method

### DIFF
--- a/drivers/backup/backup.go
+++ b/drivers/backup/backup.go
@@ -252,6 +252,11 @@ type Backup interface {
 	WaitForBackupCompletion(ctx context.Context, backupName string, orgID string,
 		timeout time.Duration, timeBeforeRetry time.Duration) error
 
+	// WaitForBackupPartialCompletion waits for backup to partial complete successfully
+	// or till timeout is reached. API should poll every `timeBeforeRetry`
+	WaitForBackupPartialCompletion(ctx context.Context, backupName string, orgID string,
+		timeout time.Duration, timeBeforeRetry time.Duration) error
+
 	// WaitForBackupDeletion waits for backup to be deleted successfully
 	// or till timeout is reached. API should poll every `timeBeforeRetry
 	WaitForBackupDeletion(ctx context.Context, backupName string, orgID string,


### PR DESCRIPTION
… and its portworx implementation

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Add a method to backup driver to wait until the backup is in partial success state

**Which issue(s) this PR fixes** (optional)
Closes #PB-6777

**Special notes for your reviewer**:

