### PR TITLE
Upgrade cluster test is panicking when printing pxctl status 

### DIFF
--- a/tests/basic/upgrade_cluster_test.go
+++ b/tests/basic/upgrade_cluster_test.go
@@ -2,6 +2,10 @@ package tests
 
 import (
 	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
 	oputil "github.com/libopenstorage/operator/pkg/util/test"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -17,9 +21,6 @@ import (
 	"github.com/portworx/torpedo/pkg/log"
 	. "github.com/portworx/torpedo/tests"
 	corev1 "k8s.io/api/core/v1"
-	"net/url"
-	"strings"
-	"time"
 )
 
 var _ = Describe("{UpgradeCluster}", func() {
@@ -90,6 +91,10 @@ var _ = Describe("{UpgradeCluster}", func() {
 
 				err = Inst().S.UpgradeScheduler(version)
 				if err != nil {
+					err = Inst().S.RefreshNodeRegistry()
+					log.FailOnError(err, "Refresh Node Registry failed")
+					err = Inst().V.RefreshDriverEndpoints()
+					log.FailOnError(err, "Refresh Driver Endpoints failed")
 					PrintPxctlStatus()
 					PrintK8sClusterInfo()
 				}


### PR DESCRIPTION
…pgrade test failure

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Upgrade cluster test is panicking when printing pxctl status  during upgrade test failure.

Node were deleted and re-created during scheduler upgrade, test update the node registry but node also has to be updated weather nodes are storage nodes or not.

It was failing during `node.GetStorageNodes()[0]` call in common.go (line number 772)

**Which issue(s) this PR fixes** (optional)
Closes # PTX-21736

**Special notes for your reviewer**:
Trivial fix
https://jenkins.pwx.dev.purestorage.com/job/Torpedo/job/tp-anthos-upgrade/450/console

