### PR TITLE
Adding a new test case PartialBackupSuccessWithPxAndKDMPVolumes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/portworx/pds-api-go-client v0.0.0-20231102112445-993d38984eae
 	github.com/portworx/px-backup-api v1.2.2-0.20240513165102-9eda9e2fc169
-	github.com/portworx/sched-ops v1.20.4-rc1.0.20240603144114-c7bdf15376db
+	github.com/portworx/sched-ops v1.20.4-rc1.0.20240625095951-0b38bc239d01
 	github.com/portworx/talisman v1.1.3
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.63.0
 	github.com/prometheus/client_golang v1.17.0

--- a/go.sum
+++ b/go.sum
@@ -3081,8 +3081,8 @@ github.com/portworx/sched-ops v1.20.4-rc1.0.20221208153443-c95ed6d757fa/go.mod h
 github.com/portworx/sched-ops v1.20.4-rc1.0.20230103234348-243afb3bb8aa/go.mod h1:wQK24M7cbrhAk378J2WwR0nMx86W/iJwRc1JilEmP40=
 github.com/portworx/sched-ops v1.20.4-rc1.0.20230207070155-2e0ef25efadd/go.mod h1:JbHASXqA/GXwFD4blS1DZkrxtS5llb98ViZgUerOtQA=
 github.com/portworx/sched-ops v1.20.4-rc1.0.20230207140221-24ec094deec4/go.mod h1:drIYh+6f/vh11dVmbpwFv3GIusQCSMThPX774U8ix7w=
-github.com/portworx/sched-ops v1.20.4-rc1.0.20240603144114-c7bdf15376db h1:55WbKy3jhkXrl3+uCfslTekXSHrv8xO85LSdFyf2nzM=
-github.com/portworx/sched-ops v1.20.4-rc1.0.20240603144114-c7bdf15376db/go.mod h1:KOe618gr1FAzVmLNe9LFHss19df3MBZ0qom6Ct7RpyM=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20240625095951-0b38bc239d01 h1:4PCp2WnlCGsHjItEh9rYHSTVfpVSZFJtAUtrR0W2ewQ=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20240625095951-0b38bc239d01/go.mod h1:KOe618gr1FAzVmLNe9LFHss19df3MBZ0qom6Ct7RpyM=
 github.com/portworx/talisman v0.0.0-20191007232806-837747f38224/go.mod h1:OjpMH9Uh5o9ntVGktm4FbjLNwubJ3ITih2OfYrAeWtA=
 github.com/portworx/talisman v0.0.0-20210302012732-8af4564777f7/go.mod h1:e8a6uFpSbOlRpZQlW9aXYogC+GWAo065G0RL9hDkD4Q=
 github.com/portworx/talisman v1.1.3 h1:XrDE0fs4UACgDGi5bvt04uePC+QbhbA5YXozGYg5tr8=

--- a/tests/backup/backup_partial_test.go
+++ b/tests/backup/backup_partial_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/portworx/sched-ops/k8s/core"
 	corev1 "k8s.io/api/core/v1"
+	"os"
 	"sync"
 	"time"
 
@@ -469,5 +470,277 @@ var _ = Describe("{PartialBackupSuccessWithPxVolumes}", func() {
 		log.FailOnError(err, "Fetching px-central-admin ctx")
 		CleanupCloudSettingsAndClusters(backupLocationMap, cloudCredName, cloudCredUID, ctx)
 
+	})
+})
+
+// This testcase Verifies partial backup and restore when both Px and KDMP volumes are backed up with failing KDMP backups
+var _ = Describe("{PartialBackupSuccessWithPxAndKDMPVolumes}", func() {
+
+	var (
+		backupNames            []string
+		scheduleBackupNames    []string
+		restoreNames           []string
+		scheduledAppContexts   []*scheduler.Context
+		sourceClusterUid       string
+		cloudCredName          string
+		cloudCredUID           string
+		backupLocationUID      string
+		backupLocationName     string
+		backupLocationMap      = make(map[string]string)
+		labelSelectors         = make(map[string]string)
+		namespaceMapping       = make(map[string]string)
+		schedulePolicyName     string
+		schedulePolicyUID      string
+		schedulePolicyInterval = int64(15)
+		providers              []string
+		failedVolumes          []*corev1.PersistentVolumeClaim
+		backedUpNamespaces     []string
+		scheduleNames          []string
+	)
+
+	JustBeforeEach(func() {
+		StartPxBackupTorpedoTest("PartialBackupSuccessWithPxAndKDMPVolumes", "Verifies partial backup and restore when both Px and KDMP volumes are backed up with failing KDMP backups",
+			nil, 299230, Mkoppal, Q2FY25)
+		providers = GetBackupProviders()
+		numOfNamespace := 2
+		log.InfoD("scheduling applications")
+		scheduledAppContexts = make([]*scheduler.Context, 0)
+		appList := Inst().AppList
+		defer func() {
+			Inst().AppList = appList
+		}()
+		var err error
+		Inst().AppList, err = GetApplicationSpecForFeature("PartialBackup")
+		log.FailOnError(err, "Fetching application spec for feature PartialBackup")
+		for i := 0; i < numOfNamespace; i++ {
+			taskName := fmt.Sprintf("%s-%d", TaskNamePrefix, i)
+			appContexts := ScheduleApplications(taskName)
+			for _, appCtx := range appContexts {
+				appCtx.ReadinessTimeout = AppReadinessTimeout
+				scheduledAppContexts = append(scheduledAppContexts, appCtx)
+				appNamespace := appCtx.ScheduleOptions.Namespace
+				backedUpNamespaces = append(backedUpNamespaces, appNamespace)
+			}
+		}
+		// Setting BACKUP_TYPE env variable to "csi_offload_s3" to make CSI snapshots to be offloaded to backup-location and trigger KDMP path
+		err = os.Setenv("BACKUP_TYPE", "csi_offload_s3")
+		log.FailOnError(err, "Setting BACKUP_TYPE env variable")
+	})
+
+	It("Verifies partial backup and restore when both Px and KDMP volumes are backed up with failing KDMP backups", func() {
+		defer func() {
+			log.InfoD("switching to default context")
+			err := SetClusterContext("")
+			log.FailOnError(err, "failed to SetClusterContext to default cluster")
+		}()
+
+		Step("Validating applications", func() {
+			log.InfoD("Validating applications")
+			ValidateApplications(scheduledAppContexts)
+		})
+
+		Step("Creating backup location and cloud setting", func() {
+			log.InfoD("Creating backup location and cloud setting")
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			for _, provider := range providers {
+				cloudCredName = fmt.Sprintf("%s-%s-%v", "cred", provider, time.Now().Unix())
+				backupLocationName = fmt.Sprintf("%s-%s-bl-%v", provider, getGlobalBucketName(provider), time.Now().Unix())
+				cloudCredUID = uuid.New()
+				backupLocationUID = uuid.New()
+				backupLocationMap[backupLocationUID] = backupLocationName
+				err := CreateCloudCredential(provider, cloudCredName, cloudCredUID, BackupOrgID, ctx)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation of cloud credential named [%s] for org [%s] with [%s] as provider", cloudCredName, BackupOrgID, provider))
+				err = CreateBackupLocation(provider, backupLocationName, backupLocationUID, cloudCredName, cloudCredUID, getGlobalBucketName(provider), BackupOrgID, "", true)
+				dash.VerifyFatal(err, nil, "Creating backup location")
+			}
+		})
+
+		Step("Create schedule policy", func() {
+			log.InfoD("Creating schedule policy")
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			schedulePolicyName = fmt.Sprintf("%s-%v", "periodic-schedule-policy", RandomString(5))
+			schedulePolicyUID = uuid.New()
+			err = CreateBackupScheduleIntervalPolicy(5, schedulePolicyInterval, 5, schedulePolicyName, schedulePolicyUID, BackupOrgID, ctx, false, false)
+			dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying creation of schedule policy %s", schedulePolicyName))
+		})
+
+		Step("Registering cluster for backup", func() {
+			log.InfoD("Registering cluster for backup")
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+
+			err = CreateApplicationClusters(BackupOrgID, "", "", ctx)
+			dash.VerifyFatal(err, nil, "Creating source and destination cluster")
+
+			clusterStatus, err := Inst().Backup.GetClusterStatus(BackupOrgID, SourceClusterName, ctx)
+			log.FailOnError(err, fmt.Sprintf("Fetching [%s] cluster status", SourceClusterName))
+			dash.VerifyFatal(clusterStatus, api.ClusterInfo_StatusInfo_Online, fmt.Sprintf("Verifying if [%s] cluster is online", SourceClusterName))
+
+			sourceClusterUid, err = Inst().Backup.GetClusterUID(ctx, BackupOrgID, SourceClusterName)
+			dash.VerifyFatal(err, nil, fmt.Sprintf("Fetching [%s] cluster uid", SourceClusterName))
+
+			clusterStatus, err = Inst().Backup.GetClusterStatus(BackupOrgID, DestinationClusterName, ctx)
+			log.FailOnError(err, fmt.Sprintf("Fetching [%s] cluster status", DestinationClusterName))
+			dash.VerifyFatal(clusterStatus, api.ClusterInfo_StatusInfo_Online, fmt.Sprintf("Verifying if [%s] cluster is online", DestinationClusterName))
+		})
+
+		Step("Making a list of all CSI volumes to fail", func() {
+			log.InfoD("Making a list of all CSI volumes to fail")
+			pvcLabelSelector := make(map[string]string)
+			pvcLabelSelector["backupVolumeType"] = "csi"
+			k8sCore := k8score.Instance()
+			for _, appCtx := range scheduledAppContexts {
+				scheduledNamespace := appCtx.ScheduleOptions.Namespace
+				log.Infof("Getting PVC list with provisioner based label selector in namespace %s", scheduledNamespace)
+				pvcList, err := k8sCore.GetPersistentVolumeClaims(scheduledNamespace, pvcLabelSelector)
+				log.FailOnError(err, "Getting PVC list with provisioner based label selector")
+				for _, pvc := range pvcList.Items {
+					pvcCopy := pvc.DeepCopy()
+					log.Infof("Adding PVC Name: [%s], PVC Volume name: [%s], PVC Namespace: [%s] to failed volumes", pvc.Name, pvc.Spec.VolumeName, pvc.Namespace)
+					failedVolumes = append(failedVolumes, pvcCopy)
+				}
+				if len(pvcList.Items) > 0 {
+					appCtx.SkipPodValidation = true
+				}
+			}
+			log.Infof("List of volumes to fail during backup")
+			for _, pvc := range failedVolumes {
+				log.Infof("PVC Name: [%s], PVC Volume name: [%s], PVC Namespace: [%s]", pvc.Name, pvc.Spec.VolumeName, pvc.Namespace)
+			}
+		})
+
+		Step("Taking manual backup of application from source cluster and deleting the DE CR in parallel", func() {
+			log.InfoD("taking manual backup of applications")
+			var wg sync.WaitGroup
+			log.InfoD("taking backup of applications")
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			backupName := fmt.Sprintf("%s-%s", "auto-manual-partial-backup", RandomString(4))
+			backupNames = append(backupNames, backupName)
+			wg.Add(2)
+			// Go routine to delete DE CRs for the PVCs
+			go func() {
+				defer GinkgoRecover()
+				defer wg.Done()
+				var wg1 sync.WaitGroup
+				wg1.Add(len(failedVolumes))
+				for _, pvc := range failedVolumes {
+					go func(pvc *corev1.PersistentVolumeClaim) {
+						defer GinkgoRecover()
+						defer wg1.Done()
+						log.Infof("Deleting Data export CR for %s [%s] in namespace %s", pvc.Name, pvc.Spec.VolumeName, pvc.Namespace)
+						err = DeleteDataExportCRForVolume(pvc)
+						log.FailOnError(err, fmt.Sprintf("error deleting DE CR for %s [%s] in namespace %s", pvc.Name, pvc.Spec.VolumeName, pvc.Namespace))
+					}(pvc)
+				}
+				wg1.Wait()
+			}()
+			// Go routine to create backup
+			go func() {
+				defer GinkgoRecover()
+				defer wg.Done()
+				log.InfoD("creating backup [%s] in source cluster [%s] (%s), organization [%s], in backup location [%s]", backupName, SourceClusterName, sourceClusterUid, BackupOrgID, backupLocationName)
+				err = CreatePartialBackupWithValidationWithVscMapping(ctx, backupName, SourceClusterName, backupLocationName, backupLocationUID, scheduledAppContexts, labelSelectors, BackupOrgID, sourceClusterUid, "", "", "", "", make(map[string]string), false, failedVolumes)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Creation and Validation of partial backup while DE CR for CSI volumes are bring deleted [%s]", backupName))
+			}()
+			wg.Wait()
+
+		})
+
+		Step("Start watchers to kill the DE CR", func() {
+			log.InfoD("Starting watchers to kill the DE CR")
+			err := WatchAndKillDataExportCR(backedUpNamespaces)
+			log.FailOnError(err, "Watching and killing DE CR")
+		})
+
+		Step("Taking scheduled backup of application from source cluster", func() {
+			log.InfoD("taking scheduled backup of applications")
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			scheduleName := fmt.Sprintf("%s-%s", "schedule-partial", RandomString(4))
+			scheduleBackupName, err := CreatePartialScheduleBackupWithValidationWithVscMapping(ctx, scheduleName, SourceClusterName, backupLocationName, backupLocationUID, scheduledAppContexts, labelSelectors, BackupOrgID, "", "", "", "", schedulePolicyName, schedulePolicyUID, make(map[string]string), false, failedVolumes)
+			dash.VerifyFatal(err, nil, fmt.Sprintf("Creation and Validation of partial schedule backup [%s]", scheduleBackupName))
+			scheduleBackupNames = append(scheduleBackupNames, scheduleBackupName)
+			backupNames = append(backupNames, scheduleBackupName)
+			scheduleNames = append(scheduleNames, scheduleName)
+			err = SuspendBackupSchedule(scheduleName, schedulePolicyName, BackupOrgID, ctx)
+			dash.VerifyFatal(err, nil, fmt.Sprintf("Suspending Backup Schedule :[%s]", scheduleName))
+		})
+
+		Step("Restoring the backed up namespaces in new namespace in destination cluster ", func() {
+			log.InfoD("Restoring the backed up namespaces in new namespace in destination cluster ")
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			for _, namespace := range backedUpNamespaces {
+				namespaceMapping[namespace] = namespace + RandomString(4)
+			}
+			for _, backupName := range backupNames {
+				restoreName := fmt.Sprintf("%s-%s-%s", "default", backupName, RandomString(4))
+				log.InfoD("Restoring from the [%s] backup with namespaceMapping [%v]", backupName, namespaceMapping)
+				err = CreatePartialRestoreWithValidation(ctx, restoreName, backupName, namespaceMapping, make(map[string]string), DestinationClusterName, BackupOrgID, scheduledAppContexts, failedVolumes)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Creation and Validation of restore [%s]", restoreName))
+				restoreNames = append(restoreNames, restoreName)
+			}
+		})
+
+		Step("Restoring the backed up namespaces in same namespace on source with retain", func() {
+			log.InfoD("Restoring the backed up namespaces in same namespace on source with retain")
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			for _, backupName := range backupNames {
+				restoreName := fmt.Sprintf("%s-%s-%s", "retain", backupName, RandomString(4))
+				log.InfoD("Restoring from the [%s] backup ", backupName)
+				err := CreatePartialRestoreWithReplacePolicyWithValidation(restoreName, backupName, namespaceMapping, DestinationClusterName, BackupOrgID, ctx, make(map[string]string), 1, scheduledAppContexts, failedVolumes)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Creation and Validation of restore [%s]", restoreName))
+				restoreNames = append(restoreNames, restoreName)
+			}
+		})
+
+		Step("Restoring the backed up namespaces in same namespace on source with replace", func() {
+			log.InfoD("Restoring the backed up namespaces in same namespace on source with replace")
+			ctx, err := backup.GetAdminCtxFromSecret()
+			log.FailOnError(err, "Fetching px-central-admin ctx")
+			for _, backupName := range backupNames {
+				restoreName := fmt.Sprintf("%s-%s-%s", "replace", backupName, RandomString(4))
+				err := CreatePartialRestoreWithReplacePolicyWithValidation(restoreName, backupName, namespaceMapping, DestinationClusterName, BackupOrgID, ctx, make(map[string]string), 2, scheduledAppContexts, failedVolumes)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Creating restore [%s]", restoreName))
+				restoreNames = append(restoreNames, restoreName)
+			}
+		})
+	})
+
+	JustAfterEach(func() {
+		defer EndPxBackupTorpedoTest(make([]*scheduler.Context, 0))
+		defer func() {
+			log.Infof("Unsetting BACKUP_TYPE env variable")
+			err := os.Unsetenv("BACKUP_TYPE")
+			log.FailOnError(err, "Unsetting BACKUP_TYPE env variable")
+		}()
+
+		ctx, err := backup.GetAdminCtxFromSecret()
+		log.FailOnError(err, "Fetching px-central-admin ctx")
+		for _, scheduleName := range scheduleNames {
+			err = DeleteSchedule(scheduleName, SourceClusterName, BackupOrgID, ctx)
+			dash.VerifySafely(err, nil, fmt.Sprintf("Verification of deleting backup schedule - %s", scheduleName))
+		}
+		err = Inst().Backup.DeleteBackupSchedulePolicy(BackupOrgID, []string{schedulePolicyName})
+		dash.VerifySafely(err, nil, "Deleting backup schedule policies")
+		// Cleanup all backups
+		allBackups, err := GetAllBackupsAdmin()
+		dash.VerifySafely(err, nil, "Verifying fetching of all backups")
+		for _, backupName := range allBackups {
+			backupUID, err := Inst().Backup.GetBackupUID(ctx, backupName, BackupOrgID)
+			dash.VerifySafely(err, nil, fmt.Sprintf("Getting backuip UID for backup %s", backupName))
+			_, err = DeleteBackup(backupName, backupUID, BackupOrgID, ctx)
+			dash.VerifySafely(err, nil, fmt.Sprintf("Verifying backup deletion - %s", backupName))
+		}
+		log.Info("Deleting restored namespaces")
+		for _, restoreName := range restoreNames {
+			err = DeleteRestore(restoreName, BackupOrgID, ctx)
+			dash.VerifySafely(err, nil, fmt.Sprintf("Deleting Restore [%s]", restoreName))
+		}
+		CleanupCloudSettingsAndClusters(backupLocationMap, cloudCredName, cloudCredUID, ctx)
 	})
 })

--- a/vendor/github.com/portworx/sched-ops/k8s/core/serviceaccounts.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/core/serviceaccounts.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 
+	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -19,6 +20,8 @@ type ServiceAccountOps interface {
 	DeleteServiceAccount(accountName, namespace string) error
 	// ListServiceAccount in given namespace
 	ListServiceAccount(namespace string, opts metav1.ListOptions) (*corev1.ServiceAccountList, error)
+	// CreateToken creates a token associated with a serviceaccount through a tokenRequest
+	CreateToken(name, namespace string, tokenRequest *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error)
 }
 
 // CreateServiceAccount creates the given service account
@@ -66,4 +69,13 @@ func (c *Client) DeleteServiceAccount(accountName, namespace string) error {
 	return c.kubernetes.CoreV1().ServiceAccounts(namespace).Delete(context.TODO(), accountName, metav1.DeleteOptions{
 		PropagationPolicy: &deleteForegroundPolicy,
 	})
+}
+
+// CreateToken creates the server's representation of the tokenRequest associated with a service account
+func (c *Client) CreateToken(name, namespace string, tokenRequest *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	return c.kubernetes.CoreV1().ServiceAccounts(namespace).CreateToken(context.TODO(), name, tokenRequest, metav1.CreateOptions{})
 }

--- a/vendor/github.com/portworx/sched-ops/k8s/kdmp/dataexport.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/kdmp/dataexport.go
@@ -3,6 +3,7 @@ package kdmp
 import (
 	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/watch"
 	"time"
 
 	"github.com/portworx/sched-ops/k8s/errors"
@@ -26,6 +27,8 @@ type DataExportOps interface {
 	DeleteDataExport(string, string) error
 	// ValidateDataExport validates the DataExport CR
 	ValidateDataExport(string, string, time.Duration, time.Duration) error
+	// WatchDataExport sends a watcher for DataExport CR
+	WatchDataExport(string, metav1.ListOptions) (watch.Interface, error)
 }
 
 // CreateDataExport creates the DataExport CR
@@ -105,4 +108,16 @@ func (c *Client) ValidateDataExport(name string, namespace string, timeout, retr
 	}
 
 	return nil
+}
+
+// WatchDataExport sends a watcher for DataExport CR
+func (c *Client) WatchDataExport(namespace string, opts metav1.ListOptions) (watch.Interface, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	watcher, err := c.kdmp.KdmpV1alpha1().DataExports(namespace).Watch(context.TODO(), opts)
+	if err != nil {
+		return nil, err
+	}
+	return watcher, nil
 }

--- a/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_pod_security_admission_configuration_template_defaults.go
+++ b/vendor/github.com/rancher/rancher/pkg/client/generated/management/v3/zz_generated_pod_security_admission_configuration_template_defaults.go
@@ -18,4 +18,3 @@ type PodSecurityAdmissionConfigurationTemplateDefaults struct {
 	Warn           string `json:"warn,omitempty" yaml:"warn,omitempty"`
 	WarnVersion    string `json:"warn-version,omitempty" yaml:"warn-version,omitempty"`
 }
-

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1343,7 +1343,7 @@ github.com/portworx/pds-api-go-client/pds/v1alpha1
 github.com/portworx/px-backup-api/pkg/apis/v1
 github.com/portworx/px-backup-api/pkg/kubeauth
 github.com/portworx/px-backup-api/pkg/kubeauth/gcp
-# github.com/portworx/sched-ops v1.20.4-rc1.0.20240603144114-c7bdf15376db
+# github.com/portworx/sched-ops v1.20.4-rc1.0.20240625095951-0b38bc239d01
 ## explicit; go 1.19
 github.com/portworx/sched-ops/k8s/admissionregistration
 github.com/portworx/sched-ops/k8s/anthos


### PR DESCRIPTION
**What this PR does / why we need it**:
- [x] Adding a new test case `PartialBackupSuccessWithPxAndKDMPVolumes`
- [x] Added a new helper function to delete DE CR for a particular volume - `DeleteDataExportCRForVolume`
- [x] Added a helper function to watch and kill all DE CRs in namespaces provided

**Which issue(s) this PR fixes** (optional)
Closes #PB-7354

**Special notes for your reviewer**:
[Jenkins BYOC with OCP](https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/5930/)

