### PR TITLE
Adding pool delete event for longevity

### DIFF
--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -3947,7 +3947,7 @@ func (k *K8s) ValidateVolumes(ctx *scheduler.Context, timeout, retryInterval tim
 				}
 				log.Infof("[%v] Validated PVC: %v size based on Autopilot rules", ctx.App.Key, obj.Name)
 			} else {
-				log.Warnf("[%v] Autopilot is not enabled, PVC: %v size validation is not possible", ctx.App.Key, obj.Name)
+				log.Debugf("[%v] Autopilot is not enabled, Skipping PVC: %v size validation with autopilot rules", ctx.App.Key, obj.Name)
 			}
 		} else if obj, ok := specObj.(*snapv1.VolumeSnapshot); ok {
 			if err := k8sExternalStorage.ValidateSnapshot(obj.Metadata.Name, obj.Metadata.Namespace, true, timeout,

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -788,8 +788,9 @@ func (d *portworx) isMetadataNode(node node.Node, address string) (bool, error) 
 	if err != nil {
 		return false, fmt.Errorf("failed to get metadata nodes, Err: %v", err)
 	}
+	log.Infof(fmt.Sprintf("members %v", members))
 
-	ipRegex := regexp.MustCompile(`http://(?P<address>.*):d+`)
+	ipRegex := regexp.MustCompile(`http:\/\/(?P<address>[\d\.]+):(?P<port>\d+)`)
 	for _, value := range members {
 		for _, url := range value.ClientUrls {
 			result := getGroupMatches(ipRegex, url)
@@ -3995,6 +3996,7 @@ func (d *portworx) UpgradeStork(specGenUrl string) error {
 }
 
 func (d *portworx) RestartDriver(n node.Node, triggerOpts *driver_api.TriggerOptions) error {
+	log.Infof(fmt.Sprintf("Restarting volume driver on node [%s]", n.Name))
 	return driver_api.PerformTask(
 		func() error {
 			return d.schedOps.RestartPxOnNode(n)
@@ -4433,6 +4435,7 @@ func (d *portworx) updateNodeID(n *node.Node, nManager ...api.OpenStorageNodeCli
 
 func getGroupMatches(groupRegex *regexp.Regexp, str string) map[string]string {
 	match := groupRegex.FindStringSubmatch(str)
+	log.Infof("matches for url [%s]: %v", str, match)
 	result := make(map[string]string)
 	if len(match) > 0 {
 		for i, name := range groupRegex.SubexpNames() {

--- a/tests/basic/node_decommission_test.go
+++ b/tests/basic/node_decommission_test.go
@@ -181,7 +181,7 @@ var _ = Describe("{DecommissionNode}", func() {
 
 					return false, true, fmt.Errorf("node %s not joined yet", nodeToDecommission.Name)
 				}
-				_, err = task.DoRetryWithTimeout(t, appReadinessTimeout, defaultRetryInterval)
+				_, err = task.DoRetryWithTimeout(t, 20*time.Minute, defaultRetryInterval)
 				log.FailOnError(err, fmt.Sprintf("error joining the node [%s]", nodeToDecommission.Name))
 				dash.VerifyFatal(rejoinedNode != nil, true, fmt.Sprintf("verify node [%s] rejoined PX cluster", nodeToDecommission.Name))
 				err = Inst().S.RefreshNodeRegistry()
@@ -343,7 +343,7 @@ var _ = Describe("{KvdbDecommissionNode}", func() {
 
 					return false, true, fmt.Errorf("node %s not joined yet", nodeToDecommission.Name)
 				}
-				_, err = task.DoRetryWithTimeout(t, appReadinessTimeout, defaultRetryInterval)
+				_, err = task.DoRetryWithTimeout(t, 20*time.Minute, defaultRetryInterval)
 				log.FailOnError(err, fmt.Sprintf("error joining the node [%s]", nodeToDecommission.Name))
 				dash.VerifyFatal(rejoinedNode != nil, true, fmt.Sprintf("verify node [%s] rejoined PX cluster", nodeToDecommission.Name))
 				err = Inst().S.RefreshNodeRegistry()

--- a/tests/basic/pure_test.go
+++ b/tests/basic/pure_test.go
@@ -5242,7 +5242,8 @@ var _ = Describe("{DisableCsiTopologyandDeletePool}", func() {
 			log.InfoD(stepLog)
 			nodeForPoolDelete = append(nodeForPoolDelete, stNodes[rand.Intn(len(stNodes))])
 			log.InfoD("Deleting the pool on the node [%v]", nodeForPoolDelete[0].Name)
-			deletePoolAndValidate(nodeSelected, fmt.Sprintf("%d", nodePool.ID))
+			err = DeletePoolAndValidate(nodeSelected, fmt.Sprintf("%d", nodePool.ID))
+			dash.VerifyFatal(err, nil, fmt.Sprintf("Validate pool [%d] deletion in the node [%s]", nodePool.ID, nodeSelected.Name))
 		})
 		stepLog = "Add a Cloud Drive on same node and check if it is added successfully"
 		Step(stepLog, func() {

--- a/tests/longevity/longevity_helper.go
+++ b/tests/longevity/longevity_helper.go
@@ -222,6 +222,7 @@ func populateDisruptiveTriggers() {
 		CrashPXDaemon:                   true,
 		PowerOffAllVMs:                  true,
 		RestartKubeletService:           true,
+		PoolDelete:                      true,
 	}
 }
 
@@ -617,6 +618,7 @@ func populateIntervals() {
 	triggerInterval[ScaleFADAVolumeAttach] = map[int]time.Duration{}
 	triggerInterval[DeleteCloudsnaps] = make(map[int]time.Duration)
 	triggerInterval[RestartKubeletService] = make(map[int]time.Duration)
+	triggerInterval[PoolDelete] = make(map[int]time.Duration)
 
 	baseInterval := 10 * time.Minute
 	triggerInterval[BackupScaleMongo][10] = 1 * baseInterval
@@ -1553,6 +1555,17 @@ func populateIntervals() {
 	triggerInterval[KVDBFailover][6] = 5 * baseInterval
 	triggerInterval[KVDBFailover][5] = 6 * baseInterval
 
+	triggerInterval[PoolDelete][10] = 1 * baseInterval
+	triggerInterval[PoolDelete][9] = 2 * baseInterval
+	triggerInterval[PoolDelete][8] = 3 * baseInterval
+	triggerInterval[PoolDelete][7] = 4 * baseInterval
+	triggerInterval[PoolDelete][6] = 5 * baseInterval
+	triggerInterval[PoolDelete][5] = 6 * baseInterval
+	triggerInterval[PoolDelete][4] = 18 * baseInterval
+	triggerInterval[PoolDelete][3] = 21 * baseInterval
+	triggerInterval[PoolDelete][2] = 24 * baseInterval
+	triggerInterval[PoolDelete][1] = 27 * baseInterval
+
 	triggerInterval[VolumesDelete][10] = 1 * baseInterval
 	triggerInterval[VolumesDelete][9] = 3 * baseInterval
 	triggerInterval[VolumesDelete][8] = 6 * baseInterval
@@ -1762,6 +1775,7 @@ func populateIntervals() {
 	triggerInterval[ResetDiscardMounts][0] = 0
 	triggerInterval[ScaleFADAVolumeAttach][0] = 0
 	triggerInterval[RestartKubeletService][0] = 0
+	triggerInterval[PoolDelete][0] = 0
 
 }
 

--- a/tests/longevity/longevity_test.go
+++ b/tests/longevity/longevity_test.go
@@ -110,6 +110,7 @@ var _ = Describe("{Longevity}", func() {
 		ResetDiscardMounts:                TriggerResetDiscardMounts,
 		ScaleFADAVolumeAttach:             TriggerScaleFADAVolumeAttach,
 		RestartKubeletService:             TriggerKubeletRestart,
+		PoolDelete:                        TriggerPoolDelete,
 	}
 	//Creating a distinct trigger to make sure email triggers at regular intervals
 	emailTriggerFunction = map[string]func(){


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
- Added pool delete for longevity
- Fixed isMetadataNode check while initialisation
- Adding more wait for kvdb node to rejoin after decomm
- Fixed autopilot warning when it is not enabled 

**Which issue(s) this PR fixes** (optional)
Closes #PTX-24735

**Special notes for your reviewer**:

https://jenkins.pwx.dev.purestorage.com/job/Users/job/Leela/job/leela-torpedo-only/348/console