### PR TITLE
[PTX-23856] Increase Timeout In ValidateStorageCluster

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -5232,7 +5232,8 @@ func (d *portworx) ValidateDriver(endpointVersion string, autoUpdateComponents b
 		}
 
 		// Validate StorageCluster
-		if err = optest.ValidateStorageCluster(imageList, newStc, validateStorageClusterTimeout, defaultRetryInterval, true); err != nil {
+		storageClusterValidateTimeout := time.Duration(len(node.GetStorageDriverNodes())*9) * time.Minute
+		if err = optest.ValidateStorageCluster(imageList, newStc, storageClusterValidateTimeout, defaultRetryInterval, true); err != nil {
 			return err
 		}
 	}
@@ -5276,8 +5277,8 @@ func (d *portworx) updateAndValidateStorageCluster(cluster *v1.StorageCluster, f
 			}
 		}
 	}
-
-	if err = optest.ValidateStorageCluster(imageList, stc, validateStorageClusterTimeout, defaultRetryInterval, true); err != nil {
+	storageClusterValidateTimeout := time.Duration(len(node.GetStorageDriverNodes())*9) * time.Minute
+	if err = optest.ValidateStorageCluster(imageList, stc, storageClusterValidateTimeout, defaultRetryInterval, true); err != nil {
 		return nil, err
 	}
 	return stc, nil

--- a/tests/basic/upgrade_test.go
+++ b/tests/basic/upgrade_test.go
@@ -457,7 +457,8 @@ var _ = Describe("{UpgradeVolumeDriverFromCatalog}", func() {
 				imageList, err := optest.GetImagesFromVersionURL(upgradeHop, k8sVersion.String())
 				log.FailOnError(err, "error getting images using URL [%s] and k8s version [%s]", upgradeHop, k8sVersion.String())
 
-				err = optest.ValidateStorageCluster(imageList, stc, ValidateStorageClusterTimeout, defaultRetryInterval, true)
+				storageClusterValidateTimeout := time.Duration(len(node.GetStorageDriverNodes())*9) * time.Minute
+				err = optest.ValidateStorageCluster(imageList, stc, storageClusterValidateTimeout, defaultRetryInterval, true)
 				dash.VerifyFatal(err, nil, fmt.Sprintf("Verify PX upgrade from version [%s] to version [%s]", currPXVersion, nextPXVersion))
 
 				timeAfterUpgrade = time.Now()

--- a/tests/testTriggers.go
+++ b/tests/testTriggers.go
@@ -6252,7 +6252,8 @@ func TriggerUpgradeVolumeDriverFromCatalog(contexts *[]*scheduler.Context, recor
 					UpdateOutcome(event, fmt.Errorf("error getting images using URL [%s] and k8s version [%s]. Err: [%v]", upgradeHop, k8sVersion.String(), err))
 					return
 				}
-				err = oputil.ValidateStorageCluster(imageList, stc, ValidateStorageClusterTimeout, defaultRetryInterval, true)
+				storageClusterValidateTimeout := time.Duration(len(node.GetStorageDriverNodes())*9) * time.Minute
+				err = oputil.ValidateStorageCluster(imageList, stc, storageClusterValidateTimeout, defaultRetryInterval, true)
 				if err != nil {
 					UpdateOutcome(event, fmt.Errorf("error validating storage cluster after upgrade. Err: [%v]", err))
 					return


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR sets the timeout for ValidateStorageCluster based on the number of storage driver nodes.

**Which issue(s) this PR fixes** (optional)
Closes #PTX-23856

**Special notes for your reviewer**:
There is no easy way to test this, so I will monitor the pipeline once the changes are merged.