### PR TITLE
Fixing the test RebootNodesWhenBackupsAreInProgress for non-px runs

### DIFF
--- a/drivers/node/ssh/ssh.go
+++ b/drivers/node/ssh/ssh.go
@@ -363,7 +363,6 @@ func (s *SSH) TestConnection(n node.Node, options node.ConnectionOpts) error {
 
 // RebootNode reboots given node
 func (s *SSH) RebootNode(n node.Node, options node.RebootNodeOpts) error {
-	log.Infof("Rebooting node %s", n.SchedulerNodeName)
 	rebootCmd := "sudo reboot"
 	if options.Force {
 		rebootCmd = rebootCmd + " -f"

--- a/drivers/volume/ocp/ocp.go
+++ b/drivers/volume/ocp/ocp.go
@@ -2,6 +2,7 @@ package ocp
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/libopenstorage/openstorage/api"
 	"github.com/portworx/torpedo/drivers/node"
@@ -102,6 +103,12 @@ func (o *ocp) InspectVolume(name string) (*api.Volume, error) {
 		Type:      "Function",
 		Operation: "InspectVolume()",
 	}
+}
+
+// WaitDriverUpOnNode must wait till the volume driver becomes usable on a given node
+func (o *ocp) WaitDriverUpOnNode(n node.Node, timeout time.Duration) error {
+	log.Warnf("WaitDriverUpOnNode function has not been implemented for volume driver - %s", o.String())
+	return nil
 }
 
 // UpdateFBDANFSEndpoint updates the NFS endpoint for a given FBDA volume


### PR DESCRIPTION
**What this PR does / why we need it**:
The test case `RebootNodesWhenBackupsAreInProgress` was failing when running on OCP with OCS - https://aetos.pwx.purestorage.com/resultSet/testSetID/696808
Fixing it by selecting any worker node in case of non-px cluster

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
[Jenkins BYOC run](https://jenkins.pwx.dev.purestorage.com/job/Users/job/Mithun/job/BYOC-%20For%20PSO/77/)

