### PR TITLE
Adding token for pxctl commands if security is enabled

### DIFF
--- a/drivers/node/ssh/ssh.go
+++ b/drivers/node/ssh/ssh.go
@@ -607,7 +607,29 @@ func (s *SSH) RunCommandWithNoRetry(n node.Node, command string, options node.Co
 	if s.IsUsingSSH() {
 		return s.doCmdSSH(n, options, command, options.IgnoreError)
 	}
-	return s.doCmdUsingPodWithoutRetry(n, command)
+
+	token := os.Getenv("PXCTL_AUTH_TOKEN")
+	if len(token) > 0 && strings.Contains(command, "pxctl") && !strings.Contains(command, "which") {
+		createCtxCmd := fmt.Sprintf("%s context create admin --token=%s", "sudo /opt/pwx/bin/pxctl", token)
+		_, err := s.doCmdUsingPod(n, options, createCtxCmd, false)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	out, err := s.doCmdUsingPodWithoutRetry(n, command)
+	if err != nil {
+		return "", err
+	}
+
+	if len(token) > 0 && strings.Contains(command, "pxctl") && !strings.Contains(command, "which") {
+		deleteCtxCmd := fmt.Sprintf("%s context delete admin", "sudo /opt/pwx/bin/pxctl")
+		_, err = s.doCmdUsingPod(n, options, deleteCtxCmd, false)
+		if err != nil {
+			return "", err
+		}
+	}
+	return out, nil
 }
 
 // FindFiles finds files from give path on given node
@@ -695,7 +717,30 @@ func (s *SSH) doCmd(n node.Node, options node.ConnectionOpts, cmd string, ignore
 	if s.IsUsingSSH() {
 		return s.doCmdSSH(n, options, cmd, ignoreErr)
 	}
-	return s.doCmdUsingPod(n, options, cmd, ignoreErr)
+	token := os.Getenv("PXCTL_AUTH_TOKEN")
+	if len(token) > 0 && strings.Contains(cmd, "pxctl") && !strings.Contains(cmd, "which") && !strings.Contains(cmd, "context") {
+		log.Infof("PX secure is enabled, creating admin context for pxctl in node [%s]", n.Name)
+		createCtxCmd := fmt.Sprintf("%s context create admin --token=%s", "sudo /opt/pwx/bin/pxctl", token)
+		_, err := s.doCmdUsingPod(n, options, createCtxCmd, ignoreErr)
+		if err != nil {
+			return "", err
+		}
+	}
+	out, err := s.doCmdUsingPod(n, options, cmd, ignoreErr)
+	if err != nil {
+		return "", err
+	}
+
+	if len(token) > 0 && strings.Contains(cmd, "pxctl") && !strings.Contains(cmd, "which") && !strings.Contains(cmd, "context") {
+		log.Infof("Deleting admin context in node [%s]", n.Name)
+		deleteCtxCmd := fmt.Sprintf("%s context delete admin", "sudo /opt/pwx/bin/pxctl")
+		_, err = s.doCmdUsingPod(n, options, deleteCtxCmd, ignoreErr)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return out, nil
 }
 
 func (s *SSH) doCmdUsingPodWithoutRetry(n node.Node, cmd string) (string, error) {
@@ -800,9 +845,15 @@ func (s *SSH) doCmdSSH(n node.Node, options node.ConnectionOpts, cmd string, ign
 	if err != nil {
 		return "", fmt.Errorf("fail to setup stdout, err: %v", err)
 	}
+
+	token := os.Getenv("PXCTL_AUTH_TOKEN")
+	if strings.Contains(cmd, "pxctl") && len(token) > 0 {
+		cmd = fmt.Sprintf("PXCTL_AUTH_TOKEN=%s %s", token, cmd)
+	}
 	if options.Sudo {
 		cmd = fmt.Sprintf("sudo su -c '%s' -", cmd) // Hyphen necessary to preserve PATH for commands like "which pxctl"
 	}
+	log.Debugf("Running command on node %s [%s]", n.Name, cmd)
 	session.Start(cmd)
 	err = session.Wait()
 	if resp, err1 := ioutil.ReadAll(stdout); err1 == nil {
@@ -820,7 +871,7 @@ func (s *SSH) doCmdSSH(n node.Node, options node.ConnectionOpts, cmd string, ign
 		log.Infof("SSH ERR: %v", err)
 		return out, &node.ErrFailedToRunCommand{
 			Addr:  n.Name,
-			Cause: fmt.Sprintf("failed to run command. sterr: %v, err: %v", sterr, err),
+			Cause: fmt.Sprintf("failed to run command [%s] . sterr: %v, err: %v", cmd, sterr, err),
 		}
 	}
 	return out, nil

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -344,8 +344,7 @@ func (d *portworx) GetStorageSpec() (*pxapi.StorageSpec, error) {
 
 // ListStoragePools returns all PX storage pools
 func (d *portworx) ListStoragePools(labelSelector metav1.LabelSelector) (map[string]*api.StoragePool, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultPXAPITimeout)
-	defer cancel()
+	ctx := d.getContext()
 
 	// TODO PX SDK currently does not have a way of directly getting storage pool objects.
 	// We need to list nodes and then inspect each node
@@ -4644,6 +4643,12 @@ func (d *portworx) GetKvdbMembers(n node.Node) (map[string]*torpedovolume.Metada
 		return nil, err
 	}
 	req := c.Get().Resource("kvmembers")
+
+	if len(d.token) > 0 {
+		// Set the Authorization header with the access token
+		req.SetHeader("Authorization", "Bearer "+d.token)
+	}
+
 	resp := req.Do()
 	if resp.Error() != nil {
 		if strings.Contains(resp.Error().Error(), "command not supported") {

--- a/tests/common.go
+++ b/tests/common.go
@@ -709,8 +709,11 @@ func InitInstance() {
 	if Inst().ConfigMap != "" {
 		log.Infof("Using Config Map: %s ", Inst().ConfigMap)
 		token, err = Inst().S.GetTokenFromConfigMap(Inst().ConfigMap)
-		log.FailOnError(err, "Error occured while getting token from config map")
+		log.FailOnError(err, "Error occurred while getting token from config map")
 		log.Infof("Token used for initializing: %s ", token)
+		err = os.Setenv("PXCTL_AUTH_TOKEN", token)
+		log.FailOnError(err, "Error occurred while setting PXCTL_AUTH_TOKEN")
+
 	} else {
 		token = ""
 	}
@@ -718,17 +721,17 @@ func InitInstance() {
 	err = Inst().N.Init(node.InitOptions{
 		SpecDir: Inst().SpecDir,
 	})
-	log.FailOnError(err, "Error occured while Node Driver Initialization")
+	log.FailOnError(err, "Error occurred while Node Driver Initialization")
 
 	err = Inst().V.Init(Inst().S.String(), Inst().N.String(), token, Inst().Provisioner, Inst().CsiGenericDriverConfigMap)
-	log.FailOnError(err, "Error occured while Volume Driver Initialization")
+	log.FailOnError(err, "Error occurred while Volume Driver Initialization")
 
 	err = Inst().M.Init(Inst().JobName, Inst().JobType)
-	log.FailOnError(err, "Error occured while monitor Initialization")
+	log.FailOnError(err, "Error occurred while monitor Initialization")
 
 	if Inst().Backup != nil {
 		err = Inst().Backup.Init(Inst().S.String(), Inst().N.String(), Inst().V.String(), token)
-		log.FailOnError(err, "Error occured while Backup Driver Initialization")
+		log.FailOnError(err, "Error occurred while Backup Driver Initialization")
 	}
 	SetupTestRail()
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
- Fix for running pxctl commands with admin context when security is enabled
**Which issue(s) this PR fixes** (optional)
Closes #PTX-24835

**Special notes for your reviewer**:

Result: https://aetos.pwx.purestorage.com/resultSet/testSetID/699250 