### PR TITLE
[PTX-24076] Add Ginkgo Support To Deployment Script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,10 @@ RUN apk add --no-cache openssh sshpass
 # Install dependancy for OCP 4.14 CLI
 RUN apk --update add gcompat
 
+# Install yq
+RUN wget https://github.com/mikefarah/yq/releases/download/v4.25.1/yq_linux_amd64 -O /usr/bin/yq && \
+    chmod +x /usr/bin/yq
+
 # Copy ginkgo & binaries over from previous container
 COPY --from=build /go/bin/ginkgo /bin/ginkgo
 COPY --from=build /go/src/github.com/portworx/torpedo/bin bin


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR adds logic to scrape the Torpedo pod yaml spec to form a Ginkgo command, which can be run directly, thereby making the deployment script more flexible. This is useful in scenarios where the Torpedo pod cannot be deployed.

**Which issue(s) this PR fixes** (optional)
Closes #PTX-24076

**Special notes for your reviewer**:
Please review the following Jenkins builds:

With `RUN_GINKGO_COMMAND`:

Jenkins: https://jenkins.pwx.dev.purestorage.com/job/Users/job/Leela/job/tp-byoc/749/
Aetos Dashboard: https://aetos.pwx.purestorage.com/resultSet/testSetID/644657

Without `RUN_GINKGO_COMMAND`:

Jenkins: https://jenkins.pwx.dev.purestorage.com/job/Users/job/Leela/job/tp-byoc/750/
Aetos Dashboard: https://aetos.pwx.purestorage.com/resultSet/testSetID/644658

Logs:

```bash
Formatted Ginkgo Command: ginkgo --trace --timeout 720h0m0s --fail-fast --poll-progress-after 20m --junit-report=/testresults/junit_basic.xml "" "" bin/basic.test -- --spec-dir ../drivers/scheduler/k8s/specs --app-list "" --deploy-pds-apps=false --pds-driver "" --secure-apps "" --repl1-apps "" --csi-app-list "" --scheduler k8s --max-storage-nodes-per-az 2 --backup-driver "" --log-level debug --node-driver ssh --scale-factor 10 --hyper-converged=true --fail-on-px-pod-restartcount=false --minimun-runtime-mins 0 --driver-start-timeout 10m0s --chaos-level 5 --storagenode-recovery-timeout 35m0s --provisioner portworx --storage-driver pxd --config-map "" --custom-config "" --storage-upgrade-endpoint-url= --storage-upgrade-endpoint-version= --upgrade-storage-driver-endpoint-list= --enable-stork-upgrade=false --secret-type=k8s --pure-volumes=false --pure-fa-snapshot-restore-to-many-test=false --pure-san-type=ISCSI --vault-addr= --vault-token= --px-runtime-opts= --px-cluster-opts= --anthos-ws-node-ip= --anthos-inst-path= --autopilot-upgrade-version= --csi-generic-driver-config-map= --sched-upgrade-hops= --migration-hops= --license_expiry_timeout_hours=1h0m0s --metering_interval_mins=10m0s --testrail-milestone= --testrail-run-name= --testrail-run-id= --testrail-jeknins-build-url= --testrail-host= --testrail-username= --testrail-password= --jira-username= --jira-token= --jira-account-id= --user=krishna --enable-dash=true --data-integrity-validation-tests= --test-desc= --test-type= --test-tags= --testset-id=0 --branch= --product= --torpedo-job-name=torpedo-daily-job --torpedo-job-type=functional --torpedo-skip-system-checks=true --fa-secret= 

Cleaned Ginkgo Command: ginkgo --trace --timeout 720h0m0s --fail-fast --poll-progress-after 20m --junit-report=/testresults/junit_basic.xml "" "" bin/basic.test -- --spec-dir ../drivers/scheduler/k8s/specs --deploy-pds-apps=false --scheduler k8s --max-storage-nodes-per-az 2 --log-level debug --node-driver ssh --scale-factor 10 --hyper-converged=true --fail-on-px-pod-restartcount=false --minimun-runtime-mins 0 --driver-start-timeout 10m0s --chaos-level 5 --storagenode-recovery-timeout 35m0s --provisioner portworx --storage-driver pxd --storage-upgrade-endpoint-url= --storage-upgrade-endpoint-version= --upgrade-storage-driver-endpoint-list= --enable-stork-upgrade=false --secret-type=k8s --pure-volumes=false --pure-fa-snapshot-restore-to-many-test=false --pure-san-type=ISCSI --vault-addr= --vault-token= --px-runtime-opts= --px-cluster-opts= --anthos-ws-node-ip= --anthos-inst-path= --autopilot-upgrade-version= --csi-generic-driver-config-map= --sched-upgrade-hops= --migration-hops= --license_expiry_timeout_hours=1h0m0s --metering_interval_mins=10m0s --testrail-milestone= --testrail-run-name= --testrail-run-id= --testrail-jeknins-build-url= --testrail-host= --testrail-username= --testrail-password= --jira-username= --jira-token= --jira-account-id= --user=krishna --enable-dash=true --data-integrity-validation-tests= --test-desc= --test-type= --test-tags= --testset-id=0 --branch= --product= --torpedo-job-name=torpedo-daily-job --torpedo-job-type=functional --torpedo-skip-system-checks=true --fa-secret=
```