### PR TITLE
Fix Workload and Validate Dataservice Deployment and Update

### DIFF
--- a/drivers/pds/dataservice/workloads.go
+++ b/drivers/pds/dataservice/workloads.go
@@ -147,7 +147,7 @@ func createClusterRole(resourceName string) (*rbacv1.ClusterRole, error) {
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{"deployments.pds.portworx.com"},
-				Resources: []string{resourceName + "s"},
+				Resources: []string{resourceName},
 				Verbs:     []string{"get", "list"},
 			},
 		},

--- a/drivers/unifiedPlatform/pdsLibs/common.go
+++ b/drivers/unifiedPlatform/pdsLibs/common.go
@@ -63,6 +63,20 @@ const (
 	consul        = "Consul"
 )
 
+var CrdMap = map[string]string{
+	"postgresql":    "postgresqls",
+	"elasticsearch": "elasticsearches",
+	"couchbase":     "couchbases",
+	"cassandra":     "cassandras",
+	"rabbitmq":      "rabbitmqs",
+	"mysql":         "mysqls",
+	"redis":         "redis",
+	"mongodb":       "mongodbs",
+	"sqlserver":     "sqlservers",
+	"kafka":         "kafkas",
+	"consul":        "consuls",
+}
+
 type PDSDataService struct {
 	DeploymentName        string "json:\"DeploymentName\""
 	Name                  string "json:\"Name\""

--- a/tests/unifiedPlatform/pds2/pds_resiliency_test.go
+++ b/tests/unifiedPlatform/pds2/pds_resiliency_test.go
@@ -17,51 +17,6 @@ const (
 	DeletePdsDeploymentPodAndValidateDeploymentHealth = "delete-pdsDeploymentPods-validate-deployment-health"
 )
 
-var _ = Describe("{ValidatePdsHealthIncaseofFailures}", func() {
-	var (
-		workflowResiliency pds.WorkflowPDSResiliency
-		deployment         *automationModels.PDSDeploymentResponse
-		err                error
-	)
-
-	JustBeforeEach(func() {
-		StartPDSTorpedoTest("ValidatePdsHealthIncaseofFailures", "Deploy data services and validate PDS health in case of PDS pod deletion", nil, 0)
-	})
-
-	It("Deploy and Validate DataService", func() {
-		for _, ds := range NewPdsParams.DataServiceToTest {
-			Step("Deploy DataService", func() {
-				log.Debugf("Deploying DataService [%s]", ds.Name)
-				deployment, err = WorkflowDataService.DeployDataService(ds, ds.Image, ds.Version, PDS_DEFAULT_NAMESPACE)
-				log.FailOnError(err, "Error while deploying ds")
-				log.Debugf("Source Deployment Id: [%s]", *deployment.Create.Meta.Uid)
-			})
-
-			//stepLog := "Running Workloads before taking backups"
-			//Step(stepLog, func() {
-			//	err := workflowDataservice.RunDataServiceWorkloads(NewPdsParams)
-			//	log.FailOnError(err, "Error while running workloads on ds")
-			//})
-
-			Step("Delete PdsDeploymentPods and check the deployment health", func() {
-				workflowResiliency.WfDataService = &WorkflowDataService
-				workflowResiliency.ResiliencyFlag = true
-				workflowResiliency.InduceFailureAndExecuteResiliencyScenario(ds, deployment, DeletePdsDeploymentPodAndValidateDeploymentHealth)
-			})
-
-			//stepLog = "Running Workloads after ScaleUp of DataService"
-			//Step(stepLog, func() {
-			//	err := workflowDataservice.RunDataServiceWorkloads(NewPdsParams)
-			//	log.FailOnError(err, "Error while running workloads on ds")
-			//})
-		}
-	})
-
-	JustAfterEach(func() {
-		defer EndPDSTorpedoTest()
-	})
-})
-
 var _ = Describe("{StopPXDuringStorageResize}", func() {
 	JustBeforeEach(func() {
 		StartTorpedoTest("StopPXDuringStorageResize", "Deploy data services, Run workloads, and Stop PX on the node while Storage resize is happening", nil, 0)

--- a/tests/unifiedPlatform/pds2/pds_restore_negative_test.go
+++ b/tests/unifiedPlatform/pds2/pds_restore_negative_test.go
@@ -66,7 +66,7 @@ var _ = Describe("{RestartPdsAgentPodAndPerformBackupAndRestore}", func() {
 			steplog = "Restart PDS Agent Pods and Validate if it comes up"
 			Step(steplog, func() {
 				log.InfoD(steplog)
-				err := WorkflowDataService.DeletePDSPods([]string{"agent", "pds-target"})
+				err := WorkflowDataService.DeletePDSPods([]string{"agent", "pds-target"}, PlatformNamespace)
 				log.FailOnError(err, "Error while deleting pds pods")
 				err = WorkflowDataService.ValidatePdsDataServiceDeployments(
 					*deployment.Create.Meta.Uid,
@@ -347,7 +347,7 @@ var _ = Describe("{PerformRestorePDSPodsDown}", func() {
 					defer wg.Done()
 					defer GinkgoRecover()
 					log.Infof("Delete backup controller and Target Controller operator pod")
-					err := WorkflowDataService.DeletePDSPods([]string{"pds-backups", "pds-target"})
+					err := WorkflowDataService.DeletePDSPods([]string{"pds-backups", "pds-target"}, PlatformNamespace)
 					if err != nil {
 						allErrors = append(allErrors, err.Error())
 					}


### PR DESCRIPTION
This PR has testcase, 
1. Added Statefulset validation for the dataservice deployment and update
2. Fixed CRD Names in Workload Generation Script
3. Modified  ValidatePdsHealthIncaseofFailures Testcase

**Which issue(s) this PR fixes** (optional)
Closes #DS-9850

Jenkins logs 
ValidatePdsHealthIncaseofFailures - https://jenkins.pwx.dev.purestorage.com/job/PDS/job/pds2.0-byoc-branch-build-test/884/

For 1, 2 - https://jenkins.pwx.dev.purestorage.com/job/PDS/job/pds2.0-byoc-branch-build-test/907/

