### PR TITLE
Modified PX Backup upgrade TC to include partial success validation

### DIFF
--- a/tests/backup_helper.go
+++ b/tests/backup_helper.go
@@ -143,8 +143,8 @@ const (
 	BackupLocationDeleteRetryTime             = 30 * time.Second
 	RebootNodeTimeout                         = 1 * time.Minute
 	RebootNodeTimeBeforeRetry                 = 5 * time.Second
-	LatestPxBackupVersion                     = "2.7.0"
-	defaultPxBackupHelmBranch                 = "2.7.0"
+	LatestPxBackupVersion                     = "2.7.2"
+	defaultPxBackupHelmBranch                 = "2.7.2"
 	pxCentralPostInstallHookJobName           = "pxcentral-post-install-hook"
 	quickMaintenancePod                       = "quick-maintenance-repo"
 	fullMaintenancePod                        = "full-maintenance-repo"


### PR DESCRIPTION
Modified the TC **PXBackupEndToEndBackupAndRestoreWithUpgrade** to include additional steps for validating the backups with Partial Success.

**Which issue(s) this PR fixes** (optional)
Closes #PB-7198

**Special notes for your reviewer**:
Only the newly added steps could be verified due to the a bug:
Upgrade path: 2.6.0 -> 2.7.2
https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/5963/
Upgrade path: 2.7.0 -> 2.7.2
https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/5967/
Upgrade path: 2.7.1 -> 2.7.2
https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/5956/