### PR TITLE
Added method CreateVolumeSnapshotClassesWithParameters

### DIFF
--- a/drivers/scheduler/dcos/dcos.go
+++ b/drivers/scheduler/dcos/dcos.go
@@ -1000,6 +1000,15 @@ func (d *dcos) CreateVolumeSnapshotClasses(snapClassName string, provisioner str
 	}
 }
 
+// CreateVolumeSnapshotClassesWithParameters creates a volume snapshot class with additional parameters
+func (d *dcos) CreateVolumeSnapshotClassesWithParameters(snapClassName string, provisioner string, isDefault bool, deletePolicy string, parameters map[string]string) (*volsnapv1.VolumeSnapshotClass, error) {
+	//CreateVolumeSnapshotClassesWithParameters is not supported
+	return nil, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "CreateVolumeSnapshotClassesWithParameters()",
+	}
+}
+
 func (d *dcos) CreateCsiSnapshot(name string, namespace string, class string, pvc string) (*volsnapv1.VolumeSnapshot, error) {
 	//CreateCsiSanpshot is not supported
 	return nil, &errors.ErrNotSupported{

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -8149,6 +8149,41 @@ func (k *K8s) CreateVolumeSnapshotClasses(snapClassName string, provisioner stri
 	return volumeSnapClass, nil
 }
 
+// CreateVolumeSnapshotClassesWithParameters creates a volume snapshot class with additional parameters
+func (k *K8s) CreateVolumeSnapshotClassesWithParameters(snapClassName string, provisioner string, isDefault bool, deletePolicy string, parameters map[string]string) (*volsnapv1.VolumeSnapshotClass, error) {
+	var err error
+	var annotation = make(map[string]string)
+	var volumeSnapClass *volsnapv1.VolumeSnapshotClass
+	if isDefault {
+		annotation["snapshot.storage.kubernetes.io/is-default-class"] = "true"
+	} else {
+		annotation = make(map[string]string)
+	}
+
+	v1obj := metav1.ObjectMeta{
+		Name:        snapClassName,
+		Annotations: annotation,
+	}
+	if len(deletePolicy) == 0 {
+		deletePolicy = "Delete"
+	}
+	snapClass := volsnapv1.VolumeSnapshotClass{
+		ObjectMeta:     v1obj,
+		Driver:         provisioner,
+		DeletionPolicy: volsnapv1.DeletionPolicy(deletePolicy),
+		Parameters:     parameters,
+	}
+
+	log.Infof("Creating volume snapshot class: %v with provisioner %v", snapClassName, provisioner)
+	if volumeSnapClass, err = k8sExternalsnap.CreateSnapshotClass(&snapClass); err != nil {
+		return nil, &scheduler.ErrFailedToCreateSnapshotClass{
+			Name:  snapClassName,
+			Cause: err,
+		}
+	}
+	return volumeSnapClass, nil
+}
+
 // waitForCsiSnapToBeReady wait for snapshot status to be ready
 func (k *K8s) waitForCsiSnapToBeReady(snapName string, namespace string) error {
 	var snap *volsnapv1.VolumeSnapshot

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -395,6 +395,9 @@ type Driver interface {
 	// CreateVolumeSnapshotClasses creates a volume snapshot class
 	CreateVolumeSnapshotClasses(snapClassName string, provisioner string, isDefault bool, deletePolicy string) (*volsnapv1.VolumeSnapshotClass, error)
 
+	// CreateVolumeSnapshotClassesWithParameters creates a volume snapshot class with additional parameters
+	CreateVolumeSnapshotClassesWithParameters(snapClassName string, provisioner string, isDefault bool, deletePolicy string, parameters map[string]string) (*volsnapv1.VolumeSnapshotClass, error)
+
 	// CreateCsiSnapshot create csi snapshot for given pvc
 	// TODO: there's probably better place to place this test, it creates the snapshot and also does the validation.
 	// At the same time, there's also other validation functions in this interface as well. So we should look into ways

--- a/tests/backup_helper.go
+++ b/tests/backup_helper.go
@@ -8948,3 +8948,14 @@ func UpdateMaintenanceCronJob(backupLocation string, maintenanceJobType Maintena
 	_, err = k8sBatch.UpdateCronJob(cronJob)
 	return err
 }
+
+// CreateInvalidVolumeSnapshotClass creates invalid VolumeSnapshotClass for given provisioner
+func CreateInvalidVolumeSnapshotClass(snapShotClassName, provisioner string) (*volsnapv1.VolumeSnapshotClass, error) {
+	volumeSnapshotClassParameters := make(map[string]string)
+	volumeSnapshotClassParameters["invalidParameter"] = "invalidValue"
+	volumeSnapshotClass, err := Inst().S.CreateVolumeSnapshotClassesWithParameters(snapShotClassName, provisioner, false, "Delete", volumeSnapshotClassParameters)
+	if err != nil {
+		return nil, err
+	}
+	return volumeSnapshotClass, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Added method CreateVolumeSnapshotClassesWithParameters , This is required for creating invalid volumesnapshotclass for failing csi backups for px-backup tests.

**Which issue(s) this PR fixes** (optional)
Closes #PB-7192
#PB-7190

**Special notes for your reviewer**:
Did a dry run along withhttps://github.com/portworx/torpedo/pull/2588   (ignore the failure, as the complete partial backup methods are not ready.)

https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/5375/
https://aetos.pwx.purestorage.com/resultSet/testSetID/665862

