### PR TITLE
label for partial backup tests

### DIFF
--- a/tests/backup/backup_partial_test.go
+++ b/tests/backup/backup_partial_test.go
@@ -273,7 +273,7 @@ var _ = Describe("{BackupCSIVolumesWithPartialSuccess}", Label(TestCaseLabelsMap
 })
 
 // This testcase verified the partial backup success when few Px volumes snapshots are successful and few are failed
-var _ = Describe("{PartialBackupSuccessWithPxVolumes}", func() {
+var _ = Describe("{PartialBackupSuccessWithPxVolumes}", Label(TestCaseLabelsMap[PartialBackupSuccessWithPxVolumes]...), func() {
 
 	var (
 		scheduledAppContexts []*scheduler.Context
@@ -464,7 +464,7 @@ var _ = Describe("{PartialBackupSuccessWithPxVolumes}", func() {
 })
 
 // This testcase Verifies partial backup and restore when both Px and KDMP volumes are backed up with failing KDMP backups
-var _ = Describe("{PartialBackupSuccessWithPxAndKDMPVolumes}", func() {
+var _ = Describe("{PartialBackupSuccessWithPxAndKDMPVolumes}", Label(TestCaseLabelsMap[PartialBackupSuccessWithPxAndKDMPVolumes]...), func() {
 
 	var (
 		backupNames            []string
@@ -983,7 +983,7 @@ var _ = Describe("{BackupStateTransitionForScheduledBackups}", Label(TestCaseLab
 })
 
 // This testcase verifies that the restoring from a partial backup with a lower stork version on the destination fails with the correct error message
-var _ = Describe("{PartialBackupWithLowerStorkVersion}", func() {
+var _ = Describe("{PartialBackupWithLowerStorkVersion}", Label(TestCaseLabelsMap[PartialBackupWithLowerStorkVersion]...), func() {
 	var (
 		backupNames          []string
 		scheduledAppContexts []*scheduler.Context
@@ -1217,7 +1217,7 @@ var _ = Describe("{PartialBackupWithLowerStorkVersion}", func() {
 })
 
 // This testcase verifies the partial backup success when few Px volumes backups failed while taking backup to Azure Global Location when env variable is set to non-global location.
-var _ = Describe("{PartialBackupSuccessWithAzureEndpoint}", func() {
+var _ = Describe("{PartialBackupSuccessWithAzureEndpoint}", Label(TestCaseLabelsMap[PartialBackupSuccessWithAzureEndpoint]...), func() {
 
 	var (
 		backupNames                []string
@@ -1240,7 +1240,7 @@ var _ = Describe("{PartialBackupSuccessWithAzureEndpoint}", func() {
 	)
 
 	JustBeforeEach(func() {
-		StartPxBackupTorpedoTest("PartialBackupSuccessWithAzureEndpoint", "verifies the partial backup success when few Px volumes backups failed while taking backup to Azure Global Location when env variable is set to non-global location", nil, 299236, Ak, Q2FY25)
+		StartPxBackupTorpedoTest("PartialBackupSuccessWithAzureEndpoint", "Verifies the partial backup success when few Px volumes backups failed while taking backup to Azure Global Location when env variable is set to non-global location", nil, 299236, Ak, Q2FY25)
 		// This testcase is specific to Azure provider with Px Volumes
 		provider = "azure"
 		numOfNamespace := 1

--- a/tests/backup/backup_test_labels.go
+++ b/tests/backup/backup_test_labels.go
@@ -129,6 +129,10 @@ const (
 	BackupCSIVolumesWithPartialSuccess                                                 TestCaseName = "BackupCSIVolumesWithPartialSuccess"
 	RestoreFromHigherPrivilegedNamespaceToLower                                        TestCaseName = "RestoreFromHigherPrivilegedNamespaceToLower"
 	BackupStateTransitionForScheduledBackups                                           TestCaseName = "BackupStateTransitionForScheduledBackups"
+	PartialBackupSuccessWithPxVolumes                                                  TestCaseName = "PartialBackupSuccessWithPxVolumes"
+	PartialBackupSuccessWithPxAndKDMPVolumes                                           TestCaseName = "PartialBackupSuccessWithPxAndKDMPVolumes"
+	PartialBackupWithLowerStorkVersion                                                 TestCaseName = "PartialBackupWithLowerStorkVersion"
+	PartialBackupSuccessWithAzureEndpoint                                              TestCaseName = "PartialBackupSuccessWithAzureEndpoint"
 )
 
 // Test case labels
@@ -256,6 +260,10 @@ const (
 	BackupStateTransitionForScheduledBackupsLabel                                           TestCaseLabel = "BackupStateTransitionForScheduledBackups"
 	EnableNsAndClusterLevelPSAWithBackupAndRestoreLabel                                     TestCaseLabel = "EnableNsAndClusterLevelPSAWithBackupAndRestore"
 	RestoreFromHigherPrivilegedNamespaceToLowerLabel                                        TestCaseLabel = "RestoreFromHigherPrivilegedNamespaceToLower"
+	PartialBackupSuccessWithPxVolumesLabel                                                  TestCaseLabel = "PartialBackupSuccessWithPxVolumes"
+	PartialBackupSuccessWithPxAndKDMPVolumesLabel                                           TestCaseLabel = "PartialBackupSuccessWithPxAndKDMPVolumes"
+	PartialBackupWithLowerStorkVersionLabel                                                 TestCaseLabel = "PartialBackupWithLowerStorkVersion"
+	PartialBackupSuccessWithAzureEndpointLabel                                              TestCaseLabel = "PartialBackupSuccessWithAzureEndpoint"
 )
 
 // Common Labels
@@ -379,13 +387,19 @@ const (
 
 // Backup location labels
 const (
-	NfsBackupLocationLabel = "nfs"
-	S3BackupLocationLabel  = "s3"
+	NfsBackupLocationLabel   = "nfs"
+	S3BackupLocationLabel    = "s3"
+	AzureBackupLocationLabel = "Azure"
 )
 
 // App labels
 const (
 	KubevirtAppLabel = "kubevirt-app"
+)
+
+// Feature labels
+const (
+	PartialBackupLabel = "PartialBackup"
 )
 
 var TestCaseLabelsMap = map[TestCaseName][]TestCaseLabel{
@@ -506,8 +520,12 @@ var TestCaseLabelsMap = map[TestCaseName][]TestCaseLabel{
 	CloudSnapshotMissingValidationForNFSLocation:                     {CloudSnapshotMissingValidationForNFSLocationLabel},
 	MultipleProvisionerCsiKdmpBackupAndRestore:                       {MultipleProvisionerCsiKdmpBackupAndRestoreLabel},
 	KubevirtVMMigrationTest:                                          {KubevirtVMMigrationTestLabel, KubevirtAppLabel},
-	BackupCSIVolumesWithPartialSuccess:                               {BackupCSIVolumesWithPartialSuccessLabel},
-	BackupStateTransitionForScheduledBackups:                         {BackupStateTransitionForScheduledBackupsLabel},
+	BackupCSIVolumesWithPartialSuccess:                               {BackupCSIVolumesWithPartialSuccessLabel, PartialBackupLabel},
+	BackupStateTransitionForScheduledBackups:                         {BackupStateTransitionForScheduledBackupsLabel, PartialBackupLabel},
 	EnableNsAndClusterLevelPSAWithBackupAndRestore:                   {EnableNsAndClusterLevelPSAWithBackupAndRestoreLabel},
 	RestoreFromHigherPrivilegedNamespaceToLower:                      {RestoreFromHigherPrivilegedNamespaceToLowerLabel, rkePipelineNightly},
+	PartialBackupSuccessWithPxVolumes:                                {PartialBackupSuccessWithPxVolumesLabel, PartialBackupLabel},
+	PartialBackupSuccessWithPxAndKDMPVolumes:                         {PartialBackupSuccessWithPxAndKDMPVolumesLabel, PartialBackupLabel},
+	PartialBackupWithLowerStorkVersion:                               {PartialBackupWithLowerStorkVersionLabel, PartialBackupLabel},
+	PartialBackupSuccessWithAzureEndpoint:                            {PartialBackupSuccessWithAzureEndpointLabel, PartialBackupLabel, AzureBackupLocationLabel},
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding label for partial backup tests

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

--label-filter='PartialBackup' 
======================
 ginkgo --dry-run -v --label-filter='PartialBackup' -- -spec-dir /Users/ak/Documents/workspace/2024/partial-label-new/torpedo/drivers/scheduler/k8s/specs -log-location `pwd` --app-list postgres-backup --backup-driver pxb --product px-backup --test-desc "Px-Backup System Tests" --user ak 

PartialBackupSuccessWithAzureEndpoint
PartialBackupSuccessWithPxAndKDMPVolumes
BackupStateTransitionForScheduledBackups
BackupCSIVolumesWithPartialSuccess
PartialBackupSuccessWithPxVolumes
PartialBackupWithLowerStorkVersion

ginkgo --dry-run -v --label-filter='PartialBackup && !Azure' -- -spec-dir /Users/ak/Documents/workspace/2024/partial-label-new/torpedo/drivers/scheduler/k8s/specs -log-location `pwd` --app-list postgres-backup --backup-driver pxb --product px-backup --test-desc "Px-Backup System Tests" --user ak
}'

--label-filter='PartialBackup && !Azure' 
=========================
PartialBackupWithLowerStorkVersion
PartialBackupSuccessWithPxAndKDMPVolumes
PartialBackupSuccessWithPxVolumes
BackupStateTransitionForScheduledBackups
BackupCSIVolumesWithPartialSuccess

