### PR TITLE
Fixing the user name length because it is used in namespace creation …

### DIFF
--- a/tests/backup_helper.go
+++ b/tests/backup_helper.go
@@ -2076,10 +2076,10 @@ func CreateUsers(numberOfUsers int) []string {
 	log.InfoD("Creating %d users", numberOfUsers)
 	var wg sync.WaitGroup
 	for i := 1; i <= numberOfUsers; i++ {
-		userName := fmt.Sprintf("testuser%v-%v", i, time.Now().Unix())
-		firstName := fmt.Sprintf("FirstName%v", i)
-		lastName := fmt.Sprintf("LastName%v", i)
-		email := fmt.Sprintf("%v@cnbu.com", userName)
+		userName := fmt.Sprintf("tp-user%d-%s", i, RandomString(4))
+		firstName := fmt.Sprintf("FirstName%d", i)
+		lastName := fmt.Sprintf("LastName%d", i)
+		email := fmt.Sprintf("%s@cnbu.com", userName)
 		wg.Add(1)
 		go func(userName, firstName, lastName, email string) {
 			defer GinkgoRecover()


### PR DESCRIPTION
…and exceeding 63 chars

The user name which was getting appended to the namespace was crossing 63 chars and failing. Fixed it by reducing the username length.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
[Jenkins Run with S3](https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/5142/)
[Jenkins Run with NFS](https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/5143/)
