### PR TITLE
PTX-24898 Restart the px while managment interface is down and enable interface during start of px

### DIFF
--- a/tests/basic/pure_test.go
+++ b/tests/basic/pure_test.go
@@ -6302,6 +6302,121 @@ var _ = Describe("{RestartPXonAllWorkerNodesandCheckVolumes}", func() {
 		AfterEachTest(contexts)
 	})
 })
+var _ = Describe("{RestartPxandRestartNodeWithMgmtInterfaceDown}", func() {
+	/*
+	   https://purestorage.atlassian.net/browse/PTX-24898
+	   1.Deploy Applications
+	   2.Validate Applications are Deployed
+	   3.Stop portworx on all nodes
+	   4.Make the Management Interface Down on the backend FA
+	   5.Start the PX and after that wait for a minute make the management interface up and then check if px is up
+	   6.Validate the Applications are running
+	*/
+	JustBeforeEach(func() {
+		StartTorpedoTest("RestartPxandRestartNodeWithMgmtInterfaceDown",
+			"Restart Portworx and Restart Node with Mgmt Interface of the backend FA being down for few minutes", nil, 0)
+	})
+	var contexts []*scheduler.Context
+	itLog := "RestartPxandRestartNodeWithMgmtInterfaceDown"
+	It(itLog, func() {
+		log.InfoD(itLog)
+		var (
+			LastDisabledInterface string
+			PureFaClientVif       *newFlashArray.Client
+			FadaPvcList           []string
+			FaDetails             []pureutils.FlashArrayEntry
+		)
+		pxNodes := node.GetStorageDriverNodes()
+		for i := 0; i < Inst().GlobalScaleFactor; i++ {
+			taskName := "restartpxandrebootnodewithmgmtinterfacedown"
+			Provisioner := fmt.Sprintf("%v", portworx.PortworxCsi)
+			context, err := Inst().S.Schedule(taskName, scheduler.ScheduleOptions{
+				AppKeys:            Inst().AppList,
+				CsiAppKeys:         Inst().CsiAppList,
+				StorageProvisioner: Provisioner,
+				Namespace:          taskName,
+			})
+			log.FailOnError(err, "Failed to schedule application of %v namespace", taskName)
+			contexts = append(contexts, context...)
+		}
+		ValidateApplications(contexts)
+		defer DestroyApps(contexts, nil)
+		//GetVolumeNameFromPvc will collect volume name from pvc which indirect will be the px volume name and this name is suffix to the volumes created in FA backend
+		GetVolumeNameFromPvc := func(namespace string, pvclist []string) []string {
+			allPvcList, err := core.Instance().GetPersistentVolumeClaims(namespace, nil)
+			log.FailOnError(err, fmt.Sprintf("error getting pvcs from namespace [%s]", namespace))
+			for _, p := range allPvcList.Items {
+				scForPvc, err := k8sCore.GetStorageClassForPVC(&p)
+				log.FailOnError(err, "Failed to get storage class for pvc [%s]", p.Name)
+				backend, _ := scForPvc.Parameters["backend"]
+				if backend == "pure_block" {
+					pvclist = append(pvclist, p.Spec.VolumeName)
+				}
+			}
+			return pvclist
+		}
+		for _, ctx := range contexts {
+			FadaPvcList = GetVolumeNameFromPvc(ctx.App.NameSpace, nil)
+		}
+		for _, volname := range FadaPvcList {
+			FaDetails, err = GetFADetailsFromVolumeName(volname)
+			log.FailOnError(err, "Failed to get FA details from volume name")
+			break
+		}
+		stepLog := "Stop portworx on all Nodes"
+		Step(stepLog, func() {
+			log.InfoD(stepLog)
+			log.InfoD("Stopping portworx  Service on Nodes")
+			err := Inst().V.StopDriver(pxNodes, false, nil)
+			dash.VerifyFatal(err, nil, "Failed to stop portworx on nodes")
+			log.InfoD("stopped portworx on all nodes")
+		})
+		stepLog = "Make the Management Interface Down on the backend FA"
+		Step(stepLog, func() {
+			log.InfoD(stepLog)
+			volDriverNamespace, err := Inst().V.GetVolumeDriverNamespace()
+			log.FailOnError(err, "failed to get volume driver [%s] namespace", Inst().V.String())
+			secret, err := pureutils.GetPXPureSecret(volDriverNamespace)
+			log.FailOnError(err, "failed to get secret [%s/%s]", PureSecretName, volDriverNamespace)
+			for _, fa := range FaDetails {
+				faClient, err := pureutils.PureCreateClientAndConnectRest2_x(fa.MgmtEndPoint, fa.APIToken)
+				apiToken, err := pureutils.GetApiTokenForFAMgmtEndpoint(secret, fa.MgmtEndPoint)
+				log.FailOnError(err, "failed to get API token for FA with IP [%s]", fa.MgmtEndPoint)
+				PureFaClientVif, err = GetVifInterface(faClient, fa.MgmtEndPoint, apiToken)
+				log.FailOnError(err, "failed to get vif interface for FA with IP [%s]", fa.MgmtEndPoint)
+				LastDisabledInterface, err = DisableManagementInterface(PureFaClientVif, fa.MgmtEndPoint, false)
+			}
+		})
+		stepLog = "Start the PX and after that wait for a minute make the management interface up and then check if px is up"
+		Step(stepLog, func() {
+			log.InfoD(stepLog)
+			log.InfoD("Starting portworx  Service on Nodes")
+			for _, node := range pxNodes {
+				err := Inst().V.StartDriver(node)
+				log.FailOnError(err, "Failed to start portworx on node [%s]", node.Name)
+			}
+			log.InfoD("Wait for a minute and make the management interface up")
+			time.Sleep(1 * time.Minute)
+			_, err := pureutils.SetInterfaceEnabled(PureFaClientVif, LastDisabledInterface, true)
+			log.FailOnError(err, "Failed to enable the management interface")
+			for _, node := range pxNodes {
+				err = Inst().V.WaitDriverUpOnNode(node, Inst().DriverStartTimeout)
+				dash.VerifyFatal(err, nil, fmt.Sprintf("Verifying the node driver status of rebooted node %s", node.Name))
+			}
+			log.InfoD("Portworx is up on all nodes")
+
+		})
+		stepLog = "Validate the applications are in running state"
+		Step(stepLog, func() {
+			log.InfoD(stepLog)
+			ValidateApplications(contexts)
+		})
+	})
+	JustAfterEach(func() {
+		EndTorpedoTest()
+		AfterEachTest(contexts)
+	})
+})
 
 var _ = Describe("{RestartPXAfterPureSecretRecreation}", func() {
 	/*


### PR DESCRIPTION
…nable it to check if px is up

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR  Stops PX and then makes management interface down and starts the PX after that it makes mgmt interface Up and check if PX is up

**Which issue(s) this PR fixes** (optional)
Closes #
https://purestorage.atlassian.net/browse/PTX-24898

**Special notes for your reviewer**:

https://jenkins.pwx.dev.purestorage.com/job/Users/job/krishna/job/tp-pxe-byoc/3753/display/redirect