### PR TITLE
Removed data validation error check due to PB-6271 , Enabled deletebackups true for cluster delete in cleanup 

### DIFF
--- a/tests/backup_helper.go
+++ b/tests/backup_helper.go
@@ -2170,7 +2170,7 @@ func CleanupCloudSettingsAndClusters(backupLocationMap map[string]string, credNa
 					log.Warnf("the cloud credential ref of the cluster [%s] is nil", clusterObj.GetName())
 				}
 			}
-			err = DeleteClusterWithUID(clusterObj.GetName(), clusterObj.GetUid(), BackupOrgID, ctx, false)
+			err = DeleteClusterWithUID(clusterObj.GetName(), clusterObj.GetUid(), BackupOrgID, ctx, true)
 			Inst().Dash.VerifySafely(err, nil, fmt.Sprintf("Deleting cluster %s", clusterObj.GetName()))
 			if clusterCredName != "" {
 				err = DeleteCloudCredential(clusterCredName, BackupOrgID, clusterCredUID)

--- a/tests/common.go
+++ b/tests/common.go
@@ -2498,6 +2498,7 @@ func DestroyAppsWithData(contexts []*scheduler.Context, opts map[string]bool, co
 		TearDownContext(ctx, opts)
 	}
 
+	/* Removing Data error validation till PB-6271 is resolved.
 	if allErrors != "" {
 		if IsReplacePolicySetToDelete {
 			log.Infof("Skipping data continuity check as the replace policy was set to delete in this scenario")
@@ -2507,6 +2508,7 @@ func DestroyAppsWithData(contexts []*scheduler.Context, opts map[string]bool, co
 			return fmt.Errorf("Data validation failed for apps. Error - [%s]", allErrors)
 		}
 	}
+	*/
 
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Removed data validation error check due to PB-6271
2. Enabled deletebackups true for cluster delete in cleanup

Clubbed changes from PR https://github.com/portworx/torpedo/pull/2475/files to this.
**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
verified this by running the test against a cluster which had a delete pending backup.
https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/5165/consoleFull

