### PR TITLE
Adding APIs for defrag schedule

### DIFF
--- a/drivers/volume/common.go
+++ b/drivers/volume/common.go
@@ -1235,3 +1235,59 @@ func (d *DefaultDriver) UpdateSkinnySnapReplNum(repl string) error {
 		Operation: "UpdateSkinnySnapReplNum()",
 	}
 }
+
+// CreateDefragSchedule create defrag schedule for provided defrag job
+func (d *DefaultDriver) CreateDefragSchedule(startTime string, defragJob *api.DefragJob) (*api.SdkCreateDefragScheduleResponse, error) {
+	return nil, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "CreateDefragSchedule()",
+	}
+}
+
+// GetDefragNodeStatus  get defrag schedule status on a given node
+func (d *DefaultDriver) GetDefragNodeStatus(n node.Node) (*api.SdkGetDefragNodeStatusResponse, error) {
+	return nil, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "GetDefragNodeStatus()",
+	}
+}
+
+// GetDefragClusterStatus get defrag schedule status for whole cluster
+func (d *DefaultDriver) GetDefragClusterStatus() (*api.SdkEnumerateDefragStatusResponse, error) {
+	return nil, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "GetDefragClusterStatus()",
+	}
+}
+
+// CleanUpDefragSchedules cleans up all defrag schedules and stop all defrag operations
+func (d *DefaultDriver) CleanUpDefragSchedules() error {
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "CleanUpDefragSchedules()",
+	}
+}
+
+// DeleteDefragSchedule deletes provided defrag schedule
+func (d *DefaultDriver) DeleteDefragSchedule(defragSchedId string) error {
+	return &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "DeleteDefragSchedule()",
+	}
+}
+
+// GetAllDefragSchedules return all defrag schedules in a cluster
+func (d *DefaultDriver) GetAllDefragSchedules() (*api.SdkEnumerateSchedulesResponse, error) {
+	return nil, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "GetAllDefragSchedules()",
+	}
+}
+
+// InspectDefragSchedules return information about provided schedule id
+func (d *DefaultDriver) InspectDefragSchedules(defragSchedId string) (*api.SdkInspectScheduleResponse, error) {
+	return nil, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "InspectDefragSchedules()",
+	}
+}

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -529,6 +529,27 @@ type Driver interface {
 
 	// ValidatePureFBDAMountSource checks that, on all the given nodes, all the provided FBDA volumes are mounted using the expected IP
 	ValidatePureFBDAMountSource(nodes []node.Node, vols []*Volume, expectedIP string) error
+
+	// CreateDefragSchedule create defrag schedule
+	CreateDefragSchedule(startTime string, defragJob *api.DefragJob) (*api.SdkCreateDefragScheduleResponse, error)
+
+	// GetDefragNodeStatus  get defrag schedule status on a given node
+	GetDefragNodeStatus(n node.Node) (*api.SdkGetDefragNodeStatusResponse, error)
+
+	// GetDefragClusterStatus get defrag schedule status for whole cluster
+	GetDefragClusterStatus() (*api.SdkEnumerateDefragStatusResponse, error)
+
+	// CleanUpDefragSchedules cleans up all defrag schedules and stop all defrag operations
+	CleanUpDefragSchedules() error
+
+	// DeleteDefragSchedule delete specificed defrag schedule
+	DeleteDefragSchedule(defragSchedId string) error
+
+	// GetAllDefragSchedules return all defrag schedules in a cluster
+	GetAllDefragSchedules() (*api.SdkEnumerateSchedulesResponse, error)
+
+	// InspectDefragSchedules return information about provided schedule id
+	InspectDefragSchedules(defragSchedId string) (*api.SdkInspectScheduleResponse, error)
 }
 
 // StorageProvisionerType provisioner to be used for torpedo volumes


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Adding APIs for defrag schedules. These APIs are required to implement defrag schedule longevity triggers

**Which issue(s) this PR fixes** (optional)
Closes # PTX-24479

**Special notes for your reviewer**:
These are generic defrag schedule apis
