### PR TITLE
PB-7345: Bump up the mysql version in all backup specs to `8.4`

### DIFF
--- a/drivers/scheduler/k8s/specs/mysql-backup-data/px-mysql-app.yaml
+++ b/drivers/scheduler/k8s/specs/mysql-backup-data/px-mysql-app.yaml
@@ -51,7 +51,7 @@ spec:
             - name: mysql-persistent-storage-seq
               mountPath: /var/lib/mysql-seq
       containers:
-        - image: mysql:5.6
+        - image: mysql:8.4
           name: mysql
           env:
             - name: MYSQL_ROOT_PASSWORD

--- a/drivers/scheduler/k8s/specs/mysql-backup/px-mysql-app.yaml
+++ b/drivers/scheduler/k8s/specs/mysql-backup/px-mysql-app.yaml
@@ -40,7 +40,7 @@ spec:
     spec:
       schedulerName: stork
       containers:
-      - image: mysql:5.6
+      - image: mysql:8.4
         name: mysql
         env:
         - name: MYSQL_ROOT_PASSWORD

--- a/drivers/scheduler/k8s/specs/mysql-ibm/mysql-app.yaml
+++ b/drivers/scheduler/k8s/specs/mysql-ibm/mysql-app.yaml
@@ -32,7 +32,7 @@ spec:
         app: mysql
     spec:
       containers:
-        - image: mysql:5.6
+        - image: mysql:8.4
           name: mysql
           env:
             - name: MYSQL_ROOT_PASSWORD


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Post restore of mysql KDMP backups, mysql pods fail with the below trace: 
```
[root@ip-10-13-226-135 ~]# kubectl  logs -n mysql-baseline mysql-5d79766c6b-n88hk 
2024-06-24 04:38:01+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 5.6.51-1debian9 started.
2024-06-24 04:38:01+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
2024-06-24 04:38:01+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 5.6.51-1debian9 started.
2024-06-24 04:38:01 0 [Warning] TIMESTAMP with implicit DEFAULT value is deprecated. Please use --explicit_defaults_for_timestamp server option (see documentation for more details).
2024-06-24 04:38:01 0 [Note] mysqld (mysqld 5.6.51) starting as process 1 ...
2024-06-24 04:38:01 1 [Note] Plugin 'FEDERATED' is disabled.
2024-06-24 04:38:01 1 [Note] InnoDB: Using atomics to ref count buffer pool pages
2024-06-24 04:38:01 1 [Note] InnoDB: The InnoDB memory heap is disabled
2024-06-24 04:38:01 1 [Note] InnoDB: Mutexes and rw_locks use GCC atomic builtins
2024-06-24 04:38:01 1 [Note] InnoDB: Memory barrier is not used
2024-06-24 04:38:01 1 [Note] InnoDB: Compressed tables use zlib 1.2.11
2024-06-24 04:38:01 1 [Note] InnoDB: Using Linux native AIO
2024-06-24 04:38:01 1 [Note] InnoDB: Using CPU crc32 instructions
2024-06-24 04:38:01 1 [Note] InnoDB: Initializing buffer pool, size = 128.0M
2024-06-24 04:38:01 1 [Note] InnoDB: Completed initialization of buffer pool
2024-06-24 04:38:01 1 [Note] InnoDB: Highest supported file format is Barracuda.
2024-06-24 04:38:01 1 [Note] InnoDB: Log scan progressed past the checkpoint lsn 74463688243
2024-06-24 04:38:01 1 [Note] InnoDB: Database was not shutdown normally!
2024-06-24 04:38:01 1 [Note] InnoDB: Starting crash recovery.
2024-06-24 04:38:01 1 [Note] InnoDB: Reading tablespace information from the .ibd files...
2024-06-24 04:38:01 1 [Note] InnoDB: Restoring possible half-written data pages 
2024-06-24 04:38:01 1 [Note] InnoDB: from the doublewrite buffer...
InnoDB: Doing recovery: scanned up to log sequence number 74468931072
InnoDB: Doing recovery: scanned up to log sequence number 74473545348
2024-06-24 04:38:01 1 [Note] InnoDB: Starting an apply batch of log records to the database...
InnoDB: Progress in percent: 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 InnoDB: Error: trying to access page number 0 in space 768521,
InnoDB: space name mysqlslap/t1,
InnoDB: which is outside the tablespace bounds.
InnoDB: Byte offset 0, len 16384, i/o type 10.
InnoDB: If you get this error at mysqld startup, please check that
InnoDB: your my.cnf matches the ibdata files that you have in the
InnoDB: MySQL server.
2024-06-24 04:38:01 7f4343c04040  InnoDB: Assertion failure in thread 139926876209216 in file fil0fil.cc line 5674
InnoDB: We intentionally generate a memory trap.
InnoDB: Submit a detailed bug report to http://bugs.mysql.com/.
InnoDB: If you get repeated assertion failures or crashes, even
InnoDB: immediately after the mysqld startup, there may be
InnoDB: corruption in the InnoDB tablespace. Please refer to
InnoDB: http://dev.mysql.com/doc/refman/5.6/en/forcing-innodb-recovery.html
InnoDB: about forcing recovery.
04:38:01 UTC - mysqld got signal 6 ;
This could be because you hit a bug. It is also possible that this binary
or one of the libraries it was linked against is corrupt, improperly built,
or misconfigured. This error can also be caused by malfunctioning hardware.
We will try our best to scrape up some info that will hopefully help
diagnose the problem, but since we have already crashed, 
something is definitely wrong and this may fail.

key_buffer_size=8388608
read_buffer_size=131072
max_used_connections=0
max_threads=151
thread_count=0
connection_count=0
It is possible that mysqld could use up to 
key_buffer_size + (read_buffer_size + sort_buffer_size)*max_threads = 68109 K  bytes of memory
Hope that's ok; if not, decrease some variables in the equation.

Thread pointer: 0x0
Attempting backtrace. You can use the following information to find out
where mysqld died. If you see no messages after this, something went
terribly wrong...
stack_bottom = 0 thread_stack 0x40000
mysqld(my_print_stacktrace+0x2c)[0x55fb7f92fadc]
mysqld(handle_fatal_signal+0x4b1)[0x55fb7f6ca5f1]
/lib/x86_64-linux-gnu/libpthread.so.0(+0x110e0)[0x7f43437dd0e0]
/lib/x86_64-linux-gnu/libc.so.6(gsignal+0xcf)[0x7f4342379fff]
/lib/x86_64-linux-gnu/libc.so.6(abort+0x16a)[0x7f434237b42a]
mysqld(+0x8d5e54)[0x55fb7fabae54]
mysqld(+0x8a1c71)[0x55fb7fa86c71]
mysqld(+0x8a3a04)[0x55fb7fa88a04]
mysqld(+0x7bbcaf)[0x55fb7f9a0caf]
mysqld(+0x7be48a)[0x55fb7f9a348a]
mysqld(+0x8349bb)[0x55fb7fa199bb]
mysqld(+0x777d08)[0x55fb7f95cd08]
mysqld(_Z24ha_initialize_handlertonP13st_plugin_int+0x46)[0x55fb7f6188d6]
mysqld(+0x569bc1)[0x55fb7f74ebc1]
mysqld(_Z11plugin_initPiPPci+0x76c)[0x55fb7f754d6c]
mysqld(+0x42bb9b)[0x55fb7f610b9b]
mysqld(_Z11mysqld_mainiPPc+0x3d8)[0x55fb7f611ac8]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf1)[0x7f43423672e1]
mysqld(_start+0x2a)[0x55fb7f60584a]
The manual page at http://dev.mysql.com/doc/mysql/en/crashing.html contains
information that should help you find out what is causing the crash.
```

- [x]  Bump up the mysql version in all backup specs to `8.4`

Successful run: 
 https://aetos.pwx.purestorage.com/resultSet/testSetID/678081 

**Which issue(s) this PR fixes** (optional)
Closes #PB-7345

**Special notes for your reviewer**:

