### PR TITLE
PB-7095 & PB-7096: Add libs for enabling cluster wide PSA

### DIFF
--- a/tests/backup/backup_psa_test.go
+++ b/tests/backup/backup_psa_test.go
@@ -1,0 +1,30 @@
+// TODO: Remove this file before merging to master
+package tests
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/portworx/torpedo/pkg/log"
+	. "github.com/portworx/torpedo/tests"
+)
+
+// This is a dummy PSA testcase to validate the PSA related methods for RKE
+var _ = Describe("{DummyPSATestcase}", Label(TestCaseLabelsMap[DummyPSATestcase]...), func() {
+	JustBeforeEach(func() {
+		log.InfoD("No pre-configuration needed")
+	})
+
+	It("Dummy PSA testcase to validate the PSA related methods for vanilla", func() {
+		Step("Dummy PSA testcase to validate the PSA related methods for vanilla", func() {
+			err := ConfigureClusterLevelPSA("restricted", []string{})
+			dash.VerifyFatal(err, nil, "Setting PSA level configuration ")
+			err = VerifyClusterlevelPSA()
+			dash.VerifyFatal(err, nil, "Verify PSA level configuration ")
+			err = RevertClusterLevelPSA()
+			dash.VerifyFatal(err, nil, "Revert PSA level configuration ")
+		})
+	})
+
+	JustAfterEach(func() {
+		log.InfoD("Nothing to be deleted")
+	})
+})

--- a/tests/backup/backup_test_labels.go
+++ b/tests/backup/backup_test_labels.go
@@ -124,6 +124,7 @@ const (
 	CloudSnapshotMissingValidationForNFSLocation                                       TestCaseName = "CloudSnapshotMissingValidationForNFSLocation"
 	MultipleProvisionerCsiKdmpBackupAndRestore                                         TestCaseName = "MultipleProvisionerCsiKdmpBackupAndRestore"
 	KubevirtVMMigrationTest                                                            TestCaseName = "KubevirtVMMigrationTest"
+	DummyPSATestcase                                                                   TestCaseName = "DummyPSATestcase"
 )
 
 // Test case labels


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

- [x] Add func `runCmdOnceNonRoot()` to run commands without root
- [x] Add constants to hold file paths
- [x]  Add func `RunCmdsOnAllMasterNodes()` to run a command on all master nodes of a give cluster
- [x] Add func `ConfigureClusterLevelPSA()` to configure cluster level PSA setting on Vanilla cluster
- [x] Add func `RevertClusterLevelPSA()` to revert cluster level PSA configurations
- [x] Add func `VerifyClusterlevelPSA()` to verify if cluster level PSA settings are set on Kube-API server
- [x] Add dummy test `DummyPSATestcase` to test the libs 


**Which issue(s) this PR fixes** (optional)
Closes #PB-7095 PB-7096

Successful run link: 
https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/azurechina-byoc/163/console
~https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/azurechina-byoc/157/console~
~https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/azurechina-byoc/154/console~

**Special notes for your reviewer**:

