### PR TITLE
Adding ability to run Px-Backup tests with Px-Security enabled

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -3,6 +3,7 @@ package portworx
 import (
 	"context"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"math"
@@ -488,6 +489,16 @@ func (d *portworx) Init(sched, nodeDriver, token, storageProvisioner, csiGeneric
 }
 
 func (d *portworx) RefreshDriverEndpoints() error {
+
+	secretConfigMap := flag.Lookup("config-map").Value.(flag.Getter).Get().(string)
+	if secretConfigMap != "" {
+		log.Infof("Fetching token from configmap: %s", secretConfigMap)
+		token, err := d.schedOps.GetTokenFromConfigMap(secretConfigMap)
+		if err != nil {
+			return err
+		}
+		d.token = token
+	}
 
 	// getting namespace again (refreshing it) as namespace of portworx in switched context might have changed
 	namespace, err := d.GetVolumeDriverNamespace()

--- a/drivers/volume/portworx/schedops/dcos-schedops.go
+++ b/drivers/volume/portworx/schedops/dcos-schedops.go
@@ -12,6 +12,10 @@ import (
 type dcosSchedOps struct {
 }
 
+func (d *dcosSchedOps) GetTokenFromConfigMap(configMapName string) (string, error) {
+	return "", nil
+}
+
 func (d *dcosSchedOps) GetKubernetesVersion() (*version.Info, error) {
 	return nil, nil
 }

--- a/drivers/volume/portworx/schedops/k8s-schedops.go
+++ b/drivers/volume/portworx/schedops/k8s-schedops.go
@@ -65,6 +65,8 @@ const (
 	k8sRoleNodeInfraLabelKey = "node-role.kubernetes.io/infra"
 	// k8sRoleNodeComputeLabelKey is the label used to check whether node has compute=true label on OpenShift Enterprise environment
 	k8sRoleNodeComputeLabelKey = "node-role.kubernetes.io/compute"
+	secretNameKey              = "secret_name"
+	secretNamespaceKey         = "secret_namespace"
 
 	// nodeType is label used to check kubernetes node-type
 	dcosNodeType                = "kubernetes.dcos.io/node-type"
@@ -1080,6 +1082,22 @@ func (k *k8sSchedOps) GetPortworxNamespace() (string, error) {
 	}
 	return ns, nil
 
+}
+
+func (k *k8sSchedOps) GetTokenFromConfigMap(configMapName string) (string, error) {
+	var token string
+	var err error
+	var configMap *corev1.ConfigMap
+	k8sOps := k8sCore
+	if configMap, err = k8sOps.GetConfigMap(configMapName, "default"); err == nil {
+		if secret, err := k8sOps.GetSecret(configMap.Data[secretNameKey], configMap.Data[secretNamespaceKey]); err == nil {
+			if tk, ok := secret.Data["auth-token"]; ok {
+				token = string(tk)
+			}
+		}
+	}
+	log.Infof("Token from secret: %s", token)
+	return token, err
 }
 
 func printStatus(k *k8sSchedOps, pods ...corev1.Pod) {

--- a/drivers/volume/portworx/schedops/schedops.go
+++ b/drivers/volume/portworx/schedops/schedops.go
@@ -38,6 +38,8 @@ type Driver interface {
 	GetVolumeName(v *volume.Volume) string
 	// GetPortworxNamespace returns the Portworx namespace
 	GetPortworxNamespace() (string, error)
+	// GetTokenFromConfigMap returns the token from the configmap
+	GetTokenFromConfigMap(configMapName string) (string, error)
 	// GetServiceEndpoint returns the hostname of portworx service if it is present
 	GetServiceEndpoint() (string, error)
 	// UpgradePortworx upgrades portworx to the given docker image and tag

--- a/tests/backup/backup_basic_test.go
+++ b/tests/backup/backup_basic_test.go
@@ -80,13 +80,23 @@ func BackupInitInstance() {
 	var commitID string
 	log.Infof("Inside BackupInitInstance")
 	err = Inst().S.Init(scheduler.InitOptions{
-		SpecDir:            Inst().SpecDir,
-		VolDriverName:      Inst().V.String(),
-		StorageProvisioner: Inst().Provisioner,
-		NodeDriverName:     Inst().N.String(),
-		CustomAppConfig:    Inst().CustomAppConfig,
+		SpecDir:             Inst().SpecDir,
+		VolDriverName:       Inst().V.String(),
+		StorageProvisioner:  Inst().Provisioner,
+		NodeDriverName:      Inst().N.String(),
+		CustomAppConfig:     Inst().CustomAppConfig,
+		SecretConfigMapName: Inst().ConfigMap,
+		SecureApps:          Inst().SecureAppList,
 	})
 	log.FailOnError(err, "Error occurred while Scheduler Driver Initialization")
+	if Inst().ConfigMap != "" {
+		log.Infof("Using Config Map: %s ", Inst().ConfigMap)
+		token, err = Inst().S.GetTokenFromConfigMap(Inst().ConfigMap)
+		log.FailOnError(err, "Error occured while getting token from config map")
+		log.Infof("Token used for initializing: %s ", token)
+	} else {
+		token = ""
+	}
 	err = Inst().N.Init(node.InitOptions{
 		SpecDir: Inst().SpecDir,
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
We need these changes to make sure that Px-Backup pipelines run with Px-Security and the tokens are fetched and used even after switching between clusters.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
[Jenkins Run on Vanilla pipeline](https://jenkins.pwx.dev.purestorage.com/job/Users/job/Mithun/job/Vanilla-Px-Security/15/)
[Jenkins Run on BYOC](https://jenkins.pwx.dev.purestorage.com/job/Users/job/Mithun/job/BYOC-Px-Security/9/)

