### PR TITLE
Fixing OCP zones

### DIFF
--- a/drivers/node/vsphere/vsphere.go
+++ b/drivers/node/vsphere/vsphere.go
@@ -403,15 +403,15 @@ func (v *vsphere) DetachDisk(vmUuid string, path string) error {
 	return fmt.Errorf("No device selected for VM: %q", vmMo)
 }
 
-//Match the paths between fileNamePath and absolute vmdk path
+// Match the paths between fileNamePath and absolute vmdk path
 func matchVirtualDiskAndVolPath(diskPath, volPath string) bool {
 	diskPath = strings.TrimSuffix(diskPath, filepath.Ext(diskPath))
 	volPath = strings.TrimSuffix(volPath, filepath.Ext(volPath))
 	return diskPath == volPath
 }
 
-//Get virtual disk path.
-//TODO need to filter only of type: DrivePaths
+// Get virtual disk path.
+// TODO need to filter only of type: DrivePaths
 func GetDiskPaths(driveset DriveSet) []string {
 	diskPaths := []string{}
 	for vmdkPath, configs := range driveset.Configs {
@@ -433,7 +433,7 @@ func GetDiskPaths(driveset DriveSet) []string {
 	return diskPaths
 }
 
-//GetDatastore
+// GetDatastore
 func GetDatastore(configs DriveConfig) string {
 	for key, val := range configs.Labels {
 		if key == "datastore" {
@@ -443,7 +443,7 @@ func GetDatastore(configs DriveConfig) string {
 	return ""
 }
 
-//GetCloudDriveConfigmapData Get clouddrive configMap data.
+// GetCloudDriveConfigmapData Get clouddrive configMap data.
 func GetCloudDriveConfigmapData(cluster *corev1.StorageCluster) (map[string]DriveSet, error) {
 	cloudDriveConfigmapName := pxutil.GetCloudDriveConfigMapName(cluster)
 	var PortworxNamespace = "kube-system"
@@ -476,6 +476,10 @@ func (v *vsphere) AddMachine(vmName string) error {
 	err = vm.Properties(v.ctx, vm.Reference(), []string{"guest.hostName"}, &vmMo)
 	if err != nil {
 		return err
+	}
+
+	if vmMo.Guest == nil {
+		return fmt.Errorf("failed to find guest info for virtual machine %s", vmName)
 	}
 
 	// Get the hostname
@@ -566,7 +570,7 @@ func (v *vsphere) PowerOnVMByName(vmName string) error {
 	// Make sure vmName is part of vmMap before using this method
 
 	var err error
-	//Reestblish connection to avoid session timeout.
+	//Reestablish connection to avoid session timeout.
 	err = v.connect()
 	if err != nil {
 		return err

--- a/drivers/scheduler/openshift/openshift.go
+++ b/drivers/scheduler/openshift/openshift.go
@@ -1298,6 +1298,9 @@ func updatePrometheusAndAutopilot() error {
 
 func (k *openshift) SetASGClusterSize(replicas int64, timeout time.Duration) error {
 	initialMachineCount, err := k.getMachinesCount()
+	if err != nil {
+		return err
+	}
 
 	machineSetName, err := getMachineSetName()
 	if err != nil {
@@ -1333,6 +1336,30 @@ func (k *openshift) SetASGClusterSize(replicas int64, timeout time.Duration) err
 	}
 
 	if _, err := k.checkAndGetNewNode(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (k *openshift) GetASGClusterSize() (int64, error) {
+	machineCount, err := k.getMachinesCount()
+	if err != nil {
+		return 0, err
+	}
+
+	return int64(machineCount), nil
+}
+
+func (k *openshift) GetZones() ([]string, error) {
+	//OCP has one zone
+	return []string{"zone-1"}, nil
+}
+
+func (k *openshift) Init(schedOpts scheduler.InitOptions) error {
+
+	err := k.K8s.Init(schedOpts)
+	if err != nil {
 		return err
 	}
 

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -662,16 +662,9 @@ func (d *portworx) comparePoolsAndDisks(srcNode *api.StorageNode,
 	srcDisks := srcNode.Disks
 	dstDisks := dstNode.Disks
 
-	for disk, value := range srcDisks {
-		if !srcDisks[disk].Metadata && !dstDisks[disk].Metadata {
-			if value.Id != dstDisks[disk].Id {
-				return false
-			}
-		} else if srcDisks[disk].Metadata && dstDisks[disk].Metadata {
-			if value.Id != dstDisks[disk].Id {
-				return false
-			}
-		}
+	if len(srcDisks) != len(dstDisks) {
+		log.Errorf("Source disks: [%v] not macthing with Destination disks: [%v]", srcDisks, dstDisks)
+		return false
 	}
 	return true
 }
@@ -2902,7 +2895,7 @@ func (d *portworx) ValidateRebalanceJobs() error {
 }
 
 func (d *portworx) ResizeStoragePoolByPercentage(poolUUID string, e api.SdkStoragePool_ResizeOperationType, percentage uint64) error {
-	log.InfoD("Initiating pool %v resize by %v with operationtype %v", poolUUID, percentage, e.String())
+	log.InfoD("Initiating pool %v resize by %v with operation-type %v", poolUUID, percentage, e.String())
 
 	// Start a task to check if pool  resize is done
 	t := func() (interface{}, bool, error) {

--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -5043,7 +5043,7 @@ var _ = Describe("{ResizeKvdbNoQuorum}", func() {
 		ValidateApplications(contexts)
 		defer appsValidateAndDestroy(contexts)
 
-		stoageDriverNodes := node.GetStorageDriverNodes()
+		stoageDriverNodes := node.GetStorageNodes()
 
 		nonKvdbNodes := make([]node.Node, 0)
 		kvdbNodes := make([]node.Node, 0)
@@ -5063,6 +5063,10 @@ var _ = Describe("{ResizeKvdbNoQuorum}", func() {
 			} else {
 				nonKvdbNodes = append(nonKvdbNodes, n)
 			}
+		}
+
+		if len(nonKvdbNodes) == 0 {
+			log.FailOnError(fmt.Errorf("No non kvdb nodes found"), "non kvdb nodes doesnt not exist in the cluster")
 		}
 
 		selPool := nonKvdbNodes[0].Pools[0]


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
- Fixes for OCP GetZones and Node Recycle
- Fixes for forcing pool expansion in case of previous expansion failed to unclean volumes in longevity
- Fix for KVDB no quorum test  not to panic when only 3 storage nodes are there in the set up

**Which issue(s) this PR fixes** (optional)
Closes #PTX-24215,PTX-24216

**Special notes for your reviewer**:
Results : 
https://aetos.pwx.purestorage.com/resultSet/testSetID/650542
