### PR TITLE
PB-7687:  Change check to see if PX is healthy or not

### DIFF
--- a/tests/backup/backup_upgrade_test.go
+++ b/tests/backup/backup_upgrade_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"github.com/hashicorp/go-version"
 	k8score "github.com/portworx/sched-ops/k8s/core"
+	"github.com/portworx/torpedo/drivers/node"
 	corev1 "k8s.io/api/core/v1"
-	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -1341,11 +1341,11 @@ var _ = Describe("{PXBackupClusterUpgradeTest}", Label(TestCaseLabelsMap[PXBacku
 					err = Inst().V.RefreshDriverEndpoints()
 					log.FailOnError(err, "Refresh Driver Endpoints failed")
 
-					urlToParse := fmt.Sprintf("%s/%s", Inst().StorageDriverUpgradeEndpointURL, Inst().StorageDriverUpgradeEndpointVersion)
-					u, err := url.Parse(urlToParse)
-					log.FailOnError(err, fmt.Sprintf("error parsing PX version the url [%s]", urlToParse))
-					err = Inst().V.ValidateDriver(u.String(), true)
-					dash.VerifyFatal(err, nil, fmt.Sprintf("verify volume driver after upgrade to %s", version))
+					storageNodes := node.GetStorageDriverNodes()
+					for index := range storageNodes {
+						err = Inst().V.WaitDriverUpOnNode(storageNodes[index], time.Minute*5)
+						dash.VerifyFatal(err, nil, fmt.Sprintf("Validate if PX is UP on %s", storageNodes[index].Name))
+					}
 
 					// Printing cluster node info after the upgrade
 					PrintK8sClusterInfo()
@@ -1361,11 +1361,11 @@ var _ = Describe("{PXBackupClusterUpgradeTest}", Label(TestCaseLabelsMap[PXBacku
 					err = Inst().V.RefreshDriverEndpoints()
 					log.FailOnError(err, "Refresh Driver Endpoints failed")
 
-					urlToParse = fmt.Sprintf("%s/%s", Inst().StorageDriverUpgradeEndpointURL, Inst().StorageDriverUpgradeEndpointVersion)
-					u, err = url.Parse(urlToParse)
-					log.FailOnError(err, fmt.Sprintf("error parsing PX version the url [%s]", urlToParse))
-					err = Inst().V.ValidateDriver(u.String(), true)
-					dash.VerifyFatal(err, nil, fmt.Sprintf("verify volume driver after upgrade to %s", version))
+					storageNodes = node.GetStorageDriverNodes()
+					for index := range storageNodes {
+						err = Inst().V.WaitDriverUpOnNode(storageNodes[index], time.Minute*5)
+						dash.VerifyFatal(err, nil, fmt.Sprintf("Validate if PX is UP on %s", storageNodes[index].Name))
+					}
 
 					// Printing cluster node info after the upgrade
 					PrintK8sClusterInfo()


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Currently we are using the below code to check if PX is in healthy state or not post K8s upgrade
```
urlToParse := fmt.Sprintf("%s/%s", Inst().StorageDriverUpgradeEndpointURL, Inst().StorageDriverUpgradeEndpointVersion)
u, err := url.Parse(urlToParse)
log.FailOnError(err, fmt.Sprintf("error parsing PX version the url [%s]", urlToParse))
err = Inst().V.ValidateDriver(u.String(), true)
dash.VerifyFatal(err, nil, fmt.Sprintf("verify volume driver after upgrade to %s", version))
```

The problem with this is that Px-Backup usually runs on a higher stork when compared to PX where the stork version in the endpoint and the stork version on the cluster will never match causing the test to fail when run against unreleased version of Px-Backup and corresponding stork. Hence change the check to a much simpler check. 

- [x]  Change check to see if PX is healthy or not

Successful run: 
https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/6209/consoleFull
~https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/6208/consoleFull~

**Which issue(s) this PR fixes** (optional)
Closes #PB-7687

**Special notes for your reviewer**:

