### PR TITLE
[PTX-25417] Resolve Panic Due to errChan Closure in Longevity

### DIFF
--- a/drivers/scheduler/k8s/specs/elasticsearch/px-elasticdata-app.yaml
+++ b/drivers/scheduler/k8s/specs/elasticsearch/px-elasticdata-app.yaml
@@ -61,7 +61,7 @@ spec:
         storageClassName: elasticsearch-sc
         resources:
           requests:
-            storage: 10Gi
+            storage: 200Gi
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/tests/testTriggers.go
+++ b/tests/testTriggers.go
@@ -796,7 +796,6 @@ func TriggerDeployNewApps(contexts *[]*scheduler.Context, recordChan *chan *Even
 		UpdateOutcome(event, updatePxRuntimeOpts())
 	})
 
-	errorChan := make(chan error, errorChannelSize)
 	labels := Inst().TopologyLabels
 	dashStats := make(map[string]string)
 	dashStats["app-list"] = strings.Join(Inst().AppList, ", ")
@@ -805,25 +804,35 @@ func TriggerDeployNewApps(contexts *[]*scheduler.Context, recordChan *chan *Even
 	Step("Deploy applications", func() {
 		if len(labels) > 0 {
 			for i := 0; i < Inst().GlobalScaleFactor; i++ {
+				errorChan := make(chan error, errorChannelSize)
 				newContexts := ScheduleAppsInTopologyEnabledCluster(
 					fmt.Sprintf("longevity-%d", i), labels, &errorChan,
 				)
+				for err := range errorChan {
+					log.Errorf("failed to deploy apps in iteration [%d] with error [%v]", i, err)
+					UpdateOutcome(event, err)
+				}
 				*contexts = append(*contexts, newContexts...)
 			}
 		} else {
 			for i := 0; i < Inst().GlobalScaleFactor; i++ {
+				errorChan := make(chan error, errorChannelSize)
 				newContexts := ScheduleApplications(fmt.Sprintf("longevity-%d", i), &errorChan)
+				for err := range errorChan {
+					log.Errorf("failed to deploy apps in iteration [%d] with error [%v]", i, err)
+					UpdateOutcome(event, err)
+				}
 				*contexts = append(*contexts, newContexts...)
 			}
 		}
 
-		for _, ctx := range *contexts {
-			log.Infof("Validating context: %v", ctx.App.Key)
+		for i, ctx := range *contexts {
+			log.Infof("Validating context[%d]: %v", i, ctx.App.Key)
 			ctx.SkipVolumeValidation = false
-			errorChan = make(chan error, errorChannelSize)
+			errorChan := make(chan error, errorChannelSize)
 			ValidateContext(ctx, &errorChan)
 			for err := range errorChan {
-				log.Infof("Error: %v", err)
+				log.Errorf("failed to validate context[%d] [%s] with error [%v]", i, ctx.App.Key, err)
 				UpdateOutcome(event, err)
 			}
 		}


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR ensures a new errorChan is created for every ScheduleApplications and ValidateContext call.

**Which issue(s) this PR fixes** (optional)
Closes #PTX-25417

**Special notes for your reviewer**:
Please review the Jenkins build: https://jenkins.pwx.dev.purestorage.com/job/Users/job/krishna/job/tp-pxe-byoc/4208/

Aetos Dashboard: https://aetos.pwx.purestorage.com/resultSet/testSetID/719193

Note: Please observe `ScheduleOptions: Scheduling Apps with hyper-converged` is printed 5 (SCALE_FACTOR) times in the logs.