### PR TITLE
Keep count for how many backend API Calls are being made via PX

### DIFF
--- a/tests/common.go
+++ b/tests/common.go
@@ -8016,9 +8016,10 @@ func StartTorpedoTest(testName, testDescription string, tags map[string]string, 
 		RunIdForSuite = testrailuttils.AddRunsToMilestone(testRepoID)
 		CurrentTestRailTestCaseId = testRepoID
 	}
+	apiCalls := countAPICallsOnNodes()
 	log.Infof("API Count per node (Start of Test):")
-	for node, count := range countAPICallsOnNodes() {
-		log.Infof("API calls made by node %s: %d", node, count)
+	for node, count := range apiCalls {
+		log.Infof("%s: %d", node, count)
 	}
 }
 
@@ -8059,9 +8060,10 @@ func EnableAutoFSTrim() {
 func EndTorpedoTest() {
 	CloseLogger(TestLogger)
 	dash.TestCaseEnd()
+	apiCalls := countAPICallsOnNodes()
 	log.Infof("API Count per node (End of Test):")
-	for node, count := range countAPICallsOnNodes() {
-		log.Infof("API calls made by node %s: %d", node, count)
+	for node, count := range apiCalls {
+		log.Infof("%s: %d", node, count)
 	}
 }
 


### PR DESCRIPTION
This change addresses https://purestorage.atlassian.net/browse/PTX-23799
It keeps a count of how many API calls are being made to the backend. As of now it supports vsphere cloud drives and facd. 

Jenkins run: 
https://jenkins.pwx.dev.purestorage.com/job/Users/job/Dhruv/job/3102-pipeline/42
https://jenkins.pwx.dev.purestorage.com/job/Users/job/Dhruv/job/3102-pipeline/43

