### PR TITLE
PWX-36514: Adding validation for node PDB during k8s upgrade

### DIFF
--- a/drivers/scheduler/openshift/openshift.go
+++ b/drivers/scheduler/openshift/openshift.go
@@ -708,7 +708,7 @@ func downloadOCP4Client(ocpVersion string) error {
 	}
 
 	log.Infof("Downloading OCP [%s] client from URL [%s] to [%s]...", ocpVersion, downloadURL, clientName)
-	stdout, err := exec.Command("curl", "-o", "-L", clientName, downloadURL).CombinedOutput()
+	stdout, err := exec.Command("curl", "-o", clientName, "-L", downloadURL).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to download OpenShift [%s] client from [%s], Err %v %v", clientName, downloadURL, stdout, err)
 	}

--- a/drivers/scheduler/openshift/openshift.go
+++ b/drivers/scheduler/openshift/openshift.go
@@ -708,7 +708,7 @@ func downloadOCP4Client(ocpVersion string) error {
 	}
 
 	log.Infof("Downloading OCP [%s] client from URL [%s] to [%s]...", ocpVersion, downloadURL, clientName)
-	stdout, err := exec.Command("curl", "-o", clientName, downloadURL).CombinedOutput()
+	stdout, err := exec.Command("curl", "-o", "-L", clientName, downloadURL).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to download OpenShift [%s] client from [%s], Err %v %v", clientName, downloadURL, stdout, err)
 	}

--- a/tests/basic/upgrade_cluster_test.go
+++ b/tests/basic/upgrade_cluster_test.go
@@ -114,7 +114,7 @@ var _ = Describe("{UpgradeCluster}", func() {
 
 				err = Inst().S.UpgradeScheduler(version)
 				if err != nil {
-					err = Inst().S.RefreshNodeRegistry()
+					err := Inst().S.RefreshNodeRegistry()
 					log.FailOnError(err, "Refresh Node Registry failed")
 					err = Inst().V.RefreshDriverEndpoints()
 					log.FailOnError(err, "Refresh Driver Endpoints failed")

--- a/tests/basic/upgrade_cluster_test.go
+++ b/tests/basic/upgrade_cluster_test.go
@@ -77,8 +77,9 @@ var _ = Describe("{UpgradeCluster}", func() {
 		pxVersionString, err := Inst().V.GetDriverVersion()
 		var pxVersion *version.Version
 		if err == nil {
-			pxVersion, _ = version.NewVersion(pxVersionString)
+			pxVersion, err = version.NewVersion(pxVersionString)
 		}
+		log.FailOnError(err, "failed to get px version")
 		for _, version := range versions {
 			Step(fmt.Sprintf("start [%s] scheduler upgrade to version [%s]", Inst().S.String(), version), func() {
 				stopSignal := make(chan struct{})

--- a/tests/basic/upgrade_cluster_test.go
+++ b/tests/basic/upgrade_cluster_test.go
@@ -85,12 +85,12 @@ var _ = Describe("{UpgradeCluster}", func() {
 
 				var mError error
 				opver, err := oputil.GetPxOperatorVersion()
-				if err == nil && opver.GreaterThanOrEqual(ParallelUpgradeOperatorVersion) && pxVersion.GreaterThanOrEqual(ParallelUpgradePXVersion) {
+				if err == nil && opver.GreaterThanOrEqual(ParallelUpgradeMinOpVersion) && pxVersion.GreaterThanOrEqual(ParallelUpgradeMinPxVersion) {
 					go DoParallelUpgradePDBValidation(stopSignal, &mError)
 					defer func() {
 						close(stopSignal)
 					}()
-				} else if err == nil && opver.GreaterThanOrEqual(PDBValidationMinOpVersion) && opver.LessThan(ParallelUpgradeOperatorVersion) {
+				} else if err == nil && opver.GreaterThanOrEqual(PDBValidationMinOpVersion) && opver.LessThan(ParallelUpgradeMinOpVersion) {
 					go DoPDBValidation(stopSignal, &mError)
 					defer func() {
 						close(stopSignal)
@@ -101,15 +101,15 @@ var _ = Describe("{UpgradeCluster}", func() {
 
 				var vQuorumError error
 				// validate volume quorum during upgrade
-				if opver.GreaterThanOrEqual(ParallelUpgradeOperatorVersion) && pxVersion.GreaterThanOrEqual(ParallelUpgradePXVersion) {
+				if opver.GreaterThanOrEqual(ParallelUpgradeMinOpVersion) && pxVersion.GreaterThanOrEqual(ParallelUpgradeMinPxVersion) {
 					log.Info("Starting volume quorum validation for Portworx upgrade .......")
 					stopVolumeQuorumValidationSignal := make(chan struct{})
 					go DoVolumeQuorumValidation(stopVolumeQuorumValidationSignal, &vQuorumError)
 					defer close(stopVolumeQuorumValidationSignal)
 				} else {
 					log.Warnf("Skipping volume quorum validation due to version constraints.......")
-					log.Warnf("Required Operator version: %s, actual Operator version: %s", ParallelUpgradeOperatorVersion, opver)
-					log.Warnf("Required PX version: %s, actual PX version: %s", ParallelUpgradePXVersion, pxVersion)
+					log.Warnf("Required Operator version: %s, actual Operator version: %s", PDBValidationMinOpVersion, opver)
+					log.Warnf("Required PX version: %s, actual PX version: %s", ParallelUpgradeMinPxVersion, pxVersion)
 				}
 
 				err = Inst().S.UpgradeScheduler(version)

--- a/tests/basic/upgrade_cluster_test.go
+++ b/tests/basic/upgrade_cluster_test.go
@@ -91,7 +91,7 @@ var _ = Describe("{UpgradeCluster}", func() {
 					defer func() {
 						close(stopSignal)
 					}()
-				} else if err == nil && opver.GreaterThanOrEqual(PDBValidationMinOpVersion) && opver.LessThan(ParallelUpgradeMinOpVersion) {
+				} else if err == nil && opver.GreaterThanOrEqual(PDBValidationMinOpVersion) && (opver.LessThan(ParallelUpgradeMinOpVersion) || pxVersion.LessThan(ParallelUpgradeMinPxVersion)) {
 					go DoPDBValidation(stopSignal, &mError)
 					defer func() {
 						close(stopSignal)

--- a/tests/basic/upgrade_cluster_test.go
+++ b/tests/basic/upgrade_cluster_test.go
@@ -2,10 +2,11 @@ package tests
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-version"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/go-version"
 
 	oputil "github.com/libopenstorage/operator/pkg/util/test"
 	. "github.com/onsi/ginkgo/v2"
@@ -103,7 +104,7 @@ var _ = Describe("{UpgradeCluster}", func() {
 				var vQuorumError error
 				// validate volume quorum during upgrade
 				if opver.GreaterThanOrEqual(ParallelUpgradeMinOpVersion) && pxVersion.GreaterThanOrEqual(ParallelUpgradeMinPxVersion) {
-					log.Info("Starting volume quorum validation for Portworx upgrade .......")
+					log.Info("Starting volume quorum validation for cluster upgrade .......")
 					stopVolumeQuorumValidationSignal := make(chan struct{})
 					go DoVolumeQuorumValidation(stopVolumeQuorumValidationSignal, &vQuorumError)
 					defer close(stopVolumeQuorumValidationSignal)

--- a/tests/basic/upgrade_test.go
+++ b/tests/basic/upgrade_test.go
@@ -165,15 +165,15 @@ var _ = Describe("{UpgradeVolumeDriver}", func() {
 			log.FailOnError(err, "error getting driver version")
 			pxVersion, _ := version.NewVersion(pxver)
 
-			if opver.GreaterThanOrEqual(ParallelUpgradeOperatorVersion) && pxVersion.GreaterThanOrEqual(ParallelUpgradePXVersion) {
+			if opver.GreaterThanOrEqual(ParallelUpgradeMinOpVersion) && pxVersion.GreaterThanOrEqual(ParallelUpgradeMinPxVersion) {
 				log.Info("Starting volume quorum validation for Portworx upgrade")
 				stopVolumeQuorumValidationSignal := make(chan struct{})
 				go DoVolumeQuorumValidation(stopVolumeQuorumValidationSignal, &vQuorumError)
 				defer close(stopVolumeQuorumValidationSignal)
 			} else {
 				log.Warnf("Skipping volume quorum validation due to version constraints.......")
-				log.Warnf("Required Operator version: %s, actual Operator version: %s", ParallelUpgradeOperatorVersion, opver)
-				log.Warnf("Required PX version: %s, actual PX version: %s", ParallelUpgradePXVersion, pxVersion)
+				log.Warnf("Required Operator version: %s, actual Operator version: %s", ParallelUpgradeMinOpVersion, opver)
+				log.Warnf("Required PX version: %s, actual PX version: %s", ParallelUpgradeMinPxVersion, pxVersion)
 			}
 
 			// Perform upgrade hops of volume driver based on a given list of upgradeEndpoints passed

--- a/tests/common.go
+++ b/tests/common.go
@@ -232,9 +232,11 @@ var (
 
 var (
 	// PDBValidationMinOpVersion specifies the minimum PX Operator version required to enable PDB validation in the UpgradeCluster
-	PDBValidationMinOpVersion, _      = version.NewVersion("24.1.0-")
-	ParallelUpgradeOperatorVersion, _ = version.NewVersion("24.2.0-")
-	ParallelUpgradePXVersion, _       = version.NewVersion("3.1.2")
+	PDBValidationMinOpVersion, _ = version.NewVersion("24.1.0-")
+	// ParallelUpgradeMinOpVersion specifies the minimum operator version that supports smart and parallel upgrades
+	ParallelUpgradeMinOpVersion, _ = version.NewVersion("24.2.0-")
+	// ParallelUpgradePxVersion specifies minimum portworx version that supports parallel upgrade
+	ParallelUpgradeMinPxVersion, _ = version.NewVersion("3.1.2")
 )
 
 type OwnershipAccessType int32

--- a/tests/common.go
+++ b/tests/common.go
@@ -14274,7 +14274,7 @@ func ValidateNodePDB(minAvailable int, totalNodes int, errChan ...*chan error) {
 	}()
 	t := func() (interface{}, bool, error) {
 		pdblist, err := ListNodePDBs()
-		if pdblist == nil {
+		if pdblist == nil || len(pdblist) == 0 {
 			return nil, true, fmt.Errorf("error listing node PDBs :%s", err)
 		}
 		nodesDown := 0
@@ -14285,6 +14285,8 @@ func ValidateNodePDB(minAvailable int, totalNodes int, errChan ...*chan error) {
 		}
 		// NodesDown only counts nodes which have PDB minAvailable 0. There can be nodes which are in the process of upgrade
 		// Such nodes do not have any PDB and that count is got by the difference of total nodes in the cluster and nodes that have a pdb
+		log.Debugf("Nodes with minAvailable 0: %d", nodesDown)
+		log.Debugf("Total nodes in the cluster: %d, and nodes with PDB: %d", totalNodes, len(pdblist))
 		nodesDown = nodesDown + (totalNodes - len(pdblist))
 		return nodesDown, false, nil
 	}

--- a/tests/common.go
+++ b/tests/common.go
@@ -14168,7 +14168,11 @@ func ValidateVolumeQuorum(errChan ...*chan error) {
 
 				// if node is in storage down state and runtime state is not clean, fail the test
 				log.Infof("Node [%s] status: %v", replicaNodes[i], nodeStatus)
-				dash.VerifyFatal(nodeStatus, opsapi.Status_STATUS_STORAGE_DOWN, fmt.Sprintf("Validating the node [%s ] state where volume [%s] has %s", replicaNodes[i], apiVol.Id, runTimeState))
+				if reflect.DeepEqual(nodeStatus, opsapi.Status_STATUS_STORAGE_DOWN) {
+					err = fmt.Errorf("node [%s] is in %v Runtime state ", replicaNodes[i], runTimeState)
+					processError(err, errChan...)
+					return
+				}
 			}
 		}
 	}

--- a/tests/common.go
+++ b/tests/common.go
@@ -14298,6 +14298,4 @@ func ValidateNodePDB(minAvailable int, totalNodes int, errChan ...*chan error) {
 			processError(err, errChan...)
 		}
 	})
-
-	// PTX-25027: Validate that volume quorum is maintained here
 }

--- a/tests/common.go
+++ b/tests/common.go
@@ -1080,7 +1080,7 @@ func ListNodePDBs() ([]*v1.PodDisruptionBudget, error) {
 	}
 	pdbList := make([]*v1.PodDisruptionBudget, 0)
 	for _, pdb := range pdbs.Items {
-		if strings.HasPrefix(pdb.Name, "px") && pdb.Name != "px-storage" && pdb.Name != "px-kvdb" {
+		if strings.HasPrefix(pdb.Name, "px") && pdb.Name != "px-kvdb" {
 			pdbList = append(pdbList, &pdb)
 		}
 	}
@@ -14283,6 +14283,8 @@ func ValidateNodePDB(minAvailable int, totalNodes int, errChan ...*chan error) {
 				nodesDown++
 			}
 		}
+		// NodesDown only counts nodes which have PDB minAvailable 0. There can be nodes which are in the process of upgrade
+		// Such nodes do not have any PDB and that count is got by the difference of total nodes in the cluster and nodes that have a pdb
 		nodesDown = nodesDown + (totalNodes - len(pdblist))
 		return nodesDown, false, nil
 	}

--- a/tests/common.go
+++ b/tests/common.go
@@ -65,6 +65,7 @@ import (
 	"github.com/portworx/sched-ops/k8s/stork"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/portworx/sched-ops/task"
+	v1 "k8s.io/api/policy/v1"
 
 	"go.uber.org/multierr"
 	"golang.org/x/sync/errgroup"
@@ -1063,6 +1064,25 @@ func GetPDBValue() (int, int) {
 		return -1, -1
 	}
 	return pdb.Spec.MinAvailable.IntValue(), int(pdb.Status.DisruptionsAllowed)
+}
+
+// Return a list of PodDisruptionBudegts of type PodDisruptionBudget
+func ListNodePDBs() ([]*v1.PodDisruptionBudget, error) {
+	stc, err := Inst().V.GetDriver()
+	if err != nil {
+		return nil, err
+	}
+	pdbs, err := policyops.Instance().ListPodDisruptionBudget(stc.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	pdbList := make([]*v1.PodDisruptionBudget, 0)
+	for _, pdb := range pdbs.Items {
+		if strings.HasPrefix(pdb.Name, "px") && pdb.Name != "px-storage" && pdb.Name != "px-kvdb" {
+			pdbList = append(pdbList, &pdb)
+		}
+	}
+	return pdbList, nil
 }
 
 func ValidatePureCloudDriveTopologies() error {
@@ -14104,6 +14124,48 @@ func DoVolumeQuorumValidation(volumeQuorumValidationStopSignal chan struct{}, vQ
 		}
 	}
 }
+func DoParallelUpgradePDBValidation(stopSignal <-chan struct{}, mError *error) {
+
+	nodes, err := Inst().V.GetDriverNodes()
+	if err != nil {
+		*mError = multierr.Append(*mError, err)
+		return
+	}
+	stc, err := Inst().V.GetDriver()
+	if err != nil {
+		*mError = multierr.Append(*mError, err)
+		return
+	}
+	allowedDisruptions := (len(nodes) / 2) + 1
+	if stc.Annotations != nil && stc.Annotations["portworx.io/disable-non-disruptive-upgrade"] != "" {
+		allowedDisruptions, err = strconv.Atoi(stc.Annotations["portworx.io/disable-non-disruptive-upgrade"])
+		if err != nil {
+			*mError = multierr.Append(*mError, err)
+			return
+		}
+	}
+
+	itr := 1
+	for {
+		log.Infof("PDB validation iteration: #%d", itr)
+		select {
+		case <-stopSignal:
+			log.Infof("Exiting PDB validation routine")
+			return
+		default:
+			errorChan := make(chan error, 50)
+			ValidateNodePDB(allowedDisruptions, len(nodes), &errorChan)
+			for err := range errorChan {
+				*mError = multierr.Append(*mError, err)
+			}
+			if *mError != nil {
+				return
+			}
+			itr++
+			time.Sleep(10 * time.Second)
+		}
+	}
+}
 
 func ValidateVolumeQuorum(errChan ...*chan error) {
 	volIDs, err := Inst().V.ListAllVolumes()
@@ -14194,4 +14256,39 @@ func DeleteTorpedoApps() error {
 		}
 	}
 	return nil
+}
+func ValidateNodePDB(allowedDisruptions int, totalNodes int, errChan ...*chan error) {
+	defer func() {
+		if len(errChan) > 0 {
+			close(*errChan[0])
+		}
+	}()
+	t := func() (interface{}, bool, error) {
+		pdblist, err := ListNodePDBs()
+		if pdblist == nil {
+			return nil, true, fmt.Errorf("error listing node PDBs :%s", err)
+		}
+		nodesDown := 0
+		for _, pdb := range pdblist {
+			if pdb.Spec.MinAvailable.IntValue() == 0 {
+				nodesDown++
+			}
+		}
+		nodesDown = nodesDown + (totalNodes - len(pdblist))
+		return nodesDown, false, nil
+	}
+	nodesDown, err := task.DoRetryWithTimeout(t, 5*time.Minute, 5*time.Second)
+	if err != nil {
+		processError(err, errChan...)
+	}
+	nodesDownInt := nodesDown.(int)
+
+	Step("Validate PDB minAvailable for px storage", func() {
+		if nodesDownInt > allowedDisruptions {
+			err := fmt.Errorf("nodes down [%d] is more than allowed disruptions [%d]", nodesDownInt, allowedDisruptions)
+			processError(err, errChan...)
+		}
+	})
+
+	// PTX-25027: Validate that volume quorum is maintained here
 }


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: From operator 24.2.0, there will no longer be cluster wide PDB, instead there will only be per node PDB. Thus adding validation for node PDBs during k8s cluster upgrades. The code will validate that only maximum of numNodes-quorum nodes have PDB minAvailable 0 at a time and are down. This count is the total number of nodes that can be upgraded at a time. 
The quorum value by default is n/2+1 but can be changed based on valid `portworx.io/storage-pdb-min-available` value.

**Which issue(s) this PR fixes** (optional)
Closes # PWX-36514, 

**Special notes for your reviewer**: validation for maintaining volume quorum will be done as a part of another PTX

