### PR TITLE
Adding stop kubelet test

### DIFF
--- a/drivers/node/node.go
+++ b/drivers/node/node.go
@@ -165,6 +165,12 @@ type Driver interface {
 	// Systemctl runs a systemctl command for the given service on the node
 	Systemctl(node Node, service string, options SystemctlOpts) error
 
+	// StartKubelet runs a  command to start service on the node
+	StartKubelet(node Node, options SystemctlOpts) error
+
+	// StopKubelet runs a  command to start service on the node
+	StopKubelet(node Node, options SystemctlOpts) error
+
 	// TestConnection tests connection to given node. returns nil if driver can connect to given node
 	TestConnection(node Node, options ConnectionOpts) error
 
@@ -547,5 +553,19 @@ func (d *notSupportedDriver) RemoveNonRootDisks(node Node) error {
 	return &errors.ErrNotSupported{
 		Type:      "Function",
 		Operation: "RemoveNonRootDisks()",
+	}
+}
+
+func (d *notSupportedDriver) StartKubelet(node Node, options SystemctlOpts) error {
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "StartKubelet()",
+	}
+}
+
+func (d *notSupportedDriver) StopKubelet(node Node, options SystemctlOpts) error {
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "StopKubelet()",
 	}
 }

--- a/drivers/node/node.go
+++ b/drivers/node/node.go
@@ -165,12 +165,6 @@ type Driver interface {
 	// Systemctl runs a systemctl command for the given service on the node
 	Systemctl(node Node, service string, options SystemctlOpts) error
 
-	// StartKubelet runs a  command to start service on the node
-	StartKubelet(node Node, options SystemctlOpts) error
-
-	// StopKubelet runs a  command to start service on the node
-	StopKubelet(node Node, options SystemctlOpts) error
-
 	// TestConnection tests connection to given node. returns nil if driver can connect to given node
 	TestConnection(node Node, options ConnectionOpts) error
 
@@ -553,19 +547,5 @@ func (d *notSupportedDriver) RemoveNonRootDisks(node Node) error {
 	return &errors.ErrNotSupported{
 		Type:      "Function",
 		Operation: "RemoveNonRootDisks()",
-	}
-}
-
-func (d *notSupportedDriver) StartKubelet(node Node, options SystemctlOpts) error {
-	return &errors.ErrNotSupported{
-		Type:      "Function",
-		Operation: "StartKubelet()",
-	}
-}
-
-func (d *notSupportedDriver) StopKubelet(node Node, options SystemctlOpts) error {
-	return &errors.ErrNotSupported{
-		Type:      "Function",
-		Operation: "StopKubelet()",
 	}
 }

--- a/drivers/node/ssh/ssh.go
+++ b/drivers/node/ssh/ssh.go
@@ -670,50 +670,6 @@ func (s *SSH) Systemctl(n node.Node, service string, options node.SystemctlOpts)
 	return nil
 }
 
-// StopKubelet allows to stop kubelet on a give node
-func (s *SSH) StopKubelet(n node.Node, options node.SystemctlOpts) error {
-	systemctlCmd := fmt.Sprintf("sudo systemctl stop %s", "kubelet")
-	t := func() (interface{}, bool, error) {
-		out, err := s.doCmd(n, options.ConnectionOpts, systemctlCmd, false)
-		if err != nil {
-			return out, true, err
-		}
-		return out, false, nil
-	}
-
-	if _, err := task.DoRetryWithTimeout(t,
-		options.ConnectionOpts.Timeout,
-		options.ConnectionOpts.TimeBeforeRetry); err != nil {
-		return &node.ErrFailedToRunSystemctlOnNode{
-			Node:  n,
-			Cause: err.Error(),
-		}
-	}
-	return nil
-}
-
-// StartKubelet allows to start kubelet on a give node
-func (s *SSH) StartKubelet(n node.Node, options node.SystemctlOpts) error {
-	systemctlCmd := fmt.Sprintf("sudo systemctl start %s", "kubelet")
-	t := func() (interface{}, bool, error) {
-		out, err := s.doCmd(n, options.ConnectionOpts, systemctlCmd, false)
-		if err != nil {
-			return out, true, err
-		}
-		return out, false, nil
-	}
-
-	if _, err := task.DoRetryWithTimeout(t,
-		options.ConnectionOpts.Timeout,
-		options.ConnectionOpts.TimeBeforeRetry); err != nil {
-		return &node.ErrFailedToRunSystemctlOnNode{
-			Node:  n,
-			Cause: err.Error(),
-		}
-	}
-	return nil
-}
-
 // SystemctlUnitExist checks if a given service exists on the node
 func (s *SSH) SystemctlUnitExist(n node.Node, service string, options node.SystemctlOpts) (bool, error) {
 	systemctlCmd := fmt.Sprintf("sudo systemctl list-units --full --all | grep \"%s.service\" || true", service)

--- a/drivers/node/ssh/ssh.go
+++ b/drivers/node/ssh/ssh.go
@@ -670,6 +670,50 @@ func (s *SSH) Systemctl(n node.Node, service string, options node.SystemctlOpts)
 	return nil
 }
 
+// StopKubelet allows to stop kubelet on a give node
+func (s *SSH) StopKubelet(n node.Node, options node.SystemctlOpts) error {
+	systemctlCmd := fmt.Sprintf("sudo systemctl stop %s", "kubelet")
+	t := func() (interface{}, bool, error) {
+		out, err := s.doCmd(n, options.ConnectionOpts, systemctlCmd, false)
+		if err != nil {
+			return out, true, err
+		}
+		return out, false, nil
+	}
+
+	if _, err := task.DoRetryWithTimeout(t,
+		options.ConnectionOpts.Timeout,
+		options.ConnectionOpts.TimeBeforeRetry); err != nil {
+		return &node.ErrFailedToRunSystemctlOnNode{
+			Node:  n,
+			Cause: err.Error(),
+		}
+	}
+	return nil
+}
+
+// StartKubelet allows to start kubelet on a give node
+func (s *SSH) StartKubelet(n node.Node, options node.SystemctlOpts) error {
+	systemctlCmd := fmt.Sprintf("sudo systemctl start %s", "kubelet")
+	t := func() (interface{}, bool, error) {
+		out, err := s.doCmd(n, options.ConnectionOpts, systemctlCmd, false)
+		if err != nil {
+			return out, true, err
+		}
+		return out, false, nil
+	}
+
+	if _, err := task.DoRetryWithTimeout(t,
+		options.ConnectionOpts.Timeout,
+		options.ConnectionOpts.TimeBeforeRetry); err != nil {
+		return &node.ErrFailedToRunSystemctlOnNode{
+			Node:  n,
+			Cause: err.Error(),
+		}
+	}
+	return nil
+}
+
 // SystemctlUnitExist checks if a given service exists on the node
 func (s *SSH) SystemctlUnitExist(n node.Node, service string, options node.SystemctlOpts) (bool, error) {
 	systemctlCmd := fmt.Sprintf("sudo systemctl list-units --full --all | grep \"%s.service\" || true", service)

--- a/drivers/scheduler/dcos/dcos.go
+++ b/drivers/scheduler/dcos/dcos.go
@@ -1166,6 +1166,22 @@ func (d *dcos) SetASGClusterSize(perZoneCount int64, timeout time.Duration) erro
 	}
 }
 
+func (d *dcos) StopKubelet(n node.Node, options node.SystemctlOpts) error {
+	// StopKubelet is not supported
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "StopKubelet()",
+	}
+}
+
+func (d *dcos) StartKubelet(n node.Node, options node.SystemctlOpts) error {
+	// StartKubelet is not supported
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "StartKubelet()",
+	}
+}
+
 func init() {
 	d := &dcos{}
 	scheduler.Register(SchedName, d)

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -6988,6 +6988,22 @@ func (k *K8s) SaveSchedulerLogsToFile(n node.Node, location string) error {
 	return err
 }
 
+// StopKubelet allows to stop kubelet on a give node
+func (k *K8s) StopKubelet(n node.Node, options node.SystemctlOpts) error {
+	systemctlCmd := fmt.Sprintf("sudo systemctl stop %s", "kubelet")
+	driver, _ := node.Get(k.NodeDriverName)
+	_, err := driver.RunCommand(n, systemctlCmd, options.ConnectionOpts)
+	return err
+}
+
+// StartKubelet allows to start kubelet on a give node
+func (k *K8s) StartKubelet(n node.Node, options node.SystemctlOpts) error {
+	systemctlCmd := fmt.Sprintf("sudo systemctl start %s", "kubelet")
+	driver, _ := node.Get(k.NodeDriverName)
+	_, err := driver.RunCommand(n, systemctlCmd, options.ConnectionOpts)
+	return err
+}
+
 func (k *K8s) addLabelsToPVC(pvc *corev1.PersistentVolumeClaim, labels map[string]string) {
 	if len(pvc.Labels) == 0 {
 		pvc.Labels = map[string]string{}

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -460,6 +460,11 @@ type Driver interface {
 
 	// SetASGClusterSize sets node count for an asg cluster
 	SetASGClusterSize(perZoneCount int64, timeout time.Duration) error
+
+	// StopKubelet stops kubelet on the given node
+	StopKubelet(appNode node.Node, opts node.SystemctlOpts) error
+	// StartKubelet starts kubelet on the given node
+	StartKubelet(appNode node.Node, opts node.SystemctlOpts) error
 }
 
 var (

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -758,9 +758,7 @@ func (d *portworx) updateNode(n *node.Node, pxNodes []*api.StorageNode) error {
 
 					if pxNode.Pools != nil && len(pxNode.Pools) > 0 {
 						log.Infof("Updating node [%s] as storage node", n.Name)
-					}
-
-					if n.StoragePools == nil {
+						n.StoragePools = nil
 						for _, pxNodePool := range pxNode.Pools {
 							storagePool := node.StoragePool{
 								StoragePool:       pxNodePool,
@@ -768,15 +766,8 @@ func (d *portworx) updateNode(n *node.Node, pxNodes []*api.StorageNode) error {
 							}
 							n.StoragePools = append(n.StoragePools, storagePool)
 						}
-					} else {
-						for idx, nodeStoragePool := range n.StoragePools {
-							for _, pxNodePool := range pxNode.Pools {
-								if nodeStoragePool.Uuid == pxNodePool.Uuid {
-									n.StoragePools[idx].StoragePool = pxNodePool
-								}
-							}
-						}
 					}
+
 					if err = node.UpdateNode(*n); err != nil {
 						return fmt.Errorf("failed to update node [%s], Err: %v", n.Name, err)
 					}

--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -45,6 +45,7 @@ const (
 	AsyncDREventName                        = "Async DR"
 	MetroDREventName                        = "Metro DR"
 	StorkApplicationBackupEventName         = "Stork App Backup"
+	RestartKubeletEventName                 = "Restart Kubelet on the node"
 )
 
 // Add more fields here if required

--- a/tests/basic/misc_test.go
+++ b/tests/basic/misc_test.go
@@ -1604,22 +1604,22 @@ var _ = Describe("{KvdbFailoverSnapVolCreateDelete}", func() {
 	})
 })
 
-// Volume Driver Plugin has crashed - and the client container should not be impacted.
+// Kubelet stopped on the nodes - and the client container should not be impacted.
 var _ = Describe("{StopKubeletOnNodes}", func() {
 
 	JustBeforeEach(func() {
-		StartTorpedoTest("StopKubeletOnNodes", "Validate PX after volume driver crash", nil, 0)
+		StartTorpedoTest("StopKubeletOnNodes", "Validate PX after kubelet is restarted", nil, 0)
 
 	})
 	var contexts []*scheduler.Context
 
-	stepLog := "has to schedule apps and crash stop kubelet app nodes"
+	stepLog := "has to schedule apps and stop kubelet app nodes"
 	It(stepLog, func() {
 		log.InfoD(stepLog)
 		contexts = make([]*scheduler.Context, 0)
 
 		for i := 0; i < Inst().GlobalScaleFactor; i++ {
-			contexts = append(contexts, ScheduleApplications(fmt.Sprintf("voldrivercrash-%d", i))...)
+			contexts = append(contexts, ScheduleApplications(fmt.Sprintf("kubeletrsrt-%d", i))...)
 		}
 
 		ValidateApplications(contexts)
@@ -1629,11 +1629,11 @@ var _ = Describe("{StopKubeletOnNodes}", func() {
 			pureCleanupFunction = StartPureBackgroundWriteRoutines()
 		}
 
-		stepLog = "stop kubelet on all storage driver nodes"
+		stepLog = "restart kubelet on all storage driver nodes"
 		Step(stepLog, func() {
 			log.InfoD(stepLog)
 			for _, appNode := range node.GetStorageDriverNodes() {
-				stepLog = fmt.Sprintf("crash volume driver %s on node: %v",
+				stepLog = fmt.Sprintf("restart kubelet %s on node: %v",
 					Inst().V.String(), appNode.Name)
 				Step(stepLog,
 					func() {

--- a/tests/basic/upgrade_cluster_test.go
+++ b/tests/basic/upgrade_cluster_test.go
@@ -237,20 +237,20 @@ func validateClusterNodes(stopSignal <-chan struct{}, mError *error) {
 				return
 			}
 
-			nodeNotReadyeCount := 0
+			nodeNotReadyCount := 0
 			for _, k8sNode := range nodeList.Items {
 				for _, status := range k8sNode.Status.Conditions {
 					if status.Type == corev1.NodeReady {
 						nodeSchedulableStatus[k8sNode.Name] = string(status.Status)
 						if status.Status != corev1.ConditionTrue && stNodeNames[k8sNode.Name] {
-							nodeNotReadyeCount += 1
+							nodeNotReadyCount += 1
 						}
 						break
 					}
 				}
 
 			}
-			if nodeNotReadyeCount > 1 {
+			if nodeNotReadyCount > 1 {
 				err = fmt.Errorf("multiple  nodes are Unschedulable at same time,"+
 					"node status:%#v", nodeSchedulableStatus)
 				log.Errorf("Got error : %s", err.Error())

--- a/tests/common.go
+++ b/tests/common.go
@@ -2511,8 +2511,8 @@ func RestartKubelet(appNodes []node.Node, errChan ...*chan error) {
 	for _, appNode := range appNodes {
 
 		log.InfoD("Stopping kubelet service on node %s", appNode.Name)
-		err := Inst().N.Systemctl(appNode, "kubelet", node.SystemctlOpts{
-			Action: "stop",
+
+		err := Inst().N.StopKubelet(appNode, node.SystemctlOpts{
 			ConnectionOpts: node.ConnectionOpts{
 				Timeout:         1 * time.Minute,
 				TimeBeforeRetry: 10 * time.Second,
@@ -2556,19 +2556,15 @@ func RestartKubelet(appNodes []node.Node, errChan ...*chan error) {
 	log.Infof("waiting for 5 mins before starting kubelet")
 	time.Sleep(5 * time.Minute)
 
-	if Inst().N.String() == ssh.DriverName || Inst().N.String() == vsphere.DriverName {
+	for _, appNode := range appNodes {
 
-		for _, appNode := range appNodes {
-
-			log.InfoD("Starting kubelet service on node %s", appNode.Name)
-			err := Inst().N.Systemctl(appNode, "kubelet", node.SystemctlOpts{
-				Action: "start",
-				ConnectionOpts: node.ConnectionOpts{
-					Timeout:         1 * time.Minute,
-					TimeBeforeRetry: 10 * time.Second,
-				}})
-			processError(err, errChan...)
-		}
+		log.InfoD("Starting kubelet service on node %s", appNode.Name)
+		err := Inst().N.StartKubelet(appNode, node.SystemctlOpts{
+			ConnectionOpts: node.ConnectionOpts{
+				Timeout:         1 * time.Minute,
+				TimeBeforeRetry: 10 * time.Second,
+			}})
+		processError(err, errChan...)
 	}
 
 	log.InfoD("Waiting for kubelet service to start on nodes %v", appNodes)

--- a/tests/common.go
+++ b/tests/common.go
@@ -2489,6 +2489,123 @@ func CrashPXDaemonAndWait(appNodes []node.Node, errChan ...*chan error) {
 	})
 }
 
+// RestartKubelet stops kubelet service on given app nodes and waits till kubelet is back up
+func RestartKubelet(appNodes []node.Node, errChan ...*chan error) {
+	defer func() {
+		if len(errChan) > 0 {
+			close(*errChan[0])
+		}
+	}()
+
+	nodeList, err := core.Instance().GetNodes()
+	processError(err, errChan...)
+	nodeSchedulableStatus := make(map[string]corev1.ConditionStatus)
+	for _, k8sNode := range nodeList.Items {
+		for _, status := range k8sNode.Status.Conditions {
+			if status.Type == corev1.NodeReady {
+				nodeSchedulableStatus[k8sNode.Name] = status.Status
+			}
+		}
+	}
+
+	for _, appNode := range appNodes {
+
+		log.InfoD("Stopping kubelet service on node %s", appNode.Name)
+		err := Inst().N.Systemctl(appNode, "kubelet", node.SystemctlOpts{
+			Action: "stop",
+			ConnectionOpts: node.ConnectionOpts{
+				Timeout:         1 * time.Minute,
+				TimeBeforeRetry: 10 * time.Second,
+			}})
+		processError(err, errChan...)
+	}
+
+	log.InfoD("Waiting for kubelet service to stop on the give nodes %v", appNodes)
+
+	t := func() (interface{}, bool, error) {
+		nodeList, err = core.Instance().GetNodes()
+		if err != nil {
+			return "", true, err
+		}
+
+		for _, appNode := range appNodes {
+			for _, k8sNode := range nodeList.Items {
+				if k8sNode.Name == appNode.Name {
+					log.InfoD("Waiting for node [%s] in Not Ready state", appNode.Name)
+					for _, status := range k8sNode.Status.Conditions {
+						if status.Type == corev1.NodeReady {
+							if status.Status == corev1.ConditionTrue {
+								return "", true, fmt.Errorf("node [%s] is in Ready state, waiting for node to go down", appNode.Name)
+							} else {
+								if nodeSchedulableStatus[k8sNode.Name] == corev1.ConditionTrue {
+									log.Infof("Node [%s] is in Not Ready state with status [%s]", appNode.Name, status.Status)
+									nodeSchedulableStatus[k8sNode.Name] = status.Status
+								}
+								break
+							}
+						}
+					}
+				}
+			}
+		}
+
+		return "", false, nil
+	}
+	_, err = task.DoRetryWithTimeout(t, 3*time.Minute, 10*time.Second)
+	processError(err, errChan...)
+	log.Infof("waiting for 5 mins before starting kubelet")
+	time.Sleep(5 * time.Minute)
+
+	if Inst().N.String() == ssh.DriverName || Inst().N.String() == vsphere.DriverName {
+
+		for _, appNode := range appNodes {
+
+			log.InfoD("Starting kubelet service on node %s", appNode.Name)
+			err := Inst().N.Systemctl(appNode, "kubelet", node.SystemctlOpts{
+				Action: "start",
+				ConnectionOpts: node.ConnectionOpts{
+					Timeout:         1 * time.Minute,
+					TimeBeforeRetry: 10 * time.Second,
+				}})
+			processError(err, errChan...)
+		}
+	}
+
+	log.InfoD("Waiting for kubelet service to start on nodes %v", appNodes)
+	t = func() (interface{}, bool, error) {
+		nodeList, err = core.Instance().GetNodes()
+		if err != nil {
+			return "", true, err
+		}
+
+		for _, appNode := range appNodes {
+			for _, k8sNode := range nodeList.Items {
+				if k8sNode.Name == appNode.Name {
+					log.InfoD("Waiting for node [%s] in Ready state", appNode.Name)
+					for _, status := range k8sNode.Status.Conditions {
+						if status.Type == corev1.NodeReady {
+							if status.Status != corev1.ConditionTrue {
+								return "", true, fmt.Errorf("node [%s] is in [%s] state, waiting for node to be Ready", appNode.Name, status.Status)
+							} else {
+								if nodeSchedulableStatus[k8sNode.Name] != corev1.ConditionTrue {
+									log.Infof("Node [%s] is in Ready state with status [%s]", appNode.Name, status.Status)
+									nodeSchedulableStatus[k8sNode.Name] = status.Status
+								}
+								break
+							}
+						}
+					}
+				}
+			}
+		}
+
+		return "", false, nil
+	}
+	_, err = task.DoRetryWithTimeout(t, 3*time.Minute, 10*time.Second)
+	processError(err, errChan...)
+
+}
+
 // ValidateAndDestroy validates application and then destroys them
 func ValidateAndDestroy(contexts []*scheduler.Context, opts map[string]bool) {
 	Step("validate apps", func() {
@@ -8579,6 +8696,7 @@ func GetPoolExpansionEligibility(stNode *node.Node, expandType opsapi.SdkStorage
 		return nil, err
 	}
 
+	log.Infof("Node [%s] has [%d] pools", stNode.Name, len(stNode.StoragePools))
 	for _, pool := range stNode.StoragePools {
 		eligibilityMap[pool.Uuid] = true
 
@@ -8618,8 +8736,9 @@ func GetPoolExpansionEligibility(stNode *node.Node, expandType opsapi.SdkStorage
 						if stc.Spec.CloudStorage.KvdbDeviceSpec != nil || stc.Spec.CloudStorage.SystemMdDeviceSpec != nil {
 							expectedNodeDrivesAfterExpansion++
 						}
+						log.Infof("Expected node drives after pool [%s ] expansion for node [%s] is [%d], max cloud drives allowed [%d]", pool.Uuid, stNode.Name, expectedNodeDrivesAfterExpansion, maxCloudDrives)
 						if expectedNodeDrivesAfterExpansion > maxCloudDrives {
-							log.Infof("node %s  will reach max drives if pool %s expanded to size [%v] using add-drive", stNode.Id, pool.Uuid, targetSizeGiB)
+							log.Infof("node %s  will reach max drives if pool %s expanded to size [%v] using add-drive", stNode.Name, pool.Uuid, targetSizeGiB)
 							eligibilityMap[pool.Uuid] = false
 							eligibilityMap[stNode.Id] = false
 						}
@@ -11785,6 +11904,7 @@ func deleteAndValidateBucketDeletion(client *s3.S3, bucketName string) error {
 	}, func(page *s3.ListObjectsV2Output, lastPage bool) bool {
 		// Iterate through the objects in the bucket and delete them
 		var objects []*s3.ObjectIdentifier
+
 		for _, obj := range page.Contents {
 			objects = append(objects, &s3.ObjectIdentifier{
 				Key: obj.Key,
@@ -11799,7 +11919,7 @@ func deleteAndValidateBucketDeletion(client *s3.S3, bucketName string) error {
 			},
 		})
 		if err != nil {
-			fmt.Printf("Failed to delete objects in bucket: %v\n", err)
+			log.Warnf("failed to delete objects in bucket: %v", err)
 			return false
 		}
 
@@ -11807,6 +11927,39 @@ func deleteAndValidateBucketDeletion(client *s3.S3, bucketName string) error {
 	})
 	if err != nil {
 		return fmt.Errorf("failed to delete objects in bucket: %v", err)
+	}
+
+	// List the objects in the bucket
+	listObjectsInput := s3.ListObjectsV2Input{
+		Bucket: aws.String(bucketName),
+	}
+
+	listObjectsOutput, err := client.ListObjectsV2(&listObjectsInput)
+	if err != nil {
+		return err
+	}
+	if len(listObjectsOutput.Contents) == 0 {
+		log.Debugf("Bucket [%s] is empty", bucketName)
+	} else {
+		// Delete the objects
+		deleteObjectsInput := &s3.DeleteObjectsInput{
+			Bucket: aws.String(bucketName),
+			Delete: &s3.Delete{
+				Objects: make([]*s3.ObjectIdentifier, len(listObjectsOutput.Contents)),
+				Quiet:   aws.Bool(true),
+			},
+		}
+
+		for i, object := range listObjectsOutput.Contents {
+			deleteObjectsInput.Delete.Objects[i] = &s3.ObjectIdentifier{
+				Key: aws.String(*object.Key),
+			}
+		}
+
+		_, err = client.DeleteObjects(deleteObjectsInput)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Delete the bucket

--- a/tests/longevity/longevity_helper.go
+++ b/tests/longevity/longevity_helper.go
@@ -221,6 +221,7 @@ func populateDisruptiveTriggers() {
 		OCPStorageNodeRecycle:           true,
 		CrashPXDaemon:                   true,
 		PowerOffAllVMs:                  true,
+		RestartKubeletService:           true,
 	}
 }
 
@@ -615,6 +616,7 @@ func populateIntervals() {
 	triggerInterval[ResetDiscardMounts] = make(map[int]time.Duration)
 	triggerInterval[ScaleFADAVolumeAttach] = map[int]time.Duration{}
 	triggerInterval[DeleteCloudsnaps] = make(map[int]time.Duration)
+	triggerInterval[RestartKubeletService] = make(map[int]time.Duration)
 
 	baseInterval := 10 * time.Minute
 	triggerInterval[BackupScaleMongo][10] = 1 * baseInterval
@@ -989,6 +991,17 @@ func populateIntervals() {
 	triggerInterval[CrashPXDaemon][3] = 21 * baseInterval
 	triggerInterval[CrashPXDaemon][2] = 24 * baseInterval
 	triggerInterval[CrashPXDaemon][1] = 27 * baseInterval
+
+	triggerInterval[RestartKubeletService][10] = 1 * baseInterval
+	triggerInterval[RestartKubeletService][9] = 3 * baseInterval
+	triggerInterval[RestartKubeletService][8] = 6 * baseInterval
+	triggerInterval[RestartKubeletService][7] = 9 * baseInterval
+	triggerInterval[RestartKubeletService][6] = 12 * baseInterval
+	triggerInterval[RestartKubeletService][5] = 15 * baseInterval
+	triggerInterval[RestartKubeletService][4] = 18 * baseInterval
+	triggerInterval[RestartKubeletService][3] = 21 * baseInterval
+	triggerInterval[RestartKubeletService][2] = 24 * baseInterval
+	triggerInterval[RestartKubeletService][1] = 27 * baseInterval
 
 	triggerInterval[PowerOffAllVMs][10] = 1 * baseInterval
 	triggerInterval[PowerOffAllVMs][9] = 3 * baseInterval
@@ -1748,6 +1761,8 @@ func populateIntervals() {
 	triggerInterval[SetDiscardMounts][0] = 0
 	triggerInterval[ResetDiscardMounts][0] = 0
 	triggerInterval[ScaleFADAVolumeAttach][0] = 0
+	triggerInterval[RestartKubeletService][0] = 0
+
 }
 
 func isTriggerEnabled(triggerType string) (time.Duration, bool) {

--- a/tests/longevity/longevity_test.go
+++ b/tests/longevity/longevity_test.go
@@ -109,6 +109,7 @@ var _ = Describe("{Longevity}", func() {
 		PowerOffAllVMs:                    TriggerPowerOffAllVMs,
 		ResetDiscardMounts:                TriggerResetDiscardMounts,
 		ScaleFADAVolumeAttach:             TriggerScaleFADAVolumeAttach,
+		RestartKubeletService:             TriggerKubeletRestart,
 	}
 	//Creating a distinct trigger to make sure email triggers at regular intervals
 	emailTriggerFunction = map[string]func(){


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
- Add test to stop kubelet service in vsphere, ocp, eks and aks platforms
- Fixed pool expansion with volumes in trashcan test
**Which issue(s) this PR fixes** (optional)
Closes #PTX-23047,PTX-23584

**Special notes for your reviewer**:
Results:
Vsphere:
https://aetos.pwx.purestorage.com/resultSet/testSetID/673167 

EKS:
https://jenkins.pwx.dev.purestorage.com/job/Torpedo/view/Torpedo%20NextPX%20Cloud/job/tp-nextpx-btrfs-eks/108/console

AKS:
https://jenkins.pwx.dev.purestorage.com/job/Torpedo/view/Torpedo%20NextPX%20Cloud/job/tp-nextpx-aks/763/console

OCP:
https://aetos.pwx.purestorage.com/resultSet/testSetID/674399 
