### PR TITLE
[PTX-24636] Fix createStorageObject

### DIFF
--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -1928,8 +1928,12 @@ func (k *K8s) createStorageObject(spec interface{}, ns *corev1.Namespace, app *s
 	if obj, ok := spec.(*storageapi.StorageClass); ok {
 		obj.Namespace = ns.Name
 
+		// volume.GetStorageProvisioner() returns the corresponding value from the portworx.provisioners map
+		// based on the --provisioner flag, such as "kubernetes.io/portworx-volume", "pxd.portworx.com", or "strict".
 		if volume.GetStorageProvisioner() != PortworxStrict {
-			if options.StorageProvisioner == string(volume.DefaultStorageProvisioner) || options.StorageProvisioner == CsiProvisioner {
+			// options.StorageProvisioner corresponds to the --provisioner flag (portworx or csi).
+			if options.StorageProvisioner == string(volume.DefaultStorageProvisioner) || options.StorageProvisioner == string(volume.CSIStorageProvisioner) {
+				// app.IsCSI is true if the app is in CSI_APP_LIST.
 				if app.IsCSI {
 					obj.Provisioner = CsiProvisioner
 				} else {

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -537,6 +537,8 @@ type StorageProvisionerType string
 const (
 	// DefaultStorageProvisioner default storage provisioner name
 	DefaultStorageProvisioner StorageProvisionerType = "portworx"
+	// CSIStorageProvisioner is the CSI (Container Storage Interface) storage provisioner name
+	CSIStorageProvisioner StorageProvisionerType = "csi"
 )
 
 var (


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR ensures the provisioner in StorageClass is set to pxd.portworx.com when the app is present in CSI_APP_LIST.

**Which issue(s) this PR fixes** (optional)
Closes #PTX-24636

**Special notes for your reviewer**:
Please review the following Jenkins builds

--provisioner csi; --app-list postgres-backup; --csi-app-list postgres-backup

https://jenkins.pwx.dev.purestorage.com/job/Users/job/krishna/job/tp-pxe-byoc/3406/

Aetos Dashboard: https://aetos.pwx.purestorage.com/resultSet/testSetID/669690

```bash
kubectl get sc
NAME                                 PROVISIONER                     RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
postgres-sc                          pxd.portworx.com                Delete          Immediate           true                   119s
```

--provisioner portworx; --app-list postgres-backup

https://jenkins.pwx.dev.purestorage.com/job/Users/job/krishna/job/tp-pxe-byoc/3407/

Aetos Dashboard: https://aetos.pwx.purestorage.com/resultSet/testSetID/669697

```bash
kubectl get sc
NAME                                 PROVISIONER                     RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
postgres-sc                          kubernetes.io/portworx-volume   Delete          Immediate           true                   36s
```

--provisioner csi; --app-list postgres-backup

https://jenkins.pwx.dev.purestorage.com/job/Users/job/krishna/job/tp-pxe-byoc/3408/

Aetos Dashboard: https://aetos.pwx.purestorage.com/resultSet/testSetID/669704

```bash
kubectl get sc
NAME                                 PROVISIONER                     RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
postgres-sc                          pxd.portworx.com                Delete          Immediate           true                   119s
```