### PR TITLE
PTX-25726 update maxUnavailable for OCP MCP to accept integer instead of str

### DIFF
--- a/drivers/scheduler/openshift/openshift.go
+++ b/drivers/scheduler/openshift/openshift.go
@@ -331,8 +331,12 @@ func (k *openshift) createTorpedoSecurityContextConstraints() (*ocpsecurityv1api
 func updateMaxUnavailableWorkerMCP() error {
 
 	maxUnavailable := os.Getenv("OCP_SURGE_UPGRADE_VALUE")
+	if maxUnavailable == "" {
+		log.Warnf("OCP_SURGE_UPGRADE_VALUE is not set!")
+		return nil
+	}
 	log.Info("Setting maxUnavailable value for worker MCP to [%s]", maxUnavailable)
-	patchData := fmt.Sprintf(`{"spec":{"maxUnavailable":"%s"}}`, maxUnavailable)
+	patchData := fmt.Sprintf(`{"spec":{"maxUnavailable":%s}}`, maxUnavailable)
 
 	t := func() (interface{}, bool, error) {
 		var output []byte


### PR DESCRIPTION
**What this PR does / why we need it**:
There was a regression introduced due to incorrect formatting of the `maxUnavailable` value passed during OCP upgrade. This PR fixes it by accepting `int` instead of `str`

**Which issue(s) this PR fixes** (optional)
Closes #PTX-25726

