### PR TITLE
Run torpedo as a pod in anthos user cluster

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -238,6 +238,11 @@ if [ -n "$ANTHOS_INST_PATH" ]; then
     ANTHOS_INST_PATH="${ANTHOS_INST_PATH}"
 fi
 
+if [ -n "$ANTHOS_HOST_PATH" ]; then
+    ANTHOS_HOST_PATH="${ANTHOS_HOST_PATH}"
+fi
+
+
 for i in $@
 do
 case $i in
@@ -317,6 +322,9 @@ TESTRESULTS_MOUNT="{ \"name\": \"testresults\", \"mountPath\": \"/testresults/\"
 AWS_VOLUME="{ \"name\": \"aws-volume\", \"configMap\": { \"name\": \"aws-cm\", \"items\": [{\"key\": \"credentials\", \"path\": \"credentials\"}, {\"key\": \"config\", \"path\": \"config\"}]} }"
 AWS_VOLUME_MOUNT="{ \"name\": \"aws-volume\", \"mountPath\": \"/root/.aws/\" }"
 
+ANTHOS_VOLUME="{ \"name\": \"anthosdir\", \"hostPath\": { \"path\": \"${ANTHOS_HOST_PATH}\", \"type\": \"Directory\" } }"
+ANTHOS_VOLUME_MOUNT="{ \"name\": \"anthosdir\", \"mountPath\": \"/anthosdir\" }"
+
 VOLUMES="${TESTRESULTS_VOLUME}"
 
 if [ "${STORAGE_DRIVER}" == "aws" ]; then
@@ -363,6 +371,11 @@ fi
 
 if [ -n "${TORPEDO_CUSTOM_PARAM_MOUNT}" ]; then
     VOLUME_MOUNTS="${VOLUME_MOUNTS},${TORPEDO_CUSTOM_PARAM_MOUNT}"
+fi
+
+if [ -n "${ANTHOS_HOST_PATH}" ]; then
+  VOLUMES="${VOLUMES},${ANTHOS_VOLUME}"
+  VOLUME_MOUNTS="${VOLUME_MOUNTS},${ANTHOS_VOLUME_MOUNT}"
 fi
 
 BUSYBOX_IMG="busybox"


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Currently torpedo pods run as a local container and it throws I/O error when trying to connect PX pods.


**Which issue(s) this PR fixes** (optional)
Closes # PTX-24059

**Special notes for your reviewer**:
Minor changes
Testing the changes in below jobs: 
https://jenkins.pwx.dev.purestorage.com/job/Torpedo/job/tp-nextpx-anthos-op/325/console
https://jenkins.pwx.dev.purestorage.com/job/Torpedo/view/Torpedo-Detailed/job/tp-k8s-matrix-op-csi/1033/console
