### PR TITLE
Fixing the nexus URL for travis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ LABEL maintainer="harsh@portworx.com"
 ARG MAKE_TARGET
 
 WORKDIR /go/src/github.com/portworx/torpedo
-ENV NEXUS_URL="https://nexus.pwx.dev.purestorage.com"
 
 # Install setup dependencies
 RUN apk update && apk add --no-cache bash git gcc musl-dev make curl openssh-client coreutils python3
@@ -18,7 +17,7 @@ RUN mkdir bin && \
     mv aws-iam-authenticator bin
 
 # Install IBM Cloud SDK
-RUN curl -fskSL $NEXUS_URL/repository/store/ibmcloud/linux | bash && \
+RUN curl -fsSL https://clis.cloud.ibm.com/install/linux | sh && \
     ibmcloud plugin install -v 11.3.0 -f vpc-infrastructure && \
     ibmcloud plugin install -f container-service
 


### PR DESCRIPTION
``aniket-landing :: ~/torpedo » export DOCKER_HUB_REPO=portworx                                                                     
export DOCKER_HUB_TORPEDO_IMAGE=torpedo
export DOCKER_HUB_TAG=FIX-NEXUS
make deploy

Building basic.test container portworx/torpedo:FIX-NEXUS
sudo DOCKER_BUILDKIT=1 docker build --tag portworx/torpedo:FIX-NEXUS --build-arg MAKE_TARGET=build -f Dockerfile .
[sudo] password for ubuntu: 
[+] Building 330.2s (53/53) FINISHED                                                                                                              
 => [internal] load build definition from Dockerfile                                                                                         0.2s
 => => transferring dockerfile: 3.86kB                                                                                                       0.0s
 => [internal] load .dockerignore                                                                                                            0.2s
 => => transferring context: 2B                                                                                                              0.0s
 => [internal] load metadata for docker.io/library/alpine:3.18.5                                                                             1.1s
 => [internal] load metadata for docker.io/library/golang:1.21.6-alpine                                                                      1.0s
 => [auth] library/golang:pull token for registry-1.docker.io                                                                                0.0s
 => [auth] library/alpine:pull token for registry-1.docker.io                                                                                0.0s
 => [internal] load build context                                                                                                           12.1s
 => => transferring context: 518.67MB                                                                                                       12.0s
 => [stage-1  1/24] FROM docker.io/library/alpine:3.18.5@sha256:34871e7290500828b39e22294660bee86d966bc0017544e848dd9a255cdf59e0             0.6s
 => => resolve docker.io/library/alpine:3.18.5@sha256:34871e7290500828b39e22294660bee86d966bc0017544e848dd9a255cdf59e0                       0.0s
 => => sha256:d695c3de6fcd8cfe3a6222b0358425d40adfd129a8a47c3416faff1a8aece389 528B / 528B                                                   0.0s
 => => sha256:b541f2080109ab7b6bf2c06b28184fb750cdd17836c809211127717f48809858 1.47kB / 1.47kB                                               0.0s
 => => sha256:c926b61bad3b94ae7351bafd0c184c159ebf0643b085f7ef1d47ecdc7316833c 3.40MB / 3.40MB                                               0.3s
 => => sha256:34871e7290500828b39e22294660bee86d966bc0017544e848dd9a255cdf59e0 1.64kB / 1.64kB                                               0.0s
 => => extracting sha256:c926b61bad3b94ae7351bafd0c184c159ebf0643b085f7ef1d47ecdc7316833c                                                    0.1s
 => [build  1/18] FROM docker.io/library/golang:1.21.6-alpine@sha256:a6a7f1fcf12f5efa9e04b1e75020931a616cd707f14f62ab5262bfbe109aa84a        8.4s
 => => resolve docker.io/library/golang:1.21.6-alpine@sha256:a6a7f1fcf12f5efa9e04b1e75020931a616cd707f14f62ab5262bfbe109aa84a                0.0s
 => => sha256:1139ce7fbe827ed81020b14ded1fb5897308fa84286d1b5820827e4a25498f9a 2.13kB / 2.13kB                                               0.0s
 => => sha256:e8e7baba97f57fa5df2e96f78c627013fec3c450d844769a62de7f40cc5bbed1 284.20kB / 284.20kB                                           0.1s
 => => sha256:dae04b0c6bbc66c34f591a7f12f3abd4d0c941a911c71665e01df894ed018351 67.06MB / 67.06MB                                             1.3s
 => => sha256:a6a7f1fcf12f5efa9e04b1e75020931a616cd707f14f62ab5262bfbe109aa84a 1.65kB / 1.65kB                                               0.0s
 => => sha256:bb943c432d54b16abd59d0240a4d0bbaae8781925f117a78355b908d197a1da1 1.36kB / 1.36kB                                               0.0s
 => => extracting sha256:e8e7baba97f57fa5df2e96f78c627013fec3c450d844769a62de7f40cc5bbed1                                                    0.1s
 => => sha256:5ac343c6ec1bf70460a5ad3e0453ee8b07e06b5579e6bd41fedaa449916624e7 173B / 173B                                                   0.4s
 => => sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1 32B / 32B                                                   328.3s
 => => extracting sha256:dae04b0c6bbc66c34f591a7f12f3abd4d0c941a911c71665e01df894ed018351                                                    4.3s
 => => extracting sha256:5ac343c6ec1bf70460a5ad3e0453ee8b07e06b5579e6bd41fedaa449916624e7                                                    0.0s
 => => extracting sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1                                                    0.0s
 => FROM docker.io/alpine/helm:latest                                                                                                        0.9s
 => FROM docker.io/lachlanevenson/k8s-kubectl:latest                                                                                         4.3s
 => => resolve docker.io/lachlanevenson/k8s-kubectl:latest                                                                                   1.0s
 => => sha256:be98414e6907f0e6913c54ad98cfa59ffb86b843d2d7cf10dd7107e4d1822866 946B / 946B                                                   0.0s
 => => sha256:8c37cace829170f3e776d50ed0ac124b0e0ff8c606c6cdf58dcc65eabd5c598b 3.79kB / 3.79kB                                               0.0s
 => => sha256:c158987b05517b6f2c5913f3acef1f2182a32345a304fe357e3ace5fadcad715 3.37MB / 3.37MB                                               0.3s
 => => sha256:080f96913dabab03b398a3aec10677887fe33d212a2f71640c3c9da5a5f3e135 15.54MB / 15.54MB                                             0.8s
 => => sha256:6e16ad356091ddfc95cd90fb7145b927531b45798e89d397a4c5e8fb64f8a5f5 1.36kB / 1.36kB                                               0.0s
 => => extracting sha256:c158987b05517b6f2c5913f3acef1f2182a32345a304fe357e3ace5fadcad715                                                    0.2s
 => => sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1 32B / 32B                                                     0.8s
 => => extracting sha256:080f96913dabab03b398a3aec10677887fe33d212a2f71640c3c9da5a5f3e135                                                    0.7s
 => => extracting sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1                                                    0.0s
 => [auth] lachlanevenson/k8s-kubectl:pull token for registry-1.docker.io                                                                    0.0s
 => [stage-1  2/24] RUN apk add --no-cache ca-certificates bash curl jq libc6-compat coreutils                                               4.8s
 => [stage-1  3/24] RUN apk add --no-cache --update python3 py3-pip                                                                          5.5s
 => [build  2/18] WORKDIR /go/src/github.com/portworx/torpedo                                                                                2.4s
 => [build  3/18] RUN apk update && apk add --no-cache bash git gcc musl-dev make curl openssh-client coreutils python3                      8.5s
 => [stage-1  4/24] RUN apk add --no-cache --update --virtual=build gcc musl-dev python3-dev libffi-dev openssl-dev cargo make && pip3 in  134.9s
 => [build  4/18] RUN GOFLAGS= GO111MODULE=on go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.15.0                                  15.4s
 => [build  5/18] RUN mkdir bin &&     curl -o aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.16.8/2020-04-16/bin/li  9.8s
 => [build  6/18] RUN curl -fsSL https://clis.cloud.ibm.com/install/linux | sh &&     ibmcloud plugin install -v 11.3.0 -f vpc-infrastructu  7.9s
 => [build  7/18] RUN curl -L -o vcluster "https://github.com/loft-sh/vcluster/releases/latest/download/vcluster-linux-amd64"      && insta  2.9s
 => [build  8/18] COPY vendor vendor                                                                                                         2.9s
 => [build  9/18] COPY Makefile Makefile                                                                                                     0.3s
 => [build 10/18] COPY go.mod go.mod                                                                                                         0.2s
 => [build 11/18] COPY go.sum go.sum                                                                                                         0.1s
 => [build 12/18] COPY pkg pkg                                                                                                               0.1s
 => [build 13/18] COPY scripts scripts                                                                                                       0.1s
 => [build 14/18] COPY drivers drivers                                                                                                       0.6s
 => [build 15/18] COPY deployments deployments                                                                                               0.2s
 => [build 16/18] COPY .git .git                                                                                                             2.6s
 => [build 17/18] COPY tests tests                                                                                                           0.2s
 => [build 18/18] RUN --mount=type=cache,target=/root/.cache/go-build make build                                                           249.9s
 => [stage-1  5/24] RUN bash -c "$(curl -L https://raw.githubusercontent.com/oracle/oci-cli/master/scripts/install/install.sh)" -- --pytho  55.7s
 => [stage-1  6/24] COPY --from=lachlanevenson/k8s-kubectl:latest /usr/local/bin/kubectl /usr/local/bin/kubectl                              0.3s
 => [stage-1  7/24] COPY --from=alpine/helm:latest /usr/bin/helm /usr/local/bin/helm                                                         0.9s
 => [stage-1  8/24] WORKDIR /torpedo                                                                                                         0.2s
 => [stage-1  9/24] COPY deployments deployments                                                                                             0.1s
 => [stage-1 10/24] COPY scripts scripts                                                                                                     0.1s
 => [stage-1 11/24] RUN apk update && apk upgrade     && apk add --no-cache         nodejs         npm     && rm -rf /var/cache/apk/*        7.7s
 => [stage-1 12/24] RUN npm install -g newman                                                                                                7.7s
 => [stage-1 13/24] WORKDIR /go/src/github.com/portworx/torpedo                                                                              0.5s
 => [stage-1 14/24] RUN apk add --update --no-cache docker                                                                                   4.5s
 => [stage-1 15/24] RUN apk add --no-cache openssh sshpass                                                                                   1.7s
 => [stage-1 16/24] RUN apk --update add gcompat                                                                                             1.5s
 => [stage-1 17/24] RUN wget https://github.com/mikefarah/yq/releases/download/v4.25.1/yq_linux_amd64 -O /usr/bin/yq &&     chmod +x /usr/b  3.1s
 => [stage-1 18/24] COPY --from=build /go/bin/ginkgo /bin/ginkgo                                                                             0.4s
 => [stage-1 19/24] COPY --from=build /go/src/github.com/portworx/torpedo/bin bin                                                            1.2s
 => [stage-1 20/24] COPY --from=build /go/src/github.com/portworx/torpedo/bin/aws-iam-authenticator /bin/aws-iam-authenticator               0.2s
 => [stage-1 21/24] COPY --from=build /usr/local/bin/ibmcloud /bin/ibmcloud                                                                  0.2s
 => [stage-1 22/24] COPY --from=build /usr/local/bin/vcluster /bin/vcluster                                                                  1.0s
 => [stage-1 23/24] COPY --from=build /root/.bluemix/plugins /root/.bluemix/plugins                                                          0.3s
 => [stage-1 24/24] COPY drivers drivers                                                                                                     0.2s
 => exporting to image                                                                                                                      10.2s
 => => exporting layers                                                                                                                     10.2s
 => => writing image sha256:529719383dc41d5531a1814219e7799c6f2cebd7ebb8eb11ff4297a05e4a1c58                                                 0.0s
 => => naming to docker.io/portworx/torpedo:FIX-NEXUS                                                                                        0.0s
sudo docker push portworx/torpedo:FIX-NEXUS
The push refers to repository [docker.io/portworx/torpedo]
d60202fa3d8d: Pushed 
23d9731ac643: Pushed 
95de94ec36de: Pushed 
99aa0b1c89dd: Pushed 
630245eabc38: Pushed 
794fbb53a51f: Pushed 
594e0b684625: Pushed 
0f0777a081e0: Pushed 
d4528eea69fc: Pushed 
9894f9ef0a6c: Pushed 
35668e6bb68f: Pushed 
30b0091f2d38: Pushed 
053c993b33c7: Pushed 
8491fc277fcf: Pushed 
18d7a8e5b3b8: Pushed 
bbbef973119e: Pushed 
75c2cadbc027: Pushed 
7fa1eaf1ed9e: Pushed 
a9e26a9dd431: Pushed 
011c6c7a1978: Pushed 
7ab35eea289b: Pushed 
46da3211ba89: Pushed 
0bbb2229f5f2: Pushed 
9fe9a137fd00: Layer already exists 
FIX-NEXUS: digest: sha256:433546a416a56c67840051e67e03be299264330e6659ae8b320a89e0113cf6d6 size: 5380`