### PR TITLE
PB-7801: Add TC to verify deletion on backup objects in once retention is met

### DIFF
--- a/tests/backup/backup_basic_test.go
+++ b/tests/backup/backup_basic_test.go
@@ -64,18 +64,6 @@ func TestBasic(t *testing.T) {
 	RunSpecs(t, "Torpedo : Backup")
 }
 
-// triggerCleanup returns if cleanup should happen or not based on ENVs set in torpedo
-func triggerCleanup() bool {
-	lockedBucketName := os.Getenv("LOCKED_BUCKET_NAME")
-	if lockedBucketName == "" {
-		return true
-	}
-
-	// TODO: Add code not cleanup if you wish to debug anything
-
-	return false
-}
-
 // BackupInitInstance initialises instances required for backup
 func BackupInitInstance() {
 	var err error
@@ -272,7 +260,7 @@ var _ = AfterSuite(func() {
 	defer dash.TestSetEnd()
 	defer EndTorpedoTest()
 
-	cleanup := triggerCleanup()
+	cleanup := TriggerCleanup()
 	log.InfoD(fmt.Sprintf("Cleanup state is set to %t", cleanup))
 	if cleanup {
 		ctx, err := backup.GetAdminCtxFromSecret()

--- a/tests/backup/backup_test_labels.go
+++ b/tests/backup/backup_test_labels.go
@@ -137,6 +137,8 @@ const (
 	AzureCloudAccountCreationWithMandatoryAndNonMandatoryFields                        TestCaseName = "AzureCloudAccountCreationWithMandatoryAndNonMandatoryFields"
 	AzureCloudAccountForLockedBucket                                                   TestCaseName = "AzureCloudAccountForLockedBucket"
 	PXBackupUpgradeWithAzureCredChange                                                 TestCaseName = "PXBackupUpgradeWithAzureCredChange"
+	VerifyBackupDeletionWhenRetentionIsMet                                             TestCaseName = "VerifyBackupDeletionWhenRetentionIsMet"
+	DeleteVerifyBackupDeletionWhenRetentionIsMet                                       TestCaseName = "DeleteVerifyBackupDeletionWhenRetentionIsMet"
 )
 
 // Test case labels


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
- [x] Add func `reconstructBackupNsMap()`
- [x] Add tc `VerifyBackupDeletionWhenRetentionIsMet` and `DeleteVerifyBackupDeletionWhenRetentionIsMet` please note it's a locked bucket test hence we need to two cases where the delete logic is in the second part. 
- [x] Add func `IsAllVolumesBackupFull()` to check if backup is a full backup or not
- [x] Add func `IsBackupPresent()` to check if a backup is present or not. 
- [x] Add func `GetRetentionTimeStamp()` to fetch the value of the `RetentionTimeStamp` for the backup object
- [x] Add func `IsRetentionTimestampUpdated()` to check if `RetentionTimeStamp` was updated or not
- [x] Add func `UpdateBackupWithLabel()` to update the label for backup  
- [x] Move func `triggerCleanup()` to `common.go` and rename to `TriggerCleanup()`
- [x] Update func `CreateAzureCredentialsForImmutableBackupLocations()` to send back UID and Names separately   

Dashboard links: 
Regression Run: https://aetos.pwx.purestorage.com/resultSet/testSetID/746035
`VerifyBackupDeletionWhenRetentionIsMet` Run:  https://aetos.pwx.purestorage.com/resultSet/testSetID/746182 
`DeleteVerifyBackupDeletionWhenRetentionIsMet` Run:

**Which issue(s) this PR fixes** (optional)
Closes #PB-7801

**Special notes for your reviewer**:
