### PR TITLE
PTX-24281:moving repls on the node before pool deletion

### DIFF
--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -5560,8 +5560,8 @@ var _ = Describe("{PoolIncreaseSize20TB}", func() {
 		var expectedSize uint64
 		var expectedSizeWithJournal uint64
 
-		// Marking the expected size to be 2TB
-		expectedSize = (2048 * 1024 * 1024 * 1024 * 1024) / units.TiB
+		// Marking the expected size to be 20TB
+		expectedSize = (2048 * 1024 * 1024 * 1024 * 1024 * 1024) / units.TiB
 
 		stepLog = "Calculate expected pool size and trigger pool resize"
 		Step(stepLog, func() {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
moving repls on the node before pool deletion

**Which issue(s) this PR fixes** (optional)
Closes #PTX-24281

**Special notes for your reviewer**:

