### PR TITLE
Fixing creds issue for GKE Jobs launching from spawn container

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -242,7 +242,6 @@ if [ -n "$ANTHOS_HOST_PATH" ]; then
     ANTHOS_HOST_PATH="${ANTHOS_HOST_PATH}"
 fi
 
-
 for i in $@
 do
 case $i in
@@ -861,6 +860,10 @@ if [ "${RUN_GINKGO_COMMAND}" = "true" ]; then
     $cleaned_torpedo_pod_ginkgo_command
     exit $?
 fi
+
+if [ -z "${ANTHOS_HOST_PATH}" ]; then
+  sed -i  '/GOOGLE_APPLICATION_CREDENTIALS/d' torpedo.yaml
+fi 
 
 # If these are passed, we will create a docker config secret to use to pull images
 if [ ! -z $IMAGE_PULL_SERVER ] && [ ! -z $IMAGE_PULL_USERNAME ] && [ ! -z $IMAGE_PULL_PASSWORD ]; then


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Fixing GKE Creds issue

**Which issue(s) this PR fixes** (optional)
Closes # PTX-24512

**Special notes for your reviewer**:
Minor changes
https://jenkins.pwx.dev.purestorage.com/job/Torpedo/view/Operator%20Release%20Cloud%20Dashboard/job/tp-nextpx-gke-op-helm/39/console
https://jenkins.pwx.dev.purestorage.com/job/Torpedo/job/tp-nextpx-anthos-op/352/
