### PR TITLE
Fixing the sed command to remove env variable from the spec

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -867,7 +867,7 @@ if [ "${RUN_GINKGO_COMMAND}" = "true" ]; then
 fi
 
 if [ -z "${ANTHOS_HOST_PATH}" ]; then
-  sed -i  '/GOOGLE_APPLICATION_CREDENTIALS/d' torpedo.yaml
+  sed -i  '/GOOGLE_APPLICATION_CREDENTIALS/, +1d' torpedo.yaml
 fi 
 
 # If these are passed, we will create a docker config secret to use to pull images


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Fixing sed command to remove env variable properly from torpedo pod spec

**Which issue(s) this PR fixes** (optional)
Closes # PTX-24664

**Special notes for your reviewer**:
Trivial change
https://jenkins.pwx.dev.purestorage.com/job/Torpedo/view/Operator%20Release%20Cloud%20Dashboard/job/tp-nextpx-gke-upgrade-hops-op/38/
