### PR TITLE
Increasing the wait time after Px STC update

### DIFF
--- a/drivers/scheduler/k8s/specs/pg-mysql-multiprov-iks/pg-deployment.yaml
+++ b/drivers/scheduler/k8s/specs/pg-mysql-multiprov-iks/pg-deployment.yaml
@@ -14,6 +14,13 @@ spec:
       labels:
         app: postgres
     spec:
+      initContainers:
+        - name: init-mysql
+          image: busybox
+          command: [ 'sh', '-c', "dd if=/dev/urandom of=/etc/postgresql/conf.d/dummyfile bs=1M count=100" ]
+          volumeMounts:
+            - name: postgres-ibmc
+              mountPath: /etc/postgresql/conf.d
       containers:
         - name: postgres
           image: postgres:13

--- a/tests/backup_helper.go
+++ b/tests/backup_helper.go
@@ -10353,8 +10353,8 @@ func UpdateDriverWithEnvVariable(envVariables map[string]string) error {
 	if err != nil {
 		return err
 	}
-	log.InfoD("Sleeping for 5 minutes for PX cluster to stabilise after deletion of pods")
-	time.Sleep(5 * time.Minute)
+	log.InfoD("Sleeping for 10 minutes for PX cluster to stabilise after deletion of pods")
+	time.Sleep(10 * time.Minute)
 	_, err = optest.ValidateStorageClusterIsOnline(clusterSpec, 10*time.Minute, 3*time.Minute)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:
On IKS cluster, 5 minutes was not enough to stabilise the px pods after updating the STC. Increasing it to 10 min.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
[Jenkins Cloud BYOC run with IKS](https://jenkins.pwx.dev.purestorage.com/job/Users/job/Mithun/job/Cloud%20BYOC/43/)

