### PR TITLE
Fixes dmsetup ls for partitions

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -2086,7 +2086,7 @@ func (d *portworx) collectLocalNodeInfo(n node.Node) (map[string]pureLocalPathEn
 		if !strings.Contains(line, schedops.PureVolumeOUI) {
 			continue
 		}
-		if strings.Contains(line, "-part") {
+		if strings.Contains(line, "p") { // If this contains either "-part#" or "p#", we want to ignore it. 'p' is not in the hex character set so this is safe.
 			continue
 		}
 		mapperName := strings.Split(line, "\t")[0]


### PR DESCRIPTION
**What this PR does / why we need it**:
I fixed for lsblk but not for dmsetup. I have now built this and confirmed it gets past the startup phase on a cluster.
