### PR TITLE
PTX-25747: Counting only storage nodes for pdb validation

### DIFF
--- a/tests/common.go
+++ b/tests/common.go
@@ -12813,11 +12813,7 @@ func SwitchBothKubeConfigANDContext(cluster string) error {
 func DoPDBValidation(stopSignal <-chan struct{}, mError *error) {
 	pdbValue, allowedDisruptions := GetPDBValue()
 	isClusterParallelyUpgraded := false
-	nodes, err := Inst().V.GetDriverNodes()
-	if err != nil {
-		*mError = multierr.Append(*mError, err)
-		return
-	}
+	nodes := node.GetStorageNodes()
 	totalNodes := len(nodes)
 	itr := 1
 	for {
@@ -14329,11 +14325,7 @@ func DoVolumeQuorumValidation(volumeQuorumValidationStopSignal chan struct{}, vQ
 }
 func DoParallelUpgradePDBValidation(stopSignal <-chan struct{}, mError *error) {
 
-	nodes, err := Inst().V.GetDriverNodes()
-	if err != nil {
-		*mError = multierr.Append(*mError, err)
-		return
-	}
+	nodes := node.GetStorageNodes()
 	stc, err := Inst().V.GetDriver()
 	if err != nil {
 		*mError = multierr.Append(*mError, err)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: Initially to get the total number of storage nodes, the function used included storageless nodes as well. This PR will fix the issue and only count the storagenodes for PDB validation. This includes for both cluster wide and node PDB

**Which issue(s) this PR fixes** (optional)
Closes # PTX-25747


