### PR TITLE
Removed aks node driver

### DIFF
--- a/deployments/deploy-pxb-cloud.sh
+++ b/deployments/deploy-pxb-cloud.sh
@@ -356,9 +356,6 @@ if [ -z "${NODE_DRIVER}" ]; then
 fi
 if [ -n "${K8S_VENDOR}" ]; then
     case "$K8S_VENDOR" in
-        aks)
-            NODE_DRIVER="aks"
-            ;;
         oracle)
             NODE_DRIVER="oracle"
             ;;


### PR DESCRIPTION
**What this PR does / why we need it**:
Removed aks node driver from deploy-pxb-cloud.sh as we are using ssh for aks.

This is required for testing aks with px

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
KINDLY ignore the jenkins failure .
https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/Cloud_BYOC/250/console
