### PR TITLE
PTX-22409:Fixing cluster status validation during platform upgrades

### DIFF
--- a/tests/basic/upgrade_cluster_test.go
+++ b/tests/basic/upgrade_cluster_test.go
@@ -2,22 +2,24 @@ package tests
 
 import (
 	"fmt"
-	"github.com/portworx/torpedo/drivers/node"
-	"github.com/portworx/torpedo/drivers/scheduler/iks"
-	"github.com/portworx/torpedo/drivers/scheduler/oke"
-	"net/url"
-	"strings"
-	"time"
-
 	oputil "github.com/libopenstorage/operator/pkg/util/test"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/portworx/sched-ops/k8s/core"
+	"github.com/portworx/sched-ops/task"
+	"github.com/portworx/torpedo/drivers/node"
 	"github.com/portworx/torpedo/drivers/scheduler"
 	"github.com/portworx/torpedo/drivers/scheduler/aks"
 	"github.com/portworx/torpedo/drivers/scheduler/eks"
 	"github.com/portworx/torpedo/drivers/scheduler/gke"
+	"github.com/portworx/torpedo/drivers/scheduler/iks"
+	"github.com/portworx/torpedo/drivers/scheduler/oke"
 	"github.com/portworx/torpedo/pkg/log"
 	. "github.com/portworx/torpedo/tests"
+	corev1 "k8s.io/api/core/v1"
+	"net/url"
+	"strings"
+	"time"
 )
 
 var _ = Describe("{UpgradeCluster}", func() {
@@ -44,16 +46,14 @@ var _ = Describe("{UpgradeCluster}", func() {
 		}
 		Expect(versions).NotTo(BeEmpty())
 
-		// TODO: Commenting out below changes as it doesn't work for most distros upgrades, see PTX-22409
-		/*var mError error
+		var mError error
 		if Inst().S.String() != aks.SchedName {
 			stopSignal := make(chan struct{})
-			go getClusterNodesInfo(stopSignal, &mError)
-
+			go validateClusterNodes(stopSignal, &mError)
 			defer func() {
 				close(stopSignal)
 			}()
-		}*/
+		}
 
 		preUpgradeNodeDisksMap := make(map[string]map[string]int)
 		printDisks := func(nodeDiskMap map[string]map[string]int) {
@@ -172,10 +172,9 @@ var _ = Describe("{UpgradeCluster}", func() {
 
 			})
 
-			// TODO: This currently doesn't work for most distros and commenting out this change, see PTX-22409
-			/*if Inst().S.String() != aks.SchedName {
-				dash.VerifyFatal(mError, nil, "validate no parallel upgrade of nodes")
-			}*/
+			if Inst().S.String() != aks.SchedName {
+				dash.VerifySafely(mError, nil, "validate no parallel upgrade of nodes")
+			}
 
 			Step("validate all apps after upgrade", func() {
 				ValidateApplications(contexts)
@@ -196,3 +195,88 @@ var _ = Describe("{UpgradeCluster}", func() {
 		AfterEachTest(contexts)
 	})
 })
+
+func validateClusterNodes(stopSignal <-chan struct{}, mError *error) {
+	stNodes := node.GetStorageNodes()
+
+	nodeSchedulableStatus := make(map[string]string)
+	stNodeNames := make(map[string]bool)
+
+	for _, stNode := range stNodes {
+		stNodeNames[stNode.Name] = true
+	}
+
+	//Handling case where we have storageless node as kvdb node with dedicated kvdb device attached.
+	kvdbNodes, _ := GetAllKvdbNodes()
+	for _, kvdbNode := range kvdbNodes {
+		sNode, err := node.GetNodeDetailsByNodeID(kvdbNode.ID)
+		if err == nil {
+			stNodeNames[sNode.Name] = true
+		} else {
+			log.Errorf("got error while getting with id [%s]", kvdbNode.ID)
+		}
+	}
+
+	log.Infof("storage nodes are %#v", stNodeNames)
+	itr := 1
+	for {
+		log.Infof("K8s node validation. iteration: #%d", itr)
+		select {
+		case <-stopSignal:
+			log.Infof("Exiting node validations routine")
+			return
+		default:
+
+			var nodeList *corev1.NodeList
+			var err error
+			t := func() (interface{}, bool, error) {
+				nodeList, err = core.Instance().GetNodes()
+				if err != nil {
+					return "", true, err
+				}
+				return "", false, nil
+			}
+			_, err = task.DoRetryWithTimeout(t, 2*time.Minute, 5*time.Second)
+
+			if err != nil {
+				log.Errorf("Got error : %s", err.Error())
+				*mError = err
+				return
+			}
+
+			nodeNotReadyeCount := 0
+			for _, k8sNode := range nodeList.Items {
+				for _, status := range k8sNode.Status.Conditions {
+					if status.Type == corev1.NodeReady {
+						nodeSchedulableStatus[k8sNode.Name] = string(status.Status)
+						if status.Status != corev1.ConditionTrue && stNodeNames[k8sNode.Name] {
+							nodeNotReadyeCount += 1
+						}
+						break
+					}
+				}
+
+			}
+			if nodeNotReadyeCount > 1 {
+				err = fmt.Errorf("multiple  nodes are Unschedulable at same time,"+
+					"node status:%#v", nodeSchedulableStatus)
+				log.Errorf("Got error : %s", err.Error())
+				log.Infof("Node Details: %#v", nodeList.Items)
+				*mError = err
+				output, cerr := Inst().N.RunCommand(stNodes[0], "pxctl status", node.ConnectionOpts{
+					IgnoreError:     false,
+					TimeBeforeRetry: defaultRetryInterval,
+					Timeout:         defaultTimeout,
+					Sudo:            true,
+				})
+				if cerr != nil {
+					log.Errorf("failed to get pxctl status, Err: %v", cerr)
+				}
+				log.Infof(output)
+				return
+			}
+		}
+		itr++
+		time.Sleep(30 * time.Second)
+	}
+}

--- a/tests/testTriggers.go
+++ b/tests/testTriggers.go
@@ -18,7 +18,6 @@ import (
 	"text/template"
 	"time"
 
-
 	"github.com/devans10/pugo/flasharray"
 	oputil "github.com/libopenstorage/operator/pkg/util/test"
 	"github.com/portworx/torpedo/drivers/scheduler/aks"
@@ -3632,8 +3631,8 @@ func TriggerCloudSnapShot(contexts *[]*scheduler.Context, recordChan *chan *Even
 
 }
 
-//TriggerDeleteCloudsnaps
-func TriggerDeleteCloudsnaps(contexts *[]*scheduler.Context, recordChan *chan *EventRecord){
+// TriggerDeleteCloudsnaps
+func TriggerDeleteCloudsnaps(contexts *[]*scheduler.Context, recordChan *chan *EventRecord) {
 	defer ginkgo.GinkgoRecover()
 	defer endLongevityTest()
 	startLongevityTest(DeleteCloudsnaps)
@@ -3653,14 +3652,14 @@ func TriggerDeleteCloudsnaps(contexts *[]*scheduler.Context, recordChan *chan *E
 	stepLog := "Delete all cloudsnaps"
 	Step(stepLog, func() {
 		log.Infof(stepLog)
-        var volCloudsnapMap = make(map[string][]string)
+		var volCloudsnapMap = make(map[string][]string)
 		for _, ctx := range *contexts {
 			vols, err := Inst().S.GetVolumeParameters(ctx)
 			log.Infof("Validating context: %v", ctx.App.Key)
 			log.Infof("Volumes : %v", vols)
 			UpdateOutcome(event, err)
 			for vol, params := range vols {
-				inspectedVol, err:= Inst().V.InspectVolume(vol)
+				inspectedVol, err := Inst().V.InspectVolume(vol)
 				UpdateOutcome(event, err)
 				csBksps, err := Inst().V.GetCloudsnapsOfGivenVolume(vol, inspectedVol.Id, params)
 				UpdateOutcome(event, err)
@@ -3670,7 +3669,7 @@ func TriggerDeleteCloudsnaps(contexts *[]*scheduler.Context, recordChan *chan *E
 				}
 				if len(csBksps) > 0 {
 					volCloudsnapMap[vol] = cloudsnapIds
-					err = Inst().V.DeleteAllCloudsnaps(vol,csBksps[0].SrcVolumeId, params)
+					err = Inst().V.DeleteAllCloudsnaps(vol, csBksps[0].SrcVolumeId, params)
 					if err != nil && !strings.Contains(err.Error(), "Key already exists") {
 						UpdateOutcome(event, err)
 					}
@@ -3680,24 +3679,24 @@ func TriggerDeleteCloudsnaps(contexts *[]*scheduler.Context, recordChan *chan *E
 		log.Infof("Wait for 10 minutes")
 		time.Sleep(600 * time.Second)
 		for _, ctx := range *contexts {
-				vols, err := Inst().S.GetVolumeParameters(ctx)
+			vols, err := Inst().S.GetVolumeParameters(ctx)
+			UpdateOutcome(event, err)
+			for vol, params := range vols {
+				log.Infof("Volume Name : %s", vol)
+				inspectedVol, err := Inst().V.InspectVolume(vol)
 				UpdateOutcome(event, err)
-				for vol, params := range vols {
-					log.Infof("Volume Name : %s", vol)
-					inspectedVol, err:= Inst().V.InspectVolume(vol)
-					UpdateOutcome(event, err)
-					csBksps, err := Inst().V.GetCloudsnapsOfGivenVolume(vol, inspectedVol.Id, params)
-					UpdateOutcome(event, err)
-					cloudsnapIds, ok := volCloudsnapMap[vol]
-					if ok {
-						for _, bk := range csBksps {
-							if slices.Contains(cloudsnapIds, bk.Id ){
-								log.Infof("Cloud snap hasn not deleted successfully : %s: vol %s", bk.Id , vol )
-								UpdateOutcome(event, fmt.Errorf("Cloud snap has not deleted successfully : %s: vol %s", bk.Id , vol))
-							}
+				csBksps, err := Inst().V.GetCloudsnapsOfGivenVolume(vol, inspectedVol.Id, params)
+				UpdateOutcome(event, err)
+				cloudsnapIds, ok := volCloudsnapMap[vol]
+				if ok {
+					for _, bk := range csBksps {
+						if slices.Contains(cloudsnapIds, bk.Id) {
+							log.Infof("Cloud snap hasn not deleted successfully : %s: vol %s", bk.Id, vol)
+							UpdateOutcome(event, fmt.Errorf("Cloud snap has not deleted successfully : %s: vol %s", bk.Id, vol))
 						}
 					}
 				}
+			}
 		}
 		updateMetrics(*event)
 	})
@@ -6814,11 +6813,11 @@ func TriggerPowerOffAllVMs(contexts *[]*scheduler.Context, recordChan *chan *Eve
 func TriggerVolumeIOProfileUpdate(contexts *[]*scheduler.Context, recordChan *chan *EventRecord) {
 	defer ginkgo.GinkgoRecover()
 	defer endLongevityTest()
-	startLongevityTest(UpdateVolume)
+	startLongevityTest(UpdateIOProfile)
 	event := &EventRecord{
 		Event: Event{
 			ID:   GenerateUUID(),
-			Type: UpdateVolume,
+			Type: UpdateIOProfile,
 		},
 		Start:   time.Now().Format(time.RFC1123),
 		Outcome: []error{},

--- a/tests/testTriggers.go
+++ b/tests/testTriggers.go
@@ -7092,11 +7092,13 @@ func validateAutoFsTrim(contexts *[]*scheduler.Context, event *EventRecord) {
 					log.Infof("autofstrim status for volume %v, status: %v", appVol.Id, val.String())
 					if fsTrimStatus != -1 {
 						if fsTrimStatus == opsapi.FilesystemTrim_FS_TRIM_COMPLETED {
+							log.InfoD("autofstrim status for volume %v completed successfully [%v]", v.ID, val.String())
 							return nil, false, nil
 						} else if fsTrimStatus == opsapi.FilesystemTrim_FS_TRIM_FAILED {
 							return nil, false, fmt.Errorf("autoFstrim failed for volume %v, status: %v", v.ID, val.String())
 						} else {
-							return nil, true, fmt.Errorf("current autofstrim status for volume %v is %v. Expected status is %v", v.ID, val.String(), opsapi.FilesystemTrim_FS_TRIM_COMPLETED)
+							log.InfoD("current autofstrim status for volume %v is %v", v.ID, val.String())
+							return nil, false, nil
 						}
 					} else {
 						return nil, true, fmt.Errorf("autofstrim for volume %v not started yet", v.ID)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
- Adding cluster status validation during platfrom upgrades
- Fixing autofstrim trigger in longevity

**Which issue(s) this PR fixes** (optional)
Closes #PTX-22409,PTX-24172

**Special notes for your reviewer**:
Results:
https://jenkins.pwx.dev.purestorage.com/job/Torpedo/view/Torpedo%20NextPX%20Cloud/job/tp-nextpx-dmthin-eks-upgrade-hops/7/console
https://jenkins.pwx.dev.purestorage.com/job/Torpedo/view/Torpedo%20NextPX%20Cloud/job/tp-nextpx-aks-upgrade-hops/

