### PR TITLE
FADA Mapper Partition Fix (part 2)

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -2019,7 +2019,7 @@ func parseLsblkOutput(out string) (map[string]pureLocalPathEntry, error) {
 		}
 
 		// Ignore partitions, skip straight to the parent mapper device
-		if strings.Contains(line, "-part") {
+		if strings.Contains(line, "p") && !strings.Contains(line, "sd") { // "p" covers both "<serial>p<number>" and "<serial>-part<number>", but we don't want to skip "sd*p" devices
 			continue
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
My last PR #2585 works for some OSes (which use `<serial>-part<number>`), but other OSes use `<serial>p<number>` so it was still breaking. I've fixed it so it works for both cases and added unit tests for this parsing code.


