### PR TITLE
Adding alert and path validation for svmotion test

### DIFF
--- a/drivers/scheduler/dcos/dcos.go
+++ b/drivers/scheduler/dcos/dcos.go
@@ -3,6 +3,7 @@ package dcos
 import (
 	"encoding/json"
 	"fmt"
+	v1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -1187,6 +1188,13 @@ func (d *dcos) StartKubelet(n node.Node, options node.SystemctlOpts) error {
 	return &errors.ErrNotSupported{
 		Type:      "Function",
 		Operation: "StartKubelet()",
+	}
+}
+
+func (d *dcos) GetPXCloudDriveConfigMap(cluster *v1.StorageCluster) (map[string]node.DriveSet, error) {
+	return nil, &errors.ErrNotSupported{
+		Type:      "Function",
+		Operation: "GetPXCloudDriveConfigMap()",
 	}
 }
 

--- a/drivers/scheduler/k8s/k8s.go
+++ b/drivers/scheduler/k8s/k8s.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	baseErrors "errors"
 	"fmt"
+	pxutil "github.com/libopenstorage/operator/drivers/storage/portworx/util"
 	"io"
 	"io/ioutil"
 	random "math/rand"
@@ -36,6 +37,7 @@ import (
 	apapi "github.com/libopenstorage/autopilot-api/pkg/apis/autopilot/v1alpha1"
 	osapi "github.com/libopenstorage/openstorage/api"
 	"github.com/libopenstorage/openstorage/pkg/units"
+	operatorcorev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
 	storkapi "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	admissionregistration "github.com/portworx/sched-ops/k8s/admissionregistration"
 	"github.com/portworx/sched-ops/k8s/apiextensions"
@@ -8755,6 +8757,18 @@ func rotateTopologyArray(options *scheduler.ScheduleOptions) {
 		arr = append(arr, firstElem)
 		options.TopologyLabels = arr
 	}
+}
+
+// GetPXCloudDriveConfigMap retruns px cloud derive config map data
+func (k *K8s) GetPXCloudDriveConfigMap(cluster *operatorcorev1.StorageCluster) (map[string]node.DriveSet, error) {
+	cloudDriveConfigmapName := pxutil.GetCloudDriveConfigMapName(cluster)
+	cloudDriveConfifmap, _ := k8sCore.GetConfigMap(cloudDriveConfigmapName, cluster.Namespace)
+	var configData map[string]node.DriveSet
+	err := json.Unmarshal([]byte(cloudDriveConfifmap.Data["cloud-drive"]), &configData)
+	if err != nil {
+		return nil, err
+	}
+	return configData, nil
 }
 
 func init() {

--- a/drivers/scheduler/scheduler.go
+++ b/drivers/scheduler/scheduler.go
@@ -11,6 +11,7 @@ import (
 	volsnapv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	snapv1 "github.com/kubernetes-incubator/external-storage/snapshot/pkg/apis/crd/v1"
 	apapi "github.com/libopenstorage/autopilot-api/pkg/apis/autopilot/v1alpha1"
+	operatorcorev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
 	"github.com/portworx/torpedo/drivers/api"
 	"github.com/portworx/torpedo/drivers/node"
 	"github.com/portworx/torpedo/drivers/scheduler/spec"
@@ -474,6 +475,9 @@ type Driver interface {
 	StopKubelet(appNode node.Node, opts node.SystemctlOpts) error
 	// StartKubelet starts kubelet on the given node
 	StartKubelet(appNode node.Node, opts node.SystemctlOpts) error
+
+	// GetPXCloudDriveConfigMap gets the PX-Cloud drive config map
+	GetPXCloudDriveConfigMap(cluster *operatorcorev1.StorageCluster) (map[string]node.DriveSet, error)
 }
 
 var (

--- a/tests/basic/storage_pool_test.go
+++ b/tests/basic/storage_pool_test.go
@@ -9601,7 +9601,7 @@ func pickPoolToResize(contexts []*scheduler.Context, expandType api.SdkStoragePo
 	}
 
 	for _, poolID := range poolsWithIO {
-		log.Infof("checking pool expansion eliginblity of pool [%s] with IOs", poolID)
+		log.Infof("checking pool expansion eligibility of pool [%s] with IOs", poolID)
 		n, err := GetNodeWithGivenPoolID(poolID)
 		if err != nil {
 			continue

--- a/tests/basic/upgrade_cluster_test.go
+++ b/tests/basic/upgrade_cluster_test.go
@@ -116,10 +116,10 @@ var _ = Describe("{UpgradeCluster}", func() {
 
 				err = Inst().S.UpgradeScheduler(version)
 				if err != nil {
-					err := Inst().S.RefreshNodeRegistry()
-					log.FailOnError(err, "Refresh Node Registry failed")
-					err = Inst().V.RefreshDriverEndpoints()
-					log.FailOnError(err, "Refresh Driver Endpoints failed")
+					neErr := Inst().S.RefreshNodeRegistry()
+					log.FailOnError(neErr, "Refresh Node Registry failed")
+					neErr = Inst().V.RefreshDriverEndpoints()
+					log.FailOnError(neErr, "Refresh Driver Endpoints failed")
 					PrintPxctlStatus()
 					PrintK8sClusterInfo()
 				}


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
- Adding ID validation after storage vmotion
- moving datastore validation to common
- Adding alert validation after storage vmotion

**Which issue(s) this PR fixes** (optional)
Closes # PTX-25462,PTX-25459,PTX-25458

**Special notes for your reviewer**:

Result:
https://aetos.pwx.purestorage.com/resultSet/testSetID/736590/testCaseID/4838306
