### PR TITLE
Fix ScaleMongoDBWhileBackupAndRestore failure on OCP with OCS

### DIFF
--- a/tests/backup_helper.go
+++ b/tests/backup_helper.go
@@ -2028,14 +2028,14 @@ func CreateRestoreWithoutCheck(restoreName string, backupName string,
 	var bkp *api.BackupObject
 	var bkpUid string
 	backupDriver := Inst().Backup
-	log.Infof("Getting the UID of the backup needed to be restored")
+	log.Infof("Getting the UID of the backup [%s] needed to be restored", backupName)
 	bkpEnumerateReq := &api.BackupEnumerateRequest{
 		OrgId: orgID}
 	curBackups, _ := backupDriver.EnumerateBackup(ctx, bkpEnumerateReq)
-	log.Debugf("Enumerate backup response -\n%v", curBackups)
 	for _, bkp = range curBackups.GetBackups() {
 		if bkp.Name == backupName {
 			bkpUid = bkp.Uid
+			log.Infof("Backup UID for %s - %s", backupName, bkpUid)
 			break
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
The test case `ScaleMongoDBWhileBackupAndRestore` was failing on OCP with OCS platform while restoring a KDMP backup. This was because we were trying to restore multiple backups in the same destination namespace at the same time in parallel. This was causing the KDMP restore to stay in progress for ever. And this is an invalid use case for any platform. So now, I will be restoring the 5 backups taken into 5 different destination namespaces.

**Which issue(s) this PR fixes** (optional)
Closes #PB-7596

**Special notes for your reviewer**:
[Jenkins Run](https://jenkins.pwx.dev.purestorage.com/job/Users/job/Mithun/job/BYOC-%20For%20PSO/98/)

