### PR TITLE
Added helper function to take multiple backups efficiently

### DIFF
--- a/tests/backup/backup_scale_test.go
+++ b/tests/backup/backup_scale_test.go
@@ -441,7 +441,7 @@ var _ = Describe("{CreateMultipleBackupsPerDeployment}", func() {
 		backupNameList            []string
 		srcClusterUid             string
 		destClusterUid            string
-		numDeployments            = 20
+		numDeployments            = 50
 		numOfBackupsPerDeployment = 5
 		snapshotLimit             = 4
 	)

--- a/tests/backup/backup_scale_test.go
+++ b/tests/backup/backup_scale_test.go
@@ -441,8 +441,8 @@ var _ = Describe("{CreateMultipleBackupsPerDeployment}", func() {
 		backupNameList            []string
 		srcClusterUid             string
 		destClusterUid            string
-		numDeployments            = 50
-		numOfBackupsPerDeployment = 5
+		numDeployments            = 25
+		numOfBackupsPerDeployment = 10
 		snapshotLimit             = 4
 	)
 	JustBeforeEach(func() {

--- a/tests/backup_helper.go
+++ b/tests/backup_helper.go
@@ -1006,71 +1006,78 @@ func CreateBackupWithCustomResourceTypeWithValidation(ctx context1.Context, back
 	return ValidateBackup(ctx, backupName, orgID, scheduledAppContextsToBackup, resourceTypesFilter)
 }
 
-// TakeMultipleBackupsPerDeployment takes n multiple backups for every deployment for the specified cluster
-func TakeMultipleBackupsPerDeployment(ctx context1.Context, backupOrgID string, clusterName string, numOfBackups int, snapShotLimit int, backupLocationName, backupLocationUid string, scheduledAppContextsToBackup []*scheduler.Context, backupNamePrefix string) ([]string, error) {
+// TakeMultipleBackupsPerDeployment takes multiple backups for each deployment in the specified cluster.
+func TakeMultipleBackupsPerDeployment(ctx context1.Context, backupOrgID, clusterName string, numOfBackups, snapShotLimit int, backupLocationName, backupLocationUid string, scheduledAppContextsToBackup []*scheduler.Context, backupNamePrefix string) ([]string, error) {
 	labelSelectors := make(map[string]string)
 	type backupResult struct {
 		name       string
 		err        error
 		bkpContext *scheduler.Context
 	}
-
-	backupResults := make(chan backupResult)
-	var wg sync.WaitGroup
 	ctx, cancel := context1.WithCancel(ctx)
 	defer cancel()
+
+	var (
+		backupNameList []string
+		errList        []error
+		mu             sync.Mutex
+		wg             sync.WaitGroup
+		backupResults  = make(chan backupResult)
+	)
 
 	for _, scheduledAppContext := range scheduledAppContextsToBackup {
 		wg.Add(1)
 		go func(scheduledAppContext *scheduler.Context) {
 			defer wg.Done()
 			defer GinkgoRecover()
-			log.Infof("Taking backup of application from cluster %s", clusterName)
+
 			currentClusterUid, err := Inst().Backup.GetClusterUID(ctx, backupOrgID, clusterName)
 			if err != nil {
 				log.Errorf("Failed to get cluster UID for cluster %s: %v", clusterName, err)
+				mu.Lock()
+				errList = append(errList, err)
+				mu.Unlock()
+				cancel()
 				return
 			}
+
 			var innerWg sync.WaitGroup
-			semaphore := make(chan struct{}, snapShotLimit) // Semaphore scoped to each scheduledAppContext
+			semaphore := make(chan struct{}, snapShotLimit)
 			for i := 0; i < numOfBackups; i++ {
-				semaphore <- struct{}{} // Acquire semaphore
 				innerWg.Add(1)
 				go func(i int) {
 					defer innerWg.Done()
 					defer GinkgoRecover()
-					defer func() { <-semaphore }() // Release semaphore
+
 					select {
+					case semaphore <- struct{}{}:
+						defer func() { <-semaphore }()
 					case <-ctx.Done():
 						return
-					default:
-						currentBackupName := fmt.Sprintf("%s-%v-%v", backupNamePrefix, RandomString(8), i+1)
-						err := CreateBackup(currentBackupName, clusterName, backupLocationName, backupLocationUid, []string{scheduledAppContext.ScheduleOptions.Namespace}, labelSelectors, backupOrgID, currentClusterUid, "", "", "", "", ctx)
-						backupResults <- backupResult{name: currentBackupName, err: err, bkpContext: scheduledAppContext}
 					}
+					currentBackupName := fmt.Sprintf("%s-%s-%d", backupNamePrefix, RandomString(8), i+1)
+					err := CreateBackup(currentBackupName, clusterName, backupLocationName, backupLocationUid, []string{scheduledAppContext.ScheduleOptions.Namespace}, labelSelectors, backupOrgID, currentClusterUid, "", "", "", "", ctx)
+					backupResults <- backupResult{name: currentBackupName, err: err, bkpContext: scheduledAppContext}
 				}(i)
 			}
+
 			innerWg.Wait()
 		}(scheduledAppContext)
 	}
-
 	go func() {
 		wg.Wait()
 		close(backupResults)
 	}()
 
-	var backupNameList []string
-	var errList []error
 	backupMap := make(map[string]*scheduler.Context)
-
 	for result := range backupResults {
 		if result.err != nil {
-			log.Errorf("Failed to create and validate backup: %v", result.err)
+			log.Errorf("Failed to create backup: %v", result.err)
 			errList = append(errList, result.err)
 			cancel()
 			break
 		} else {
-			log.Infof("Successfully created and validated backup [%s]", result.name)
+			log.Infof("Successfully created backup [%s]", result.name)
 			backupNameList = append(backupNameList, result.name)
 			backupMap[result.name] = result.bkpContext
 		}
@@ -1079,31 +1086,29 @@ func TakeMultipleBackupsPerDeployment(ctx context1.Context, backupOrgID string, 
 	if len(errList) > 0 {
 		return backupNameList, fmt.Errorf("some backups failed")
 	}
-
-	// If all backups are successful, validate the backups
 	validationResults := make(chan error)
-	var validationWg sync.WaitGroup
+
+	// Validate all the backups.
 	for backupName, bkpContext := range backupMap {
-		validationWg.Add(1)
+		wg.Add(1)
 		go func(backupName string, bkpContext *scheduler.Context) {
-			defer validationWg.Done()
+			defer wg.Done()
 			defer GinkgoRecover()
-			err := ValidateBackup(ctx, backupName, backupOrgID, []*scheduler.Context{bkpContext}, make([]string, 0))
+
+			err := ValidateBackup(ctx, backupName, backupOrgID, []*scheduler.Context{bkpContext}, nil)
 			validationResults <- err
 		}(backupName, bkpContext)
 	}
 	go func() {
-		validationWg.Wait()
+		wg.Wait()
 		close(validationResults)
 	}()
-
 	for err := range validationResults {
 		if err != nil {
-			log.Errorf("Validation failed for some backups: %v", err)
+			log.Errorf("Validation failed for backup: %v", err)
 			errList = append(errList, err)
 		}
 	}
-
 	if len(errList) > 0 {
 		return backupNameList, fmt.Errorf("some validations failed")
 	}


### PR DESCRIPTION
Added a helper function **TakeMultipleBackupsPerDeployment** to take multiple backups for each deployment in the specified cluster.

**Which issue(s) this PR fixes** (optional)
Closes # PB-7651
Closes # PB-7834

**Special notes for your reviewer**:
1. Refer to the testcase **CreateMultipleBackupsPerDeployment**
2. Test runs:
250 backups: 
https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/6326/
https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/6303/
200 backups:
https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/6302/
150 backups:
https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/6301/