### PR TITLE
Add Max Unavailable option for OCP surge upgrades

### DIFF
--- a/deployments/deploy-ssh.sh
+++ b/deployments/deploy-ssh.sh
@@ -824,6 +824,8 @@ spec:
       value: "${GKE_SURGE_VALUE}"
     - name: AKS_SURGE_UPGRADE_VALUE
       value: "${AKS_SURGE_UPGRADE_VALUE}"
+    - name: OCP_SURGE_UPGRADE_VALUE
+      value: "${OCP_SURGE_UPGRADE_VALUE}"
     - name: GOOGLE_APPLICATION_CREDENTIALS
       value: "${GOOGLE_APPLICATION_CREDENTIALS}"
     - name: TOGGLE_PURE_MGMT_IP

--- a/drivers/scheduler/openshift/openshift.go
+++ b/drivers/scheduler/openshift/openshift.go
@@ -341,6 +341,14 @@ func updateMaxUnavailableWorkerMCP() error {
 			return nil, true, fmt.Errorf("failed to update machine config pool - worker, Err: %v %v", string(output), err)
 		}
 		log.Info(string(output))
+		args = []string{"get", "mcp", "worker", "-o", "jsonpath={.spec.maxUnavailable}"}
+		output, err := exec.Command("oc", args...).CombinedOutput()
+		if err != nil {
+			return nil, true, fmt.Errorf("failed to get maxUnavailable for worker MCP, Err: %v %v", string(output), err)
+		}
+		if string(output) != maxUnavailable {
+			return nil, true, fmt.Errorf("maxUnavailable for worker MCP does not match, expected: %s, got: %s", maxUnavailable, string(output))
+		}
 
 		log.Infof("Successfully updated maxUnavailable for worker MCP to [%s]", maxUnavailable)
 		return nil, false, nil


### PR DESCRIPTION
**What this PR does / why we need it**: 
Set the maxUnavailable for worker MCP to allow surge upgrades.

**Which issue(s) this PR fixes** (optional)
Closes # PTX-25469


