### PR TITLE
fixing elastic search load app for generating IOs

### DIFF
--- a/drivers/scheduler/k8s/specs/elasticsearch-stress/aws/aws-storage-class.yaml
+++ b/drivers/scheduler/k8s/specs/elasticsearch-stress/aws/aws-storage-class.yaml
@@ -1,0 +1,8 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: elasticsearch-sc
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp2
+  fsType: ext4

--- a/drivers/scheduler/k8s/specs/elasticsearch-stress/azure/azure-storage-class.yaml
+++ b/drivers/scheduler/k8s/specs/elasticsearch-stress/azure/azure-storage-class.yaml
@@ -1,0 +1,9 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: elasticsearch-sc
+provisioner: kubernetes.io/azure-disk
+parameters:
+  skuName: Standard_LRS
+  location: eastus
+  storageAccount: pwxautomation

--- a/drivers/scheduler/k8s/specs/elasticsearch-stress/pure/pure-storage-class.yaml
+++ b/drivers/scheduler/k8s/specs/elasticsearch-stress/pure/pure-storage-class.yaml
@@ -1,0 +1,17 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+    name: elasticsearch-sc
+provisioner: pxd.portworx.com
+parameters:
+  # Tests:
+  # * FlashArray Direct Access w/ filesystem
+  # * Specifying filesystem type, creation options, and mount options
+  # * Specifying QoS
+  backend: "pure_block"
+  max_iops: "30000"
+  max_bandwidth: "10G"
+  csi.storage.k8s.io/fstype: ext4
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+

--- a/drivers/scheduler/k8s/specs/elasticsearch-stress/px-elasticdata-app.yaml
+++ b/drivers/scheduler/k8s/specs/elasticsearch-stress/px-elasticdata-app.yaml
@@ -1,0 +1,179 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch-cluster
+spec:
+  clusterIP: None
+  selector:
+    app: es-cluster
+  ports:
+    - name: transport
+      port: 9300
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch-api
+spec:
+  selector:
+    app: es-cluster
+  ports:
+    - name: http
+      port: 9200
+      targetPort: 9200
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: es-config
+data:
+  elasticsearch.yml: |
+    cluster.name: my-elastic-cluster
+    network.host: "0.0.0.0"
+    bootstrap.memory_lock: false
+    discovery.seed_hosts: ["esnode-0.elasticsearch-cluster.${POD_NAMESPACE}.svc.cluster.local", "esnode-1.elasticsearch-cluster.${POD_NAMESPACE}.svc.cluster.local", "esnode-2.elasticsearch-cluster.${POD_NAMESPACE}.svc.cluster.local"]
+    cluster.initial_master_nodes: ["esnode-0", "esnode-1", "esnode-2"]
+    xpack.security.enabled: false
+    xpack.monitoring.enabled: false
+  ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+  startup.sh: |
+    #!/bin/sh
+    CONFIG_FILE="/usr/share/elasticsearch/config/elasticsearch.yml"
+    cp /config/elasticsearch.yml $CONFIG_FILE
+    exec /usr/local/bin/docker-entrypoint.sh eswrapper
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: esnode
+spec:
+  serviceName: elasticsearch-cluster
+  replicas: 3
+  selector:
+    matchLabels:
+      app: es-cluster
+  template:
+    metadata:
+      labels:
+        app: es-cluster
+    spec:
+      securityContext:
+        fsGroup: 1000
+      initContainers:
+        - name: init-sysctl
+          image: busybox
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          command: ["sysctl", "-w", "vm.max_map_count=262144"]
+        - name: init-copy-script
+          image: busybox
+          command: ["sh", "-c", "cp /config/startup.sh /startup/startup.sh && chmod +x /startup/startup.sh"]
+          volumeMounts:
+            - name: elasticsearch-config
+              mountPath: /config
+            - name: writable-startup-script
+              mountPath: /startup
+      containers:
+        - name: elasticsearch
+          image: docker.elastic.co/elasticsearch/elasticsearch:7.2.0
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              memory: 1Gi
+              cpu: "0.5"
+            limits:
+              cpu: "1.0"
+          securityContext:
+            privileged: true
+            runAsUser: 1000
+            capabilities:
+              add:
+                - IPC_LOCK
+                - SYS_RESOURCE
+          env:
+            - name: ES_JAVA_OPTS
+              valueFrom:
+                configMapKeyRef:
+                  name: es-config
+                  key: ES_JAVA_OPTS
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          readinessProbe:
+            httpGet:
+              scheme: HTTP
+              path: /_cluster/health?local=true
+              port: 9200
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          ports:
+            - containerPort: 9200
+              name: es-http
+            - containerPort: 9300
+              name: es-transport
+          volumeMounts:
+            - name: es-data
+              mountPath: /usr/share/elasticsearch/data
+            - name: elasticsearch-config
+              mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
+              subPath: elasticsearch.yml
+            - name: writable-startup-script
+              mountPath: /startup
+          command: ["/bin/sh", "-c", "/startup/startup.sh"]
+      volumes:
+        - name: elasticsearch-config
+          configMap:
+            name: es-config
+            items:
+              - key: elasticsearch.yml
+                path: elasticsearch.yml
+              - key: ES_JAVA_OPTS
+                path: ES_JAVA_OPTS
+              - key: startup.sh
+                path: startup.sh
+        - name: writable-startup-script
+          emptyDir: {}
+  volumeClaimTemplates:
+    - metadata:
+        name: es-data
+      spec:
+        storageClassName: elasticsearch-sc
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 200Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: es-load
+  labels:
+    app: es-load
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: es-load
+  template:
+    metadata:
+      labels:
+        app: es-load
+    spec:
+      containers:
+        - name: es-load
+          image: portworx/torpedo-esload:1.1
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /bin/bash
+            - -c
+            - "./esload.sh --es_address esnode-0.elasticsearch-cluster.$POD_NAMESPACE.svc.cluster.local:9200 --indices 4 --documents 5 --seconds 120 --not-green --clients 1"
+      restartPolicy: Always

--- a/drivers/scheduler/k8s/specs/elasticsearch-stress/pxd/px-storage-class.yaml
+++ b/drivers/scheduler/k8s/specs/elasticsearch-stress/pxd/px-storage-class.yaml
@@ -1,0 +1,18 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+    name: elasticsearch-sc
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  {{ if .Repl }}
+  repl: "{{ .Repl }}"
+  {{ else }}
+  repl: "3"{{ end }}
+  nodiscard: "true"
+  {{ if .IoProfile }}
+  io_profile: "{{ .IoProfile }}"{{ end }}
+  {{ if .Fs }}
+  fs: {{ .Fs }}{{ end }}
+  {{ if .Journal }}
+  journal: "true"{{ end }}
+allowVolumeExpansion: true

--- a/drivers/scheduler/k8s/specs/elasticsearch/px-elasticdata-app.yaml
+++ b/drivers/scheduler/k8s/specs/elasticsearch/px-elasticdata-app.yaml
@@ -1,156 +1,91 @@
----
 apiVersion: v1
 kind: Service
 metadata:
-  name: elasticsearch-cluster
+  name: elasticsearch
+  labels:
+    app: elasticsearch
 spec:
+  ports:
+    - port: 9200
+      name: http
+    - port: 9300
+      name: transport
   clusterIP: None
   selector:
-    app: es-cluster
-  ports:
-  - name: transport
-    port: 9300
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: elasticsearch-api
-spec:
-  selector:
-    app: es-cluster
-  ports:
-  - name: http
-    port: 9200
-    targetPort: 9200
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: es-config
-data:
-  elasticsearch.yml: |
-    cluster.name: my-elastic-cluster
-    network.host: "0.0.0.0"
-    bootstrap.memory_lock: false
-    discovery.zen.ping.unicast.hosts: elasticsearch-cluster
-    discovery.zen.minimum_master_nodes: 1
-    xpack.security.enabled: false
-    xpack.monitoring.enabled: false
-  ES_JAVA_OPTS: -Xms512m -Xmx512m
+    app: elasticsearch
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: esnode
+  name: elasticsearch
 spec:
-  serviceName: elasticsearch-api
+  serviceName: "elasticsearch"
   replicas: 3
   selector:
     matchLabels:
-      app: es-cluster
-  updateStrategy:
-    type: RollingUpdate
+      app: elasticsearch
   template:
     metadata:
       labels:
-        app: es-cluster
+        app: elasticsearch
     spec:
-      schedulerName: stork
       securityContext:
         fsGroup: 1000
-      initContainers:
-      - name: init-sysctl
-        image: busybox
-        imagePullPolicy: IfNotPresent
-        securityContext:
-          privileged: true
-        command: ["sysctl", "-w", "vm.max_map_count=262144"]
+        runAsUser: 1000
       containers:
-      - name: elasticsearch
+        - name: elasticsearch
+          image: docker.elastic.co/elasticsearch/elasticsearch:7.10.1
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "0.5"
+            limits:
+              memory: "2Gi"
+              cpu: "1"
+          ports:
+            - containerPort: 9200
+              name: http
+            - containerPort: 9300
+              name: transport
+          env:
+            - name: discovery.type
+              value: single-node
+          volumeMounts:
+            - name: elasticsearch-storage
+              mountPath: /usr/share/elasticsearch/data
+  volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-storage
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: elasticsearch-sc
         resources:
           requests:
-            memory: 1Gi
-            cpu: "0.5"
-          limits:
-            cpu: "1.0"
-        securityContext:
-          privileged: true
-          runAsUser: 1000
-          capabilities:
-            add:
-              - IPC_LOCK
-              - SYS_RESOURCE
-        image: docker.elastic.co/elasticsearch/elasticsearch:7.2.0
-        imagePullPolicy: IfNotPresent
-        env:
-        - name: ES_JAVA_OPTS
-          valueFrom:
-            configMapKeyRef:
-              name: es-config
-              key: ES_JAVA_OPTS
-        readinessProbe:
-          httpGet:
-            scheme: HTTP
-            path: /_cluster/health?local=true
-            port: 9200
-          initialDelaySeconds: 5
-        ports:
-        - containerPort: 9200
-          name: es-http
-        - containerPort: 9300
-          name: es-transport
-        volumeMounts:
-        - name: es-data
-          mountPath: /usr/share/elasticsearch/data
-        - name: elasticsearch-config
-          mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
-          subPath: elasticsearch.yml
-      volumes:
-      - name: elasticsearch-config
-        configMap:
-          name: es-config
-          items:
-          - key: elasticsearch.yml
-            path: elasticsearch.yml
-  volumeClaimTemplates:
-  - metadata:
-      name: es-data
-    spec:
-      storageClassName: elasticsearch-sc
-      accessModes: [ "ReadWriteOnce" ]
-      resources:
-        requests:
-          storage: 5Gi
+            storage: 10Gi
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: es-load
-  namespace: default
-  labels:
-    app: es-load
+  name: io-app
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
-      app: es-load
+      app: io-app
   template:
     metadata:
       labels:
-        app: es-load
+        app: io-app
     spec:
       containers:
-      - name: es-load
-        image: portworx/torpedo-esload:1.1
-        imagePullPolicy: IfNotPresent
-        env:
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        command:
-          - /bin/bash
-          - -c
-          - "./esload.sh --es_address esnode-0.elasticsearch-api.$POD_NAMESPACE.svc.cluster.local:9200 --indices 4 --documents 5 --seconds 120 --not-green --clients 1"
-      restartPolicy: Always
-
+        - name: io-container
+          image: appropriate/curl
+          command: ["/bin/sh", "-c", "while true; do \
+          timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ); \
+          value=$((RANDOM % 100)); \
+          user_id=$((RANDOM % 1000)); \
+          status=$(if [ $((RANDOM % 2)) -eq 0 ]; then echo \"active\"; else echo \"inactive\"; fi); \
+          large_text=$(head -c 10000 </dev/urandom | tr -dc A-Za-z0-9); \
+          json_payload=$(printf '{\"timestamp\": \"%s\", \"message\": \"Hello from the I/O app\", \"value\": %d, \"user_id\": %d, \"status\": \"%s\", \"large_text\": \"%s\"}' \"$timestamp\" \"$value\" \"$user_id\" \"$status\" \"$large_text\"); \
+          curl -X POST \"http://elasticsearch:9200/my-index/_doc/\" -H 'Content-Type: application/json' -d \"$json_payload\"; \
+          done"]


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes # PTX-25231

**Special notes for your reviewer**:

Tested in vsphere set up 

```
Starting initialization of esnode-0.elasticsearch-cluster.es-3.svc.cluster.local:9200
Done!
Creating indices..
Generating documents and workers..
Done!
Starting the test. Will print stats every 30 seconds.
The test would run for 120 seconds, but it might take a bit more because we are waiting for current bulk operation to complete.

Elapsed time: 76 seconds
Successful bulks: 2 (2000 documents)
Failed bulks: 0 (0 documents)
Indexed approximately 26 MB which is 0.34 MB/s

Elapsed time: 106 seconds
Successful bulks: 5 (5000 documents)
Failed bulks: 1 (1000 documents)
Indexed approximately 129 MB which is 1.22 MB/s


Test is done! Final results:
Elapsed time: 123 seconds
Successful bulks: 8 (8000 documents)
Failed bulks: 1 (1000 documents)
Indexed approximately 208 MB which is 1.69 MB/s

Cleaning up created indices..  Done!
+ sleep 5
+ true
+ python elasticsearch-stress-test.py --es_address esnode-0.elasticsearch-cluster.es-3.svc.cluster.local:9200 --indices 4 --documents 5 --seconds 120 --not-green --clients 1

Starting initialization of esnode-0.elasticsearch-cluster.es-3.svc.cluster.local:9200
Done!
Creating indices..
Generating documents and workers..
Done!
Starting the test. Will print stats every 30 seconds.
The test would run for 120 seconds, but it might take a bit more because we are waiting for current bulk operation to complete.

Elapsed time: 32 seconds
Successful bulks: 7 (7000 documents)
Failed bulks: 0 (0 documents)
Indexed approximately 138 MB which is 4.31 MB/s

Elapsed time: 62 seconds
Successful bulks: 18 (18000 documents)
Failed bulks: 0 (0 documents)
Indexed approximately 353 MB which is 5.69 MB/s

Elapsed time: 92 seconds
Successful bulks: 30 (30000 documents)
Failed bulks: 0 (0 documents)
Indexed approximately 587 MB which is 6.38 MB/s


Test is done! Final results:
Elapsed time: 121 seconds
Successful bulks: 43 (43000 documents)
Failed bulks: 0 (0 documents)
Indexed approximately 841 MB which is 6.95 MB/s

Cleaning up created indices..  Done!
```

```
root@ip-10-13-94-12:~# pxctl v i pvc-e66a2301-1a78-4580-b617-4533c32cbe55
	Volume          	 :  513762271669466351
	Name            	 :  pvc-e66a2301-1a78-4580-b617-4533c32cbe55
	Size            	 :  200 GiB
	Format          	 :  ext4
	HA              	 :  3
	IO Priority     	 :  LOW
	Creation time   	 :  Jul 22 04:13:50 UTC 2024
	Shared          	 :  no
	Status          	 :  up
	State           	 :  Attached: 03110c43-17ca-433c-964f-f9daa353d3b6 (10.13.94.17)
	Last Attached   	 :  Jul 22 04:14:00 UTC 2024
	Device Path     	 :  /dev/pxd/pxd513762271669466351
	Labels          	 :  app=es-cluster,namespace=es-3,nodiscard=true,pvc=es-data-esnode-0,repl=3
	Mount Options          	 :  nodiscard
	Auto Fstrim      	 :  true
	Reads           	 :  410
	Reads MS        	 :  854
	Bytes Read      	 :  30392320
	Writes          	 :  16106
	Writes MS       	 :  92471
	Bytes Written   	 :  6010114048
	IOs in progress 	 :  1
	Bytes used      	 :  1.4 GiB
	Replica sets on nodes:
		Set 0
		  Node 		 : 10.13.94.16
		   Pool UUID	 : 40be97d7-b1a8-48f2-9531-dc97386bcabe
		  Node 		 : 10.13.94.17
		   Pool UUID	 : 83c850d1-3790-4abb-8364-2d2aa437f969
		  Node 		 : 10.13.93.198
		   Pool UUID	 : 39732722-0de9-44b5-8ed2-634d02392406
	Replication Status	 :  Up
	Volume consumers	 :
		- Name           : esnode-0 (bbf50ce6-1069-4337-8a6c-724a3fd4753c) (Pod)
		  Namespace      : es-3
		  Running on     : ip-10-13-94-17.pwx.purestorage.com
		  Controlled by  : esnode (StatefulSet)
```

```
kubectl -n es-3 get pvc
NAME               STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS       VOLUMEATTRIBUTESCLASS   AGE
es-data-esnode-0   Bound    pvc-e66a2301-1a78-4580-b617-4533c32cbe55   200Gi      RWO            elasticsearch-sc   <unset>                 8m23s
es-data-esnode-1   Bound    pvc-0606449d-3413-4da3-a33e-bd21901a1d59   200Gi      RWO            elasticsearch-sc   <unset>                 7m2s
es-data-esnode-2   Bound    pvc-44af4bdc-32cd-4247-b527-f330614268fc   200Gi      RWO            elasticsearch-sc   <unset>                 6m14s
kubectl -n es-3 get po
NAME                       READY   STATUS    RESTARTS   AGE
es-load-85cb87778b-cd4bw   1/1     Running   0          8m27s
esnode-0                   1/1     Running   0          8m27s
esnode-1                   1/1     Running   0          7m7s
esnode-2                   1/1     Running   0          6m19s

```
OCP validation :https://aetos.pwx.purestorage.com/resultSet/testSetID/704305