### PR TITLE
Enabled deletebackups true for cluster delete in cleanup

### DIFF
--- a/tests/backup_helper.go
+++ b/tests/backup_helper.go
@@ -2170,7 +2170,7 @@ func CleanupCloudSettingsAndClusters(backupLocationMap map[string]string, credNa
 					log.Warnf("the cloud credential ref of the cluster [%s] is nil", clusterObj.GetName())
 				}
 			}
-			err = DeleteClusterWithUID(clusterObj.GetName(), clusterObj.GetUid(), BackupOrgID, ctx, false)
+			err = DeleteClusterWithUID(clusterObj.GetName(), clusterObj.GetUid(), BackupOrgID, ctx, true)
 			Inst().Dash.VerifySafely(err, nil, fmt.Sprintf("Deleting cluster %s", clusterObj.GetName()))
 			if clusterCredName != "" {
 				err = DeleteCloudCredential(clusterCredName, BackupOrgID, clusterCredUID)


### PR DESCRIPTION
**What this PR does / why we need it**:
Due to. [PB-5031](https://purestorage.atlassian.net/browse/PB-5031) The is change in behaviour for cluster deletion, The cluster will deleting state untill delete pending or in progress  backups are done with process.

This has caused some of runs to hang up in cleanup stage.
https://aetos.pwx.purestorage.com/resultSet/testSetID/636578/testCaseID/3958221

Hence enabling the boolean to delete all backups before we delete cluster
**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:



[PB-5031]: https://purestorage.atlassian.net/browse/PB-5031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ